### PR TITLE
fix(models): allow stream of post in ascending order

### DIFF
--- a/nexus-api/benches/streams_benches/author.rs
+++ b/nexus-api/benches/streams_benches/author.rs
@@ -1,6 +1,7 @@
 use crate::{run_setup, streams_benches::LIMIT_20};
 use criterion::Criterion;
 use nexus_common::{
+    db::kv::SortOrder,
     models::post::{PostStream, StreamSource},
     types::StreamSorting,
 };
@@ -26,10 +27,17 @@ pub fn bench_stream_author_timeline(c: &mut Criterion) {
             };
 
             // Run the benchmark
-            let post_stream =
-                PostStream::get_posts(source, LIMIT_20, StreamSorting::Timeline, None, None, None)
-                    .await
-                    .unwrap();
+            let post_stream = PostStream::get_posts(
+                source,
+                LIMIT_20,
+                SortOrder::Descending,
+                StreamSorting::Timeline,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
             criterion::black_box(post_stream);
         });
     });
@@ -55,6 +63,7 @@ pub fn bench_stream_author_total_engagement(c: &mut Criterion) {
             let post_stream = PostStream::get_posts(
                 source,
                 LIMIT_20,
+                SortOrder::Descending,
                 StreamSorting::TotalEngagement,
                 None,
                 None,
@@ -84,10 +93,17 @@ pub fn bench_stream_author_replies_timeline(c: &mut Criterion) {
             };
 
             // Run the benchmark
-            let post_stream =
-                PostStream::get_posts(source, LIMIT_20, StreamSorting::Timeline, None, None, None)
-                    .await
-                    .unwrap();
+            let post_stream = PostStream::get_posts(
+                source,
+                LIMIT_20,
+                SortOrder::Descending,
+                StreamSorting::Timeline,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
             criterion::black_box(post_stream);
         });
     });

--- a/nexus-api/benches/streams_benches/bookmarks.rs
+++ b/nexus-api/benches/streams_benches/bookmarks.rs
@@ -1,6 +1,7 @@
 use crate::run_setup;
 use crate::streams_benches::LIMIT_20;
 use criterion::Criterion;
+use nexus_common::db::kv::SortOrder;
 use nexus_common::models::post::{PostStream, StreamSource};
 use nexus_common::types::StreamSorting;
 use tokio::runtime::Runtime;
@@ -25,10 +26,17 @@ pub fn bench_stream_bookmarks_timeline(c: &mut Criterion) {
             };
 
             // Run the benchmark
-            let post_stream =
-                PostStream::get_posts(source, LIMIT_20, StreamSorting::Timeline, None, None, None)
-                    .await
-                    .unwrap();
+            let post_stream = PostStream::get_posts(
+                source,
+                LIMIT_20,
+                SortOrder::Descending,
+                StreamSorting::Timeline,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
             criterion::black_box(post_stream);
         });
     });
@@ -53,6 +61,7 @@ pub fn bench_stream_bookmarks_total_engagement(c: &mut Criterion) {
             let post_stream = PostStream::get_posts(
                 source,
                 LIMIT_20,
+                SortOrder::Descending,
                 StreamSorting::TotalEngagement,
                 None,
                 None,

--- a/nexus-api/benches/streams_benches/kind.rs
+++ b/nexus-api/benches/streams_benches/kind.rs
@@ -1,6 +1,7 @@
 use crate::run_setup;
 use crate::streams_benches::LIMIT_20;
 use criterion::Criterion;
+use nexus_common::db::kv::SortOrder;
 use nexus_common::models::post::{PostStream, StreamSource};
 use nexus_common::types::StreamSorting;
 use pubky_app_specs::PubkyAppPostKind;
@@ -25,6 +26,7 @@ pub fn bench_stream_post_kind_short(c: &mut Criterion) {
             let post_stream = PostStream::get_posts(
                 source,
                 LIMIT_20,
+                SortOrder::Descending,
                 StreamSorting::Timeline,
                 None,
                 None,
@@ -55,6 +57,7 @@ pub fn bench_stream_post_kind_long(c: &mut Criterion) {
             let post_stream = PostStream::get_posts(
                 source,
                 LIMIT_20,
+                SortOrder::Descending,
                 StreamSorting::Timeline,
                 None,
                 None,
@@ -85,6 +88,7 @@ pub fn bench_stream_post_kind_image(c: &mut Criterion) {
             let post_stream = PostStream::get_posts(
                 source,
                 LIMIT_20,
+                SortOrder::Descending,
                 StreamSorting::Timeline,
                 None,
                 None,
@@ -115,6 +119,7 @@ pub fn bench_stream_post_kind_video(c: &mut Criterion) {
             let post_stream = PostStream::get_posts(
                 source,
                 LIMIT_20,
+                SortOrder::Descending,
                 StreamSorting::Timeline,
                 None,
                 None,
@@ -145,6 +150,7 @@ pub fn bench_stream_post_kind_link(c: &mut Criterion) {
             let post_stream = PostStream::get_posts(
                 source,
                 LIMIT_20,
+                SortOrder::Descending,
                 StreamSorting::Timeline,
                 None,
                 None,
@@ -175,6 +181,7 @@ pub fn bench_stream_post_kind_file(c: &mut Criterion) {
             let post_stream = PostStream::get_posts(
                 source,
                 LIMIT_20,
+                SortOrder::Descending,
                 StreamSorting::Timeline,
                 None,
                 None,

--- a/nexus-api/benches/streams_benches/reach.rs
+++ b/nexus-api/benches/streams_benches/reach.rs
@@ -1,6 +1,7 @@
 use crate::run_setup;
 use crate::streams_benches::LIMIT_20;
 use criterion::Criterion;
+use nexus_common::db::kv::SortOrder;
 use nexus_common::models::post::{PostStream, StreamSource};
 use nexus_common::types::StreamSorting;
 use tokio::runtime::Runtime;
@@ -25,10 +26,17 @@ pub fn bench_stream_followers_timeline(c: &mut Criterion) {
             };
 
             // Run the benchmark
-            let post_stream =
-                PostStream::get_posts(source, LIMIT_20, StreamSorting::Timeline, None, None, None)
-                    .await
-                    .unwrap();
+            let post_stream = PostStream::get_posts(
+                source,
+                LIMIT_20,
+                SortOrder::Descending,
+                StreamSorting::Timeline,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
             criterion::black_box(post_stream);
         });
     });
@@ -51,10 +59,17 @@ pub fn bench_stream_following_timeline(c: &mut Criterion) {
             };
 
             // Run the benchmark
-            let post_stream =
-                PostStream::get_posts(source, LIMIT_20, StreamSorting::Timeline, None, None, None)
-                    .await
-                    .unwrap();
+            let post_stream = PostStream::get_posts(
+                source,
+                LIMIT_20,
+                SortOrder::Descending,
+                StreamSorting::Timeline,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
             criterion::black_box(post_stream);
         });
     });
@@ -77,10 +92,17 @@ pub fn bench_stream_friends_timeline(c: &mut Criterion) {
             };
 
             // Run the benchmark
-            let post_stream =
-                PostStream::get_posts(source, LIMIT_20, StreamSorting::Timeline, None, None, None)
-                    .await
-                    .unwrap();
+            let post_stream = PostStream::get_posts(
+                source,
+                LIMIT_20,
+                SortOrder::Descending,
+                StreamSorting::Timeline,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
             criterion::black_box(post_stream);
         });
     });
@@ -106,6 +128,7 @@ pub fn bench_stream_followers_total_engagement(c: &mut Criterion) {
             let post_stream = PostStream::get_posts(
                 source,
                 LIMIT_20,
+                SortOrder::Descending,
                 StreamSorting::TotalEngagement,
                 None,
                 None,
@@ -138,6 +161,7 @@ pub fn bench_stream_following_total_engagement(c: &mut Criterion) {
             let post_stream = PostStream::get_posts(
                 source,
                 LIMIT_20,
+                SortOrder::Descending,
                 StreamSorting::TotalEngagement,
                 None,
                 None,
@@ -170,6 +194,7 @@ pub fn bench_stream_friends_total_engagement(c: &mut Criterion) {
             let post_stream = PostStream::get_posts(
                 source,
                 LIMIT_20,
+                SortOrder::Descending,
                 StreamSorting::TotalEngagement,
                 None,
                 None,

--- a/nexus-api/benches/streams_benches/sorting.rs
+++ b/nexus-api/benches/streams_benches/sorting.rs
@@ -1,5 +1,6 @@
 use crate::{run_setup, streams_benches::LIMIT_20};
 use criterion::Criterion;
+use nexus_common::db::kv::SortOrder;
 use nexus_common::models::post::{PostStream, StreamSource};
 use nexus_common::types::StreamSorting;
 use tokio::runtime::Runtime;
@@ -20,10 +21,17 @@ pub fn bench_stream_all_timeline(c: &mut Criterion) {
             let source = StreamSource::All;
 
             // Run the benchmark
-            let post_stream =
-                PostStream::get_posts(source, LIMIT_20, StreamSorting::Timeline, None, None, None)
-                    .await
-                    .unwrap();
+            let post_stream = PostStream::get_posts(
+                source,
+                LIMIT_20,
+                SortOrder::Descending,
+                StreamSorting::Timeline,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
             criterion::black_box(post_stream);
         });
     });
@@ -47,6 +55,7 @@ pub fn bench_stream_all_total_engagement(c: &mut Criterion) {
             let post_stream = PostStream::get_posts(
                 source,
                 LIMIT_20,
+                SortOrder::Descending,
                 StreamSorting::TotalEngagement,
                 None,
                 None,

--- a/nexus-api/benches/streams_benches/tag.rs
+++ b/nexus-api/benches/streams_benches/tag.rs
@@ -1,6 +1,7 @@
 use crate::run_setup;
 use crate::streams_benches::LIMIT_20;
 use criterion::Criterion;
+use nexus_common::db::kv::SortOrder;
 use nexus_common::models::post::{PostStream, StreamSource};
 use nexus_common::types::StreamSorting;
 use tokio::runtime::Runtime;
@@ -26,6 +27,7 @@ pub fn bench_stream_tag_timeline(c: &mut Criterion) {
             let post_stream = PostStream::get_posts(
                 source,
                 LIMIT_20,
+                SortOrder::Descending,
                 StreamSorting::Timeline,
                 None,
                 Some(vec![TAG.to_string()]),
@@ -56,6 +58,7 @@ pub fn bench_stream_tag_total_engagement(c: &mut Criterion) {
             let post_stream = PostStream::get_posts(
                 source,
                 LIMIT_20,
+                SortOrder::Descending,
                 StreamSorting::TotalEngagement,
                 None,
                 Some(vec![TAG.to_string()]),

--- a/nexus-api/src/routes/v0/stream/posts.rs
+++ b/nexus-api/src/routes/v0/stream/posts.rs
@@ -106,8 +106,8 @@ pub async fn stream_posts_handler(
     }
 
     let source = query.source.unwrap_or_default(); // StreamSource::All is default
-    let sorting = query.sorting.unwrap_or_default(); // StreamSorting::Timeline) is default
-    let order = query.order.unwrap_or_default(); // StreamSorting::Timeline) is default
+    let sorting = query.sorting.unwrap_or_default(); // StreamSorting::Timeline is default
+    let order = query.order.unwrap_or_default(); // SortOrder::Descending is default
 
     match PostStream::get_posts(
         source,

--- a/nexus-api/src/routes/v0/stream/posts.rs
+++ b/nexus-api/src/routes/v0/stream/posts.rs
@@ -1,6 +1,7 @@
 use crate::routes::v0::endpoints::STREAM_POSTS_ROUTE;
 use crate::{Error, Result as AppResult};
 use axum::{extract::Query, Json};
+use nexus_common::db::kv::SortOrder;
 use nexus_common::types::StreamSorting;
 use nexus_common::{
     models::post::{PostStream, StreamSource},
@@ -19,6 +20,7 @@ pub struct PostStreamQuery {
     pub source: Option<StreamSource>,
     #[serde(flatten)]
     pub pagination: Pagination,
+    pub order: Option<SortOrder>,
     pub sorting: Option<StreamSorting>,
     pub viewer_id: Option<String>,
     #[serde(default, deserialize_with = "deserialize_comma_separated")]
@@ -62,6 +64,7 @@ where
         ("author_id" = Option<String>, Query, description = "Filter posts by an specific author User ID"),
         ("post_id" = Option<String>, Query, description = "This parameter is needed when we want to retrieve the replies stream for a post"),
         ("sorting" = Option<StreamSorting>, Query, description = "StreamSorting method"),
+        ("order" = Option<SortOrder>, Query, description = "Ordering of response list. Either 'ascending' or 'descending'. Defaults to descending."),
         ("tags" = Option<Vec<String>>, Query, description = "Filter by a list of comma-separated tags (max 5). E.g.,`&tags=dev,free,opensource`. Only posts matching at least one of the tags will be returned."),
         ("kind" = Option<PubkyAppPostKind>, Query, description = "Specifies the type of posts to retrieve: short, long, image, video, link and file"),
         ("skip" = Option<usize>, Query, description = "Skip N posts"),
@@ -104,10 +107,12 @@ pub async fn stream_posts_handler(
 
     let source = query.source.unwrap_or_default(); // StreamSource::All is default
     let sorting = query.sorting.unwrap_or_default(); // StreamSorting::Timeline) is default
+    let order = query.order.unwrap_or_default(); // StreamSorting::Timeline) is default
 
     match PostStream::get_posts(
         source,
         query.pagination,
+        order,
         sorting,
         query.viewer_id,
         query.tags,

--- a/nexus-api/tests/stream/post/post_replies.rs
+++ b/nexus-api/tests/stream/post/post_replies.rs
@@ -36,12 +36,12 @@ async fn test_stream_posts_replies() -> Result<()> {
     assert_eq!(post_reply_stream.0.len(), 6);
 
     let replies_order = vec![
-        CHILD_6_POST_ID,
-        CHILD_5_POST_ID,
-        CHILD_4_POST_ID,
-        CHILD_3_POST_ID,
-        CHILD_2_POST_ID,
         CHILD_1_POST_ID,
+        CHILD_2_POST_ID,
+        CHILD_3_POST_ID,
+        CHILD_4_POST_ID,
+        CHILD_5_POST_ID,
+        CHILD_6_POST_ID,
     ];
 
     check_replies_timeline(post_reply_stream.0, replies_order);
@@ -69,7 +69,7 @@ async fn test_stream_posts_replies_with_limit() -> Result<()> {
     // Assert the post number
     assert_eq!(post_reply_stream.0.len(), 3);
 
-    let replies_order = vec![CHILD_6_POST_ID, CHILD_5_POST_ID, CHILD_4_POST_ID];
+    let replies_order = vec![CHILD_1_POST_ID, CHILD_2_POST_ID, CHILD_3_POST_ID];
 
     check_replies_timeline(post_reply_stream.0, replies_order);
 
@@ -94,9 +94,14 @@ async fn test_stream_posts_replies_with_start_query() -> Result<()> {
         "Post stream should not be empty"
     );
     // Assert the post number
-    assert_eq!(post_reply_stream.0.len(), 2);
+    assert_eq!(post_reply_stream.0.len(), 4);
 
-    let replies_order = vec![CHILD_2_POST_ID, CHILD_1_POST_ID];
+    let replies_order = vec![
+        CHILD_3_POST_ID,
+        CHILD_4_POST_ID,
+        CHILD_5_POST_ID,
+        CHILD_6_POST_ID,
+    ];
 
     check_replies_timeline(post_reply_stream.0, replies_order);
 
@@ -123,7 +128,7 @@ async fn test_stream_posts_replies_with_end_query() -> Result<()> {
     // Assert the post number
     assert_eq!(post_reply_stream.0.len(), 3);
 
-    let replies_order = vec![CHILD_6_POST_ID, CHILD_5_POST_ID, CHILD_4_POST_ID];
+    let replies_order = vec![CHILD_1_POST_ID, CHILD_2_POST_ID, CHILD_3_POST_ID];
 
     check_replies_timeline(post_reply_stream.0, replies_order);
 
@@ -151,10 +156,10 @@ async fn test_stream_posts_replies_with_start_and_end_query() -> Result<()> {
     assert_eq!(post_reply_stream.0.len(), 4);
 
     let replies_order = vec![
-        CHILD_5_POST_ID,
-        CHILD_4_POST_ID,
-        CHILD_3_POST_ID,
         CHILD_2_POST_ID,
+        CHILD_3_POST_ID,
+        CHILD_4_POST_ID,
+        CHILD_5_POST_ID,
     ];
 
     check_replies_timeline(post_reply_stream.0, replies_order);
@@ -182,7 +187,7 @@ async fn test_stream_posts_replies_with_start_and_end_also_limit_query() -> Resu
     // Assert the post number
     assert_eq!(post_reply_stream.0.len(), 3);
 
-    let replies_order = vec![CHILD_5_POST_ID, CHILD_4_POST_ID, CHILD_3_POST_ID];
+    let replies_order = vec![CHILD_3_POST_ID, CHILD_4_POST_ID, CHILD_5_POST_ID];
 
     check_replies_timeline(post_reply_stream.0, replies_order);
 

--- a/nexus-api/tests/stream/post/post_replies.rs
+++ b/nexus-api/tests/stream/post/post_replies.rs
@@ -36,12 +36,12 @@ async fn test_stream_posts_replies() -> Result<()> {
     assert_eq!(post_reply_stream.0.len(), 6);
 
     let replies_order = vec![
-        CHILD_1_POST_ID,
-        CHILD_2_POST_ID,
-        CHILD_3_POST_ID,
-        CHILD_4_POST_ID,
-        CHILD_5_POST_ID,
         CHILD_6_POST_ID,
+        CHILD_5_POST_ID,
+        CHILD_4_POST_ID,
+        CHILD_3_POST_ID,
+        CHILD_2_POST_ID,
+        CHILD_1_POST_ID,
     ];
 
     check_replies_timeline(post_reply_stream.0, replies_order);
@@ -69,7 +69,7 @@ async fn test_stream_posts_replies_with_limit() -> Result<()> {
     // Assert the post number
     assert_eq!(post_reply_stream.0.len(), 3);
 
-    let replies_order = vec![CHILD_1_POST_ID, CHILD_2_POST_ID, CHILD_3_POST_ID];
+    let replies_order = vec![CHILD_6_POST_ID, CHILD_5_POST_ID, CHILD_4_POST_ID];
 
     check_replies_timeline(post_reply_stream.0, replies_order);
 
@@ -94,14 +94,9 @@ async fn test_stream_posts_replies_with_start_query() -> Result<()> {
         "Post stream should not be empty"
     );
     // Assert the post number
-    assert_eq!(post_reply_stream.0.len(), 4);
+    assert_eq!(post_reply_stream.0.len(), 2);
 
-    let replies_order = vec![
-        CHILD_3_POST_ID,
-        CHILD_4_POST_ID,
-        CHILD_5_POST_ID,
-        CHILD_6_POST_ID,
-    ];
+    let replies_order = vec![CHILD_2_POST_ID, CHILD_1_POST_ID];
 
     check_replies_timeline(post_reply_stream.0, replies_order);
 
@@ -128,7 +123,7 @@ async fn test_stream_posts_replies_with_end_query() -> Result<()> {
     // Assert the post number
     assert_eq!(post_reply_stream.0.len(), 3);
 
-    let replies_order = vec![CHILD_1_POST_ID, CHILD_2_POST_ID, CHILD_3_POST_ID];
+    let replies_order = vec![CHILD_6_POST_ID, CHILD_5_POST_ID, CHILD_4_POST_ID];
 
     check_replies_timeline(post_reply_stream.0, replies_order);
 
@@ -156,10 +151,10 @@ async fn test_stream_posts_replies_with_start_and_end_query() -> Result<()> {
     assert_eq!(post_reply_stream.0.len(), 4);
 
     let replies_order = vec![
-        CHILD_2_POST_ID,
-        CHILD_3_POST_ID,
-        CHILD_4_POST_ID,
         CHILD_5_POST_ID,
+        CHILD_4_POST_ID,
+        CHILD_3_POST_ID,
+        CHILD_2_POST_ID,
     ];
 
     check_replies_timeline(post_reply_stream.0, replies_order);
@@ -187,7 +182,7 @@ async fn test_stream_posts_replies_with_start_and_end_also_limit_query() -> Resu
     // Assert the post number
     assert_eq!(post_reply_stream.0.len(), 3);
 
-    let replies_order = vec![CHILD_3_POST_ID, CHILD_4_POST_ID, CHILD_5_POST_ID];
+    let replies_order = vec![CHILD_5_POST_ID, CHILD_4_POST_ID, CHILD_3_POST_ID];
 
     check_replies_timeline(post_reply_stream.0, replies_order);
 

--- a/nexus-common/src/db/kv/index/sorted_sets.rs
+++ b/nexus-common/src/db/kv/index/sorted_sets.rs
@@ -1,9 +1,14 @@
 use crate::db::get_redis_conn;
 use crate::types::DynError;
 use redis::AsyncCommands;
+use serde::Deserialize;
+use utoipa::ToSchema;
 
+#[derive(Clone, Deserialize, Debug, ToSchema, Default)]
+#[serde(rename_all = "snake_case")]
 pub enum SortOrder {
     Ascending,
+    #[default]
     Descending,
 }
 

--- a/nexus-common/src/models/post/stream.rs
+++ b/nexus-common/src/models/post/stream.rs
@@ -405,7 +405,7 @@ impl PostStream {
             end,
             None,
             limit,
-            SortOrder::Descending,
+            SortOrder::Ascending,
             None,
         )
         .await?;

--- a/nexus-common/src/models/post/stream.rs
+++ b/nexus-common/src/models/post/stream.rs
@@ -81,6 +81,7 @@ impl PostStream {
     pub async fn get_posts(
         source: StreamSource,
         pagination: Pagination,
+        order: SortOrder,
         sorting: StreamSorting,
         viewer_id: Option<String>,
         tags: Option<Vec<String>>,
@@ -90,7 +91,7 @@ impl PostStream {
         let use_index = Self::can_use_index(&sorting, &source, &tags, &kind);
 
         let post_keys = match use_index {
-            true => Self::get_from_index(source, sorting, &tags, pagination).await?,
+            true => Self::get_from_index(source, sorting, order, &tags, pagination).await?,
             false => Self::get_from_graph(source, sorting, &tags, pagination, kind).await?,
         };
 
@@ -137,6 +138,7 @@ impl PostStream {
     async fn get_from_index(
         source: StreamSource,
         sorting: StreamSorting,
+        order: SortOrder,
         tags: &Option<Vec<String>>,
         pagination: Pagination,
     ) -> Result<Vec<String>, DynError> {
@@ -148,7 +150,7 @@ impl PostStream {
         match (source, tags) {
             // Global post streams
             (StreamSource::All, None) => {
-                Self::get_global_posts_keys(sorting, start, end, skip, limit).await
+                Self::get_global_posts_keys(sorting, order, start, end, skip, limit).await
             }
             // Streams by tags
             (StreamSource::All, Some(tags)) if tags.len() == 1 => {
@@ -156,22 +158,24 @@ impl PostStream {
             }
             // Bookmark streams
             (StreamSource::Bookmarks { observer_id }, None) => {
-                Self::get_bookmarked_posts(&observer_id, start, end, skip, limit).await
+                Self::get_bookmarked_posts(&observer_id, order, start, end, skip, limit).await
             }
             // Stream of replies to specific a post
             (StreamSource::PostReplies { author_id, post_id }, None) => {
-                Self::get_post_replies(&author_id, &post_id, start, end, limit).await
+                Self::get_post_replies(&author_id, &post_id, order, start, end, limit).await
             }
             // Stream of parent post from a given author
             (StreamSource::Author { author_id }, None) => {
-                Self::get_author_posts(&author_id, start, end, skip, limit, false).await
+                Self::get_author_posts(&author_id, order, start, end, skip, limit, false).await
             }
             // Streams of replies from a given author
             (StreamSource::AuthorReplies { author_id }, None) => {
-                Self::get_author_posts(&author_id, start, end, skip, limit, true).await
+                Self::get_author_posts(&author_id, order, start, end, skip, limit, true).await
             }
             // Streams by simple source/reach: Following, Followers, Friends
-            (source, None) => Self::get_posts_by_source(source, start, end, skip, limit).await,
+            (source, None) => {
+                Self::get_posts_by_source(source, order, start, end, skip, limit).await
+            }
             _ => Ok(vec![]),
         }
     }
@@ -212,6 +216,7 @@ impl PostStream {
 
     pub async fn get_global_posts_keys(
         sorting: StreamSorting,
+        order: SortOrder,
         start: Option<f64>,
         end: Option<f64>,
         skip: Option<usize>,
@@ -225,7 +230,7 @@ impl PostStream {
                     end,
                     skip,
                     limit,
-                    SortOrder::Descending,
+                    order,
                     None,
                 )
                 .await?
@@ -237,7 +242,7 @@ impl PostStream {
                     end,
                     skip,
                     limit,
-                    SortOrder::Descending,
+                    order,
                     None,
                 )
                 .await?
@@ -281,6 +286,7 @@ impl PostStream {
 
     pub async fn get_author_posts(
         user_id: &str,
+        order: SortOrder,
         start: Option<f64>,
         end: Option<f64>,
         skip: Option<usize>,
@@ -294,16 +300,9 @@ impl PostStream {
         };
 
         let key_parts = [&key_parts[..], &[user_id]].concat();
-        let post_ids = Self::try_from_index_sorted_set(
-            &key_parts,
-            start,
-            end,
-            skip,
-            limit,
-            SortOrder::Descending,
-            None,
-        )
-        .await?;
+        let post_ids =
+            Self::try_from_index_sorted_set(&key_parts, start, end, skip, limit, order, None)
+                .await?;
 
         if let Some(post_ids) = post_ids {
             let post_keys = post_ids
@@ -318,6 +317,7 @@ impl PostStream {
 
     pub async fn get_posts_by_source(
         source: StreamSource,
+        order: SortOrder,
         start: Option<f64>,
         end: Option<f64>,
         skip: Option<usize>,
@@ -353,6 +353,7 @@ impl PostStream {
 
             let post_keys = Self::get_posts_for_user_ids(
                 &user_ids.iter().map(AsRef::as_ref).collect::<Vec<_>>(),
+                order,
                 start,
                 end,
                 skip,
@@ -367,22 +368,16 @@ impl PostStream {
 
     pub async fn get_bookmarked_posts(
         user_id: &str,
+        order: SortOrder,
         start: Option<f64>,
         end: Option<f64>,
         skip: Option<usize>,
         limit: Option<usize>,
     ) -> Result<Vec<String>, DynError> {
         let key_parts = [&BOOKMARKS_USER_KEY_PARTS[..], &[user_id]].concat();
-        let post_keys = Self::try_from_index_sorted_set(
-            &key_parts,
-            start,
-            end,
-            skip,
-            limit,
-            SortOrder::Descending,
-            None,
-        )
-        .await?;
+        let post_keys =
+            Self::try_from_index_sorted_set(&key_parts, start, end, skip, limit, order, None)
+                .await?;
 
         if let Some(post_keys) = post_keys {
             Ok(post_keys.into_iter().map(|(key, _)| key).collect())
@@ -394,21 +389,15 @@ impl PostStream {
     pub async fn get_post_replies(
         author_id: &str,
         post_id: &str,
+        order: SortOrder,
         start: Option<f64>,
         end: Option<f64>,
         limit: Option<usize>,
     ) -> Result<Vec<String>, DynError> {
         let key_parts = [&POST_REPLIES_PER_POST_KEY_PARTS[..], &[author_id, post_id]].concat();
-        let post_replies = Self::try_from_index_sorted_set(
-            &key_parts,
-            start,
-            end,
-            None,
-            limit,
-            SortOrder::Ascending,
-            None,
-        )
-        .await?;
+        let post_replies =
+            Self::try_from_index_sorted_set(&key_parts, start, end, None, limit, order, None)
+                .await?;
         let replies_keys = post_replies.map_or(Vec::new(), |post_entry| {
             post_entry.into_iter().map(|(post_id, _)| post_id).collect()
         });
@@ -420,6 +409,7 @@ impl PostStream {
     // TODO rethink, we could also fallback to graph
     async fn get_posts_for_user_ids(
         user_ids: &[&str],
+        order: SortOrder,
         start: Option<f64>,
         end: Option<f64>,
         skip: Option<usize>,
@@ -440,7 +430,7 @@ impl PostStream {
                 end,
                 None, // We do not apply skip and limit here, as we need the full sorted set
                 None,
-                SortOrder::Descending,
+                order.clone(),
                 None,
             )
             .await?

--- a/nexus-watcher/tests/bookmarks/del.rs
+++ b/nexus-watcher/tests/bookmarks/del.rs
@@ -66,9 +66,16 @@ async fn test_homeserver_unbookmark() -> Result<()> {
     }
 
     // CACHE_OP: Assert the index is clear of the bookmark
-    let bookmarks = PostStream::get_bookmarked_posts(&bookmarker_id, None, None, None, None)
-        .await
-        .unwrap();
+    let bookmarks = PostStream::get_bookmarked_posts(
+        &bookmarker_id,
+        nexus_common::db::kv::SortOrder::Descending,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
     assert!(bookmarks.is_empty(), "The bookmark list should be empty");
 
     let exist_bookmark = Bookmark::get_from_index(&author_id, &post_id, &bookmarker_id)

--- a/nexus-watcher/tests/bookmarks/raw.rs
+++ b/nexus-watcher/tests/bookmarks/raw.rs
@@ -57,9 +57,16 @@ async fn test_homeserver_bookmark() -> Result<()> {
     assert_eq!(user_counts.bookmarks, 1);
 
     // INDEX_OP: Assert if the event writes the indexes
-    let result_bookmarks = PostStream::get_bookmarked_posts(&user_id, None, None, None, None)
-        .await
-        .unwrap();
+    let result_bookmarks = PostStream::get_bookmarked_posts(
+        &user_id,
+        nexus_common::db::kv::SortOrder::Descending,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
 
     assert_eq!(result_bookmarks.len(), 1);
     assert_eq!(result_bookmarks[0], format!("{}:{}", user_id, post_id));

--- a/nexus-watcher/tests/bookmarks/viewer.rs
+++ b/nexus-watcher/tests/bookmarks/viewer.rs
@@ -63,9 +63,16 @@ async fn test_homeserver_viewer_bookmark() -> Result<()> {
     assert_eq!(viewer_bookmark.id, bookmark_id);
 
     // INDEX_OP: Assert if the event writes the indexes
-    let result_bookmarks = PostStream::get_bookmarked_posts(&viewer_id, None, None, None, None)
-        .await
-        .unwrap();
+    let result_bookmarks = PostStream::get_bookmarked_posts(
+        &viewer_id,
+        nexus_common::db::kv::SortOrder::Descending,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
 
     assert_eq!(result_bookmarks.len(), 1);
     assert_eq!(result_bookmarks[0], format!("{}:{}", user_id, post_id));

--- a/nexus-watcher/tests/posts/reply.rs
+++ b/nexus-watcher/tests/posts/reply.rs
@@ -7,7 +7,7 @@ use crate::users::utils::find_user_counts;
 use crate::utils::watcher::WatcherTest;
 use anyhow::Result;
 use nexus_common::{
-    db::RedisOps,
+    db::{kv::SortOrder, RedisOps},
     models::post::{PostDetails, PostRelationships, PostStream},
 };
 use pubky::Keypair;
@@ -72,9 +72,16 @@ async fn test_homeserver_post_reply() -> Result<()> {
     // CACHE_OP: Check if the event writes in the index
     // ########### PARENT RELATED INDEXES ################
     // Sorted:Post:Replies:user_id:post_id
-    let post_replies = PostStream::get_post_replies(&user_id, &parent_post_id, None, None, None)
-        .await
-        .unwrap();
+    let post_replies = PostStream::get_post_replies(
+        &user_id,
+        &parent_post_id,
+        SortOrder::Descending,
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
     assert_eq!(post_replies.len(), 1);
     let post_key = format!("{}:{}", user_id, reply_id);
     assert_eq!(post_replies[0], post_key);


### PR DESCRIPTION
Sorting post replies in ascending order helps in a great way to fix https://github.com/pubky/pubky-app/issues/1241
as @flaviomoceri requested, `order=ascending|descending` can not be requested by the client.

# Pre-submission Checklist

> For tests to work you need a working neo4j and redis instance with the example dataset in `docker/db-graph`

- [ ] **Testing**: Implement and pass new tests for the new features/fixes, `cargo nextest run`.
- [ ] **Performance**: Ensure new code has relevant performance benchmarks, `cargo bench -p nexus-api`
