### PR TITLE
fix(common): redis with deadpool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -960,10 +960,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ed5957ff93768adf7a65ab167a17835c3d2c3c50d084fe305174c112f468e2f"
+dependencies = [
+ "deadpool-runtime",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-redis"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c136f185b3ca9d1f4e4e19c11570e1002f4bfdd592d589053e225716d613851f"
+dependencies = [
+ "deadpool 0.12.2",
+ "redis",
+]
+
+[[package]]
 name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+dependencies = [
+ "tokio",
+]
 
 [[package]]
 name = "delegate"
@@ -2249,7 +2273,7 @@ dependencies = [
  "bytes",
  "chrono",
  "chrono-tz",
- "deadpool",
+ "deadpool 0.9.5",
  "delegate",
  "futures",
  "log",
@@ -2313,6 +2337,7 @@ version = "0.4.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "deadpool-redis",
  "neo4rs",
  "once_cell",
  "opentelemetry",

--- a/nexus-common/Cargo.toml
+++ b/nexus-common/Cargo.toml
@@ -19,6 +19,7 @@ opentelemetry_sdk = { version = "0.29", features = ["rt-tokio"] }
 pubky = "0.4.2"
 pubky-app-specs = { version = "0.3.3", features = ["openapi"] }
 redis = { version = "0.29.5", features = ["tokio-comp", "json"] }
+deadpool-redis = "0.20.0"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.140"
 thiserror = "2.0.12"

--- a/nexus-common/src/db/connectors/redis.rs
+++ b/nexus-common/src/db/connectors/redis.rs
@@ -1,61 +1,46 @@
 use crate::types::DynError;
+use deadpool_redis::{Config, Connection, Pool, Runtime};
 use once_cell::sync::OnceCell;
-use redis::aio::MultiplexedConnection;
-use redis::Client;
 use std::fmt;
 
 pub struct RedisConnector {
-    client: OnceCell<Client>,
-}
-
-impl Default for RedisConnector {
-    fn default() -> Self {
-        Self::new()
-    }
+    pool: Pool,
 }
 
 impl RedisConnector {
-    pub fn new() -> Self {
-        Self {
-            client: OnceCell::new(),
-        }
+    /// Creates a new RedisConnector instance by building a connection pool using the provided URI.
+    pub async fn new_connection(uri: &str) -> Result<Self, DynError> {
+        // Create the deadpool-redis configuration from the URI.
+        let cfg = Config::from_url(uri.to_string());
+
+        // Create the connection pool. We use the Tokio runtime.
+        let pool = cfg.create_pool(Some(Runtime::Tokio1))?;
+        Ok(Self { pool })
     }
 
-    pub async fn connect(&self, uri: &str) -> Result<(), Box<dyn std::error::Error>> {
-        let client = Client::open(uri)?;
-        self.client
-            .set(client)
-            .map_err(|_| "Failed to set Redis client instance")?;
-        Ok(())
-    }
-
-    pub async fn new_connection(uri: &str) -> Result<Self, Box<dyn std::error::Error>> {
-        let redis_connector = RedisConnector::new();
-        redis_connector.connect(uri).await?;
-        Ok(redis_connector)
-    }
-
-    pub fn client(&self) -> &Client {
-        self.client.get().expect("Not connected to Redis")
+    /// Returns a reference to the underlying connection pool.
+    pub fn pool(&self) -> &Pool {
+        &self.pool
     }
 }
 
 impl fmt::Debug for RedisConnector {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RedisConnector")
-            .field("client", &"Redis client instance")
+            .field("pool", &"deadpool_redis::Pool")
             .finish()
     }
 }
 
-/// Retrieves a Redis connection.
-pub async fn get_redis_conn() -> Result<MultiplexedConnection, DynError> {
-    let redis_client = REDIS_CONNECTOR
-        .get()
-        .ok_or("RedisConnector not initialized")?
-        .client();
-    let redis_conn = redis_client.get_multiplexed_async_connection().await?;
-    Ok(redis_conn)
-}
-
+/// Global RedisConnector instance.
+/// Make sure to initialize this once when your application starts.
 pub static REDIS_CONNECTOR: OnceCell<RedisConnector> = OnceCell::new();
+
+/// Retrieves a Redis connection from the pool.
+pub async fn get_redis_conn() -> Result<Connection, DynError> {
+    let connector = REDIS_CONNECTOR
+        .get()
+        .ok_or("RedisConnector not initialized")?;
+    let conn = connector.pool().get().await?;
+    Ok(conn)
+}


### PR DESCRIPTION
Same as #420 but using `deadpool-redis` instead for hopefully better scalability.

# Pre-submission Checklist

> For tests to work you need a working neo4j and redis instance with the example dataset in `docker/db-graph`

- [ ] **Testing**: Implement and pass new tests for the new features/fixes, `cargo nextest run`.
- [ ] **Performance**: Ensure new code has relevant performance benchmarks, `cargo bench -p nexus-api`
