### PR TITLE
feat: Add more known URIs to watcher

### DIFF
--- a/examples/from_file.rs
+++ b/examples/from_file.rs
@@ -1,0 +1,37 @@
+use anyhow::Result;
+use pubky_nexus::{setup, types::DynError, Config, EventProcessor};
+use std::fs::File;
+use std::io::{self, BufRead};
+use std::path::Path;
+
+// Create that file and add the file with that format
+// PUT homeserver_uri
+// DEL homeserver_uri
+const FILE_PATH: &str = "examples/events.txt";
+
+#[tokio::main]
+async fn main() -> Result<(), DynError> {
+    let config = Config::from_env();
+    setup(&config).await;
+
+    let mut event_processor = EventProcessor::from_config(&config).await?;
+
+    let events = read_events_from_file().unwrap();
+
+    event_processor.process_event_lines(events).await?;
+
+    Ok(())
+}
+
+fn read_events_from_file() -> io::Result<Vec<String>> {
+    let path = Path::new(FILE_PATH);
+    let file = File::open(&path)?;
+
+    let reader = io::BufReader::new(file);
+    let lines = reader
+        .lines()
+        .filter_map(|line| line.ok()) // Filter out lines with errors
+        .collect();
+
+    Ok(lines)
+}

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -106,6 +106,8 @@ impl Event {
                 file_id: parsed_uri.file_id.ok_or("Missing file_id")?,
             },
             _ if uri.contains("/blobs") => return Ok(None),
+            _ if uri.contains("/last_read") => return Ok(None),
+            _ if uri.contains("/settings") => return Ok(None),
             _ => {
                 error!("Unrecognized resource in URI: {}", uri);
                 return Err("Unrecognized resource in URI".into());

--- a/src/events/processor.rs
+++ b/src/events/processor.rs
@@ -94,7 +94,7 @@ impl EventProcessor {
         }
     }
 
-    async fn process_event_lines(&mut self, lines: Vec<String>) -> Result<(), DynError> {
+    pub async fn process_event_lines(&mut self, lines: Vec<String>) -> Result<(), DynError> {
         for line in &lines {
             if line.starts_with("cursor:") {
                 if let Some(cursor) = line.strip_prefix("cursor: ") {


### PR DESCRIPTION
# Pre-submission Checklist

> For tests to work you need a working neo4j and redis instance with the example dataset in `docker/db-graph`

- [ ] **Testing**: Implement and pass new tests for the new features/fixes, `cargo test`.
- [ ] **Performance**: Ensure new code has relevant performance benchmarks, `cargo bench`

## PR description
New URIs are being added in the homeserver, but the watcher was incorrectly treating them as errors. This behavior has been updated to ignore these URIs since the app retrieves the content of those events directly from the homeserver. These are the newly introduced URIs:
- `pubky://{user_pubky}/pub/pubky.app/settings`
- `pubky://{user_pubky}/pub/pubky.app/last_read`