### PR TITLE
Fix(watcher): panics on multibyte characters cutoffs

### DIFF
--- a/src/models/pubky_app/post.rs
+++ b/src/models/pubky_app/post.rs
@@ -80,11 +80,7 @@ impl Validatable for PubkyAppPost {
             _ => MAX_SHORT_CONTENT_LENGTH, // Default limit for other kinds
         };
 
-        let content = if content.len() > max_content_length {
-            content[..max_content_length].to_string()
-        } else {
-            content
-        };
+        let content = content.chars().take(max_content_length).collect::<String>();
 
         // Sanitize parent URI if present
         let parent = if let Some(uri_str) = &self.parent {
@@ -125,13 +121,13 @@ impl Validatable for PubkyAppPost {
         // Validate content length
         match self.kind {
             PostKind::Short => {
-                if self.content.len() > MAX_SHORT_CONTENT_LENGTH {
+                if self.content.chars().count() > MAX_SHORT_CONTENT_LENGTH {
                     return Err("Post content exceeds maximum length for Short kind".into());
                 }
             }
             PostKind::Long => {
-                if self.content.len() > MAX_LONG_CONTENT_LENGTH {
-                    return Err("Post content exceeds maximum length for Long kind".into());
+                if self.content.chars().count() > MAX_LONG_CONTENT_LENGTH {
+                    return Err("Post content exceeds maximum length for Short kind".into());
                 }
             }
             _ => (),

--- a/src/models/pubky_app/tag.rs
+++ b/src/models/pubky_app/tag.rs
@@ -35,12 +35,8 @@ impl Validatable for PubkyAppTag {
         // Convert label to lowercase and trim
         let label = self.label.trim().to_lowercase();
 
-        // Enforce maximum label length
-        let label = if label.len() > MAX_TAG_LABEL_LENGTH {
-            label[..MAX_TAG_LABEL_LENGTH].to_string()
-        } else {
-            label
-        };
+        // Enforce maximum label length safely
+        let label = label.chars().take(MAX_TAG_LABEL_LENGTH).collect::<String>();
 
         // Sanitize URI
         let uri = match Url::parse(&self.uri) {
@@ -58,8 +54,8 @@ impl Validatable for PubkyAppTag {
     async fn validate(&self, id: &str) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         self.validate_id(id).await?;
 
-        // Validate label length
-        if self.label.len() > MAX_TAG_LABEL_LENGTH {
+        // Validate label length based on characters
+        if self.label.chars().count() > MAX_TAG_LABEL_LENGTH {
             return Err("Tag label exceeds maximum length".into());
         }
 


### PR DESCRIPTION
Bug discovered by @catch-21 in https://github.com/pubky/pubky-app/issues/604

The watcher panics on sanitizing and validating strings with multibyte characters at the maximum length.

# Pre-submission Checklist

> For tests to work you need a working neo4j and redis instance with the example dataset in `docker/db-graph`

- [x] **Testing**: Implement and pass new tests for the new features/fixes, `cargo test`.
- [x] **Performance**: Ensure new code has relevant performance benchmarks, `cargo bench`
