### PR TITLE
fix: running timeframe hot tags

### DIFF
--- a/nexus-common/src/types/timeframe.rs
+++ b/nexus-common/src/types/timeframe.rs
@@ -25,12 +25,10 @@ impl Timeframe {
     pub fn to_timestamp_range(&self) -> (i64, i64) {
         let now = chrono::Utc::now();
         let start = match self {
-            Timeframe::Today => now
-                .date_naive()
-                .and_hms_opt(0, 0, 0)
-                .unwrap_or_default()
-                .and_utc()
-                .timestamp_millis(),
+            Timeframe::Today => (now - chrono::Duration::hours(24)).timestamp_millis(),
+            // TODO: This month should be a running month just like `Today`
+            // Timeframe::ThisMonth => (now - chrono::Duration::days(30)).timestamp_millis(),
+            // But we need to fix all tests.
             Timeframe::ThisMonth => now
                 .date_naive()
                 .with_day(1)


### PR DESCRIPTION
Fixes #398

# Pre-submission Checklist

> For tests to work you need a working neo4j and redis instance with the example dataset in `docker/db-graph`

- [x] **Testing**: Implement and pass new tests for the new features/fixes, `cargo nextest run`.
- [x] **Performance**: Ensure new code has relevant performance benchmarks, `cargo bench -p nexus-api`
