### PR TITLE
chore(deps): bump axum to 0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,9 +153,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-trait"
-version = "0.1.83"
+version = "0.1.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+checksum = "1b1244b10dcd56c92219da4e14caa97e312079e185f04ba3eea25061561dc0a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -190,7 +190,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.4.5",
  "axum-macros",
  "bytes",
  "futures-util",
@@ -200,7 +200,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.7.3",
  "memchr",
  "mime",
  "percent-encoding",
@@ -210,9 +210,43 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper 1.0.1",
+ "sync_wrapper",
  "tokio",
- "tower 0.5.1",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d6fd624c75e18b3b4c6b9caf42b1afe24437daaee904069137d8bab077be8b8"
+dependencies = [
+ "axum-core 0.5.0",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit 0.8.4",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -233,7 +267,27 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 1.0.1",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1362f362fd16024ae199c1970ce98f9661bf5ef94b9808fee734bc3698b733"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -245,8 +299,8 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0be6ea09c9b96cb5076af0de2e383bd2bc0c18f827cf1967bdd353e0b910d733"
 dependencies = [
- "axum",
- "axum-core",
+ "axum 0.7.9",
+ "axum-core 0.4.5",
  "bytes",
  "futures-util",
  "headers",
@@ -1888,6 +1942,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2444,8 +2504,7 @@ dependencies = [
 [[package]]
 name = "pubky-app-specs"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebb66e94b59284b847f8ab438f7e589e91c2074b1282e027ade7e9909b349ef8"
+source = "git+https://github.com/pubky/pubky-app-specs#b885faa516058137615b58b959d69160a26d4bde"
 dependencies = [
  "base32",
  "blake3",
@@ -2501,7 +2560,8 @@ name = "pubky-nexus"
 version = "0.2.0"
 dependencies = [
  "anyhow",
- "axum",
+ "async-trait",
+ "axum 0.8.1",
  "base32",
  "blake3",
  "chrono",
@@ -2554,7 +2614,7 @@ version = "0.1.0"
 source = "git+https://github.com/pubky/pubky-core.git?tag=pubky-v0.3.0#aede289c2606204fe944919b5024ee8cefe32c50"
 dependencies = [
  "anyhow",
- "axum",
+ "axum 0.7.9",
  "axum-extra",
  "base32",
  "bytes",
@@ -2831,7 +2891,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.1",
+ "sync_wrapper",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -3330,12 +3390,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
@@ -3648,14 +3702,14 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 0.1.2",
+ "sync_wrapper",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -3669,7 +3723,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fd0118512cf0b3768f7fcccf0bef1ae41d68f2b45edc1e77432b36c97c56c6d"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.4.5",
  "cookie",
  "futures-util",
  "http",
@@ -3891,8 +3945,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utoipa"
 version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68e76d357bc95c7d0939c92c04c9269871a8470eea39cb1f0231eeadb0c47d0f"
+source = "git+https://github.com/juhaku/utoipa?rev=d522f744259dc4fde5f45d187983fb68c8167029#d522f744259dc4fde5f45d187983fb68c8167029"
 dependencies = [
  "indexmap",
  "serde",
@@ -3903,8 +3956,7 @@ dependencies = [
 [[package]]
 name = "utoipa-gen"
 version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "564b03f8044ad6806bdc0d635e88be24967e785eef096df6b2636d2cc1e05d4b"
+source = "git+https://github.com/juhaku/utoipa?rev=d522f744259dc4fde5f45d187983fb68c8167029#d522f744259dc4fde5f45d187983fb68c8167029"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3914,10 +3966,9 @@ dependencies = [
 [[package]]
 name = "utoipa-swagger-ui"
 version = "8.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4b5ac679cc6dfc5ea3f2823b0291c777750ffd5e13b21137e0f7ac0e8f9617"
+source = "git+https://github.com/juhaku/utoipa?rev=d522f744259dc4fde5f45d187983fb68c8167029#d522f744259dc4fde5f45d187983fb68c8167029"
 dependencies = [
- "axum",
+ "axum 0.8.1",
  "base64 0.22.1",
  "mime_guess",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,16 +14,20 @@ pkarr = { git = "https://github.com/Pubky/pkarr", branch = "v3", package = "pkar
     "async",
 ] }
 pubky = "0.3.0"
-pubky-app-specs = { version = "0.2.1", features = ["openapi"] }
+pubky-app-specs = { git = "https://github.com/pubky/pubky-app-specs", features = [
+    "openapi",
+] }
 tokio = { version = "1.42.0", features = ["full"] }
-axum = "0.7.9"
+axum = "0.8.1"
 redis = { version = "0.27.6", features = ["tokio-comp", "json"] }
 neo4rs = "0.8.0"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.134"
 once_cell = "1.20.2"
-utoipa = "5.3.0"
-utoipa-swagger-ui = { version = "8.1.0", features = ["axum"] }
+utoipa = { git = "https://github.com/juhaku/utoipa", rev = "d522f744259dc4fde5f45d187983fb68c8167029" }
+utoipa-swagger-ui = { git = "https://github.com/juhaku/utoipa", rev = "d522f744259dc4fde5f45d187983fb68c8167029", features = [
+    "axum",
+] }
 tower-http = { version = "0.6.2", features = ["fs", "cors"] }
 dotenv = "0.15"
 log = "0.4.22"
@@ -36,6 +40,7 @@ reqwest = "0.12.9"
 base32 = "0.5.1"
 blake3 = "1.5.5"
 url = "2.5.4"
+async-trait = "0.1.84"
 
 [dev-dependencies]
 anyhow = "1.0.95"
@@ -45,6 +50,9 @@ pubky_homeserver = { git = "https://github.com/pubky/pubky-core.git", tag = "pub
 rand = "0.8.5"
 rand_distr = "0.4.3"
 tokio-shared-rt = "0.1"
+
+[patch.crates-io]
+utoipa-swagger-ui = { git = "https://github.com/juhaku/utoipa", rev = "d522f744259dc4fde5f45d187983fb68c8167029" }
 
 [lib]
 name = "pubky_nexus"

--- a/src/db/kv/traits.rs
+++ b/src/db/kv/traits.rs
@@ -1,6 +1,6 @@
 use super::index::*;
 use crate::types::DynError;
-use axum::async_trait;
+use async_trait::async_trait;
 use json::JsonAction;
 use serde::{de::DeserializeOwned, Serialize};
 use sorted_sets::{ScoreAction, SortOrder, SORTED_PREFIX};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,5 +20,4 @@ pub use events::processor::EventProcessor;
 pub use reindex::reindex;
 pub use setup::setup;
 
-#[macro_use]
 extern crate const_format;

--- a/src/models/file/details.rs
+++ b/src/models/file/details.rs
@@ -2,7 +2,7 @@ use crate::db::graph::exec::exec_single_row;
 use crate::models::traits::Collection;
 use crate::types::DynError;
 use crate::{queries, RedisOps};
-use axum::async_trait;
+use async_trait::async_trait;
 use chrono::Utc;
 use neo4rs::Query;
 use pubky_app_specs::PubkyAppFile;

--- a/src/models/follow/followers.rs
+++ b/src/models/follow/followers.rs
@@ -1,5 +1,5 @@
 use crate::{queries, RedisOps};
-use axum::async_trait;
+use async_trait::async_trait;
 use neo4rs::Query;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;

--- a/src/models/follow/following.rs
+++ b/src/models/follow/following.rs
@@ -1,5 +1,5 @@
 use crate::{queries, RedisOps};
-use axum::async_trait;
+use async_trait::async_trait;
 use neo4rs::Query;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;

--- a/src/models/follow/traits.rs
+++ b/src/models/follow/traits.rs
@@ -2,7 +2,7 @@ use crate::db::connectors::neo4j::get_neo4j_graph;
 use crate::db::graph::exec::exec_boolean_row;
 use crate::types::DynError;
 use crate::{queries, RedisOps};
-use axum::async_trait;
+use async_trait::async_trait;
 use chrono::Utc;
 use neo4rs::Query;
 

--- a/src/models/tag/post.rs
+++ b/src/models/tag/post.rs
@@ -1,5 +1,5 @@
 use crate::RedisOps;
-use axum::async_trait;
+use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 

--- a/src/models/tag/stream.rs
+++ b/src/models/tag/stream.rs
@@ -1,7 +1,7 @@
 use crate::db::graph::exec::retrieve_from_graph;
 use crate::db::kv::index::sorted_sets::SortOrder;
 use crate::types::{DynError, Timeframe};
-use axum::async_trait;
+use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::Display;

--- a/src/models/tag/traits/collection.rs
+++ b/src/models/tag/traits/collection.rs
@@ -1,5 +1,5 @@
 use crate::types::DynError;
-use axum::async_trait;
+use async_trait::async_trait;
 use log::error;
 use neo4rs::Query;
 

--- a/src/models/tag/traits/taggers.rs
+++ b/src/models/tag/traits/taggers.rs
@@ -1,6 +1,6 @@
 use crate::types::{DynError, Pagination};
 use crate::RedisOps;
-use axum::async_trait;
+use async_trait::async_trait;
 
 use super::collection::CACHE_SET_PREFIX;
 

--- a/src/models/tag/user.rs
+++ b/src/models/tag/user.rs
@@ -1,5 +1,5 @@
 use crate::RedisOps;
-use axum::async_trait;
+use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 

--- a/src/models/traits.rs
+++ b/src/models/traits.rs
@@ -1,4 +1,4 @@
-use axum::async_trait;
+use async_trait::async_trait;
 use neo4rs::Query;
 
 use crate::db::connectors::neo4j::get_neo4j_graph;

--- a/src/models/user/details.rs
+++ b/src/models/user/details.rs
@@ -4,7 +4,7 @@ use crate::models::traits::Collection;
 use crate::types::DynError;
 use crate::types::PubkyId;
 use crate::{queries, RedisOps};
-use axum::async_trait;
+use async_trait::async_trait;
 use chrono::Utc;
 use neo4rs::Query;
 use pubky_app_specs::{PubkyAppUser, PubkyAppUserLink};

--- a/src/models/user/follows.rs
+++ b/src/models/user/follows.rs
@@ -1,7 +1,7 @@
 // use crate::db::connectors::neo4j::get_neo4j_graph;
 // use crate::db::graph::exec::exec_boolean_row;
 // use crate::{queries, RedisOps};
-// use axum::async_trait;
+// use async_trait::async_trait;
 // use chrono::Utc;
 // use neo4rs::Query;
 // use serde::{Deserialize, Serialize};

--- a/src/models/user/muted.rs
+++ b/src/models/user/muted.rs
@@ -2,7 +2,7 @@ use crate::db::connectors::neo4j::get_neo4j_graph;
 use crate::db::graph::exec::exec_single_row;
 use crate::types::DynError;
 use crate::{queries, RedisOps};
-use axum::async_trait;
+use async_trait::async_trait;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;

--- a/src/routes/macros.rs
+++ b/src/routes/macros.rs
@@ -5,12 +5,3 @@ macro_rules! register_routes {
             $(.route($path, axum::routing::get($handler)))*
     };
 }
-
-/// Transforms a "swagger-like" endpoint to "axum-like" manipulating &'static str
-/// Example `"/v1/user/{user_id}"` -> `"/v1/user/:user_id"`
-#[macro_export]
-macro_rules! to_axum {
-    ($route:expr) => {
-        str_replace!(str_replace!($route, "{", ":"), "}", "")
-    };
-}

--- a/src/routes/v0/file/mod.rs
+++ b/src/routes/v0/file/mod.rs
@@ -1,5 +1,5 @@
+use crate::register_routes;
 use crate::routes::v0::endpoints;
-use crate::{register_routes, to_axum};
 use axum::Router;
 use utoipa::OpenApi;
 
@@ -8,10 +8,10 @@ mod list;
 
 pub fn routes() -> Router {
     let router = register_routes!(Router::new(),
-        to_axum!(endpoints::FILE_ROUTE) => details::file_details_handler,
+        endpoints::FILE_ROUTE => details::file_details_handler,
     );
     router.route(
-        to_axum!(endpoints::FILE_LIST_ROUTE),
+        endpoints::FILE_LIST_ROUTE,
         axum::routing::post(list::file_details_by_uris_handler),
     )
 }

--- a/src/routes/v0/notification/mod.rs
+++ b/src/routes/v0/notification/mod.rs
@@ -1,5 +1,5 @@
+use crate::register_routes;
 use crate::routes::v0::endpoints;
-use crate::{register_routes, to_axum};
 use axum::Router;
 use utoipa::OpenApi;
 
@@ -7,7 +7,7 @@ mod list;
 
 pub fn routes() -> Router {
     register_routes!(Router::new(),
-        to_axum!(endpoints::NOTIFICATION_ROUTE) => list::list_notifications_handler
+        endpoints::NOTIFICATION_ROUTE => list::list_notifications_handler
     )
 }
 

--- a/src/routes/v0/post/mod.rs
+++ b/src/routes/v0/post/mod.rs
@@ -1,5 +1,5 @@
+use crate::register_routes;
 use crate::routes::v0::endpoints;
-use crate::{register_routes, to_axum};
 use axum::Router;
 use utoipa::OpenApi;
 
@@ -11,12 +11,12 @@ mod view;
 
 pub fn routes() -> Router {
     register_routes!(Router::new(),
-        to_axum!(endpoints::POST_ROUTE) => view::post_view_handler,
-        to_axum!(endpoints::POST_DETAILS_ROUTE) => details::post_details_handler,
-        to_axum!(endpoints::POST_COUNTS_ROUTE) => counts::post_counts_handler,
-        to_axum!(endpoints::POST_BOOKMARK_ROUTE) => bookmark::post_bookmark_handler,
-        to_axum!(endpoints::POST_TAGS_ROUTE) => tags::post_tags_handler,
-        to_axum!(endpoints::POST_TAGGERS_ROUTE) => tags::post_taggers_handler,
+        endpoints::POST_ROUTE => view::post_view_handler,
+        endpoints::POST_DETAILS_ROUTE => details::post_details_handler,
+        endpoints::POST_COUNTS_ROUTE => counts::post_counts_handler,
+        endpoints::POST_BOOKMARK_ROUTE => bookmark::post_bookmark_handler,
+        endpoints::POST_TAGS_ROUTE => tags::post_tags_handler,
+        endpoints::POST_TAGGERS_ROUTE => tags::post_taggers_handler,
     )
 }
 

--- a/src/routes/v0/search/mod.rs
+++ b/src/routes/v0/search/mod.rs
@@ -1,5 +1,5 @@
+use crate::register_routes;
 use crate::routes::v0::endpoints;
-use crate::{register_routes, to_axum};
 use axum::Router;
 use utoipa::OpenApi;
 
@@ -8,8 +8,8 @@ mod users;
 
 pub fn routes() -> Router {
     register_routes!(Router::new(),
-        to_axum!(endpoints::SEARCH_USERS_ROUTE) => users::search_users_handler,
-        to_axum!(endpoints::SEARCH_TAGS_ROUTE) => tags::search_post_tags_handler
+        endpoints::SEARCH_USERS_ROUTE => users::search_users_handler,
+        endpoints::SEARCH_TAGS_ROUTE => tags::search_post_tags_handler
     )
 }
 

--- a/src/routes/v0/tag/mod.rs
+++ b/src/routes/v0/tag/mod.rs
@@ -1,5 +1,5 @@
+use crate::register_routes;
 use crate::routes::v0::endpoints;
-use crate::{register_routes, to_axum};
 use axum::Router;
 use utoipa::OpenApi;
 
@@ -7,8 +7,8 @@ mod global;
 
 pub fn routes() -> Router {
     register_routes!(Router::new(),
-        to_axum!(endpoints::TAGS_HOT_ROUTE) => global::hot_tags_handler,
-        to_axum!(endpoints::TAG_TAGGERS_ROUTE) => global::tag_taggers_handler
+        endpoints::TAGS_HOT_ROUTE => global::hot_tags_handler,
+        endpoints::TAG_TAGGERS_ROUTE => global::tag_taggers_handler
     )
 }
 

--- a/src/routes/v0/user/mod.rs
+++ b/src/routes/v0/user/mod.rs
@@ -1,5 +1,5 @@
+use crate::register_routes;
 use crate::routes::v0::endpoints;
-use crate::{register_routes, to_axum};
 use axum::Router;
 use utoipa::OpenApi;
 
@@ -13,16 +13,16 @@ mod view;
 
 pub fn routes() -> Router {
     register_routes!(Router::new(),
-        to_axum!(endpoints::USER_ROUTE) => view::user_view_handler,
-        to_axum!(endpoints::USER_DETAILS_ROUTE) => details::user_details_handler,
-        to_axum!(endpoints::RELATIONSHIP_ROUTE) => relationship::user_relationship_handler,
-        to_axum!(endpoints::USER_TAGS_ROUTE) => tags::user_tags_handler,
-        to_axum!(endpoints::USER_TAGGERS_ROUTE) => tags::user_taggers_handler,
-        to_axum!(endpoints::USER_COUNTS_ROUTE) => counts::user_counts_handler,
-        to_axum!(endpoints::USER_FOLLOWERS_ROUTE) => follows::user_followers_handler,
-        to_axum!(endpoints::USER_FOLLOWING_ROUTE) => follows::user_following_handler,
-        to_axum!(endpoints::USER_FRIENDS_ROUTE) => follows::user_friends_handler,
-        to_axum!(endpoints::USER_MUTED_ROUTE) => muted::user_muted_handler,
+        endpoints::USER_ROUTE => view::user_view_handler,
+        endpoints::USER_DETAILS_ROUTE => details::user_details_handler,
+        endpoints::RELATIONSHIP_ROUTE => relationship::user_relationship_handler,
+        endpoints::USER_TAGS_ROUTE => tags::user_tags_handler,
+        endpoints::USER_TAGGERS_ROUTE => tags::user_taggers_handler,
+        endpoints::USER_COUNTS_ROUTE => counts::user_counts_handler,
+        endpoints::USER_FOLLOWERS_ROUTE => follows::user_followers_handler,
+        endpoints::USER_FOLLOWING_ROUTE => follows::user_following_handler,
+        endpoints::USER_FRIENDS_ROUTE => follows::user_friends_handler,
+        endpoints::USER_MUTED_ROUTE => muted::user_muted_handler,
     )
 }
 


### PR DESCRIPTION
Latest `pubky-core` conflicts in version of `bytes` with axum 0.7.9 . This can be fixed by upgrading to axum 0.8.0 which required: 
 1. Bumping utoipa to latest commit in main.
 2. Do the same in `pubky-app-specs` repo.
 2. Changing how params in endpoints are prefixed. Axum 0.8 changes `:param` to `{param}` so our macro for swagger/axum is not needed anymore.


# Pre-submission Checklist

> For tests to work you need a working neo4j and redis instance with the example dataset in `docker/db-graph`

- [ ] **Testing**: Implement and pass new tests for the new features/fixes, `cargo test`.
- [ ] **Performance**: Ensure new code has relevant performance benchmarks, `cargo bench`
