### PR TITLE
fix: update error handling in stream posts handlers

### DIFF
--- a/src/routes/v0/stream/posts.rs
+++ b/src/routes/v0/stream/posts.rs
@@ -45,8 +45,9 @@ pub async fn stream_global_posts_handler(
 
     match PostStream::get_global_posts(sorting, query.viewer_id, Some(skip), Some(limit)).await {
         Ok(Some(stream)) => Ok(Json(stream)),
-        Ok(None) => Err(Error::InternalServerError {
-            source: "No posts found".into(),
+        Ok(None) => Err(Error::PostNotFound {
+            author_id: String::from("global"),
+            post_id: String::from("N/A"),
         }),
         Err(source) => Err(Error::InternalServerError { source }),
     }
@@ -88,8 +89,9 @@ pub async fn stream_user_posts_handler(
 
     match PostStream::get_user_posts(&user_id, query.viewer_id, Some(skip), Some(limit)).await {
         Ok(Some(stream)) => Ok(Json(stream)),
-        Ok(None) => Err(Error::InternalServerError {
-            source: "No posts found".into(),
+        Ok(None) => Err(Error::PostNotFound {
+            author_id: String::from("global"),
+            post_id: String::from("N/A"),
         }),
         Err(source) => Err(Error::InternalServerError { source }),
     }
@@ -132,8 +134,9 @@ pub async fn stream_posts_by_reach_handler(
         .await
     {
         Ok(Some(stream)) => Ok(Json(stream)),
-        Ok(None) => Err(Error::InternalServerError {
-            source: "No posts found".into(),
+        Ok(None) => Err(Error::PostNotFound {
+            author_id: String::from("global"),
+            post_id: String::from("N/A"),
         }),
         Err(source) => Err(Error::InternalServerError { source }),
     }


### PR DESCRIPTION
When I received a stream of posts that exceeded the limit, I encountered a `500 Internal Server Error`. 
I have now updated it to a more appropriate error message, a `404 Not Found error`.

## Pre-submission Checklist

> For tests to work you need a working neo4j instance with the example dataset in `docker/db-migration`

- [x] **Testing**: Implement and pass new tests for all new code, while maintaining existing test suite, `cargo test`.
- [x] **Performance**: Ensure new code has relevant performance benchmarks, `cargo bench`
