### PR TITLE
Fix unreliable `unique_tags` counter

### DIFF
--- a/nexus-common/src/models/post/counts.rs
+++ b/nexus-common/src/models/post/counts.rs
@@ -111,8 +111,11 @@ impl PostCounts {
             match (score, &action) {
                 // to decrement `unique_tags`, the tag value must be less than or equal to 1
                 (Some(tag_value), JsonAction::Decrement(_)) if tag_value < 1 => (),
-                // to increment `unique_tags`, the tag must not exist in the sorted set
+
+                // to increment `unique_tags`, the tag must be less than 1, or not exist in the sorted set
+                (Some(tag_value), JsonAction::Increment(_)) if tag_value < 1 => (),
                 (None, JsonAction::Increment(_)) => (),
+
                 // Do not update the index
                 _ => return Ok(()),
             }

--- a/nexus-common/src/models/post/counts.rs
+++ b/nexus-common/src/models/post/counts.rs
@@ -109,11 +109,10 @@ impl PostCounts {
             let index_parts = [&POST_TAGS_KEY_PARTS[..], index_key].concat();
             let score = Self::check_sorted_set_member(None, &index_parts, &[label]).await?;
             match (score, &action) {
-                // to decrement `unique_tags`, the tag value must be less than or equal to 1
-                (Some(tag_value), JsonAction::Decrement(_)) if tag_value < 1 => (),
+                // If tag value is less than 1, `unique_tags` can be incremented or decremented
+                (Some(tag_value), _) if tag_value < 1 => (),
 
-                // to increment `unique_tags`, the tag must be less than 1, or not exist in the sorted set
-                (Some(tag_value), JsonAction::Increment(_)) if tag_value < 1 => (),
+                // Incrementing `unique_tags` is also allowed when the tag value doesn't exist yet in the sorted set
                 (None, JsonAction::Increment(_)) => (),
 
                 // Do not update the index

--- a/nexus-common/src/models/user/counts.rs
+++ b/nexus-common/src/models/user/counts.rs
@@ -119,8 +119,11 @@ impl UserCounts {
             match (score, &action) {
                 // to decrement `unique_tags`, the tag value must be less than or equal to 1
                 (Some(tag_value), JsonAction::Decrement(_)) if tag_value < 1 => (),
-                // to increment `unique_tags`, the tag must not exist in the sorted set
+
+                // to increment `unique_tags`, the tag must be less than 1, or not exist in the sorted set
+                (Some(tag_value), JsonAction::Increment(_)) if tag_value < 1 => (),
                 (None, JsonAction::Increment(_)) => (),
+
                 _ => return Ok(()),
             }
         }

--- a/nexus-common/src/models/user/counts.rs
+++ b/nexus-common/src/models/user/counts.rs
@@ -117,13 +117,13 @@ impl UserCounts {
             let index_parts = [&USER_TAGS_KEY_PARTS[..], &[user_id]].concat();
             let score = Self::check_sorted_set_member(None, &index_parts, &[label]).await?;
             match (score, &action) {
-                // to decrement `unique_tags`, the tag value must be less than or equal to 1
-                (Some(tag_value), JsonAction::Decrement(_)) if tag_value < 1 => (),
+                // If tag value is less than 1, `unique_tags` can be incremented or decremented
+                (Some(tag_value), _) if tag_value < 1 => (),
 
-                // to increment `unique_tags`, the tag must be less than 1, or not exist in the sorted set
-                (Some(tag_value), JsonAction::Increment(_)) if tag_value < 1 => (),
+                // Incrementing `unique_tags` is also allowed when the tag value doesn't exist yet in the sorted set
                 (None, JsonAction::Increment(_)) => (),
 
+                // Do not update the index
                 _ => return Ok(()),
             }
         }

--- a/nexus-watcher/tests/tags/post_put.rs
+++ b/nexus-watcher/tests/tags/post_put.rs
@@ -165,7 +165,7 @@ async fn test_homeserver_put_tag_post_unique_count() -> Result<()> {
         bio: Some("test_homeserver_put_tag_post_unique_count".to_string()),
         image: None,
         links: None,
-        name: "Watcher:PutTagPost:User".to_string(),
+        name: "Watcher:PutUniqueTag:Post".to_string(),
         status: None,
     };
     let tagger_user_id = test.create_user(&keypair, &tagger).await?;
@@ -180,7 +180,7 @@ async fn test_homeserver_put_tag_post_unique_count() -> Result<()> {
     };
     let post_id = test.create_post(&tagger_user_id, &post).await?;
 
-    let label = "merkle_tree";
+    let label = "tag-183";
     let tag = PubkyAppTag {
         uri: format!("pubky://{}/pub/pubky.app/posts/{}", tagger_user_id, post_id),
         label: label.to_string(),
@@ -229,12 +229,12 @@ async fn test_homeserver_put_tag_user_unique_count() -> Result<()> {
         bio: Some("test_homeserver_put_user_post_unique_count".to_string()),
         image: None,
         links: None,
-        name: "Watcher:PutTagUser:User".to_string(),
+        name: "Watcher:PutUniqueTag:User".to_string(),
         status: None,
     };
     let tagger_user_id = test.create_user(&keypair, &tagger).await?;
 
-    let label = "merkle_tree";
+    let label = "tag-237";
     let tag = PubkyAppTag {
         uri: format!("pubky://{tagger_user_id}/pub/pubky.app/profile.json"),
         label: label.to_string(),


### PR DESCRIPTION
This PR fixes an issue with the `unique_tags` counter in Redis indexes for both posts and users.

The problem can be reproduced as follows for users:

* create a new user with no new tags on its profile
* self-tag
* check the user counts at `/v0/user/{user_id}/counts`
  * they will include `tags: 1, unique_tags: 1`
* remove the user tag
* check the user counts at `/v0/user/{user_id}/counts`
  * they will include `tags: 0, unique_tags: 0`
* re-add the tag again
* check the user counts at `/v0/user/{user_id}/counts`
  * they will include `tags: 1, unique_tags: 0`
* from this point on, this discrepancy between `tags` and `unique_tags` will remain

In a similar way, it can be also reproduced for posts:

* create a new post with no new tags
* tag the post
* check the post tag counts at `/v0/post/{author_id}/{post_id}/counts`
  * they will include `tags: 1, unique_tags: 1`
* remove the post tag
* check the post tag counts at `/v0/post/{author_id}/{post_id}/counts`
  * they will include `tags: 0, unique_tags: 0`
* re-tag the post
* check the post tag counts at `/v0/post/{author_id}/{post_id}/counts`
  * they will include `tags: 1, unique_tags: 0`
 * from this point on, this discrepancy between `tags` and `unique_tags` will remain

With this PR's fix, `tags` and `unique_tags` remain in sync.

For the posts and users where `unique_tags` is already out of sync, a reindexing is needed.

Fixes https://github.com/pubky/pubky-app/issues/1400