### PR TITLE
fix(watcher): moderate orphaned files

### DIFF
--- a/nexus-watcher/src/events/mod.rs
+++ b/nexus-watcher/src/events/mod.rs
@@ -153,7 +153,7 @@ impl Event {
             }
             (PubkyAppObject::Tag(tag), Resource::Tag(tag_id)) => {
                 if moderation.should_delete(&tag, user_id.clone()).await {
-                    Moderation::apply_moderation(tag).await?
+                    Moderation::apply_moderation(tag, self.files_path).await?
                 } else {
                     handlers::tag::sync_put(tag, user_id, tag_id).await?
                 }


### PR DESCRIPTION
The uploads to `/pub/pubky.app/files` are indexed in Nexus even if not used in any post or user profile.

That will instantly make them available in the indexer (copy). This fix allows for de-indexing them as well by the moderation service to make sure these are not served from Nexus if not fulfilling the content policies set.

> For tests to work you need a working neo4j and redis instance with the example dataset in `docker/db-graph`

- [ ] **Testing**: Implement and pass new tests for the new features/fixes, `cargo nextest run`.
- [ ] **Performance**: Ensure new code has relevant performance benchmarks, `cargo bench -p nexus-api`
