### PR TITLE
Tag search: sanitize and validate query param

### DIFF
--- a/nexus-api/src/routes/v0/search/tags.rs
+++ b/nexus-api/src/routes/v0/search/tags.rs
@@ -6,6 +6,8 @@ use axum::Json;
 use nexus_common::models::post::search::PostsByTagSearch;
 use nexus_common::models::tag::search::TagSearch;
 use nexus_common::types::Pagination;
+use pubky_app_specs::traits::Validatable;
+use pubky_app_specs::PubkyAppTag;
 use serde::Deserialize;
 use tracing::info;
 use utoipa::OpenApi;
@@ -36,22 +38,39 @@ pub async fn search_tags_by_prefix_handler(
     Path(prefix): Path<String>,
     Query(query): Query<SearchTagsQuery>,
 ) -> Result<Json<Vec<TagSearch>>> {
+    let validated_prefix = sanitize_validate(&prefix)?;
+
     let mut pagination = query.pagination;
     pagination.skip.get_or_insert_default();
     pagination.limit.get_or_insert(20);
 
     info!(
-        "GET {SEARCH_TAGS_BY_PREFIX_ROUTE} prefix:{}, skip: {:?}, limit: {:?}",
-        prefix, pagination.skip, pagination.limit
+        "GET {SEARCH_TAGS_BY_PREFIX_ROUTE} validated_prefix:{}, skip: {:?}, limit: {:?}",
+        validated_prefix, pagination.skip, pagination.limit
     );
 
-    match TagSearch::get_by_label(&prefix, &pagination).await {
+    match TagSearch::get_by_label(&validated_prefix, &pagination).await {
         Ok(Some(tags_list)) => json_array_or_no_content(tags_list, "tags"),
         Ok(None) => Err(Error::TagsNotFound {
             reach: String::from("N/A"),
         }),
         Err(source) => Err(Error::InternalServerError { source }),
     }
+}
+
+fn sanitize_validate(tag_prefix: &str) -> Result<String> {
+    // Use a throwaway URI to build the tag instance, as we only need it for validation
+    let temp_tag = PubkyAppTag::new(
+        "pubky://user_pubky_id/pub/pubky.app/profile.json".into(),
+        tag_prefix.into(),
+    );
+
+    temp_tag
+        .validate(None)
+        .map_err(|e| Error::invalid_input(&format!("{e}")))?;
+
+    let sanitized = temp_tag.label;
+    Ok(sanitized)
 }
 
 #[derive(OpenApi)]

--- a/nexus-api/tests/tags/search.rs
+++ b/nexus-api/tests/tags/search.rs
@@ -30,6 +30,28 @@ async fn test_search_tags_by_prefix() -> Result<()> {
 }
 
 #[tokio_shared_rt::test(shared)]
+async fn test_search_tags_by_prefix_sanitized() -> Result<()> {
+    let label_prefix = "he "; // extra space at the end, sanitization should remove it
+    let url_path = format_search_tags_by_prefix(label_prefix);
+    let res = get_request(&url_path).await?;
+
+    assert!(res.is_array());
+
+    let fetched_tags: Vec<String> = res
+        .as_array()
+        .expect("Tag search results should be an array")
+        .iter()
+        .map(|tag| tag.as_str().expect("Tag should be a string").to_string())
+        .collect();
+
+    let expected_tags = vec!["healthily", "heavily", "hello"];
+
+    assert_eq!(fetched_tags, expected_tags);
+
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
 async fn test_search_non_existing_prefix() -> Result<()> {
     let non_existing_tag_prefix = "sdfsdf43fsddwt4g";
     let url_path = format_search_tags_by_prefix(non_existing_tag_prefix);


### PR DESCRIPTION
Sanitize and validate tag prefix, before processing the tag search.

Fixes #401