### PR TITLE
Bump `clap` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,9 +647,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.39"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -657,9 +657,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.39"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
 dependencies = [
  "anstream",
  "anstyle",
@@ -669,9 +669,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.32"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = ["nexus-api", "nexus-common", "nexus-watcher", "nexusd", "examples"]
 [workspace.dependencies]
 async-trait = "0.1.88"
 chrono = { version = "0.4.41", default-features = false, features = ["clock"] }
+clap = "4.5.40"
 neo4rs = "0.8.0"
 opentelemetry = "0.30"
 opentelemetry_sdk = { version = "0.30", features = ["rt-tokio"] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -18,4 +18,4 @@ nexus-common = { path = "../nexus-common" }
 nexus-api = { path = "../nexus-api" }
 nexus-watcher = { path = "../nexus-watcher" }
 pubky-app-specs = "0.3.4"
-clap = "4.5.39"
+clap = { workspace = true }

--- a/nexus-api/Cargo.toml
+++ b/nexus-api/Cargo.toml
@@ -13,7 +13,7 @@ async-trait = { workspace = true }
 axum = "0.8.4"
 axum-server = "0.7.2"
 chrono = { workspace = true }
-clap = { version = "4.5.39", features = ["derive"] }
+clap = { workspace = true, features = ["derive"] }
 const_format = "0.2.34"
 neo4rs = { workspace = true }
 once_cell = "1.21.3"

--- a/nexusd/Cargo.toml
+++ b/nexusd/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 async-trait = { workspace = true }
 dirs = "6.0.0"
 chrono = { workspace = true }
-clap = { version = "4.5.39", features = ["derive"] }
+clap = { workspace = true, features = ["derive"] }
 neo4rs = { workspace = true }
 nexus-api = { version = "0.4.0", path = "../nexus-api" }
 nexus-common = { version = "0.4.0", path = "../nexus-common" }


### PR DESCRIPTION
This PR bumps `clap` to the latest version and moves its definition in the workspace `Cargo.toml`.

Supersedes #478