### PR TITLE
Speed up local responsiveness by removing unnecessary recompilations

### DIFF
--- a/nexus-api/build.rs
+++ b/nexus-api/build.rs
@@ -12,8 +12,4 @@ fn main() {
 
     // Write the commit hash to an environment variable
     println!("cargo:rustc-env=GIT_COMMIT_HASH={}", git_hash);
-
-    // Re-run build.rs if .git/HEAD changes
-    println!("cargo:rerun-if-changed=../.git/HEAD");
-    println!("cargo:rerun-if-changed=../.git/refs/heads");
 }

--- a/nexus-api/build.rs
+++ b/nexus-api/build.rs
@@ -14,6 +14,6 @@ fn main() {
     println!("cargo:rustc-env=GIT_COMMIT_HASH={}", git_hash);
 
     // Re-run build.rs if .git/HEAD changes
-    println!("cargo:rerun-if-changed=.git/HEAD");
-    println!("cargo:rerun-if-changed=.git/refs/heads");
+    println!("cargo:rerun-if-changed=../.git/HEAD");
+    println!("cargo:rerun-if-changed=../.git/refs/heads");
 }


### PR DESCRIPTION
Before this PR, running any command that involved `nexus-api` code, like

```sh
cargo run -p nexusd -- db clear
```

resulted every time in ~7s of recompilation, even when no code was changed.

This is happening because the `build.rs` lines

```rust
println!("cargo:rerun-if-changed=.git/HEAD");
println!("cargo:rerun-if-changed=.git/refs/heads");
```

referenced files and folders in the workspace root's `.git` directory, from within a workspace member.

The path was incorrect, which led `cargo` to believe these files changed (cause they are missing => they were likely removed), which caused re-compilation on every run.

This PR fixes the paths, which removes unnecessary re-compilations when running commands locally.