### PR TITLE
feat(api): add response compression with tower‑http

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,6 +178,22 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a194f9d963d8099596278594b3107448656ba73831c9d8c783e613ce86da64"
+dependencies = [
+ "brotli",
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "zstd",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -483,6 +514,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fa05ad7d803d413eb8380983b092cbbaf9a85f151b871360e7b00cd7060b37"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,6 +567,8 @@ version = "1.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c736e259eea577f443d5c86c304f9f4ae0295c43f3ba05c21f1d66b5f06001af"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -2032,6 +2086,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2307,7 +2370,6 @@ dependencies = [
  "opentelemetry_sdk",
  "pubky-app-specs",
  "redis",
- "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -4401,8 +4463,10 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
 dependencies = [
+ "async-compression",
  "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
@@ -5238,4 +5302,32 @@ dependencies = [
  "log",
  "once_cell",
  "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.13+zstd.1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/nexus-api/Cargo.toml
+++ b/nexus-api/Cargo.toml
@@ -25,8 +25,12 @@ serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.140"
 thiserror = "2.0.12"
 tokio = { version = "1.44.1", features = ["full"] }
-tower-http = { version = "0.6.2", features = ["fs", "cors"] }
-tracing = "0.1"
+tower-http = { version = "0.6.2", features = [
+    "fs",
+    "cors",
+    "compression-full",
+] }
+tracing = "0.1.41"
 utoipa = "5.3.1"
 utoipa-swagger-ui = { version = "9.0.0", features = ["axum"] }
 
@@ -36,8 +40,6 @@ criterion = { version = "0.5.1", features = ["async_tokio"] }
 httpc-test = "0.1.10"
 tokio-shared-rt = "0.1"
 url = "2.5.4"
-reqwest = "0.12.15"
-
 
 [[bench]]
 name = "user"

--- a/nexus-api/src/routes/mod.rs
+++ b/nexus-api/src/routes/mod.rs
@@ -1,5 +1,6 @@
 use axum::Router;
 use std::{path::PathBuf, sync::Arc};
+use tower_http::compression::CompressionLayer;
 use tower_http::cors::{Any, CorsLayer};
 use utoipa_swagger_ui::SwaggerUi;
 
@@ -44,9 +45,10 @@ pub fn routes(files_path: PathBuf) -> Router {
         .allow_methods(Any) // Allow all HTTP methods
         .allow_headers(Any); // Allow all headers
 
-    // Layer the CORS middleware on top of the routes
+    // Layer the CORS, tracing middleware, and compression on top of the routes
     app.layer(axum::middleware::from_fn(
         middlewares::tracing::tracing_middleware,
     ))
     .layer(cors)
+    .layer(CompressionLayer::new())
 }

--- a/nexus-api/tests/stream/post/posts.rs
+++ b/nexus-api/tests/stream/post/posts.rs
@@ -1,7 +1,7 @@
 use crate::utils::{get_request, invalid_get_request};
 use anyhow::Result;
+use axum::http::StatusCode;
 use nexus_common::models::post::PostStream;
-use reqwest::StatusCode;
 
 use super::utils::{search_tag_in_post, verify_post_list, verify_timeline_post_list};
 use super::{POST_A, POST_B, POST_C, POST_F, POST_G, POST_H};

--- a/nexus-api/tests/stream/user/influencers.rs
+++ b/nexus-api/tests/stream/user/influencers.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use reqwest::StatusCode;
+use axum::http::StatusCode;
 
 use crate::utils::{get_request, invalid_get_request};
 

--- a/nexus-api/tests/stream/user/list.rs
+++ b/nexus-api/tests/stream/user/list.rs
@@ -1,6 +1,6 @@
 use crate::utils::{invalid_post_request, post_request};
 use anyhow::Result;
-use reqwest::StatusCode;
+use axum::http::StatusCode;
 use serde_json::json;
 
 // ##### LIST OF USERS BY ID ######

--- a/nexus-api/tests/stream/user/score.rs
+++ b/nexus-api/tests/stream/user/score.rs
@@ -1,6 +1,6 @@
 use crate::utils::{get_request, invalid_get_request};
 use anyhow::Result;
-use reqwest::StatusCode;
+use axum::http::StatusCode;
 
 // ##### MOST FOLLOWED USERS ######
 

--- a/nexus-api/tests/tags/post.rs
+++ b/nexus-api/tests/tags/post.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
+use axum::http::StatusCode;
 use nexus_api::routes::v0::TaggersInfoDTO;
-use reqwest::StatusCode;
 
 use crate::{
     tags::user::PUBKY_PEER,

--- a/nexus-api/tests/tags/search.rs
+++ b/nexus-api/tests/tags/search.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use reqwest::StatusCode;
+use axum::http::StatusCode;
 use serde_json::Value;
 
 use crate::utils::{get_request, invalid_get_request};

--- a/nexus-api/tests/tags/user.rs
+++ b/nexus-api/tests/tags/user.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
+use axum::http::StatusCode;
 use nexus_api::routes::v0::TaggersInfoDTO;
-use reqwest::StatusCode;
 
 use crate::{
     tags::PEER_PUBKY,

--- a/nexus-api/tests/tags/wot.rs
+++ b/nexus-api/tests/tags/wot.rs
@@ -2,12 +2,12 @@ use super::utils::{analyse_tag_details_structure, compare_tag_details, TagMockup
 use crate::utils::server::TestServiceServer;
 use crate::utils::{get_request, invalid_get_request};
 use anyhow::Result;
+use axum::http::StatusCode;
 use nexus_api::routes::v0::TaggersInfoDTO;
 use nexus_common::db::get_redis_conn;
 use nexus_common::models::tag::TagDetails;
 use nexus_common::types::DynError;
 use redis::AsyncCommands;
-use reqwest::StatusCode;
 use serde_json::Value;
 
 // ##### WoT user tags ####

--- a/nexus-api/tests/user/reach.rs
+++ b/nexus-api/tests/user/reach.rs
@@ -1,6 +1,6 @@
 use crate::utils::{get_request, invalid_get_request};
 use anyhow::Result;
-use reqwest::StatusCode;
+use axum::http::StatusCode;
 
 #[tokio_shared_rt::test(shared)]
 async fn test_get_followers() -> Result<()> {

--- a/nexus-api/tests/user/search.rs
+++ b/nexus-api/tests/user/search.rs
@@ -1,6 +1,6 @@
 use crate::utils::{get_request, invalid_get_request};
 use anyhow::Result;
-use reqwest::StatusCode;
+use axum::http::StatusCode;
 
 #[tokio_shared_rt::test(shared)]
 async fn test_search_users_by_username() -> Result<()> {

--- a/nexus-api/tests/user/views.rs
+++ b/nexus-api/tests/user/views.rs
@@ -3,7 +3,7 @@ use crate::{
     utils::{get_request, invalid_get_request},
 };
 use anyhow::Result;
-use reqwest::StatusCode;
+use axum::http::StatusCode;
 
 #[tokio_shared_rt::test(shared)]
 async fn test_user_endpoint() -> Result<()> {

--- a/nexus-api/tests/utils/mod.rs
+++ b/nexus-api/tests/utils/mod.rs
@@ -1,4 +1,4 @@
-use reqwest::{Method, StatusCode};
+use axum::http::{Method, StatusCode};
 use serde_json::Value;
 use server::{TestServiceServer, SERVER_URL};
 


### PR DESCRIPTION
# Pre-submission Checklist

- Integrates CompressionLayer from tower‑http into the Axum stack
- Automatically compresses all responses to reduce payload size and improve performance
- Remove dev dependency `reqwest` that was not really needed as we can use `axum` types.

Request responses now transfer anywhere between 60%-90% more data. A `/stream/post` with 30 members transfer only `1.7Kb` vs `15.9Kb` before this PR on a modern browser using `zstd` . It also support `gzip`, `brotli` and `deflate` depending on browser's support.

> For tests to work you need a working neo4j and redis instance with the example dataset in `docker/db-graph`

- [ ] **Testing**: Implement and pass new tests for the new features/fixes, `cargo nextest run`.
- [ ] **Performance**: Ensure new code has relevant performance benchmarks, `cargo bench -p nexus-api`
