### PR TITLE
bug: swagger endpoints

### DIFF
--- a/src/routes/v0/endpoints.rs
+++ b/src/routes/v0/endpoints.rs
@@ -6,8 +6,9 @@ const VERSION_ROUTE: &str = "/v0";
 // Info routes
 pub const INFO_ROUTE: &str = concatcp!(VERSION_ROUTE, "/info");
 
-// User routes
+// -- USER endpoints --
 const USER_PREFIX: &str = concatcp!(VERSION_ROUTE, "/user");
+// Axum routes
 pub const USER_ROUTE: &str = concatcp!(USER_PREFIX, "/:user_id");
 pub const RELATIONSHIP_ROUTE: &str = concatcp!(USER_ROUTE, "/relationship/:viewer_id");
 pub const USER_COUNTS_ROUTE: &str = concatcp!(USER_ROUTE, "/counts");
@@ -17,9 +18,21 @@ pub const USER_TAGGERS_ROUTE: &str = concatcp!(USER_ROUTE, "/taggers/:label");
 pub const USER_FOLLOWERS_ROUTE: &str = concatcp!(USER_ROUTE, "/followers");
 pub const USER_FOLLOWING_ROUTE: &str = concatcp!(USER_ROUTE, "/following");
 pub const USER_FRIENDS_ROUTE: &str = concatcp!(USER_ROUTE, "/friends");
+// Swagger routes
+pub const SWAGGER_USER_ROUTE: &str = concatcp!(USER_PREFIX, "/{user_id}");
+pub const SWAGGER_RELATIONSHIP_ROUTE: &str =
+    concatcp!(SWAGGER_USER_ROUTE, "/relationship/{viewer_id}");
+pub const SWAGGER_USER_COUNTS_ROUTE: &str = concatcp!(SWAGGER_USER_ROUTE, "/counts");
+pub const SWAGGER_USER_DETAILS_ROUTE: &str = concatcp!(SWAGGER_USER_ROUTE, "/details");
+pub const SWAGGER_USER_TAGS_ROUTE: &str = concatcp!(SWAGGER_USER_ROUTE, "/tags");
+pub const SWAGGER_USER_TAGGERS_ROUTE: &str = concatcp!(SWAGGER_USER_ROUTE, "/taggers/{label}");
+pub const SWAGGER_USER_FOLLOWERS_ROUTE: &str = concatcp!(SWAGGER_USER_ROUTE, "/followers");
+pub const SWAGGER_USER_FOLLOWING_ROUTE: &str = concatcp!(SWAGGER_USER_ROUTE, "/following");
+pub const SWAGGER_USER_FRIENDS_ROUTE: &str = concatcp!(SWAGGER_USER_ROUTE, "/friends");
 
-// Post routes
+// -- POST endpoints --
 const POST_PREFIX: &str = concatcp!(VERSION_ROUTE, "/post");
+// Axum routes
 pub const POST_ROUTE: &str = concatcp!(POST_PREFIX, "/:author_id/:post_id");
 pub const POST_RELATIONSHIPS_ROUTE: &str = concatcp!(POST_ROUTE, "/relationships");
 pub const POST_BOOKMARK_ROUTE: &str = concatcp!(POST_ROUTE, "/bookmark");
@@ -27,44 +40,66 @@ pub const POST_COUNTS_ROUTE: &str = concatcp!(POST_ROUTE, "/counts");
 pub const POST_DETAILS_ROUTE: &str = concatcp!(POST_ROUTE, "/details");
 pub const POST_TAGS_ROUTE: &str = concatcp!(POST_ROUTE, "/tags");
 pub const POST_TAGGERS_ROUTE: &str = concatcp!(POST_ROUTE, "/taggers/:label");
+// Swagger routes
+pub const SWAGGER_POST_ROUTE: &str = concatcp!(POST_PREFIX, "/{author_id}/{post_id}");
+pub const SWAGGER_POST_RELATIONSHIPS_ROUTE: &str = concatcp!(SWAGGER_POST_ROUTE, "/relationships");
+pub const SWAGGER_POST_BOOKMARK_ROUTE: &str = concatcp!(SWAGGER_POST_ROUTE, "/bookmark");
+pub const SWAGGER_POST_COUNTS_ROUTE: &str = concatcp!(SWAGGER_POST_ROUTE, "/counts");
+pub const SWAGGER_POST_DETAILS_ROUTE: &str = concatcp!(SWAGGER_POST_ROUTE, "/details");
+pub const SWAGGER_POST_TAGS_ROUTE: &str = concatcp!(SWAGGER_POST_ROUTE, "/tags");
+pub const SWAGGER_POST_TAGGERS_ROUTE: &str = concatcp!(SWAGGER_POST_ROUTE, "/taggers/{label}");
 
-// Thread routes
+// -- THREAD endpoints --
 const THREAD_PREFIX: &str = concatcp!(VERSION_ROUTE, "/thread");
+// Axum routes
 pub const THREAD_ROUTE: &str = concatcp!(THREAD_PREFIX, "/:author_id/:post_id");
+// Swagger routes
+pub const SWAGGER_THREAD_ROUTE: &str = concatcp!(THREAD_PREFIX, "/{author_id}/{post_id}");
 
-// Stream routes
-// Streams of UserView objects
+// -- STREAM endpoints --
 const STREAM_PREFIX: &str = concatcp!(VERSION_ROUTE, "/stream");
+// Axum routes: STREAM of UserView objects
 pub const STREAM_USERS_ROUTE: &str = concatcp!(STREAM_PREFIX, "/users");
 pub const STREAM_USERS_USERNAME_SEARCH_ROUTE: &str =
     concatcp!(STREAM_USERS_ROUTE, "/username-search");
 pub const STREAM_USERS_MOSTFOLLOWED_ROUTE: &str = concatcp!(STREAM_USERS_ROUTE, "/most-followed");
 pub const STREAM_USERS_PIONEERS_ROUTE: &str = concatcp!(STREAM_USERS_ROUTE, "/pioneers");
 pub const STREAM_USERS_BY_IDS_ROUTE: &str = concatcp!(STREAM_USERS_ROUTE, "/by_ids");
-
-// Streams of PostView objects
+// Axum routes: STREAM of PostView objects
 pub const STREAM_POSTS_ROUTE: &str = concatcp!(STREAM_PREFIX, "/posts");
-
-// Stream of Tags for posts
+// Axum routes: STREAM of Tags for posts
 pub const STREAM_TAGS_ROUTE: &str = concatcp!(STREAM_PREFIX, "/tags");
 pub const STREAM_TAGS_GLOBAL_ROUTE: &str = concatcp!(STREAM_TAGS_ROUTE, "/global");
 pub const STREAM_TAGS_REACH_ROUTE: &str = concatcp!(STREAM_TAGS_ROUTE, "/reached/:user_id/:reach");
+// Swagger routes: STREAM of Tags for posts
+pub const SWAGGER_STREAM_TAGS_REACH_ROUTE: &str =
+    concatcp!(STREAM_TAGS_ROUTE, "/reached/{user_id}/{reach}");
 
-// Search routes
+// -- SEARCH endpoints --
+// Axum routes
 const SEARCH_PREFIX: &str = concatcp!(VERSION_ROUTE, "/search");
 pub const SEARCH_USERS_ROUTE: &str = concatcp!(SEARCH_PREFIX, "/users");
 pub const SEARCH_TAGS_ROUTE: &str = concatcp!(SEARCH_PREFIX, "/tags/:label");
+// Swagger routes
+pub const SWAGGER_SEARCH_TAGS_ROUTE: &str = concatcp!(SEARCH_PREFIX, "/tags/{label}");
 
-// Tag routes
+// TAG endpoints
+// Axum routes
 const TAG_PREFIX: &str = concatcp!(VERSION_ROUTE, "/tag");
 pub const TAG_HOT_ROUTE: &str = concatcp!(TAG_PREFIX, "/hot");
 pub const TAG_REACH_ROUTE: &str = concatcp!(TAG_PREFIX, "/reached/:user_id/:reach");
 pub const TAG_TAGGERS_ROUTE: &str = concatcp!(TAG_PREFIX, "/taggers/:label");
+// Swagger routes
+pub const SWAGGER_TAG_REACH_ROUTE: &str = concatcp!(TAG_PREFIX, "/reached/{user_id}/{reach}");
+pub const SWAGGER_TAG_TAGGERS_ROUTE: &str = concatcp!(TAG_PREFIX, "/taggers/{label}");
 
-// File routes
+// FILE endpoints
+// Axum routes
 const FILE_PREFIX: &str = concatcp!(VERSION_ROUTE, "/files");
-pub const FILE_ROUTE: &str = concatcp!(FILE_PREFIX, "/file/:file_id");
 pub const FILE_LIST_ROUTE: &str = concatcp!(FILE_PREFIX, "/by-ids");
+pub const FILE_ROUTE: &str = concatcp!(FILE_PREFIX, "/file/:file_id");
+// Swagger routes
+pub const SWAGGER_FILE_ROUTE: &str = concatcp!(FILE_PREFIX, "/file/{file_id}");
 
 // Notification route
 pub const NOTIFICATION_ROUTE: &str = concatcp!(USER_ROUTE, "/notifications");

--- a/src/routes/v0/file/details.rs
+++ b/src/routes/v0/file/details.rs
@@ -1,7 +1,7 @@
 use crate::models::file::details::FileUrls;
 use crate::models::file::FileDetails;
 use crate::models::traits::Collection;
-use crate::routes::v0::endpoints::FILE_ROUTE;
+use crate::routes::v0::endpoints::SWAGGER_FILE_ROUTE;
 use crate::{Error, Result};
 use axum::extract::Path;
 use axum::Json;
@@ -10,7 +10,7 @@ use utoipa::OpenApi;
 
 #[utoipa::path(
     get,
-    path = FILE_ROUTE,
+    path = SWAGGER_FILE_ROUTE,
     tag = "File Details",
     params(
         ("file_uri" = String, Path, description = "File Pubky Uri")
@@ -22,7 +22,7 @@ use utoipa::OpenApi;
     )
 )]
 pub async fn file_details_handler(Path(file_uri): Path<String>) -> Result<Json<FileDetails>> {
-    info!("GET {FILE_ROUTE} file_uri:{}", file_uri);
+    info!("GET {SWAGGER_FILE_ROUTE} file_uri:{}", file_uri);
 
     let file_key = FileDetails::file_key_from_uri(&file_uri);
     let result = FileDetails::get_by_ids(

--- a/src/routes/v0/post/bookmark.rs
+++ b/src/routes/v0/post/bookmark.rs
@@ -1,5 +1,5 @@
 use crate::models::post::Bookmark;
-use crate::routes::v0::endpoints::POST_BOOKMARK_ROUTE;
+use crate::routes::v0::endpoints::SWAGGER_POST_BOOKMARK_ROUTE;
 use crate::{Error, Result};
 use axum::extract::{Path, Query};
 use axum::Json;
@@ -14,7 +14,7 @@ pub struct PostQuery {
 
 #[utoipa::path(
     get,
-    path = POST_BOOKMARK_ROUTE,
+    path = SWAGGER_POST_BOOKMARK_ROUTE,
     tag = "Post Bookmark",
     params(
         ("author_id" = String, Path, description = "Author Pubky ID"),
@@ -32,7 +32,7 @@ pub async fn post_bookmark_handler(
     Query(query): Query<PostQuery>,
 ) -> Result<Json<Bookmark>> {
     info!(
-        "GET {POST_BOOKMARK_ROUTE} author_id:{}, post_id:{}, viewer_id:{}",
+        "GET {SWAGGER_POST_BOOKMARK_ROUTE} author_id:{}, post_id:{}, viewer_id:{}",
         author_id,
         post_id,
         query.viewer_id.clone().unwrap_or_default()

--- a/src/routes/v0/post/counts.rs
+++ b/src/routes/v0/post/counts.rs
@@ -1,5 +1,5 @@
 use crate::models::post::PostCounts;
-use crate::routes::v0::endpoints::POST_COUNTS_ROUTE;
+use crate::routes::v0::endpoints::SWAGGER_POST_COUNTS_ROUTE;
 use crate::{Error, Result};
 use axum::extract::Path;
 use axum::Json;
@@ -8,7 +8,7 @@ use utoipa::OpenApi;
 
 #[utoipa::path(
     get,
-    path = POST_COUNTS_ROUTE,
+    path = SWAGGER_POST_COUNTS_ROUTE,
     tag = "Post Counts",
     params(
         ("author_id" = String, Path, description = "Author Pubky ID"),
@@ -24,7 +24,7 @@ pub async fn post_counts_handler(
     Path((author_id, post_id)): Path<(String, String)>,
 ) -> Result<Json<PostCounts>> {
     info!(
-        "GET {POST_COUNTS_ROUTE} author_id:{}, post_id:{}",
+        "GET {SWAGGER_POST_COUNTS_ROUTE} author_id:{}, post_id:{}",
         author_id, post_id
     );
 

--- a/src/routes/v0/post/details.rs
+++ b/src/routes/v0/post/details.rs
@@ -1,6 +1,6 @@
 use crate::models::post::PostDetails;
 use crate::models::pubky_app::PostKind;
-use crate::routes::v0::endpoints::POST_DETAILS_ROUTE;
+use crate::routes::v0::endpoints::SWAGGER_POST_DETAILS_ROUTE;
 use crate::{Error, Result};
 use axum::extract::Path;
 use axum::Json;
@@ -9,7 +9,7 @@ use utoipa::OpenApi;
 
 #[utoipa::path(
     get,
-    path = POST_DETAILS_ROUTE,
+    path = SWAGGER_POST_DETAILS_ROUTE,
     tag = "Post Details",
     params(
         ("author_id" = String, Path, description = "Author Pubky ID"),
@@ -25,7 +25,7 @@ pub async fn post_details_handler(
     Path((author_id, post_id)): Path<(String, String)>,
 ) -> Result<Json<PostDetails>> {
     info!(
-        "GET {POST_DETAILS_ROUTE} author_id:{}, post_id:{}",
+        "GET {SWAGGER_POST_DETAILS_ROUTE} author_id:{}, post_id:{}",
         author_id, post_id
     );
 

--- a/src/routes/v0/post/tags.rs
+++ b/src/routes/v0/post/tags.rs
@@ -2,7 +2,7 @@ use crate::models::tag::post::TagPost;
 use crate::models::tag::traits::taggers::Taggers;
 use crate::models::tag::traits::{TagCollection, TaggersCollection};
 use crate::models::tag::TagDetails;
-use crate::routes::v0::endpoints::{POST_TAGGERS_ROUTE, POST_TAGS_ROUTE};
+use crate::routes::v0::endpoints::{SWAGGER_POST_TAGGERS_ROUTE, SWAGGER_POST_TAGS_ROUTE};
 use crate::routes::v0::queries::PaginationQuery;
 use crate::routes::v0::TagsQuery;
 use crate::{Error, Result};
@@ -13,7 +13,7 @@ use utoipa::OpenApi;
 
 #[utoipa::path(
     get,
-    path = POST_TAGS_ROUTE,
+    path = SWAGGER_POST_TAGS_ROUTE,
     tag = "Post Tags",
     params(
         ("user_id" = String, Path, description = "User Pubky ID"),
@@ -32,7 +32,7 @@ pub async fn post_tags_handler(
     Query(query): Query<TagsQuery>,
 ) -> Result<Json<Vec<TagDetails>>> {
     info!(
-        "GET {POST_TAGS_ROUTE} user_id:{}, post_id: {}, limit_tags:{:?}, limit_taggers:{:?}",
+        "GET {SWAGGER_POST_TAGS_ROUTE} user_id:{}, post_id: {}, limit_tags:{:?}, limit_taggers:{:?}",
         user_id, post_id, query.limit_tags, query.limit_taggers
     );
     match TagPost::get_by_id(
@@ -51,7 +51,7 @@ pub async fn post_tags_handler(
 
 #[utoipa::path(
     get,
-    path = POST_TAGGERS_ROUTE,
+    path = SWAGGER_POST_TAGGERS_ROUTE,
     tag = "Post specific label Taggers",
     params(
         ("user_id" = String, Path, description = "User Pubky ID"),
@@ -71,7 +71,7 @@ pub async fn post_taggers_handler(
     Query(query): Query<PaginationQuery>,
 ) -> Result<Json<Taggers>> {
     info!(
-        "GET {POST_TAGGERS_ROUTE} user_id:{}, post_id: {}, label: {}, skip:{:?}, limit:{:?}",
+        "GET {SWAGGER_POST_TAGGERS_ROUTE} user_id:{}, post_id: {}, label: {}, skip:{:?}, limit:{:?}",
         user_id, post_id, label, query.skip, query.limit
     );
     match TagPost::get_tagger_by_id(&user_id, Some(&post_id), &label, query.skip, query.limit).await

--- a/src/routes/v0/post/thread.rs
+++ b/src/routes/v0/post/thread.rs
@@ -1,5 +1,5 @@
 use crate::models::post::PostThread;
-use crate::routes::v0::endpoints::THREAD_ROUTE;
+use crate::routes::v0::endpoints::SWAGGER_THREAD_ROUTE;
 use crate::{Error, Result};
 use axum::extract::{Path, Query};
 use axum::Json;
@@ -17,7 +17,7 @@ pub struct ThreadQuery {
 
 #[utoipa::path(
     get,
-    path = THREAD_ROUTE,
+    path = SWAGGER_THREAD_ROUTE,
     tag = "Post Thread",
     params(
         ("author_id" = String, Path, description = "Author Pubky ID"),
@@ -37,7 +37,7 @@ pub async fn thread_handler(
     Query(query): Query<ThreadQuery>,
 ) -> Result<Json<PostThread>> {
     info!(
-        "GET {THREAD_ROUTE} author_id:{}, post_id:{}, viewer_id:{:?}, skip:{:?}, limit:{:?}",
+        "GET {SWAGGER_THREAD_ROUTE} author_id:{}, post_id:{}, viewer_id:{:?}, skip:{:?}, limit:{:?}",
         author_id, post_id, query.viewer_id, query.skip, query.limit
     );
 

--- a/src/routes/v0/post/view.rs
+++ b/src/routes/v0/post/view.rs
@@ -1,7 +1,7 @@
 use crate::models::post::{PostRelationships, PostView};
 use crate::models::tag::post::TagPost;
 use crate::models::tag::TagDetails;
-use crate::routes::v0::endpoints::POST_ROUTE;
+use crate::routes::v0::endpoints::SWAGGER_POST_ROUTE;
 use crate::{Error, Result};
 use axum::extract::{Path, Query};
 use axum::Json;
@@ -18,7 +18,7 @@ pub struct PostQuery {
 
 #[utoipa::path(
     get,
-    path = POST_ROUTE,
+    path = SWAGGER_POST_ROUTE,
     tag = "Post",
     params(
         ("author_id" = String, Path, description = "Author Pubky ID"),
@@ -38,7 +38,7 @@ pub async fn post_view_handler(
     Query(query): Query<PostQuery>,
 ) -> Result<Json<PostView>> {
     info!(
-        "GET {POST_ROUTE} author_id:{}, post_id:{}, viewer_id:{}, max_tags:{:?}, max_taggers:{:?}",
+        "GET {SWAGGER_POST_ROUTE} author_id:{}, post_id:{}, viewer_id:{}, max_tags:{:?}, max_taggers:{:?}",
         author_id,
         post_id,
         query.viewer_id.clone().unwrap_or_default(),

--- a/src/routes/v0/search/tags.rs
+++ b/src/routes/v0/search/tags.rs
@@ -1,5 +1,5 @@
 use crate::models::tag::search::TagSearch;
-use crate::routes::v0::endpoints::SEARCH_TAGS_ROUTE;
+use crate::routes::v0::endpoints::SWAGGER_SEARCH_TAGS_ROUTE;
 use crate::routes::v0::queries::PostStreamQuery;
 use crate::{Error, Result};
 use axum::extract::{Path, Query};
@@ -9,7 +9,7 @@ use utoipa::OpenApi;
 
 #[utoipa::path(
     get,
-    path = SEARCH_TAGS_ROUTE,
+    path = SWAGGER_SEARCH_TAGS_ROUTE,
     tag = "Search Post by Tags",
     params(
         ("sorting" = Option<PostStreamSorting>, Query, description = "Sorting method"),
@@ -27,7 +27,7 @@ pub async fn search_post_tags_handler(
     Query(query): Query<PostStreamQuery>,
 ) -> Result<Json<Vec<TagSearch>>> {
     info!(
-        "GET {SEARCH_TAGS_ROUTE} label:{}, sort_by: {:?}, skip: {:?}, limit: {:?}",
+        "GET {SWAGGER_SEARCH_TAGS_ROUTE} label:{}, sort_by: {:?}, skip: {:?}, limit: {:?}",
         label, query.sorting, query.skip, query.limit
     );
 

--- a/src/routes/v0/tag/global.rs
+++ b/src/routes/v0/tag/global.rs
@@ -1,7 +1,9 @@
 use crate::models::tag::global::TagGlobal;
 use crate::models::tag::stream::{HotTag, HotTags, Taggers};
 use crate::models::user::UserStreamType;
-use crate::routes::v0::endpoints::{TAG_HOT_ROUTE, TAG_REACH_ROUTE, TAG_TAGGERS_ROUTE};
+use crate::routes::v0::endpoints::{
+    SWAGGER_TAG_REACH_ROUTE, SWAGGER_TAG_TAGGERS_ROUTE, TAG_HOT_ROUTE,
+};
 use crate::{Error, Result};
 use axum::extract::{Path, Query};
 use axum::Json;
@@ -58,7 +60,7 @@ pub struct TagTaggersQuery {
 
 #[utoipa::path(
     get,
-    path = TAG_TAGGERS_ROUTE,
+    path = SWAGGER_TAG_TAGGERS_ROUTE,
     tag = "Global tag Taggers",
     params(
         ("label" = String, Path, description = "Tag name"),
@@ -75,7 +77,7 @@ pub async fn tag_taggers_handler(
     Query(query): Query<TagTaggersQuery>,
 ) -> Result<Json<Vec<String>>> {
     info!(
-        "GET {TAG_TAGGERS_ROUTE} label:{}, reach:{:?}",
+        "GET {SWAGGER_TAG_TAGGERS_ROUTE} label:{}, reach:{:?}",
         label, query.reach
     );
 
@@ -96,7 +98,7 @@ pub struct TagsByReachQuery {
 
 #[utoipa::path(
     get,
-    path = TAG_REACH_ROUTE,
+    path = SWAGGER_TAG_REACH_ROUTE,
     tag = "Global Tags by reach",
     params(
         ("user_id" = String, Path, description = "User Pubky ID"),
@@ -109,7 +111,7 @@ pub struct TagsByReachQuery {
     )
 )]
 pub async fn tags_by_reach_handler(Path(path): Path<TagsByReachQuery>) -> Result<Json<HotTags>> {
-    info!("GET {TAG_REACH_ROUTE}");
+    info!("GET {SWAGGER_TAG_REACH_ROUTE}");
 
     let reach = path.reach.unwrap_or(UserStreamType::Following);
     let user_id = path.user_id;

--- a/src/routes/v0/user/counts.rs
+++ b/src/routes/v0/user/counts.rs
@@ -1,5 +1,5 @@
 use crate::models::user::UserCounts;
-use crate::routes::v0::endpoints::USER_COUNTS_ROUTE;
+use crate::routes::v0::endpoints::SWAGGER_USER_COUNTS_ROUTE;
 use crate::{Error, Result};
 use axum::extract::Path;
 use axum::Json;
@@ -8,7 +8,7 @@ use utoipa::OpenApi;
 
 #[utoipa::path(
     get,
-    path = USER_COUNTS_ROUTE,
+    path = SWAGGER_USER_COUNTS_ROUTE,
     tag = "User Counts",
     params(
         ("user_id" = String, Path, description = "User Pubky ID")
@@ -20,7 +20,7 @@ use utoipa::OpenApi;
     )
 )]
 pub async fn user_counts_handler(Path(user_id): Path<String>) -> Result<Json<UserCounts>> {
-    info!("GET {USER_COUNTS_ROUTE} user_id:{}", user_id);
+    info!("GET {SWAGGER_USER_COUNTS_ROUTE} user_id:{}", user_id);
 
     match UserCounts::get_by_id(&user_id).await {
         Ok(Some(counts)) => Ok(Json(counts)),

--- a/src/routes/v0/user/details.rs
+++ b/src/routes/v0/user/details.rs
@@ -1,6 +1,6 @@
 use crate::models::pubky_app::UserLink;
 use crate::models::user::{PubkyId, UserDetails};
-use crate::routes::v0::endpoints::USER_DETAILS_ROUTE;
+use crate::routes::v0::endpoints::SWAGGER_USER_DETAILS_ROUTE;
 use crate::{Error, Result};
 use axum::extract::Path;
 use axum::Json;
@@ -9,7 +9,7 @@ use utoipa::OpenApi;
 
 #[utoipa::path(
     get,
-    path = USER_DETAILS_ROUTE,
+    path = SWAGGER_USER_DETAILS_ROUTE,
     tag = "User Details",
     params(
         ("user_id" = String, Path, description = "User Pubky ID")
@@ -21,7 +21,7 @@ use utoipa::OpenApi;
     )
 )]
 pub async fn user_details_handler(Path(user_id): Path<String>) -> Result<Json<UserDetails>> {
-    info!("GET {USER_DETAILS_ROUTE} user_id:{}", user_id);
+    info!("GET {SWAGGER_USER_DETAILS_ROUTE} user_id:{}", user_id);
 
     match UserDetails::get_by_id(&user_id).await {
         Ok(Some(details)) => Ok(Json(details)),

--- a/src/routes/v0/user/follows.rs
+++ b/src/routes/v0/user/follows.rs
@@ -1,6 +1,6 @@
 use crate::models::user::{Followers, Following, Friends, UserFollows};
 use crate::routes::v0::endpoints::{
-    USER_FOLLOWERS_ROUTE, USER_FOLLOWING_ROUTE, USER_FRIENDS_ROUTE,
+    SWAGGER_USER_FOLLOWERS_ROUTE, SWAGGER_USER_FOLLOWING_ROUTE, SWAGGER_USER_FRIENDS_ROUTE,
 };
 use crate::{Error, Result};
 use axum::extract::{Path, Query};
@@ -17,7 +17,7 @@ pub struct FollowsQuery {
 
 #[utoipa::path(
     get,
-    path = USER_FOLLOWERS_ROUTE,
+    path = SWAGGER_USER_FOLLOWERS_ROUTE,
     tag = "User Followers List",
     params(
         ("user_id" = String, Path, description = "User Pubky ID"),
@@ -34,7 +34,7 @@ pub async fn user_followers_handler(
     Path(user_id): Path<String>,
     Query(query): Query<FollowsQuery>,
 ) -> Result<Json<Followers>> {
-    info!("GET {USER_FOLLOWERS_ROUTE} user_id:{}", user_id);
+    info!("GET {SWAGGER_USER_FOLLOWERS_ROUTE} user_id:{}", user_id);
 
     let skip = query.skip.unwrap_or(0);
     let limit = query.limit.unwrap_or(200);
@@ -48,7 +48,7 @@ pub async fn user_followers_handler(
 
 #[utoipa::path(
     get,
-    path = USER_FOLLOWING_ROUTE,
+    path = SWAGGER_USER_FOLLOWING_ROUTE,
     tag = "User Following List",
     params(
         ("user_id" = String, Path, description = "User Pubky ID"),
@@ -65,7 +65,7 @@ pub async fn user_following_handler(
     Path(user_id): Path<String>,
     Query(query): Query<FollowsQuery>,
 ) -> Result<Json<Following>> {
-    info!("GET {USER_FOLLOWING_ROUTE} user_id:{}", user_id);
+    info!("GET {SWAGGER_USER_FOLLOWING_ROUTE} user_id:{}", user_id);
 
     let skip = query.skip.unwrap_or(0);
     let limit = query.limit.unwrap_or(200);
@@ -79,7 +79,7 @@ pub async fn user_following_handler(
 
 #[utoipa::path(
     get,
-    path = USER_FRIENDS_ROUTE,
+    path = SWAGGER_USER_FRIENDS_ROUTE,
     tag = "User Friends List",
     params(
         ("user_id" = String, Path, description = "User Pubky ID"),
@@ -96,7 +96,7 @@ pub async fn user_friends_handler(
     Path(user_id): Path<String>,
     Query(query): Query<FollowsQuery>,
 ) -> Result<Json<Friends>> {
-    info!("GET {USER_FRIENDS_ROUTE} user_id:{}", user_id);
+    info!("GET {SWAGGER_USER_FRIENDS_ROUTE} user_id:{}", user_id);
 
     let skip = query.skip.unwrap_or(0);
     let limit = query.limit.unwrap_or(200);

--- a/src/routes/v0/user/relationship.rs
+++ b/src/routes/v0/user/relationship.rs
@@ -1,5 +1,5 @@
 use crate::models::user::Relationship;
-use crate::routes::v0::endpoints::RELATIONSHIP_ROUTE;
+use crate::routes::v0::endpoints::SWAGGER_RELATIONSHIP_ROUTE;
 use crate::{Error, Result};
 use axum::extract::Path;
 use axum::Json;
@@ -8,7 +8,7 @@ use utoipa::OpenApi;
 
 #[utoipa::path(
     get,
-    path = RELATIONSHIP_ROUTE,
+    path = SWAGGER_RELATIONSHIP_ROUTE,
     tag = "User <> Viewer Relationship",
     params(
         ("user_id" = String, Path, description = "User Pubky ID"),
@@ -24,7 +24,7 @@ pub async fn user_relationship_handler(
     Path((user_id, viewer_id)): Path<(String, String)>,
 ) -> Result<Json<Relationship>> {
     info!(
-        "GET {RELATIONSHIP_ROUTE} user_id:{}, viewer_id:{}",
+        "GET {SWAGGER_RELATIONSHIP_ROUTE} user_id:{}, viewer_id:{}",
         user_id, viewer_id
     );
 

--- a/src/routes/v0/user/tags.rs
+++ b/src/routes/v0/user/tags.rs
@@ -3,7 +3,7 @@ use crate::models::tag::traits::{TagCollection, TaggersCollection};
 use crate::models::tag::user::TagUser;
 use crate::models::tag::TagDetails;
 use crate::models::user::{ProfileTag, UserTags};
-use crate::routes::v0::endpoints::{USER_TAGGERS_ROUTE, USER_TAGS_ROUTE};
+use crate::routes::v0::endpoints::{SWAGGER_USER_TAGGERS_ROUTE, SWAGGER_USER_TAGS_ROUTE};
 use crate::routes::v0::queries::PaginationQuery;
 use crate::routes::v0::TagsQuery;
 use crate::{Error, Result};
@@ -14,7 +14,7 @@ use utoipa::OpenApi;
 
 #[utoipa::path(
     get,
-    path = USER_TAGS_ROUTE,
+    path = SWAGGER_USER_TAGS_ROUTE,
     tag = "User Tags",
     params(
         ("user_id" = String, Path, description = "User Pubky ID"),
@@ -32,7 +32,7 @@ pub async fn user_tags_handler(
     Query(query): Query<TagsQuery>,
 ) -> Result<Json<Vec<TagDetails>>> {
     info!(
-        "GET {USER_TAGS_ROUTE} user_id:{}, limit_tags:{:?}, limit_taggers:{:?}",
+        "GET {SWAGGER_USER_TAGS_ROUTE} user_id:{}, limit_tags:{:?}, limit_taggers:{:?}",
         user_id, query.limit_tags, query.limit_taggers
     );
 
@@ -45,7 +45,7 @@ pub async fn user_tags_handler(
 
 #[utoipa::path(
     get,
-    path = USER_TAGGERS_ROUTE,
+    path = SWAGGER_USER_TAGGERS_ROUTE,
     tag = "User label Taggers",
     params(
         ("user_id" = String, Path, description = "User Pubky ID"),
@@ -64,7 +64,7 @@ pub async fn user_taggers_handler(
     Query(query): Query<PaginationQuery>,
 ) -> Result<Json<Taggers>> {
     info!(
-        "GET {USER_TAGGERS_ROUTE} user_id:{}, label: {}, skip:{:?}, limit:{:?}",
+        "GET {SWAGGER_USER_TAGGERS_ROUTE} user_id:{}, label: {}, skip:{:?}, limit:{:?}",
         user_id, label, query.skip, query.limit
     );
 

--- a/src/routes/v0/user/view.rs
+++ b/src/routes/v0/user/view.rs
@@ -1,6 +1,6 @@
 use crate::models::tag::TagDetails;
 use crate::models::user::UserView;
-use crate::routes::v0::endpoints::USER_ROUTE;
+use crate::routes::v0::endpoints::SWAGGER_USER_ROUTE;
 use crate::{Error, Result};
 use axum::extract::{Path, Query};
 use axum::Json;
@@ -15,7 +15,7 @@ pub struct ProfileQuery {
 
 #[utoipa::path(
     get,
-    path = USER_ROUTE,
+    path = SWAGGER_USER_ROUTE,
     tag = "User Profile",
     params(
         ("user_id" = String, Path, description = "User Pubky ID"),
@@ -32,7 +32,7 @@ pub async fn user_view_handler(
     Query(query): Query<ProfileQuery>,
 ) -> Result<Json<UserView>> {
     info!(
-        "GET {USER_ROUTE} user_id:{}, viewer_id:{:?}",
+        "GET {SWAGGER_USER_ROUTE} user_id:{}, viewer_id:{:?}",
         user_id, query.viewer_id
     );
 


### PR DESCRIPTION
This PR:

Swagger uses {param_name} to denote path parameters in routes but axum uses `:param_name`

# Pre-submission Checklist

> For tests to work you need a working neo4j and redis instance with the example dataset in `docker/db-graph`

- [ ] **Testing**: Implement and pass new tests for the new features/fixes, `cargo test`.
- [ ] **Performance**: Ensure new code has relevant performance benchmarks, `cargo bench`
