### PR TITLE
chore: fix influencers query (#411)

### DIFF
--- a/nexus-api/tests/tags/hot.rs
+++ b/nexus-api/tests/tags/hot.rs
@@ -646,11 +646,11 @@ async fn test_hot_tags_label_taggers_with_skip_limit_and_timeframe() -> Result<(
 
     assert_eq!(
         &taggers[0],
-        "r4irb481b8qspaixq1brwre8o87cxybsbk9iwe1f6f9ukrxxs7bo"
+        "qumq6fady4bmw4w5tpsrj1tg36g3qo4tcfedga9p4bg4so4ikyzy"
     );
     assert_eq!(
         &taggers[1],
-        "qumq6fady4bmw4w5tpsrj1tg36g3qo4tcfedga9p4bg4so4ikyzy"
+        "r4irb481b8qspaixq1brwre8o87cxybsbk9iwe1f6f9ukrxxs7bo"
     );
     Ok(())
 }

--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -515,27 +515,32 @@ pub fn get_influencers_by_reach(
         format!(
             "
         {}
-        WHERE user.id = $user_id
+        WHERE user.id = $user_id  
+        WITH DISTINCT reach
 
-        OPTIONAL MATCH (others:User)-[follow:FOLLOWS]->(reach)
-        
-        OPTIONAL MATCH (reach)-[tag:TAGGED]->(:Post)
-        WHERE tag.indexed_at >= $from AND tag.indexed_at < $to
-        
-        OPTIONAL MATCH (reach)-[:AUTHORED]->(post:Post)
-        WHERE post.indexed_at >= $from AND post.indexed_at < $to
+        CALL (reach) {{
+            MATCH (others:User)-[follow:FOLLOWS]->(reach)
+            RETURN count(DISTINCT follow) as followers_count
+        }}
+        CALL (reach) {{
+            MATCH (reach)-[tag:TAGGED]->(:Post)
+            WHERE tag.indexed_at >= $from AND tag.indexed_at < $to
+            RETURN count(DISTINCT tag) as tags_count
+        }}
+        CALL (reach) {{
+            MATCH (reach)-[:AUTHORED]->(post:Post)
+            WHERE post.indexed_at >= $from AND post.indexed_at < $to
+            RETURN count(DISTINCT post) as posts_count
+        }}
 
-        WITH    reach, 
-                COUNT(DISTINCT follow) AS followers_count, 
-                COUNT(DISTINCT tag) AS tags_count,
-                COUNT(DISTINCT post) AS posts_count
-
+        WITH reach, followers_count, tags_count, posts_count
         WITH {{
             id: reach.id,
             score: (tags_count + posts_count) * sqrt(followers_count)
         }} AS influencer
         ORDER BY influencer.score DESC
-        SKIP $skip LIMIT $limit
+        SKIP $skip 
+        LIMIT $limit
         RETURN COLLECT([influencer.id, influencer.score]) as influencers
     ",
             stream_reach_to_graph_subquery(&reach),

--- a/nexus-common/src/db/graph/setup.rs
+++ b/nexus-common/src/db/graph/setup.rs
@@ -15,6 +15,7 @@ pub async fn setup_graph() -> Result<(), Box<dyn std::error::Error>> {
         "CREATE INDEX postTimestampIndex IF NOT EXISTS FOR (p:Post) ON (p.indexed_at)",
         "CREATE INDEX postKindIndex IF NOT EXISTS FOR (p:Post) ON (p.kind)",
         "CREATE INDEX taggedLabelIndex IF NOT EXISTS FOR ()-[r:TAGGED]-() ON (r.label)",
+        "CREATE INDEX taggedTimestampIndex IF NOT EXISTS FOR ()-[r:TAGGED]-() ON (r.indexed_at)",
         "CREATE INDEX fileIdIndex IF NOT EXISTS FOR (f:File) ON (f.owner_id, f.id)",
     ];
 

--- a/nexus-common/src/db/kv/index/sorted_sets.rs
+++ b/nexus-common/src/db/kv/index/sorted_sets.rs
@@ -55,8 +55,7 @@ pub async fn check_member(
 ///
 /// * `prefix` - A string slice representing the prefix for the Redis keys.
 /// * `key` - A string slice representing the key under which the sorted set is stored.
-/// * `values` - A slice of tuples where each tuple contains a reference to a string slice representing
-///              the element and a f64 representing the score of the element.
+/// * `values` - A slice of tuples where each tuple contains a reference to a string slice representing the element and a f64 representing the score of the element.
 /// * `expiration` - An optional `i64` specifying the TTL (in seconds) for the set. If `None`, no TTL will be set.
 ///
 /// # Errors

--- a/nexus-common/src/models/tag/stream.rs
+++ b/nexus-common/src/models/tag/stream.rs
@@ -121,7 +121,7 @@ impl HotTags {
             Some(hot_tags) => hot_tags,
             None => return Ok(None),
         };
-        if hot_tags.len() > 0 {
+        if !hot_tags.is_empty() {
             HotTags::set_to_global_cache(hot_tags.clone(), hot_tags_input).await?;
         }
 

--- a/nexus-common/src/models/tag/traits/collection.rs
+++ b/nexus-common/src/models/tag/traits/collection.rs
@@ -357,7 +357,6 @@ where
     /// - `extra_param` - An optional parameter for additional context, such as a post ID.
     ///   If `Some`, the function retrieves and reindexes tags specific to the post;
     ///   if `None`, it reindexes tags globally for the author.
-
     async fn reindex(author_id: &str, extra_param: Option<&str>) -> Result<(), DynError> {
         match Self::get_from_graph(author_id, extra_param, None).await? {
             Some(tag_user) => Self::put_to_index(author_id, extra_param, &tag_user, false).await?,

--- a/nexus-common/src/models/traits.rs
+++ b/nexus-common/src/models/traits.rs
@@ -93,10 +93,7 @@ where
         let mut records = Vec::with_capacity(ids.len());
 
         while let Some(row) = result.next().await? {
-            let record: Option<Self> = match row.get("record") {
-                Ok(entry) => Some(entry),
-                Err(_e) => None,
-            };
+            let record: Option<Self> = row.get("record").ok();
             records.push(record);
         }
         Ok(records)

--- a/nexus-common/src/models/user/influencers.rs
+++ b/nexus-common/src/models/user/influencers.rs
@@ -56,7 +56,7 @@ impl Influencers {
         reach: Option<StreamReach>,
         skip: usize,
         limit: usize,
-        timeframe: &Timeframe,
+        timeframe: Timeframe,
         preview: bool,
     ) -> Result<Option<Influencers>, DynError> {
         let (skip, limit) = if preview {
@@ -69,19 +69,17 @@ impl Influencers {
         } else {
             (skip, limit)
         };
-        match user_id {
-            Some(user_id) => {
-                Influencers::get_influencers_by_reach(
-                    user_id,
-                    reach.unwrap_or(StreamReach::Friends),
-                    skip,
-                    limit,
-                    timeframe,
-                )
-                .await
-            }
-            None => Influencers::get_global_influencers(skip, limit, timeframe).await,
+        if let Some(user) = user_id.filter(|_| timeframe != Timeframe::AllTime) {
+            return Influencers::get_influencers_by_reach(
+                user,
+                reach.unwrap_or(StreamReach::Friends),
+                skip,
+                limit,
+                &timeframe,
+            )
+            .await;
         }
+        Influencers::get_global_influencers(skip, limit, &timeframe).await
     }
 
     /// It first attempts to fetch a subset of global influencers from cache

--- a/nexus-common/src/models/user/stream.rs
+++ b/nexus-common/src/models/user/stream.rs
@@ -321,7 +321,7 @@ impl UserStream {
                     Some(reach.unwrap_or(StreamReach::Wot(3))),
                     skip.unwrap_or(0),
                     limit.unwrap_or(10).min(100),
-                    &timeframe.unwrap_or(Timeframe::AllTime),
+                    timeframe.unwrap_or(Timeframe::AllTime),
                     preview.unwrap_or(false),
                 )
                 .await?

--- a/nexus-common/src/types/timeframe.rs
+++ b/nexus-common/src/types/timeframe.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 use std::fmt::Display;
 use utoipa::ToSchema;
 
-#[derive(Deserialize, Debug, ToSchema, Clone)]
+#[derive(Deserialize, Debug, ToSchema, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum Timeframe {
     Today,


### PR DESCRIPTION
* delete OPTIONAL MATCH in influencer cypher

* bump crates (#410)

* bump otlp (#409)

* chore(docs): add docstring and readme to crate modules (#382)

* deps: bump clap from 4.5.32 to 4.5.34 (#405)

Bumps [clap](https://github.com/clap-rs/clap) from 4.5.32 to 4.5.34.
- [Release notes](https://github.com/clap-rs/clap/releases)
- [Changelog](https://github.com/clap-rs/clap/blob/master/CHANGELOG.md)
- [Commits](https://github.com/clap-rs/clap/compare/clap_complete-v4.5.32...clap_complete-v4.5.34)

---
updated-dependencies:
- dependency-name: clap dependency-version: 4.5.34 dependency-type: direct:production update-type: version-update:semver-patch ...




* fix query: missing timeframe. Add new index, tag.indexed_at

* taggers vector order changed

* clippy lint

* even user_id is added in influencer endpoint and timeframe is all, query from cache

---------

# Pre-submission Checklist

> For tests to work you need a working neo4j and redis instance with the example dataset in `docker/db-graph`

- [ ] **Testing**: Implement and pass new tests for the new features/fixes, `cargo nextest run`.
- [ ] **Performance**: Ensure new code has relevant performance benchmarks, `cargo bench -p nexus-api`
