### PR TITLE
Bump neo4j to v5.26.7

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   neo4j:
-    image: neo4j:5.24.2-community
+    image: neo4j:5.26.7-community
     container_name: neo4j
     restart: unless-stopped
     ports:


### PR DESCRIPTION
At the moment, nexus is using neo4j 5.24.2 community edition:
https://hub.docker.com/layers/library/neo4j/5.24.2-community/images/sha256-ffff134844a864de02be2f07eeb0e81ebd8c97b0a26f4cde981f5d4745bd559c

which has quite a bit of known vulnerabilities, compared to the latest 5.26.7:
https://hub.docker.com/layers/library/neo4j/5.26.7-community/images/sha256-a808dea9a2910966bfa6369fdb9293a34ac08217c14957c611f541b63e9ba925

5.26 is a LTS (long-term support) release and will receive hot fixes until June 2028:
https://neo4j.com/developer/kb/neo4j-supported-versions/

Therefore, this PR bumps neo4j to the latest 5.26 version.