### PR TITLE
bug: stream query includes post replies

### DIFF
--- a/docker/test-graph/mocks/posts.cypher
+++ b/docker/test-graph/mocks/posts.cypher
@@ -224,3 +224,7 @@ MERGE (p:Post {id: "SIJW1TGL5BKG7"}) SET p.content = "LINK post, pubky G", p.kin
 MATCH (u:User {id: $eixample}), (p:Post {id: "SIJW1TGL5BKG7"}) MERGE (u)-[:AUTHORED]->(p);
 MERGE (p:Post {id: "SIJW1TGL5BKG8"}) SET p.content = "LINK post, pubky H", p.kind = "link", p.indexed_at = 1980477299368;
 MATCH (u:User {id: $eixample}), (p:Post {id: "SIJW1TGL5BKG8"}) MERGE (u)-[:AUTHORED]->(p);
+// It has a reply
+MERGE (p:Post {id: "SIJW1TGL5BKG9"}) SET p.content = "LINK post, pubky H", p.kind = "link", p.indexed_at = 1980477299378;
+MATCH (u:User {id: $eixample}), (p:Post {id: "SIJW1TGL5BKG9"}) MERGE (u)-[:AUTHORED]->(p);
+MATCH (reply:Post {id: "SIJW1TGL5BKG9" }), (parent:Post {id: "SIJW1TGL5BKG8" }) MERGE (reply)-[:REPLIED]->(parent)

--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -662,6 +662,14 @@ pub fn post_stream(
         append_condition(&mut cypher, "p.kind = $kind", &mut where_clause_applied);
     }
 
+    // Filter just the parent posts: StreamSource:PostReplies and StreamSource:AuthorReplies do not reach that query
+    // so we do not need any condition to filter just parent nodes
+    append_condition(
+        &mut cypher,
+        "NOT ( (p)-[:REPLIED]->(:Post) )",
+        &mut where_clause_applied,
+    );
+
     // Apply time interval conditions. Only can be applied with timeline sorting
     // The engagament score has to be computed
     if sorting == StreamSorting::Timeline {


### PR DESCRIPTION
# Pre-submission Checklist

> For tests to work you need a working neo4j and redis instance with the example dataset in `docker/db-graph`

- [ ] **Testing**: Implement and pass new tests for the new features/fixes, `cargo nextest run`.
- [ ] **Performance**: Ensure new code has relevant performance benchmarks, `cargo bench -p nexus-api`
