### PR TITLE
Add autocomplete endpoint: user search by PK prefix

### DIFF
--- a/nexus-common/src/models/mod.rs
+++ b/nexus-common/src/models/mod.rs
@@ -7,3 +7,8 @@ pub mod post;
 pub mod tag;
 pub mod traits;
 pub mod user;
+
+/// Create tuples with a 0.0 score for each element, forcing the sorted set to support lexicographical search
+fn create_zero_score_tuples(strings: &[String]) -> Vec<(f64, &str)> {
+    strings.iter().map(|s| (0.0, s.as_str())).collect()
+}

--- a/nexus-watcher/src/events/handlers/tag.rs
+++ b/nexus-watcher/src/events/handlers/tag.rs
@@ -85,7 +85,7 @@ async fn put_sync_post(
         OperationOutcome::CreatedOrDeleted => {
             // SAVE TO INDEXES
             let post_key_slice: &[&str] = &[&author_id, post_id];
-            let tag_label_slice = &[tag_label];
+            let tag_label_slice = &[tag_label.to_string()];
 
             let indexing_results = tokio::join!(
                 // Update user counts for tagger
@@ -192,7 +192,7 @@ async fn put_sync_user(
             }
         }
         OperationOutcome::CreatedOrDeleted => {
-            let tag_label_slice = &[tag_label];
+            let tag_label_slice = &[tag_label.to_string()];
 
             // SAVE TO INDEX
             let indexing_results = tokio::join!(

--- a/nexus-webapi/src/routes/v0/endpoints.rs
+++ b/nexus-webapi/src/routes/v0/endpoints.rs
@@ -46,7 +46,9 @@ pub const STREAM_TAGS_REACH_ROUTE: &str =
 
 // -- SEARCH endpoints --
 const SEARCH_PREFIX: &str = concatcp!(VERSION_ROUTE, "/search");
-pub const SEARCH_USERS_ROUTE: &str = concatcp!(SEARCH_PREFIX, "/users");
+const SEARCH_USERS_ROUTE: &str = concatcp!(SEARCH_PREFIX, "/users");
+pub const SEARCH_USERS_BY_NAME_ROUTE: &str = concatcp!(SEARCH_USERS_ROUTE, "/by_name/{prefix}");
+pub const SEARCH_USERS_BY_ID_ROUTE: &str = concatcp!(SEARCH_USERS_ROUTE, "/by_id/{prefix}");
 pub const SEARCH_POSTS_BY_TAG_ROUTE: &str = concatcp!(SEARCH_PREFIX, "/posts/by_tag/{tag}");
 pub const SEARCH_TAGS_BY_PREFIX_ROUTE: &str = concatcp!(SEARCH_PREFIX, "/tags/by_prefix/{prefix}");
 

--- a/nexus-webapi/src/routes/v0/search/mod.rs
+++ b/nexus-webapi/src/routes/v0/search/mod.rs
@@ -8,9 +8,12 @@ mod posts;
 mod tags;
 mod users;
 
+pub const USER_ID_SEARCH_MIN_PREFIX_LEN: usize = 3;
+
 pub fn routes() -> Router<AppState> {
     register_routes!(Router::new(),
-        endpoints::SEARCH_USERS_ROUTE => users::search_users_handler,
+        endpoints::SEARCH_USERS_BY_NAME_ROUTE => users::search_users_by_name_handler,
+        endpoints::SEARCH_USERS_BY_ID_ROUTE=> users::search_users_by_id_handler,
         endpoints::SEARCH_POSTS_BY_TAG_ROUTE => posts::search_posts_by_tag_handler,
         endpoints::SEARCH_TAGS_BY_PREFIX_ROUTE => tags::search_tags_by_prefix_handler
     )

--- a/nexus-webapi/tests/user/search.rs
+++ b/nexus-webapi/tests/user/search.rs
@@ -1,12 +1,24 @@
 use crate::utils::{get_request, invalid_get_request};
 use anyhow::Result;
 use axum::http::StatusCode;
+use nexus_webapi::routes::v0::{
+    endpoints::{SEARCH_USERS_BY_ID_ROUTE, SEARCH_USERS_BY_NAME_ROUTE},
+    search::USER_ID_SEARCH_MIN_PREFIX_LEN,
+};
+
+fn format_search_users_by_name_prefix(prefix: &str) -> String {
+    SEARCH_USERS_BY_NAME_ROUTE.replace("{prefix}", prefix)
+}
+
+fn format_search_users_by_id_prefix(prefix: &str) -> String {
+    SEARCH_USERS_BY_ID_ROUTE.replace("{prefix}", prefix)
+}
 
 #[tokio_shared_rt::test(shared)]
 async fn test_search_users_by_username() -> Result<()> {
-    let username = "Jo";
-
-    let res = get_request(&format!("/v0/search/users?username={username}")).await?;
+    let user_prefix = "Jo";
+    let url_path = format_search_users_by_name_prefix(user_prefix);
+    let res = get_request(&url_path).await?;
 
     assert!(res.is_array());
 
@@ -37,14 +49,72 @@ async fn test_search_users_by_username() -> Result<()> {
 }
 
 #[tokio_shared_rt::test(shared)]
+async fn test_search_users_by_id_empty_id() -> Result<()> {
+    let url_path = format_search_users_by_id_prefix("");
+    invalid_get_request(&url_path, StatusCode::NOT_FOUND).await?;
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_search_users_by_id_invalid_prefix_length() -> Result<()> {
+    // Check if prefixes of at least 1 char, but lower than the min prefix limit are treated as invalid
+
+    for i in 1..USER_ID_SEARCH_MIN_PREFIX_LEN {
+        let invalid_prefix = "x".repeat(i).to_string();
+        let url_path = format_search_users_by_id_prefix(&invalid_prefix);
+        let res = invalid_get_request(&url_path, StatusCode::BAD_REQUEST).await?;
+
+        assert!(res["error"].is_string(), "Error message should be a string");
+        assert!(
+            res["error"]
+                .as_str()
+                .unwrap_or("")
+                .contains("ID prefix must be at least"),
+            "Error message should mention min size limit"
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_search_users_by_id() -> Result<()> {
+    // Check endpoint results for an ID prefix with a valid length
+    let id_prefix = "xte";
+    let url_path = format_search_users_by_id_prefix(id_prefix);
+    let res = get_request(&url_path).await?;
+
+    assert!(res.is_array());
+
+    let users = res
+        .as_array()
+        .expect("User search results should be an array");
+
+    // Define the expected user IDs
+    let expected_users = vec!["xtewe9x8yfuq5sr4tqrk5az47uz4qkt3gxaz5rms6nzugdfo8jao"];
+
+    // Convert the actual result to a Vec of strings
+    let actual_users: Vec<String> = users
+        .iter()
+        .map(|user| {
+            user.as_str()
+                .expect("User ID should be a string")
+                .to_string()
+        })
+        .collect();
+
+    // Assert that the actual result matches the expected result
+    assert_eq!(actual_users, expected_users);
+
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
 async fn test_search_non_existing_user() -> Result<()> {
     let non_existing_username = "idfjwfs8u9jfkoi"; // Username that doesn't exist
+    let url_path = format_search_users_by_name_prefix(non_existing_username);
 
-    let res = invalid_get_request(
-        &format!("/v0/search/users?username={non_existing_username}"),
-        StatusCode::NOT_FOUND,
-    )
-    .await?;
+    let res = invalid_get_request(&url_path, StatusCode::NOT_FOUND).await?;
 
     // Assert that the status code is 404 Not Found
     assert!(res["error"].is_string(), "Error message should be a string");
@@ -62,15 +132,13 @@ async fn test_search_non_existing_user() -> Result<()> {
 }
 
 #[tokio_shared_rt::test(shared)]
-async fn test_search_empty_username() -> Result<()> {
-    let empty_username = ""; // Empty username
+async fn test_search_non_existing_id() -> Result<()> {
+    let non_existing_id = "abcdef"; // User ID that doesn't exist
+    let url_path = format_search_users_by_id_prefix(non_existing_id);
 
-    let res = invalid_get_request(
-        &format!("/v0/search/users?username={empty_username}"),
-        StatusCode::BAD_REQUEST,
-    )
-    .await?;
+    let res = invalid_get_request(&url_path, StatusCode::NOT_FOUND).await?;
 
+    // Assert that the status code is 404 Not Found
     assert!(res["error"].is_string(), "Error message should be a string");
 
     // Optional: Check that the error message contains the correct details
@@ -78,9 +146,23 @@ async fn test_search_empty_username() -> Result<()> {
         res["error"]
             .as_str()
             .unwrap_or("")
-            .contains("Username cannot be empty"),
-        "Error message should mention that the username cannot be empty"
+            .contains(non_existing_id),
+        "Error message should mention the non-existing username"
     );
+
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_search_empty_username() -> Result<()> {
+    let empty_username = ""; // Empty username
+    let url_path = format_search_users_by_name_prefix(empty_username);
+
+    // Since the username is part of the prefix, empty username appears as if
+    // an unknown API endpoint is called, resulting in error 404 NOT_FOUND
+    // (server sees "/search/user/by_name" instead of expected "/search/user/by_name/{prefix}")
+    // Since it's thrown at router level, it has no message body
+    invalid_get_request(&url_path, StatusCode::NOT_FOUND).await?;
 
     Ok(())
 }


### PR DESCRIPTION
This PR adds a new endpoint `/search/users//by_id/{prefix}` that returns a list of User IDs based on the given ID prefix.

Fixes #446