### PR TITLE
Feat(service): add user stream by list of ids

### DIFF
--- a/src/models/user/stream.rs
+++ b/src/models/user/stream.rs
@@ -80,7 +80,10 @@ impl UserStream {
             }
         }
 
-        Ok(Some(Self(user_views)))
+        match user_views.is_empty() {
+            true => Ok(None),
+            false => Ok(Some(Self(user_views))),
+        }
     }
 
     /// Adds the post to a Redis sorted set using the follower counts as score.

--- a/src/routes/v0/endpoints.rs
+++ b/src/routes/v0/endpoints.rs
@@ -33,12 +33,16 @@ const THREAD_PREFIX: &str = concatcp!(VERSION_ROUTE, "/thread");
 pub const THREAD_ROUTE: &str = concatcp!(THREAD_PREFIX, "/:author_id/:post_id");
 
 // Stream routes
+// Streams of UserView objects
 const STREAM_PREFIX: &str = concatcp!(VERSION_ROUTE, "/stream");
 pub const STREAM_USERS_ROUTE: &str = concatcp!(STREAM_PREFIX, "/users");
 pub const STREAM_USERS_USERNAME_SEARCH_ROUTE: &str =
     concatcp!(STREAM_USERS_ROUTE, "/username-search");
-pub const STREAM_USERS_MOSTFOLLOWED_ROUTE: &str = concatcp!(STREAM_PREFIX, "/users/most-followed");
-pub const STREAM_USERS_PIONEERS_ROUTE: &str = concatcp!(STREAM_PREFIX, "/users/pioneers");
+pub const STREAM_USERS_MOSTFOLLOWED_ROUTE: &str = concatcp!(STREAM_USERS_ROUTE, "/most-followed");
+pub const STREAM_USERS_PIONEERS_ROUTE: &str = concatcp!(STREAM_USERS_ROUTE, "/pioneers");
+pub const STREAM_USERS_BY_IDS_ROUTE: &str = concatcp!(STREAM_USERS_ROUTE, "/by_ids");
+
+// Streams of PostView objects
 pub const STREAM_POSTS_ROUTE: &str = concatcp!(STREAM_PREFIX, "/posts");
 pub const STREAM_POSTS_USER_ROUTE: &str = concatcp!(STREAM_POSTS_ROUTE, "/user/:user_id");
 pub const STREAM_POSTS_REACH_ROUTE: &str = concatcp!(STREAM_POSTS_ROUTE, "/reach");

--- a/src/routes/v0/stream/mod.rs
+++ b/src/routes/v0/stream/mod.rs
@@ -7,18 +7,26 @@ mod posts;
 mod users;
 
 pub fn routes() -> Router {
-    register_routes!(Router::new(),
-        //  User stream
+    let router = register_routes!(Router::new(),
+        // User stream
         endpoints::STREAM_USERS_ROUTE => users::stream_users_handler,
         endpoints::STREAM_USERS_USERNAME_SEARCH_ROUTE => users::stream_username_search_handler,
         endpoints::STREAM_USERS_MOSTFOLLOWED_ROUTE => users::stream_most_followed_users_handler,
         endpoints::STREAM_USERS_PIONEERS_ROUTE => users::stream_pioneer_users_handler,
+
         // Post stream
         endpoints::STREAM_POSTS_ROUTE => posts::stream_global_posts_handler,
         endpoints::STREAM_POSTS_USER_ROUTE => posts::stream_user_posts_handler,
         endpoints::STREAM_POSTS_REACH_ROUTE => posts::stream_posts_by_reach_handler,
         endpoints::STREAM_POSTS_BOOKMARKED_ROUTE => posts::stream_bookmarked_posts_handler,
-        endpoints::STREAM_POSTS_TAG_ROUTE => posts::stream_posts_by_tags_handler
+        endpoints::STREAM_POSTS_TAG_ROUTE => posts::stream_posts_by_tags_handler,
+    );
+
+    // Register the POST route separately
+
+    router.route(
+        endpoints::STREAM_USERS_BY_IDS_ROUTE,
+        axum::routing::post(users::stream_users_by_ids_handler),
     )
 }
 

--- a/src/routes/v0/stream/users.rs
+++ b/src/routes/v0/stream/users.rs
@@ -1,14 +1,14 @@
 use crate::models::user::{UserStream, UserStreamType};
 use crate::routes::v0::endpoints::{
-    STREAM_USERS_MOSTFOLLOWED_ROUTE, STREAM_USERS_PIONEERS_ROUTE, STREAM_USERS_ROUTE,
-    STREAM_USERS_USERNAME_SEARCH_ROUTE,
+    STREAM_USERS_BY_IDS_ROUTE, STREAM_USERS_MOSTFOLLOWED_ROUTE, STREAM_USERS_PIONEERS_ROUTE,
+    STREAM_USERS_ROUTE, STREAM_USERS_USERNAME_SEARCH_ROUTE,
 };
 use crate::{Error, Result};
 use axum::extract::Query;
 use axum::Json;
 use log::info;
 use serde::Deserialize;
-use utoipa::OpenApi;
+use utoipa::{OpenApi, ToSchema};
 
 #[derive(Deserialize)]
 pub struct UserStreamQuery {
@@ -24,7 +24,7 @@ pub struct UserStreamQuery {
     path = STREAM_USERS_ROUTE,
     tag = "Stream Users",
     params(
-        ("user_id" = String, Path, description = "User Pubky ID"),
+        ("user_id" = Option<String>, Query, description = "User Pubky ID"),
         ("viewer_id" = Option<String>, Query, description = "Viewer Pubky ID"),
         ("skip" = Option<usize>, Query, description = "Skip N followers"),
         ("limit" = Option<usize>, Query, description = "Retrieve N followers"),
@@ -215,14 +215,66 @@ pub async fn stream_pioneer_users_handler(
     }
 }
 
+// This is a POST request because we're passing a potentially large list of user IDs in the request body,
+// which could exceed the URL length limits imposed by some servers and browsers if passed as query parameters.
+// Although we're retrieving data, using POST for this type of batch query is a common practice when dealing
+// with large request payloads.
+#[derive(ToSchema, Deserialize)]
+pub struct UserStreamByIdsRequest {
+    pub user_ids: Vec<String>,
+    pub viewer_id: Option<String>,
+}
+#[utoipa::path(
+    post,
+    path = STREAM_USERS_BY_IDS_ROUTE,
+    tag = "Stream Users By ID",
+    request_body = UserStreamByIdsRequest,
+    responses(
+        (status = 200, description = "Users stream", body = UserStream),
+        (status = 404, description = "Users not found"),
+        (status = 500, description = "Internal server error")
+    )
+)]
+pub async fn stream_users_by_ids_handler(
+    Json(request): Json<UserStreamByIdsRequest>,
+) -> Result<Json<UserStream>> {
+    info!(
+        "POST {} user_ids: {:?}",
+        STREAM_USERS_BY_IDS_ROUTE, request.user_ids
+    );
+
+    const MAX_USERS: usize = 1000;
+
+    if request.user_ids.len() > MAX_USERS {
+        return Err(Error::InvalidInput {
+            message: format!("The maximum number of user IDs allowed is {}", MAX_USERS),
+        });
+    }
+
+    if request.user_ids.is_empty() {
+        return Err(Error::InvalidInput {
+            message: "The list of user IDs provided is empty".to_string(),
+        });
+    }
+
+    match UserStream::from_listed_user_ids(&request.user_ids, request.viewer_id.as_deref()).await {
+        Ok(Some(stream)) => Ok(Json(stream)),
+        Ok(None) => Err(Error::UserNotFound {
+            user_id: "Users not found".to_string(),
+        }),
+        Err(source) => Err(Error::InternalServerError { source }),
+    }
+}
+
 #[derive(OpenApi)]
 #[openapi(
     paths(
         stream_users_handler,
         stream_most_followed_users_handler,
         stream_username_search_handler,
-        stream_pioneer_users_handler
+        stream_pioneer_users_handler,
+        stream_users_by_ids_handler
     ),
-    components(schemas(UserStream, UserStreamType))
+    components(schemas(UserStream, UserStreamType, UserStreamByIdsRequest))
 )]
 pub struct StreamUsersApiDocs;

--- a/tests/service/all.rs
+++ b/tests/service/all.rs
@@ -5,6 +5,7 @@ use std::{
 
 use anyhow::Result;
 use pubky_nexus::models::tag::TagDetails;
+use serde_json::json;
 
 const HOST_URL: &str = "http://localhost:8080";
 
@@ -526,7 +527,7 @@ async fn test_stream_most_followed() -> Result<()> {
         "There should be at least one user in the most followed stream"
     );
 
-    // List of expected user IDs (replace with actual expected IDs from your test data)
+    // List of expected user IDs
     let expected_user_ids = vec![
         "pxnu33x7jtpx9ar1ytsi4yxbp6a5o36gwhffs8zoxmbuptici1jy",
         "hj6e38w9dkmpkdmb9c9n6k1yt85ekbqhh3s4aagksdj4zssxg36o",
@@ -596,7 +597,7 @@ async fn test_stream_pioneers() -> Result<()> {
         "There should be at least one user in the most followed stream"
     );
 
-    // List of expected user IDs (replace with actual expected IDs from your test data)
+    // List of expected user IDs
     let expected_user_ids = vec![
         "pxnu33x7jtpx9ar1ytsi4yxbp6a5o36gwhffs8zoxmbuptici1jy",
         "o1gg96ewuojmopcjbz8895478wdtxtzzuxnfjjz8o8e77csa1ngo",
@@ -702,6 +703,216 @@ async fn test_stream_posts_timeline() -> Result<()> {
 }
 
 #[tokio::test]
+async fn test_stream_users_by_ids_valid_request() -> Result<()> {
+    let client = httpc_test::new_client(HOST_URL)?;
+
+    // List of valid user IDs
+    let user_ids = vec![
+        "4snwyct86m383rsduhw5xgcxpw7c63j3pq8x4ycqikxgik8y64ro",
+        "ywng83zf5paobxptt8ipkdgq5karppe3edxy1kigb7kgwai56uxo",
+        "h3fghnb3x59oh7r53x8y6a5x38oatqyjym9b31ybss17zqdnhcoy",
+    ];
+
+    // Prepare the request body
+    let request_body = json!({
+        "user_ids": user_ids,
+        "viewer_id": null
+    });
+
+    // Send the POST request to the endpoint
+    let res = client
+        .do_post("/v0/stream/users/by_ids", request_body)
+        .await?;
+
+    assert_eq!(res.status(), 200, "Expected HTTP status 200 OK");
+
+    let body = res.json_body()?;
+    assert!(body.is_array(), "Response body should be an array");
+
+    let users = body.as_array().expect("User stream should be an array");
+
+    // Check if the response has the expected number of users
+    assert_eq!(users.len(), 3, "Expected 3 users in the response");
+
+    // Verify that each expected user ID is present in the response
+    for id in &user_ids {
+        let exists = users.iter().any(|u| u["details"]["id"] == *id);
+        assert!(exists, "Expected user ID not found: {}", id);
+    }
+
+    // Additional checks for specific user attributes
+    for user in users {
+        assert!(
+            user["details"]["name"].is_string(),
+            "Name should be a string"
+        );
+        assert!(
+            user["counts"]["followers"].is_number(),
+            "Follower counts should be a number"
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_stream_users_by_ids_limit_exceeded() -> Result<()> {
+    let client = httpc_test::new_client(HOST_URL)?;
+
+    // Generate a list of 1001 user IDs to exceed the limit
+    let mut user_ids = Vec::with_capacity(1001);
+    for i in 0..1001 {
+        user_ids.push(format!("user_id_{}", i));
+    }
+
+    let request_body = json!({
+        "user_ids": user_ids,
+        "viewer_id": null
+    });
+
+    // Send the POST request to the endpoint
+    let res = client
+        .do_post("/v0/stream/users/by_ids", request_body)
+        .await?;
+
+    // Expecting a 400 Bad Request due to exceeding the limit
+    assert_eq!(res.status(), 400, "Expected HTTP status 400 Bad Request");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_stream_users_by_ids_with_invalid_ids() -> Result<()> {
+    let client = httpc_test::new_client(HOST_URL)?;
+
+    // Valid and invalid user IDs
+    let user_ids = vec![
+        "4snwyct86m383rsduhw5xgcxpw7c63j3pq8x4ycqikxgik8y64ro", // Valid
+        "nonexistent_user_id",                                  // Invalid
+        "o1gg96ewuojmopcjbz8895478wdtxtzzuxnfjjz8o8e77csa1ngo", // Valid
+    ];
+
+    let request_body = json!({
+        "user_ids": user_ids,
+        "viewer_id": null
+    });
+
+    let res = client
+        .do_post("/v0/stream/users/by_ids", request_body)
+        .await?;
+
+    // Assuming the endpoint returns 200 OK with valid users only
+    assert_eq!(res.status(), 200, "Expected HTTP status 200 OK");
+
+    let body = res.json_body()?;
+    assert!(body.is_array(), "Response body should be an array");
+
+    let users = body.as_array().expect("User stream should be an array");
+
+    // Expected valid user IDs
+    let expected_user_ids = vec![
+        "4snwyct86m383rsduhw5xgcxpw7c63j3pq8x4ycqikxgik8y64ro",
+        "o1gg96ewuojmopcjbz8895478wdtxtzzuxnfjjz8o8e77csa1ngo",
+    ];
+
+    // Check that only valid users are returned
+    assert_eq!(
+        users.len(),
+        expected_user_ids.len(),
+        "Expected {} users in the response",
+        expected_user_ids.len()
+    );
+
+    for id in &expected_user_ids {
+        let exists = users.iter().any(|u| u["details"]["id"] == *id);
+        assert!(exists, "Expected user ID not found: {}", id);
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_stream_users_by_ids_empty_list() -> Result<()> {
+    let client = httpc_test::new_client(HOST_URL)?;
+
+    // Empty list of user IDs
+    let user_ids: Vec<String> = Vec::new();
+
+    let request_body = json!({
+        "user_ids": user_ids,
+        "viewer_id": null
+    });
+
+    let res = client
+        .do_post("/v0/stream/users/by_ids", request_body)
+        .await?;
+
+    // Expecting a 400 Bad Request due to empty user_ids list
+    assert_eq!(res.status(), 400, "Expected HTTP status 400 Bad Request");
+
+    let body = res.json_body()?;
+    assert!(
+        body["error"].as_str().unwrap_or("").contains("empty"),
+        "Error message should mention that user_ids cannot be empty"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_stream_users_by_ids_with_viewer_id() -> Result<()> {
+    let client = httpc_test::new_client(HOST_URL)?;
+
+    // List of valid user IDs
+    let user_ids = vec![
+        "4snwyct86m383rsduhw5xgcxpw7c63j3pq8x4ycqikxgik8y64ro",
+        "o1gg96ewuojmopcjbz8895478wdtxtzzuxnfjjz8o8e77csa1ngo",
+    ];
+
+    let viewer_id = "kzq3o8y8w1b7ffogpq73okop4gb3ahm31ytwwk1na8p6gpr4511o";
+
+    let request_body = json!({
+        "user_ids": user_ids,
+        "viewer_id": viewer_id
+    });
+
+    let res = client
+        .do_post("/v0/stream/users/by_ids", request_body)
+        .await?;
+
+    assert_eq!(res.status(), 200, "Expected HTTP status 200 OK");
+
+    let body = res.json_body()?;
+    assert!(body.is_array(), "Response body should be an array");
+
+    let users = body.as_array().expect("User stream should be an array");
+
+    // Check that the correct number of users is returned
+    assert_eq!(
+        users.len(),
+        user_ids.len(),
+        "Expected {} users in the response",
+        user_ids.len()
+    );
+
+    // Check that viewer_id relationships are properly included
+    for user in users {
+        let relationship = &user["relationship"];
+        // Verify that relationship fields are present and correctly formatted
+        assert!(
+            relationship["followed_by"].is_boolean(),
+            "is_follower should be a boolean"
+        );
+        assert!(
+            relationship["following"].is_boolean(),
+            "is_following should be a boolean"
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_stream_posts_total_engagement() -> Result<()> {
     let client = httpc_test::new_client(HOST_URL)?;
 
@@ -772,7 +983,6 @@ async fn test_stream_posts_total_engagement() -> Result<()> {
 async fn test_stream_user_posts() -> Result<()> {
     let client = httpc_test::new_client(HOST_URL)?;
 
-    // Replace "user_id_example" with an actual user ID that exists in your test database
     let user_id = "4snwyct86m383rsduhw5xgcxpw7c63j3pq8x4ycqikxgik8y64ro";
 
     let res = client


### PR DESCRIPTION
This PR adds a new POST endpoint to get a stream of user profiles by a provided list of user_ids in the body request.

# Pre-submission Checklist

> For tests to work you need a working neo4j and redis instance with the example dataset in `docker/db-graph`

- [ ] **Testing**: Implement and pass new tests for the new features/fixes, `cargo test`.
- [ ] **Performance**: Ensure new code has relevant performance benchmarks, `cargo bench`
