### PR TITLE
Fix graph lock

### DIFF
--- a/src/models/post/bookmark.rs
+++ b/src/models/post/bookmark.rs
@@ -52,11 +52,14 @@ impl Bookmark {
         post_id: &str,
         viewer_id: &str,
     ) -> Result<Option<Bookmark>, Box<dyn std::error::Error + Send + Sync>> {
-        let graph = get_neo4j_graph()?;
-        let query = queries::post_bookmark(author_id, post_id, viewer_id);
+        let mut result;
+        {
+            let graph = get_neo4j_graph()?;
+            let query = queries::post_bookmark(author_id, post_id, viewer_id);
 
-        let graph = graph.lock().await;
-        let mut result = graph.execute(query).await?;
+            let graph = graph.lock().await;
+            result = graph.execute(query).await?;
+        }
 
         if let Some(row) = result.next().await? {
             // TODO, research why sometimes there is a result that is not a Relation here ?
@@ -83,11 +86,14 @@ impl Bookmark {
     pub async fn index_all_from_graph(
         user_id: &str,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let graph = get_neo4j_graph()?;
-        let query = queries::user_bookmarks(user_id);
+        let mut result;
+        {
+            let graph = get_neo4j_graph()?;
+            let query = queries::user_bookmarks(user_id);
 
-        let graph = graph.lock().await;
-        let mut result = graph.execute(query).await?;
+            let graph = graph.lock().await;
+            result = graph.execute(query).await?;
+        }
 
         let mut bookmarked_post_keys = Vec::new();
 

--- a/src/models/post/counts.rs
+++ b/src/models/post/counts.rs
@@ -46,11 +46,14 @@ impl PostCounts {
         author_id: &str,
         post_id: &str,
     ) -> Result<Option<PostCounts>, Box<dyn std::error::Error + Send + Sync>> {
-        let graph = get_neo4j_graph()?;
-        let query = queries::post_counts(author_id, post_id);
+        let mut result;
+        {
+            let graph = get_neo4j_graph()?;
+            let query = queries::post_counts(author_id, post_id);
 
-        let graph = graph.lock().await;
-        let mut result = graph.execute(query).await?;
+            let graph = graph.lock().await;
+            result = graph.execute(query).await?;
+        }
 
         if let Some(row) = result.next().await? {
             if !row.get("post_exists").unwrap_or(false) {

--- a/src/models/post/details.rs
+++ b/src/models/post/details.rs
@@ -63,11 +63,14 @@ impl PostDetails {
         author_id: &str,
         post_id: &str,
     ) -> Result<Option<PostDetails>, Box<dyn std::error::Error + Send + Sync>> {
-        let graph = get_neo4j_graph()?;
-        let query = queries::get_post_by_id(author_id, post_id);
+        let mut result;
+        {
+            let graph = get_neo4j_graph()?;
+            let query = queries::get_post_by_id(author_id, post_id);
 
-        let graph = graph.lock().await;
-        let mut result = graph.execute(query).await?;
+            let graph = graph.lock().await;
+            result = graph.execute(query).await?;
+        }
 
         match result.next().await? {
             Some(row) => {

--- a/src/models/post/relationships.rs
+++ b/src/models/post/relationships.rs
@@ -46,11 +46,14 @@ impl PostRelationships {
         author_id: &str,
         post_id: &str,
     ) -> Result<Option<PostRelationships>, Box<dyn std::error::Error + Send + Sync>> {
-        let graph = get_neo4j_graph()?;
-        let query = queries::post_relationships(author_id, post_id);
+        let mut result;
+        {
+            let graph = get_neo4j_graph()?;
+            let query = queries::post_relationships(author_id, post_id);
 
-        let graph = graph.lock().await;
-        let mut result = graph.execute(query).await?;
+            let graph = graph.lock().await;
+            result = graph.execute(query).await?;
+        }
 
         if let Some(row) = result.next().await? {
             let replied_post_id: Option<String> = row.get("replied_post_id")?;

--- a/src/models/tag/post.rs
+++ b/src/models/tag/post.rs
@@ -30,20 +30,23 @@ impl Deref for PostTags {
 impl PostTags {
     pub async fn get_by_id(
         user_id: &str,
-        post_id: &str
+        post_id: &str,
     ) -> Result<Option<PostTags>, Box<dyn std::error::Error + Send + Sync>> {
         Self::get_from_graph(user_id, post_id).await
     }
 
     async fn get_from_graph(
         user_id: &str,
-        post_id: &str
+        post_id: &str,
     ) -> Result<Option<PostTags>, Box<dyn std::error::Error + Send + Sync>> {
-        let query = queries::post_tags(user_id, post_id);
-        let graph = get_neo4j_graph()?;
+        let mut result;
+        {
+            let query = queries::post_tags(user_id, post_id);
+            let graph = get_neo4j_graph()?;
 
-        let graph = graph.lock().await;
-        let mut result = graph.execute(query).await?;
+            let graph = graph.lock().await;
+            result = graph.execute(query).await?;
+        }
 
         if let Some(row) = result.next().await? {
             let user_exists: bool = row.get("post_exists").unwrap_or(false);

--- a/src/models/tag/user.rs
+++ b/src/models/tag/user.rs
@@ -37,11 +37,14 @@ impl UserTags {
     async fn get_from_graph(
         user_id: &str,
     ) -> Result<Option<UserTags>, Box<dyn std::error::Error + Send + Sync>> {
-        let query = queries::user_tags(user_id);
-        let graph = get_neo4j_graph()?;
+        let mut result;
+        {
+            let query = queries::user_tags(user_id);
+            let graph = get_neo4j_graph()?;
 
-        let graph = graph.lock().await;
-        let mut result = graph.execute(query).await?;
+            let graph = graph.lock().await;
+            result = graph.execute(query).await?;
+        }
 
         if let Some(row) = result.next().await? {
             let user_exists: bool = row.get("user_exists").unwrap_or(false);

--- a/src/models/traits.rs
+++ b/src/models/traits.rs
@@ -1,8 +1,8 @@
 use axum::async_trait;
 use neo4rs::Query;
 
-use crate::RedisOps;
 use crate::db::connectors::neo4j::get_neo4j_graph;
+use crate::RedisOps;
 use std::fmt::Debug;
 
 #[async_trait]
@@ -24,7 +24,7 @@ where
     /// a queried ID, containing `Some(record)` if the record was found in either the cache or the graph database,
     /// or `None` if it was not found in either.
     async fn get_by_ids(
-        id_list: &[&str]
+        id_list: &[&str],
     ) -> Result<Vec<Option<Self>>, Box<dyn std::error::Error + Send + Sync>> {
         let key_parts_list: Vec<&[&str]> = id_list.iter().map(std::slice::from_ref).collect();
         let mut collection = Self::try_from_index_multiple_json(&key_parts_list).await?;
@@ -61,13 +61,17 @@ where
     /// This function returns a `Result` containing a vector of `Option<Self>`. Each `Option` corresponds to
     /// a queried ID, containing `Some(record)` if the record was found in the graph database, or `None` if it was not found.
     async fn from_graph(
-        missing_ids: &[&str]
+        missing_ids: &[&str],
     ) -> Result<Vec<Option<Self>>, Box<dyn std::error::Error + Send + Sync>> {
-        let graph = get_neo4j_graph()?;
-        let query = Self::graph_query(missing_ids);
+        let mut result;
+        {
+            let graph = get_neo4j_graph()?;
+            let query = Self::graph_query(missing_ids);
 
-        let graph = graph.lock().await;
-        let mut result = graph.execute(query).await?;
+            let graph = graph.lock().await;
+            result = graph.execute(query).await?;
+        }
+
         let mut missing_records = Vec::with_capacity(missing_ids.len());
 
         while let Some(row) = result.next().await? {

--- a/src/models/user/counts.rs
+++ b/src/models/user/counts.rs
@@ -48,11 +48,14 @@ impl UserCounts {
     pub async fn get_from_graph(
         user_id: &str,
     ) -> Result<Option<UserCounts>, Box<dyn std::error::Error + Send + Sync>> {
-        let graph = get_neo4j_graph()?;
-        let query = queries::user_counts(user_id);
+        let mut result;
+        {
+            let graph = get_neo4j_graph()?;
+            let query = queries::user_counts(user_id);
 
-        let graph = graph.lock().await;
-        let mut result = graph.execute(query).await?;
+            let graph = graph.lock().await;
+            result = graph.execute(query).await?;
+        }
 
         if let Some(row) = result.next().await? {
             if !row.get("user_exists").unwrap_or(false) {

--- a/src/models/user/follows.rs
+++ b/src/models/user/follows.rs
@@ -1,7 +1,7 @@
 use crate::db::connectors::neo4j::get_neo4j_graph;
 use crate::{queries, RedisOps};
-use neo4rs::Query;
 use axum::async_trait;
+use neo4rs::Query;
 use serde::{Deserialize, Serialize};
 use std::error::Error;
 use utoipa::ToSchema;
@@ -26,11 +26,14 @@ pub trait UserFollows: Sized + RedisOps + AsRef<[String]> + Default {
         skip: Option<usize>,
         limit: Option<usize>,
     ) -> Result<Option<Self>, Box<dyn Error + Send + Sync>> {
-        let graph = get_neo4j_graph()?;
-        let query = Self::get_query(user_id, skip, limit);
+        let mut result;
+        {
+            let graph = get_neo4j_graph()?;
+            let query = Self::get_query(user_id, skip, limit);
 
-        let graph = graph.lock().await;
-        let mut result = graph.execute(query).await?;
+            let graph = graph.lock().await;
+            result = graph.execute(query).await?;
+        }
 
         if let Some(row) = result.next().await? {
             let user_exists: bool = row.get("user_exists").unwrap_or(false);


### PR DESCRIPTION
Fix to release the lock on the graph as soon as we get the results. Improves performance on all benchmarks that use the graph around 15-30% (e.g. streams with tags).

## Pre-submission Checklist

> For tests to work you need a working neo4j instance with the example dataset in `docker/db-migration`

- [x] **Code Quality**: Clippy has been run with no warnings, `cargo clippy`
- [x] **Testing**: Implement and pass new tests for all new code, while maintaining existing test suite, `cargo test`.
- [x] **Performance**: Ensure new code has relevant performance benchmarks, `cargo bench`
