### PR TITLE
bug: add a custom limit for user reach in post streams

### DIFF
--- a/nexus-common/src/db/kv/index/sets.rs
+++ b/nexus-common/src/db/kv/index/sets.rs
@@ -79,6 +79,11 @@ pub async fn get_range(
 
     let mut skipped = 0;
 
+    println!(
+        "try_from_index_set: {:?}, SKIP: {:?}, LIMIT: {:?}",
+        index_key, skip, limit
+    );
+
     while collected.len() < limit {
         let result: (String, Vec<String>) = redis::cmd("SSCAN")
             .arg(&index_key)

--- a/nexus-common/src/db/kv/index/sets.rs
+++ b/nexus-common/src/db/kv/index/sets.rs
@@ -79,11 +79,6 @@ pub async fn get_range(
 
     let mut skipped = 0;
 
-    println!(
-        "try_from_index_set: {:?}, SKIP: {:?}, LIMIT: {:?}",
-        index_key, skip, limit
-    );
-
     while collected.len() < limit {
         let result: (String, Vec<String>) = redis::cmd("SSCAN")
             .arg(&index_key)

--- a/nexus-common/src/models/post/stream.rs
+++ b/nexus-common/src/models/post/stream.rs
@@ -323,27 +323,30 @@ impl PostStream {
         skip: Option<usize>,
         limit: Option<usize>,
     ) -> Result<Vec<String>, DynError> {
+        let custom_limit = limit.unwrap_or(200);
         let mut user_ids = match &source {
             StreamSource::Following { observer_id } => {
-                Following::get_by_id(observer_id, None, None)
+                Following::get_by_id(observer_id, None, Some(custom_limit))
                     .await?
                     .unwrap_or_default()
                     .0
             }
             StreamSource::Followers { observer_id } => {
-                Followers::get_by_id(observer_id, None, None)
+                Followers::get_by_id(observer_id, None, Some(custom_limit))
                     .await?
                     .unwrap_or_default()
                     .0
             }
             StreamSource::Friends { observer_id } => {
-                Friends::get_by_id(observer_id, None, None)
+                Friends::get_by_id(observer_id, None, Some(custom_limit))
                     .await?
                     .unwrap_or_default()
                     .0
             }
             _ => vec![],
         };
+
+        println!("{:?}", user_ids);
 
         if !user_ids.is_empty() {
             // Include the observer in the post stream

--- a/nexus-common/src/models/post/stream.rs
+++ b/nexus-common/src/models/post/stream.rs
@@ -323,22 +323,22 @@ impl PostStream {
         skip: Option<usize>,
         limit: Option<usize>,
     ) -> Result<Vec<String>, DynError> {
-        let custom_limit = limit.unwrap_or(200);
+        let custom_limit = Some(200);
         let mut user_ids = match &source {
             StreamSource::Following { observer_id } => {
-                Following::get_by_id(observer_id, None, Some(custom_limit))
+                Following::get_by_id(observer_id, None, custom_limit)
                     .await?
                     .unwrap_or_default()
                     .0
             }
             StreamSource::Followers { observer_id } => {
-                Followers::get_by_id(observer_id, None, Some(custom_limit))
+                Followers::get_by_id(observer_id, None, custom_limit)
                     .await?
                     .unwrap_or_default()
                     .0
             }
             StreamSource::Friends { observer_id } => {
-                Friends::get_by_id(observer_id, None, Some(custom_limit))
+                Friends::get_by_id(observer_id, None, custom_limit)
                     .await?
                     .unwrap_or_default()
                     .0

--- a/nexus-common/src/models/post/stream.rs
+++ b/nexus-common/src/models/post/stream.rs
@@ -346,8 +346,6 @@ impl PostStream {
             _ => vec![],
         };
 
-        println!("{:?}", user_ids);
-
         if !user_ids.is_empty() {
             // Include the observer in the post stream
             if let Some(observer_id) = source.get_observer() {


### PR DESCRIPTION
Previously, we were extracting 5 users in the applied reach

# Pre-submission Checklist

> For tests to work you need a working neo4j and redis instance with the example dataset in `docker/db-graph`

- [x] **Testing**: Implement and pass new tests for the new features/fixes, `cargo nextest run`.
- [x] **Performance**: Ensure new code has relevant performance benchmarks, `cargo bench -p nexus-api`
