### PR TITLE
Fix: retry event handle on any Error

### DIFF
--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -8,7 +8,7 @@ pub mod handlers;
 pub mod processor;
 pub mod uri;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 enum ResourceType {
     User {
         user_id: PubkyId,
@@ -36,13 +36,13 @@ enum ResourceType {
 }
 
 // Look for the end pattern after the start index, or use the end of the string if not found
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 enum EventType {
     Put,
     Del,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Event {
     uri: String,
     event_type: EventType,


### PR DESCRIPTION
Not the ultimate solution, but a quick fix to get some more estability when looking for new user signups and when getting random `tokio shutdown` Errors on tests.

The EventProcessor will retry handling a new event up to 3 times. Most Errors are related to Pubky client. However, sometimes, some Errors could come from Neo4J (adding  a relationship to a Node that does not exist, e.g., due to previous Error handling an Event). We might to be more granular in the future and not retry the Errors that are not due to tokio or pubky connectivity.

# Pre-submission Checklist

> For tests to work you need a working neo4j and redis instance with the example dataset in `docker/db-graph`

- [ ] **Testing**: Implement and pass new tests for the new features/fixes, `cargo test`.
- [ ] **Performance**: Ensure new code has relevant performance benchmarks, `cargo bench`
