### PR TITLE
Add redis flush on reindexer

### DIFF
--- a/src/db/kv/flush.rs
+++ b/src/db/kv/flush.rs
@@ -1,0 +1,8 @@
+use crate::db::connectors::redis::get_redis_conn;
+use std::error::Error;
+
+pub async fn clear_redis() -> Result<(), Box<dyn Error + Send + Sync>> {
+    let mut redis_conn = get_redis_conn().await?;
+    redis::cmd("FLUSHDB").query_async(&mut redis_conn).await?;
+    Ok(())
+}

--- a/src/db/kv/mod.rs
+++ b/src/db/kv/mod.rs
@@ -1,3 +1,4 @@
+pub mod flush;
 pub mod index;
 pub mod last_save;
 pub mod traits;

--- a/src/reindex.rs
+++ b/src/reindex.rs
@@ -1,3 +1,4 @@
+use crate::db::kv::flush::clear_redis;
 use crate::models::user::{Followers, Following};
 use crate::{
     db::connectors::neo4j::get_neo4j_graph,
@@ -9,6 +10,12 @@ use neo4rs::query;
 use tokio::task::JoinSet;
 
 pub async fn reindex() {
+    // Clear Redis database
+    if let Err(e) = clear_redis().await {
+        log::error!("Failed to clear Redis: {:?}", e);
+        return;
+    }
+
     let mut user_tasks = JoinSet::new();
     let mut post_tasks = JoinSet::new();
 


### PR DESCRIPTION
This PR introduces flushing (deletion) of the current redis keys before reindexing if `reindex` is `true`.

## Pre-submission Checklist

> For tests to work you need a working instance with example dataset like docker/db-migration

- [x] **Code Quality**: Cargo Clippy has been run with no warnings, `cargo clippy`
- [x] **Testing**: Implement and pass new tests for all new code, while maintaining existing test suite, `cargo test`.
- [x] **Performance**: Ensure new code has relevant performance benchmarks, `cargo bench`