### PR TITLE
test: DEL post attachments

### DIFF
--- a/nexus-api/benches/bootstrap.rs
+++ b/nexus-api/benches/bootstrap.rs
@@ -22,7 +22,7 @@ fn bench_bootstrap_user(c: &mut Criterion) {
         |b, &id| {
             b.to_async(&rt).iter(|| async {
                 let user = Bootstrap::get_by_id(id, ViewType::Full).await.unwrap();
-                criterion::black_box(user.unwrap());
+                std::hint::black_box(user.unwrap());
             });
         },
     );

--- a/nexus-api/benches/follows.rs
+++ b/nexus-api/benches/follows.rs
@@ -22,7 +22,7 @@ fn bench_get_followers_by_id(c: &mut Criterion) {
         |b, &id| {
             b.to_async(&rt).iter(|| async {
                 let followers = Followers::get_by_id(id, None, None).await.unwrap();
-                criterion::black_box(followers);
+                std::hint::black_box(followers);
             });
         },
     );
@@ -44,7 +44,7 @@ fn bench_get_followers_from_graph(c: &mut Criterion) {
         |b, &id| {
             b.to_async(&rt).iter(|| async {
                 let followers = Followers::get_from_graph(id, None, None).await.unwrap();
-                criterion::black_box(followers);
+                std::hint::black_box(followers);
             });
         },
     );
@@ -66,7 +66,7 @@ fn bench_get_following_by_id(c: &mut Criterion) {
         |b, &id| {
             b.to_async(&rt).iter(|| async {
                 let following = Following::get_by_id(id, None, None).await.unwrap();
-                criterion::black_box(following);
+                std::hint::black_box(following);
             });
         },
     );
@@ -88,7 +88,7 @@ fn bench_get_following_from_graph(c: &mut Criterion) {
         |b, &id| {
             b.to_async(&rt).iter(|| async {
                 let following = Following::get_from_graph(id, None, None).await.unwrap();
-                criterion::black_box(following);
+                std::hint::black_box(following);
             });
         },
     );

--- a/nexus-api/benches/post.rs
+++ b/nexus-api/benches/post.rs
@@ -26,7 +26,7 @@ fn bench_get_post_by_id(c: &mut Criterion) {
                 let post = PostView::get_by_id(author_id, id, Some(viewer_id), None, None)
                     .await
                     .unwrap();
-                criterion::black_box(post);
+                std::hint::black_box(post);
             });
         },
     );
@@ -51,7 +51,7 @@ fn bench_get_post_details_by_id(c: &mut Criterion) {
         |b, &id| {
             b.to_async(&rt).iter(|| async {
                 let post = PostDetails::get_by_id(author_id, id).await.unwrap();
-                criterion::black_box(post);
+                std::hint::black_box(post);
             });
         },
     );
@@ -74,7 +74,7 @@ fn bench_get_post_details_from_graph(c: &mut Criterion) {
         |b, &id| {
             b.to_async(&rt).iter(|| async {
                 let post = PostDetails::get_from_graph(author_id, id).await.unwrap();
-                criterion::black_box(post);
+                std::hint::black_box(post);
             });
         },
     );
@@ -99,7 +99,7 @@ fn bench_get_post_counts_by_id(c: &mut Criterion) {
         |b, &id| {
             b.to_async(&rt).iter(|| async {
                 let post = PostCounts::get_by_id(author_id, id).await.unwrap();
-                criterion::black_box(post);
+                std::hint::black_box(post);
             });
         },
     );
@@ -122,7 +122,7 @@ fn bench_get_post_counts_from_graph(c: &mut Criterion) {
         |b, &id| {
             b.to_async(&rt).iter(|| async {
                 let post = PostCounts::get_from_graph(author_id, id).await.unwrap();
-                criterion::black_box(post);
+                std::hint::black_box(post);
             });
         },
     );
@@ -150,7 +150,7 @@ fn bench_get_post_bookmark_by_id(c: &mut Criterion) {
                 let post = Bookmark::get_by_id(author_id, id, Some(viewer_id))
                     .await
                     .unwrap();
-                criterion::black_box(post);
+                std::hint::black_box(post);
             });
         },
     );
@@ -176,7 +176,7 @@ fn bench_get_post_bookmark_from_graph(c: &mut Criterion) {
                 let post = Bookmark::get_from_graph(author_id, id, viewer_id)
                     .await
                     .unwrap();
-                criterion::black_box(post);
+                std::hint::black_box(post);
             });
         },
     );
@@ -201,7 +201,7 @@ fn bench_get_post_relationships_by_id(c: &mut Criterion) {
         |b, &id| {
             b.to_async(&rt).iter(|| async {
                 let post = PostRelationships::get_by_id(author_id, id).await.unwrap();
-                criterion::black_box(post);
+                std::hint::black_box(post);
             });
         },
     );
@@ -226,7 +226,7 @@ fn bench_get_post_relationships_from_graph(c: &mut Criterion) {
                 let post = PostRelationships::get_from_graph(author_id, id)
                     .await
                     .unwrap();
-                criterion::black_box(post);
+                std::hint::black_box(post);
             });
         },
     );

--- a/nexus-api/benches/search.rs
+++ b/nexus-api/benches/search.rs
@@ -27,7 +27,7 @@ fn bench_user_search(c: &mut Criterion) {
                 let result = UserSearch::get_by_name(username, None, Some(40))
                     .await
                     .unwrap();
-                criterion::black_box(result);
+                std::hint::black_box(result);
             });
         },
     );
@@ -50,7 +50,7 @@ fn bench_tag_search(c: &mut Criterion) {
         |b, &prefix| {
             b.to_async(&rt).iter(|| async {
                 let result = TagSearch::get_by_label(prefix, &pagination).await.unwrap();
-                criterion::black_box(result);
+                std::hint::black_box(result);
             });
         },
     );
@@ -80,7 +80,7 @@ fn bench_post_tag_search_by_timeline(c: &mut Criterion) {
                 let result = PostsByTagSearch::get_by_label(label, None, pagination)
                     .await
                     .unwrap();
-                criterion::black_box(result);
+                std::hint::black_box(result);
             });
         },
     );

--- a/nexus-api/benches/streams_benches/author.rs
+++ b/nexus-api/benches/streams_benches/author.rs
@@ -38,7 +38,7 @@ pub fn bench_stream_author_timeline(c: &mut Criterion) {
             )
             .await
             .unwrap();
-            criterion::black_box(post_stream);
+            std::hint::black_box(post_stream);
         });
     });
 }
@@ -71,7 +71,7 @@ pub fn bench_stream_author_total_engagement(c: &mut Criterion) {
             )
             .await
             .unwrap();
-            criterion::black_box(post_stream);
+            std::hint::black_box(post_stream);
         });
     });
 }
@@ -104,7 +104,7 @@ pub fn bench_stream_author_replies_timeline(c: &mut Criterion) {
             )
             .await
             .unwrap();
-            criterion::black_box(post_stream);
+            std::hint::black_box(post_stream);
         });
     });
 }

--- a/nexus-api/benches/streams_benches/bookmarks.rs
+++ b/nexus-api/benches/streams_benches/bookmarks.rs
@@ -37,7 +37,7 @@ pub fn bench_stream_bookmarks_timeline(c: &mut Criterion) {
             )
             .await
             .unwrap();
-            criterion::black_box(post_stream);
+            std::hint::black_box(post_stream);
         });
     });
 }
@@ -69,7 +69,7 @@ pub fn bench_stream_bookmarks_total_engagement(c: &mut Criterion) {
             )
             .await
             .unwrap();
-            criterion::black_box(post_stream);
+            std::hint::black_box(post_stream);
         });
     });
 }

--- a/nexus-api/benches/streams_benches/kind.rs
+++ b/nexus-api/benches/streams_benches/kind.rs
@@ -34,7 +34,7 @@ pub fn bench_stream_post_kind_short(c: &mut Criterion) {
             )
             .await
             .unwrap();
-            criterion::black_box(post_stream);
+            std::hint::black_box(post_stream);
         });
     });
 }
@@ -65,7 +65,7 @@ pub fn bench_stream_post_kind_long(c: &mut Criterion) {
             )
             .await
             .unwrap();
-            criterion::black_box(post_stream);
+            std::hint::black_box(post_stream);
         });
     });
 }
@@ -96,7 +96,7 @@ pub fn bench_stream_post_kind_image(c: &mut Criterion) {
             )
             .await
             .unwrap();
-            criterion::black_box(post_stream);
+            std::hint::black_box(post_stream);
         });
     });
 }
@@ -127,7 +127,7 @@ pub fn bench_stream_post_kind_video(c: &mut Criterion) {
             )
             .await
             .unwrap();
-            criterion::black_box(post_stream);
+            std::hint::black_box(post_stream);
         });
     });
 }
@@ -158,7 +158,7 @@ pub fn bench_stream_post_kind_link(c: &mut Criterion) {
             )
             .await
             .unwrap();
-            criterion::black_box(post_stream);
+            std::hint::black_box(post_stream);
         });
     });
 }
@@ -189,7 +189,7 @@ pub fn bench_stream_post_kind_file(c: &mut Criterion) {
             )
             .await
             .unwrap();
-            criterion::black_box(post_stream);
+            std::hint::black_box(post_stream);
         });
     });
 }

--- a/nexus-api/benches/streams_benches/reach.rs
+++ b/nexus-api/benches/streams_benches/reach.rs
@@ -37,7 +37,7 @@ pub fn bench_stream_followers_timeline(c: &mut Criterion) {
             )
             .await
             .unwrap();
-            criterion::black_box(post_stream);
+            std::hint::black_box(post_stream);
         });
     });
 }
@@ -70,7 +70,7 @@ pub fn bench_stream_following_timeline(c: &mut Criterion) {
             )
             .await
             .unwrap();
-            criterion::black_box(post_stream);
+            std::hint::black_box(post_stream);
         });
     });
 }
@@ -103,7 +103,7 @@ pub fn bench_stream_friends_timeline(c: &mut Criterion) {
             )
             .await
             .unwrap();
-            criterion::black_box(post_stream);
+            std::hint::black_box(post_stream);
         });
     });
 }
@@ -136,7 +136,7 @@ pub fn bench_stream_followers_total_engagement(c: &mut Criterion) {
             )
             .await
             .unwrap();
-            criterion::black_box(post_stream);
+            std::hint::black_box(post_stream);
         });
     });
 }
@@ -169,7 +169,7 @@ pub fn bench_stream_following_total_engagement(c: &mut Criterion) {
             )
             .await
             .unwrap();
-            criterion::black_box(post_stream);
+            std::hint::black_box(post_stream);
         });
     });
 }
@@ -202,7 +202,7 @@ pub fn bench_stream_friends_total_engagement(c: &mut Criterion) {
             )
             .await
             .unwrap();
-            criterion::black_box(post_stream);
+            std::hint::black_box(post_stream);
         });
     });
 }

--- a/nexus-api/benches/streams_benches/sorting.rs
+++ b/nexus-api/benches/streams_benches/sorting.rs
@@ -32,7 +32,7 @@ pub fn bench_stream_all_timeline(c: &mut Criterion) {
             )
             .await
             .unwrap();
-            criterion::black_box(post_stream);
+            std::hint::black_box(post_stream);
         });
     });
 }
@@ -63,7 +63,7 @@ pub fn bench_stream_all_total_engagement(c: &mut Criterion) {
             )
             .await
             .unwrap();
-            criterion::black_box(post_stream);
+            std::hint::black_box(post_stream);
         });
     });
 }

--- a/nexus-api/benches/streams_benches/tag.rs
+++ b/nexus-api/benches/streams_benches/tag.rs
@@ -35,7 +35,7 @@ pub fn bench_stream_tag_timeline(c: &mut Criterion) {
             )
             .await
             .unwrap();
-            criterion::black_box(post_stream);
+            std::hint::black_box(post_stream);
         });
     });
 }
@@ -66,7 +66,7 @@ pub fn bench_stream_tag_total_engagement(c: &mut Criterion) {
             )
             .await
             .unwrap();
-            criterion::black_box(post_stream);
+            std::hint::black_box(post_stream);
         });
     });
 }

--- a/nexus-api/benches/streams_benches/user.rs
+++ b/nexus-api/benches/streams_benches/user.rs
@@ -37,7 +37,7 @@ pub fn bench_stream_following(c: &mut Criterion) {
             )
             .await
             .unwrap();
-            criterion::black_box(user_stream);
+            std::hint::black_box(user_stream);
         });
     });
 }
@@ -70,7 +70,7 @@ pub fn bench_stream_most_followed(c: &mut Criterion) {
             )
             .await
             .unwrap();
-            criterion::black_box(user_stream);
+            std::hint::black_box(user_stream);
         });
     });
 }
@@ -95,7 +95,7 @@ pub fn bench_stream_users_by_username_search(c: &mut Criterion) {
             )
             .await
             .unwrap();
-            criterion::black_box(user_stream);
+            std::hint::black_box(user_stream);
         });
     });
 }
@@ -128,7 +128,7 @@ pub fn bench_stream_influencers(c: &mut Criterion) {
             )
             .await
             .unwrap();
-            criterion::black_box(user_stream);
+            std::hint::black_box(user_stream);
         });
     });
 }
@@ -163,7 +163,7 @@ pub fn bench_stream_post_replies(c: &mut Criterion) {
             )
             .await
             .unwrap();
-            criterion::black_box(user_stream);
+            std::hint::black_box(user_stream);
         });
     });
 }

--- a/nexus-api/benches/tag.rs
+++ b/nexus-api/benches/tag.rs
@@ -31,7 +31,7 @@ fn bench_get_user_tags(c: &mut Criterion) {
                 let tag_details_list = TagUser::get_by_id(id, None, None, None, None, None, None)
                     .await
                     .unwrap();
-                criterion::black_box(tag_details_list);
+                std::hint::black_box(tag_details_list);
             });
         },
     );
@@ -63,7 +63,7 @@ fn bench_get_wot_user_tags(c: &mut Criterion) {
                 )
                 .await
                 .unwrap();
-                criterion::black_box(tag_details_list);
+                std::hint::black_box(tag_details_list);
             });
         },
     );
@@ -88,7 +88,7 @@ fn bench_get_user_tag_taggers(c: &mut Criterion) {
                     TagUser::get_tagger_by_id(id, None, "pubky", Pagination::default(), None, None)
                         .await
                         .unwrap();
-                criterion::black_box(taggers);
+                std::hint::black_box(taggers);
             });
         },
     );
@@ -119,7 +119,7 @@ fn bench_get_wot_user_tag_taggers(c: &mut Criterion) {
                 )
                 .await
                 .unwrap();
-                criterion::black_box(taggers);
+                std::hint::black_box(taggers);
             });
         },
     );
@@ -148,7 +148,7 @@ fn bench_get_post_tags(c: &mut Criterion) {
                     TagPost::get_by_id(params[0], Some(params[1]), None, None, None, None, None)
                         .await
                         .unwrap();
-                criterion::black_box(tag_details_list);
+                std::hint::black_box(tag_details_list);
             });
         },
     );
@@ -182,7 +182,7 @@ fn bench_get_post_tag_taggers(c: &mut Criterion) {
                 )
                 .await
                 .unwrap();
-                criterion::black_box(taggers);
+                std::hint::black_box(taggers);
             });
         },
     );
@@ -201,7 +201,7 @@ fn bench_get_global_hot_tags(c: &mut Criterion) {
         b.to_async(&rt).iter(|| async {
             let input = HotTagsInputDTO::new(Timeframe::AllTime, 0, 40, 10, None);
             let stream_tag = HotTags::get_hot_tags(None, None, &input).await.unwrap();
-            criterion::black_box(stream_tag);
+            std::hint::black_box(stream_tag);
         });
     });
 }
@@ -231,7 +231,7 @@ fn bench_get_global_tag_taggers(c: &mut Criterion) {
                 )
                 .await
                 .unwrap();
-                criterion::black_box(tag_taggers);
+                std::hint::black_box(tag_taggers);
             });
         },
     );
@@ -272,7 +272,7 @@ fn bench_get_following_reach_hot_tags(c: &mut Criterion) {
                 )
                 .await
                 .unwrap();
-                criterion::black_box(profile);
+                std::hint::black_box(profile);
             });
         },
     );
@@ -313,7 +313,7 @@ fn bench_get_followers_reach_hot_tags(c: &mut Criterion) {
                 )
                 .await
                 .unwrap();
-                criterion::black_box(profile);
+                std::hint::black_box(profile);
             });
         },
     );
@@ -354,7 +354,7 @@ fn bench_get_friends_reach_hot_tags(c: &mut Criterion) {
                 )
                 .await
                 .unwrap();
-                criterion::black_box(profile);
+                std::hint::black_box(profile);
             });
         },
     );

--- a/nexus-api/benches/user.rs
+++ b/nexus-api/benches/user.rs
@@ -54,7 +54,7 @@ fn bench_get_full_by_id(c: &mut Criterion) {
                 let user = UserView::get_by_id(id, Some(viewer_id), None)
                     .await
                     .unwrap();
-                criterion::black_box(user);
+                std::hint::black_box(user);
             });
         },
     );
@@ -77,7 +77,7 @@ fn bench_get_relationship_by_id(c: &mut Criterion) {
         |b, &id| {
             b.to_async(&rt).iter(|| async {
                 let relationship = Relationship::get_by_id(id, Some(viewer_id)).await.unwrap();
-                criterion::black_box(relationship);
+                std::hint::black_box(relationship);
             });
         },
     );
@@ -99,7 +99,7 @@ fn bench_get_counts_from_graph(c: &mut Criterion) {
         |b, &id| {
             b.to_async(&rt).iter(|| async {
                 let counts = UserCounts::get_from_graph(id).await.unwrap();
-                criterion::black_box(counts);
+                std::hint::black_box(counts);
             });
         },
     );
@@ -121,7 +121,7 @@ fn bench_get_counts_by_id(c: &mut Criterion) {
         |b, &id| {
             b.to_async(&rt).iter(|| async {
                 let counts = UserCounts::get_by_id(id).await.unwrap();
-                criterion::black_box(counts);
+                std::hint::black_box(counts);
             });
         },
     );
@@ -143,7 +143,7 @@ fn bench_get_details_from_graph(c: &mut Criterion) {
         |b, &id| {
             b.to_async(&rt).iter(|| async {
                 let details = UserDetails::get_from_graph(&[id]).await.unwrap();
-                criterion::black_box(details);
+                std::hint::black_box(details);
             });
         },
     );
@@ -165,7 +165,7 @@ fn bench_get_details_by_id(c: &mut Criterion) {
         |b, &id| {
             b.to_async(&rt).iter(|| async {
                 let details = UserDetails::get_by_id(id).await.unwrap();
-                criterion::black_box(details);
+                std::hint::black_box(details);
             });
         },
     );
@@ -186,7 +186,7 @@ fn bench_get_details_by_ids_list(c: &mut Criterion) {
         |b, &user_ids| {
             b.to_async(&rt).iter(|| async {
                 let user_details = UserDetails::get_by_ids(&user_ids).await.unwrap();
-                criterion::black_box(user_details);
+                std::hint::black_box(user_details);
             });
         },
     );
@@ -209,7 +209,7 @@ fn bench_get_details_by_ids_list_from_graph(c: &mut Criterion) {
         |b, &user_ids| {
             b.to_async(&rt).iter(|| async {
                 let user_details = UserDetails::get_by_ids(&user_ids).await.unwrap();
-                criterion::black_box(user_details);
+                std::hint::black_box(user_details);
             });
         },
     );

--- a/nexus-watcher/tests/posts/del_with_attachments.rs
+++ b/nexus-watcher/tests/posts/del_with_attachments.rs
@@ -1,0 +1,95 @@
+use std::path::Path;
+
+use crate::posts::utils::find_post_details;
+use crate::utils::watcher::WatcherTest;
+use anyhow::Result;
+use chrono::Utc;
+use nexus_common::models::{file::FileDetails, traits::Collection};
+use pubky::Keypair;
+use pubky_app_specs::{
+    traits::{HasIdPath, HashId},
+    PubkyAppBlob, PubkyAppFile, PubkyAppPost, PubkyAppPostKind, PubkyAppUser,
+};
+
+#[tokio_shared_rt::test(shared)]
+async fn test_homeserver_del_post_with_attachments() -> Result<()> {
+    let mut test = WatcherTest::setup().await?;
+
+    let keypair = Keypair::random();
+    let user = PubkyAppUser {
+        bio: Some("test_homeserver_del_post_with_attachments".to_string()),
+        image: None,
+        links: None,
+        name: "Watcher:DelWithAttachmentEvent:User".to_string(),
+        status: None,
+    };
+
+    let user_id = test.create_user(&keypair, &user).await?;
+
+    let mut file_urls = Vec::new();
+    let mut file_ids = Vec::new();
+
+    for i in 0..2 {
+        let blob_data = format!("DEL me, im part of attachment of file {}", i + 1);
+        let blob = PubkyAppBlob::new(blob_data.as_bytes().to_vec());
+        let blob_id = blob.create_id();
+        let blob_url = format!("pubky://{}{}", user_id, blob.create_path(&blob_id));
+
+        test.create_file_from_body(blob_url.as_str(), blob.0.clone())
+            .await?;
+        test.ensure_event_processing_complete().await?;
+
+        let file = PubkyAppFile {
+            name: format!("post_attachment_DEL-{}", i),
+            content_type: "text/plain".to_string(),
+            src: blob_url.clone(),
+            size: blob.0.len(),
+            created_at: Utc::now().timestamp_millis(),
+        };
+        let (file_id, file_url) = test.create_file(&user_id, &file).await?;
+        file_urls.push(file_url);
+        file_ids.push(file_id);
+    }
+
+    let post = PubkyAppPost {
+        content: "Watcher:DelWithAttachmentEvent:Post".to_string(),
+        kind: PubkyAppPostKind::Short,
+        parent: None,
+        embed: None,
+        attachments: Some(file_urls.clone()),
+    };
+
+    let post_id = test.create_post(&user_id, &post).await?;
+
+    let post_details = find_post_details(&user_id, &post_id).await.unwrap();
+
+    assert_eq!(post_details.id, post_id);
+    assert_eq!(post_details.content, post.content);
+    assert_eq!(post_details.attachments, Some(file_urls));
+
+    // Cleanup
+    test.cleanup_post(&user_id, &post_id).await?;
+    // If the post has attachments, it also needs to send DEL event
+    test.cleanup_file(&user_id, &file_ids[0]).await?;
+    test.cleanup_file(&user_id, &file_ids[1]).await?;
+
+    for i in 0..2 {
+        let files = FileDetails::get_by_ids(
+            vec![vec![user_id.as_str(), file_ids[i].as_str()].as_slice()].as_slice(),
+        )
+        .await
+        .expect("Failed to fetch files from Nexus");
+
+        let result_file = files[0].as_ref();
+        assert!(result_file.is_none());
+
+        // Assert: Ensure it's deleted
+        let blob_static_path = format!("./static/files/{}/{}/main", &user_id, &file_ids[i]);
+        assert!(
+            !Path::new(&blob_static_path).exists(),
+            "File cannot exist after DEL event"
+        );
+    }
+
+    Ok(())
+}

--- a/nexus-watcher/tests/posts/mod.rs
+++ b/nexus-watcher/tests/posts/mod.rs
@@ -6,6 +6,7 @@ mod del_bookmarked_notification;
 mod del_repost_notification;
 mod del_reposted_notification;
 mod del_tagged_notification;
+mod del_with_attachments;
 mod del_with_relations;
 mod del_without_relations;
 mod edit_bookmarked_notification;


### PR DESCRIPTION
- Fixes deprecation warning for the criterion crate: WARNING - _use of deprecated function `criterion::black_box`: use `std::hint::black_box()`_
- Adds a new integration test for the `DEL` action on posts with attachments

# Pre-submission Checklist

> For tests to work you need a working neo4j and redis instance with the example dataset in `docker/db-graph`

- [x] **Testing**: Implement and pass new tests for the new features/fixes, `cargo nextest run`.
- [x] **Performance**: Ensure new code has relevant performance benchmarks, `cargo bench -p nexus-api`
