### PR TITLE
chore: rename cli config parameter in nexusd service

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ docker-compose up -d
 # Run with defaults values. The config file will default from $HOME/.pubky-nexus/config.toml
 cargo run -p nexusd
 # Run from config file
-cargo run -p nexusd -- --config="custom/config/folder"
+cargo run -p nexusd -- --config-dir="custom/config/folder"
 # There is also an option to run services individually
 # Useful to run a database clear command before start running the watcher
 # cargo run -p nexusd -- db clear

--- a/nexus-api/src/builder.rs
+++ b/nexus-api/src/builder.rs
@@ -98,14 +98,14 @@ impl NexusApi {
     }
 
     /// Loads the configuration from a file and starts the Nexus API
-    pub async fn start_from_path(config_file: PathBuf) -> Result<(), DynError> {
-        let config = ApiConfig::read_config_file(config_file).await?;
+    pub async fn start_from_path(config_dir: PathBuf) -> Result<(), DynError> {
+        let config = ApiConfig::read_config_file(config_dir).await?;
         NexusApiBuilder(config).start().await
     }
 
     /// Loads the configuration from nexusd service and starts the Nexus API
-    pub async fn start_from_daemon(config_file: PathBuf) -> Result<(), DynError> {
-        let config = DaemonConfig::read_config_file(config_file).await?;
+    pub async fn start_from_daemon(config_dir: PathBuf) -> Result<(), DynError> {
+        let config = DaemonConfig::read_config_file(config_dir).await?;
         NexusApiBuilder(Into::<ApiConfig>::into(config))
             .start()
             .await

--- a/nexus-watcher/src/builder.rs
+++ b/nexus-watcher/src/builder.rs
@@ -96,14 +96,14 @@ impl NexusWatcher {
     }
 
     /// Loads the configuration from a file and starts the Watcher
-    pub async fn start_from_path(config_file: PathBuf) -> Result<(), DynError> {
-        let config = WatcherConfig::read_config_file(config_file).await?;
+    pub async fn start_from_path(config_dir: PathBuf) -> Result<(), DynError> {
+        let config = WatcherConfig::read_config_file(config_dir).await?;
         NexusWatcherBuilder(config).start().await
     }
 
     /// Loads the configuration from nexusd service and starts the Watcher
-    pub async fn start_from_daemon(config_file: PathBuf) -> Result<(), DynError> {
-        let config = DaemonConfig::read_config_file(config_file).await?;
+    pub async fn start_from_daemon(config_dir: PathBuf) -> Result<(), DynError> {
+        let config = DaemonConfig::read_config_file(config_dir).await?;
         NexusWatcherBuilder(Into::<WatcherConfig>::into(config))
             .start()
             .await

--- a/nexusd/src/cli.rs
+++ b/nexusd/src/cli.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 pub struct Cli {
     /// Directory containing `config.toml`
     #[arg(short, long, default_value_os_t = default_config_dir_path(), value_parser = validate_config_dir_path)]
-    pub config: PathBuf,
+    pub config_dir: PathBuf,
 
     #[command(subcommand)]
     pub command: Option<NexusCommands>,
@@ -18,7 +18,7 @@ pub struct Cli {
 impl Cli {
     pub fn receive_command(cli: Cli) -> NexusCommands {
         match cli.command {
-            None => NexusCommands::Run { config: cli.config },
+            None => NexusCommands::Run { config_dir: cli.config_dir },
             Some(command) => command,
         }
     }
@@ -58,7 +58,7 @@ pub enum NexusCommands {
     Run {
         /// Path to the configuration file
         #[arg(short, long, default_value_os_t = default_config_dir_path(), value_parser = validate_config_dir_path)]
-        config: PathBuf,
+        config_dir: PathBuf,
     },
 }
 
@@ -66,14 +66,14 @@ pub enum NexusCommands {
 pub struct ApiArgs {
     /// Optional configuration file for the watcher
     #[arg(short, long, default_value_os_t = default_config_dir_path(), value_parser = validate_config_dir_path)]
-    pub config: PathBuf,
+    pub config_dir: PathBuf,
 }
 
 #[derive(Args, Debug)]
 pub struct WatcherArgs {
     /// Optional configuration file for the watcher
     #[arg(short, long, default_value_os_t = default_config_dir_path(), value_parser = validate_config_dir_path)]
-    pub config: PathBuf,
+    pub config_dir: PathBuf,
 }
 
 #[derive(Subcommand, Debug)]

--- a/nexusd/src/cli.rs
+++ b/nexusd/src/cli.rs
@@ -18,7 +18,9 @@ pub struct Cli {
 impl Cli {
     pub fn receive_command(cli: Cli) -> NexusCommands {
         match cli.command {
-            None => NexusCommands::Run { config_dir: cli.config_dir },
+            None => NexusCommands::Run {
+                config_dir: cli.config_dir,
+            },
             Some(command) => command,
         }
     }

--- a/nexusd/src/launcher.rs
+++ b/nexusd/src/launcher.rs
@@ -11,8 +11,8 @@ use tokio::join;
 pub struct DaemonLauncher {}
 
 impl DaemonLauncher {
-    pub async fn start(config_path: PathBuf) -> Result<(), DynError> {
-        let config = DaemonConfig::read_config_file(config_path).await?;
+    pub async fn start(config_dir: PathBuf) -> Result<(), DynError> {
+        let config = DaemonConfig::read_config_file(config_dir).await?;
         let nexus_api_builder = NexusApiBuilder::with_stack(config.api, &config.stack);
         let nexus_watcher_builder = NexusWatcherBuilder::with_stack(config.watcher, &config.stack);
         let _ = join!(nexus_api_builder.start(), nexus_watcher_builder.start());

--- a/nexusd/src/main.rs
+++ b/nexusd/src/main.rs
@@ -27,7 +27,9 @@ async fn main() -> Result<(), DynError> {
                 }
             },
         },
-        NexusCommands::Api(ApiArgs { config_dir }) => NexusApi::start_from_daemon(config_dir).await?,
+        NexusCommands::Api(ApiArgs { config_dir }) => {
+            NexusApi::start_from_daemon(config_dir).await?
+        }
         NexusCommands::Watcher(WatcherArgs { config_dir }) => {
             NexusWatcher::start_from_daemon(config_dir).await?
         }

--- a/nexusd/src/main.rs
+++ b/nexusd/src/main.rs
@@ -27,11 +27,11 @@ async fn main() -> Result<(), DynError> {
                 }
             },
         },
-        NexusCommands::Api(ApiArgs { config }) => NexusApi::start_from_daemon(config).await?,
-        NexusCommands::Watcher(WatcherArgs { config }) => {
-            NexusWatcher::start_from_daemon(config).await?
+        NexusCommands::Api(ApiArgs { config_dir }) => NexusApi::start_from_daemon(config_dir).await?,
+        NexusCommands::Watcher(WatcherArgs { config_dir }) => {
+            NexusWatcher::start_from_daemon(config_dir).await?
         }
-        NexusCommands::Run { config } => DaemonLauncher::start(config).await?,
+        NexusCommands::Run { config_dir } => DaemonLauncher::start(config_dir).await?,
     }
     Ok(())
 }


### PR DESCRIPTION
# Pre-submission Checklist

> For tests to work you need a working neo4j and redis instance with the example dataset in `docker/db-graph`

- [ ] **Testing**: Implement and pass new tests for the new features/fixes, `cargo nextest run`.
- [ ] **Performance**: Ensure new code has relevant performance benchmarks, `cargo bench -p nexus-api`
