### PR TITLE
fix: ARM (Apple Silicon) build support in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@
 # ========================
 FROM rust:1.82.0-alpine3.20 AS builder
 
+# Build platform argument (x86_64 or aarch64) (default: x86_64)
+ARG TARGETARCH=x86_64
+RUN echo "TARGETARCH: $TARGETARCH"
+
 # Install build dependencies, including static OpenSSL libraries
 RUN apk add --no-cache \
     musl-dev \
@@ -13,13 +17,24 @@ RUN apk add --no-cache \
     curl \
     git
 
+# Install cross-compiler toolchain only for ARM (Apple Silicon)
+RUN if [ "$TARGETARCH" = "aarch64" ]; then \
+        wget -qO- https://musl.cc/aarch64-linux-musl-cross.tgz | tar -xz -C /usr/local && \
+        echo "/usr/local/aarch64-linux-musl-cross/bin" > /tmp/musl_cross_path; \
+    else \
+        echo "" > /tmp/musl_cross_path; \
+    fi
+
+# Set PATH only if we installed the cross compiler (will be empty string for x86)
+ENV PATH="$(cat /tmp/musl_cross_path):$PATH"
+
 # Set environment variables for static linking with OpenSSL
 ENV OPENSSL_STATIC=yes
 ENV OPENSSL_LIB_DIR=/usr/lib
 ENV OPENSSL_INCLUDE_DIR=/usr/include
 
 # Add the MUSL target for static linking
-RUN rustup target add x86_64-unknown-linux-musl
+RUN rustup target add $TARGETARCH-unknown-linux-musl
 
 # Set the working directory
 WORKDIR /usr/src/app
@@ -31,23 +46,25 @@ COPY Cargo.toml Cargo.lock ./
 COPY . .
 
 # Build the project in release mode for the MUSL target
-RUN cargo build --release --bin service --bin watcher --target x86_64-unknown-linux-musl
+RUN cargo build --release --bin service --bin watcher --target $TARGETARCH-unknown-linux-musl
 
 # Strip the binaries to reduce size
-RUN strip target/x86_64-unknown-linux-musl/release/service
-RUN strip target/x86_64-unknown-linux-musl/release/watcher
+RUN strip target/$TARGETARCH-unknown-linux-musl/release/service
+RUN strip target/$TARGETARCH-unknown-linux-musl/release/watcher
 
 # ========================
 # Runtime Stage
 # ========================
 FROM alpine:3.20
 
+ARG TARGETARCH=x86_64
+
 # Install runtime dependencies (only ca-certificates)
 RUN apk add --no-cache ca-certificates
 
 # Copy the compiled binaries from the builder stage
-COPY --from=builder /usr/src/app/target/x86_64-unknown-linux-musl/release/service /usr/local/bin/service
-COPY --from=builder /usr/src/app/target/x86_64-unknown-linux-musl/release/watcher /usr/local/bin/watcher
+COPY --from=builder /usr/src/app/target/$TARGETARCH-unknown-linux-musl/release/service /usr/local/bin/service
+COPY --from=builder /usr/src/app/target/$TARGETARCH-unknown-linux-musl/release/watcher /usr/local/bin/watcher
 
 # Set the working directory
 WORKDIR /usr/local/bin


### PR DESCRIPTION
Still defaults to x86. Pass build arg when using ARM architecture: `docker build --build-arg TARGETARCH=aarch64 .`


# Pre-submission Checklist

> For tests to work you need a working neo4j and redis instance with the example dataset in `docker/db-graph`

- ~[ ] **Testing**: Implement and pass new tests for the new features/fixes, `cargo test`.~
- ~[ ] **Performance**: Ensure new code has relevant performance benchmarks, `cargo bench`~
