### PR TITLE
feat: add reindexer functionality

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -1,6 +1,9 @@
 # Logging
 RUST_LOG=debug
 
+# Reindex on start up. Will create all Redis index keys from the Neo4J graph
+REINDEX=false
+
 # Service
 SERVER_HOST=127.0.0.1
 SERVER_PORT=8080

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ description = "Nexus between homeservers and Pubky-App. Pubky-nexus constructs a
 homepage = "https://github.com/pubky"
 repository = "https://github.com/pubky/pubky-nexus"
 license = "MIT"
+default-run = "service"
 
 [dependencies]
 tokio = { version = "1.38.1", features = ["full"] }
@@ -37,19 +38,22 @@ name = "pubky_nexus"
 path = "src/lib.rs"
 
 [[bin]]
-name = "pubky-nexus-service"
+
+name = "service"
 path = "src/service.rs"
 
 [[bin]]
-name = "pubky-nexus-watcher"
+name = "watcher"
 path = "src/watcher.rs"
 
 [[bench]]
 name = "profile"
 harness = false
-
 [[bench]]
 name = "post"
+harness = false
+[[bench]]
+name = "reindex"
 harness = false
 
 # Max performance profile

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ cargo install cargo-watch
 
 # Ideally in two terminals.
 # On terminal 1 run:
-cargo watch -q -c -w src/ -x "run --bin pubky-nexus-service"
+cargo watch -q -c -w src/ -x run
 # You can check the running service on your browser on localhost:8080/info
 
 # On terminal 2 run (for tests to work you need a working /neo4j-example instance with example dataset)

--- a/benches/reindex.rs
+++ b/benches/reindex.rs
@@ -1,0 +1,51 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use pubky_nexus::{reindex, setup, Config};
+use std::env;
+use std::time::Duration;
+use tokio::runtime::Runtime;
+
+use std::sync::Once;
+
+static INIT: Once = Once::new();
+
+pub fn run_setup() {
+    INIT.call_once(|| {
+        let rt = Runtime::new().unwrap();
+        env::set_var("RUST_LOG", "error");
+        rt.block_on(async {
+            let config = Config::from_env();
+            setup(&config).await; // Initialize any necessary setup
+        });
+    });
+}
+
+fn bench_reindex(c: &mut Criterion) {
+    println!("***************************************");
+    println!("Benchmarking the reindex function.");
+    println!("***************************************");
+
+    run_setup();
+
+    let rt = Runtime::new().unwrap();
+
+    c.bench_function("reindex", |b| {
+        b.to_async(&rt).iter(|| async {
+            reindex().await;
+        });
+    });
+}
+
+fn configure_criterion() -> Criterion {
+    Criterion::default()
+        .measurement_time(Duration::new(200, 0))
+        .sample_size(20)
+        .warm_up_time(Duration::new(1, 0))
+}
+
+criterion_group! {
+    name = benches;
+    config = configure_criterion();
+    targets = bench_reindex,
+}
+
+criterion_main!(benches);

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ pub struct Config {
     pub static_path: String,
     server_host: String,
     server_port: String,
+    pub reindex: bool,
 }
 
 impl Config {
@@ -28,6 +29,10 @@ impl Config {
             static_path: env::var("STATIC_PATH").unwrap_or_else(|_| "./".to_string()),
             server_host: env::var("SERVER_HOST").unwrap_or_else(|_| "127.0.0.1".to_string()),
             server_port: env::var("SERVER_PORT").unwrap_or_else(|_| "8080".to_string()),
+            reindex: env::var("REINDEX")
+                .unwrap_or_else(|_| "false".to_string())
+                .parse()
+                .unwrap_or(false),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ mod config;
 mod db;
 mod error;
 pub mod models;
+mod reindex;
 pub mod routes;
 mod setup;
 
@@ -9,4 +10,5 @@ pub use config::Config;
 pub use db::graph::queries;
 pub use error::{Error, Result};
 pub use models::RedisOps;
+pub use reindex::reindex;
 pub use setup::setup;

--- a/src/reindex.rs
+++ b/src/reindex.rs
@@ -1,0 +1,117 @@
+use crate::RedisOps;
+use crate::{
+    db::connectors::neo4j::get_neo4j_graph,
+    models::post::{PostCounts, PostDetails, PostRelationships},
+    models::profile::{ProfileCounts, ProfileDetails},
+};
+use log::info;
+use neo4rs::query;
+use tokio::task::JoinSet;
+
+pub async fn reindex() {
+    let mut user_tasks = JoinSet::new();
+    let mut post_tasks = JoinSet::new();
+
+    let user_ids = get_all_user_ids().await.expect("Failed to get user IDs");
+    for user_id in user_ids {
+        user_tasks.spawn(async move {
+            if let Err(e) = reindex_user(&user_id).await {
+                log::error!("Failed to reindex user {}: {:?}", user_id, e);
+            }
+        });
+    }
+
+    let post_ids = get_all_post_ids().await.expect("Failed to get post IDs");
+    for (author_id, post_id) in post_ids {
+        post_tasks.spawn(async move {
+            if let Err(e) = reindex_post(&author_id, &post_id).await {
+                log::error!("Failed to reindex post {}: {:?}", post_id, e);
+            }
+        });
+    }
+
+    while let Some(res) = user_tasks.join_next().await {
+        if let Err(e) = res {
+            log::error!("User reindexing task failed: {:?}", e);
+        }
+    }
+
+    while let Some(res) = post_tasks.join_next().await {
+        if let Err(e) = res {
+            log::error!("Post reindexing task failed: {:?}", e);
+        }
+    }
+
+    info!("Reindexing completed successfully.");
+}
+
+async fn reindex_user(user_id: &str) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let details = ProfileDetails::get_from_graph(user_id).await?;
+    let counts = ProfileCounts::get_from_graph(user_id).await?;
+
+    if let Some(details) = details {
+        details.set_index(&[user_id]).await?;
+    }
+    if let Some(counts) = counts {
+        counts.set_index(&[user_id]).await?;
+    }
+
+    Ok(())
+}
+
+async fn reindex_post(
+    author_id: &str,
+    post_id: &str,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let details = PostDetails::get_from_graph(author_id, post_id).await?;
+    let counts = PostCounts::get_from_graph(author_id, post_id).await?;
+    let relationships = PostRelationships::get_from_graph(author_id, post_id).await?;
+
+    if let Some(details) = details {
+        details.set_index(&[author_id, post_id]).await?;
+    }
+    if let Some(counts) = counts {
+        counts.set_index(&[author_id, post_id]).await?;
+    }
+    if let Some(relationships) = relationships {
+        relationships.set_index(&[author_id, post_id]).await?;
+    }
+
+    Ok(())
+}
+
+async fn get_all_user_ids() -> Result<Vec<String>, Box<dyn std::error::Error + Send + Sync>> {
+    let graph = get_neo4j_graph()?;
+    let query = query("MATCH (u:User) RETURN u.id AS id");
+
+    let graph = graph.lock().await;
+    let mut result = graph.execute(query).await?;
+
+    let mut user_ids = Vec::new();
+    while let Some(row) = result.next().await? {
+        if let Some(id) = row.get("id")? {
+            user_ids.push(id);
+        }
+    }
+
+    Ok(user_ids)
+}
+
+async fn get_all_post_ids(
+) -> Result<Vec<(String, String)>, Box<dyn std::error::Error + Send + Sync>> {
+    let graph = get_neo4j_graph()?;
+    let query =
+        query("MATCH (u:User)-[:AUTHORED]->(p:Post) RETURN u.id AS author_id, p.id AS post_id");
+
+    let graph = graph.lock().await;
+    let mut result = graph.execute(query).await?;
+
+    let mut post_ids = Vec::new();
+    while let Some(row) = result.next().await? {
+        if let (Some(author_id), Some(post_id)) = (row.get("author_id")?, row.get("post_id")?) {
+            post_ids.push((author_id, post_id));
+        }
+    }
+
+    Ok(post_ids)
+}

--- a/src/routes/v0/post/view.rs
+++ b/src/routes/v0/post/view.rs
@@ -1,4 +1,4 @@
-use crate::models::post::PostView;
+use crate::models::post::{PostRelationships, PostView};
 use crate::routes::v0::endpoints::POST_ROUTE;
 use crate::{Error, Result};
 use axum::extract::{Path, Query};
@@ -46,5 +46,8 @@ pub async fn post_view_handler(
 }
 
 #[derive(OpenApi)]
-#[openapi(paths(post_view_handler), components(schemas(PostView)))]
+#[openapi(
+    paths(post_view_handler),
+    components(schemas(PostView, PostRelationships))
+)]
 pub struct PostViewApiDoc;

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,11 +1,20 @@
 use log::info;
-use pubky_nexus::{routes, setup, Config};
+use pubky_nexus::{reindex, routes, setup, Config};
 use tokio::net::TcpListener;
 
 #[tokio::main]
 async fn main() {
     let config = Config::from_env();
     setup(&config).await;
+
+    // Reindex if REINDEX is set to true
+    match config.reindex {
+        true => {
+            info!("REINDEX=true detected. Starting reindexing process.");
+            reindex().await;
+        }
+        false => (),
+    }
 
     // App router
     let app = routes::routes();


### PR DESCRIPTION
Fixes #24

Using current `migration-db.cypher` graph:
- time: 5.26 s
- number of keys: 1650
- size of redis instance: 2.492 MB

## Pre-submission Checklist

Before submitting this pull request, please ensure the following:

**Code Quality**
- [x] Cargo Clippy has been run with no warnings:
```
cargo clippy
```

**Testing**
- [x] Implement new tests for all new code and pass successfully all of them, including existing tests:
```bash
# For tests to work you need a working instance with example dataset like docker/db-migration)
cargo test
```

**Performance**
- [x] Validate that appropriate benchmarks have been created for the new code to measure its performance.
```
cargo bench
```