### PR TITLE
experimental: disable pkarr relays on watcher

### DIFF
--- a/nexus-common/src/db/connectors/pubky.rs
+++ b/nexus-common/src/db/connectors/pubky.rs
@@ -31,6 +31,7 @@ impl PubkyClient {
                         .build()
                         .map_err(|e| PubkyClientError::ClientError(e.to_string()))?,
                     false => Client::builder()
+                        .pkarr(|b| b.no_relays())
                         .build()
                         .map_err(|e| PubkyClientError::ClientError(e.to_string()))?,
                 };


### PR DESCRIPTION
As a matter of testing reliability without using pkarr relays.

# Pre-submission Checklist

> For tests to work you need a working neo4j and redis instance with the example dataset in `docker/db-graph`

- [ ] **Testing**: Implement and pass new tests for the new features/fixes, `cargo nextest run`.
- [ ] **Performance**: Ensure new code has relevant performance benchmarks, `cargo bench -p nexus-api`
