### PR TITLE
Add method to get Redis last RDB dump timestamp

### DIFF
--- a/src/db/kv/last_save.rs
+++ b/src/db/kv/last_save.rs
@@ -1,0 +1,19 @@
+use crate::db::connectors::redis::get_redis_conn;
+use std::error::Error;
+
+pub async fn get_last_rdb_save_time() -> Result<u64, Box<dyn Error + Send + Sync>> {
+    let mut redis_conn = get_redis_conn().await?;
+    let info: String = redis::cmd("INFO")
+        .arg("persistence")
+        .query_async(&mut redis_conn)
+        .await?;
+    for line in info.lines() {
+        if line.starts_with("rdb_last_save_time:") {
+            if let Some(value_str) = line.split(':').nth(1) {
+                let timestamp = value_str.trim().parse::<u64>()?;
+                return Ok(timestamp);
+            }
+        }
+    }
+    Err("Could not find rdb_last_save_time in the info output".into())
+}

--- a/src/db/kv/mod.rs
+++ b/src/db/kv/mod.rs
@@ -1,2 +1,3 @@
 pub mod index;
+pub mod last_save;
 pub mod traits;

--- a/src/models/info.rs
+++ b/src/models/info.rs
@@ -1,6 +1,8 @@
 use serde::Serialize;
 use utoipa::ToSchema;
 
+use crate::db::kv::last_save::get_last_rdb_save_time;
+
 #[derive(Serialize, ToSchema)]
 pub struct ServerInfo {
     pub description: String,
@@ -9,16 +11,12 @@ pub struct ServerInfo {
     pub name: String,
     pub repository: String,
     pub version: String,
-}
-
-impl Default for ServerInfo {
-    fn default() -> Self {
-        Self::new()
-    }
+    pub last_index_snapshot: u64,
 }
 
 impl ServerInfo {
-    pub fn new() -> Self {
+    pub async fn new() -> Self {
+        let last_index_snapshot = get_last_rdb_save_time().await.unwrap_or_default();
         Self {
             description: env!("CARGO_PKG_DESCRIPTION").to_string(),
             homepage: env!("CARGO_PKG_HOMEPAGE").to_string(),
@@ -26,6 +24,7 @@ impl ServerInfo {
             name: env!("CARGO_PKG_NAME").to_string(),
             repository: env!("CARGO_PKG_REPOSITORY").to_string(),
             version: env!("CARGO_PKG_VERSION").to_string(),
+            last_index_snapshot,
         }
     }
 }

--- a/src/routes/v0/info.rs
+++ b/src/routes/v0/info.rs
@@ -14,7 +14,7 @@ use utoipa::OpenApi;
     )
 )]
 pub async fn info_handler() -> impl IntoResponse {
-    let info = ServerInfo::new();
+    let info = ServerInfo::new().await;
     Json(info)
 }
 


### PR DESCRIPTION
This PR:
- Adds a `kv` method to get the last time Redis performed an RDB snapshot.
- Serves the timestamp in our `/v0/info` endpoint

This function will become very useful when handling Nexus crashes. We will come back online and check the last time the index was backed up, and use it the start time to stream events from the homeserver.

## Pre-submission Checklist

Before submitting this pull request, please ensure the following:

**Code Quality**
- [x] Cargo Clippy has been run with no warnings:
```
cargo clippy
```

**Testing**
- [x] Implement new tests for all new code and pass successfully all of them, including existing tests:
```bash
# For tests to work you need a working instance with example dataset like docker/db-migration)
cargo test
```

**Performance**
- [x] Validate that appropriate benchmarks have been created for the new code to measure its performance.
```
cargo bench
```