### PR TITLE
Fix: user counts tags

### DIFF
--- a/src/db/graph/queries/read.rs
+++ b/src/db/graph/queries/read.rs
@@ -191,7 +191,7 @@ pub fn user_counts(user_id: &str) -> neo4rs::Query {
         OPTIONAL MATCH (follower:User)-[:FOLLOWS]->(u)
         OPTIONAL MATCH (u)-[:FOLLOWS]->(friend:User)-[:FOLLOWS]->(u)
         OPTIONAL MATCH (u)-[:AUTHORED]->(post:Post)
-        OPTIONAL MATCH (u)-[tag:TAGGED]->(:Post)
+        OPTIONAL MATCH (u)-[tag:TAGGED]->()
         WITH u, COUNT(DISTINCT following) AS following, 
                 COUNT(DISTINCT follower) AS followers, 
                 COUNT(DISTINCT friend) AS friends, 

--- a/src/events/handlers/tag.rs
+++ b/src/events/handlers/tag.rs
@@ -75,6 +75,8 @@ async fn put_sync_post(
 
     // TODO: Handle the errors
     let _ = tokio::join!(
+        // Update user counts for tagger
+        UserCounts::update(&tagger_user_id, "tags", JsonAction::Increment(1)),
         // Increment in one the post tags
         PostCounts::update_index_field(post_key_slice, "tags", JsonAction::Increment(1)),
         // Add label to post
@@ -129,8 +131,8 @@ async fn put_sync_user(
     .await?;
 
     // SAVE TO INDEX
-    // Update user counts in the user
-    UserCounts::update(&tagged_user_id, "tags", JsonAction::Increment(1)).await?;
+    // Update user counts for tagger
+    UserCounts::update(&tagger_user_id, "tags", JsonAction::Increment(1)).await?;
 
     // Add tagger to the user taggers list
     TagUser::add_tagger_to_index(&tagged_user_id, None, &tagger_user_id, &tag_label).await?;

--- a/tests/watcher/tags/user_to_user.rs
+++ b/tests/watcher/tags/user_to_user.rs
@@ -84,8 +84,8 @@ async fn test_homeserver_tag_to_another_user() -> Result<()> {
     // Find user as tagger in the user profile: User:Taggers:user_id
     assert_eq!(cache_tag_details[0].taggers[0], tagger_user_id);
 
-    // Check if user counts updated: User:Counts:user_id
-    let user_counts = find_user_counts(&tagged_user_id).await;
+    // Check if user counts of the tagger updated: User:Counts:user_id
+    let user_counts = find_user_counts(&tagger_user_id).await;
     assert_eq!(user_counts.tags, 1);
 
     // Check user pionner score: Sorted:Users:Pioneers


### PR DESCRIPTION
It seems there have been some confusion what `UserCounts.tags` is. This counter is the number of tags this user has placed (both to posts and to users). This PR solves the bugs this counter had.

Maybe we need to introduce a new field for `tagged` or `UserView.Tags` (`Vec<TagDetails>`) should include the total number of tags if this is needed by the frontend.

# Pre-submission Checklist

> For tests to work you need a working neo4j and redis instance with the example dataset in `docker/db-graph`

- [ ] **Testing**: Implement and pass new tests for the new features/fixes, `cargo test`.
- [ ] **Performance**: Ensure new code has relevant performance benchmarks, `cargo bench`
