### PR TITLE
Add nexus static files to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ docker/.env
 docker/.database*
 # Files
 /examples/static
+/nexus-api/static
+/nexus-watcher/static
 # Build artifacts
 /target
 # System-specific files


### PR DESCRIPTION
This is a cosmetic PR that improves dev experience.

Each time mock data is added and the tests are run, this generates quite a few static files in `nexus-api` and `nexus-watcher`. The git client shows them as untracked files, which clutters the UI and risks accidentally including them in a commit.

So this PR adds these static files to `.gitignore`.