### PR TITLE
Bump `toml` dependency, add toml parsing test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2563,6 +2563,7 @@ dependencies = [
  "nexus-webapi",
  "pubky-app-specs",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -2604,6 +2605,7 @@ dependencies = [
  "const_format",
  "criterion",
  "deadpool-redis",
+ "futures-util",
  "httpc-test",
  "neo4rs",
  "nexus-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2614,6 +2614,7 @@ dependencies = [
  "opentelemetry_sdk",
  "pkarr",
  "pubky-app-specs",
+ "pubky-testnet",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2563,7 +2563,6 @@ dependencies = [
  "nexus-webapi",
  "pubky-app-specs",
  "tokio",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2616,6 +2616,7 @@ dependencies = [
  "pubky-app-specs",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.12",
  "tokio",
  "tokio-shared-rt",
@@ -4544,9 +4545,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
  "getrandom 0.3.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,6 +745,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-hex"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e22e0ed40b96a48d3db274f72fd365bd78f67af39b6bbd47e8a15e1c6207ff"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "hex",
+ "proptest",
+ "serde",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2587,6 +2600,7 @@ dependencies = [
  "axum-server",
  "chrono",
  "clap",
+ "const-hex",
  "const_format",
  "criterion",
  "deadpool-redis",
@@ -2596,6 +2610,7 @@ dependencies = [
  "once_cell",
  "opentelemetry",
  "opentelemetry_sdk",
+ "pkarr",
  "pubky-app-specs",
  "serde",
  "serde_json",
@@ -3295,6 +3310,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
+dependencies = [
+ "bitflags",
+ "lazy_static",
+ "num-traits",
+ "rand 0.9.1",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax 0.8.5",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3658,6 +3689,15 @@ checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
  "rand 0.9.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -4983,6 +5023,12 @@ name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2543,9 +2543,11 @@ dependencies = [
  "redis",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.12",
  "tokio",
- "toml",
+ "tokio-shared-rt",
+ "toml 0.9.2",
  "tracing",
  "tracing-log",
  "tracing-subscriber",
@@ -3156,7 +3158,7 @@ dependencies = [
  "serde",
  "thiserror 2.0.12",
  "tokio",
- "toml",
+ "toml 0.8.23",
  "tower-http",
  "tower_governor",
  "tracing",
@@ -3474,7 +3476,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tokio-util",
- "toml",
+ "toml 0.8.23",
  "tower",
  "tower-cookies",
  "tower-http",
@@ -4262,6 +4264,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4776,9 +4787,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed0aee96c12fa71097902e0bb061a5e1ebd766a6636bb605ba401c45c1650eac"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned 1.0.0",
+ "toml_datetime 0.7.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
@@ -4791,6 +4817,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4798,9 +4833,18 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97200572db069e74c512a14117b296ba0a80a30123fbbb5aa1f4a348f639ca30"
+dependencies = [
  "winnow",
 ]
 
@@ -4809,6 +4853,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tonic"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ opentelemetry = "0.30"
 opentelemetry_sdk = { version = "0.30", features = ["rt-tokio"] }
 pubky = "0.5.1"
 pubky-app-specs = { version = "0.3.4", features = ["openapi"] }
+pubky-testnet = "0.5.1"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 tempfile = { version = "3.20" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ pubky = "0.5.1"
 pubky-app-specs = { version = "0.3.4", features = ["openapi"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
+tempfile = { version = "3.20" }
 thiserror = "2.0.12"
 tokio = { version = "1.46.1", features = ["full"] }
 tracing = "0.1.41"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,5 @@ serde_json = "1.0.140"
 tempfile = { version = "3.20" }
 thiserror = "2.0.12"
 tokio = { version = "1.46.1", features = ["full"] }
+tokio-shared-rt = "0.1"
 tracing = "0.1.41"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -19,3 +19,4 @@ nexus-webapi = { path = "../nexus-webapi" }
 nexus-watcher = { path = "../nexus-watcher" }
 pubky-app-specs = "0.3.4"
 clap = { workspace = true }
+tracing = { workspace = true }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -19,4 +19,3 @@ nexus-webapi = { path = "../nexus-webapi" }
 nexus-watcher = { path = "../nexus-watcher" }
 pubky-app-specs = { workspace = true }
 clap = { workspace = true }
-tracing = { workspace = true }

--- a/examples/api/api-config.toml
+++ b/examples/api/api-config.toml
@@ -1,6 +1,7 @@
 # Service name used for tracing, logging, and metrics in OpenTelemetry
 name = "nexus.example.api"
 public_addr = "127.0.0.1:8081"
+pubky_listen_socket = "127.0.0.1:8082"
 
 [stack]
 # Logging, options: error, warn, info, debug and trace

--- a/examples/api/main.rs
+++ b/examples/api/main.rs
@@ -16,10 +16,10 @@ struct Opt {
 async fn main() -> Result<(), DynError> {
     let opts = Opt::parse();
 
-    match opts.config {
+    let _nexus_api_handle = match opts.config {
         Some(path) => {
             let expanded_path = validate_and_expand_path(path)?;
-            NexusApi::start_from_path(expanded_path).await?;
+            NexusApi::start_from_path(expanded_path).await?
         }
         None => {
             let api_config = ApiConfig {
@@ -33,9 +33,9 @@ async fn main() -> Result<(), DynError> {
                 .try_build()
                 .await?;
 
-            NexusApiBuilder(api_context).start().await?;
+            NexusApiBuilder(api_context).start().await?
         }
-    }
+    };
 
     tracing::info!("Press Ctrl+C to stop the Nexus API");
     tokio::signal::ctrl_c().await?;

--- a/examples/api/main.rs
+++ b/examples/api/main.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use nexus_common::{file::validate_and_expand_path, types::DynError, ApiConfig, StackConfig};
-use nexus_webapi::{NexusApi, NexusApiBuilder};
+use nexus_webapi::{api_context::ApiContextBuilder, NexusApi, NexusApiBuilder};
 use std::{net::SocketAddr, path::PathBuf};
 
 #[derive(Parser)]
@@ -22,12 +22,18 @@ async fn main() -> Result<(), DynError> {
             NexusApi::start_from_path(expanded_path).await?
         }
         None => {
-            let config = ApiConfig {
+            let api_config = ApiConfig {
                 name: String::from("nexusd.api"),
                 public_addr: SocketAddr::from(([127, 0, 0, 1], 8081)),
                 stack: StackConfig::default(),
             };
-            NexusApiBuilder(config).start().await?;
+
+            let api_context = ApiContextBuilder::from_default_config_dir()
+                .api_config(api_config)
+                .try_build()
+                .await?;
+
+            NexusApiBuilder(api_context).start().await?;
         }
     }
 

--- a/examples/api/main.rs
+++ b/examples/api/main.rs
@@ -38,9 +38,9 @@ async fn main() -> Result<(), DynError> {
         }
     };
 
-    tracing::info!("Press Ctrl+C to stop the Nexus API");
+    println!("Press Ctrl+C to stop the Nexus API");
     tokio::signal::ctrl_c().await?;
-    tracing::info!("Shutting down Nexus API");
+    println!("Shutting down Nexus API");
 
     Ok(())
 }

--- a/examples/api/main.rs
+++ b/examples/api/main.rs
@@ -25,6 +25,7 @@ async fn main() -> Result<(), DynError> {
             let api_config = ApiConfig {
                 name: String::from("nexusd.api"),
                 public_addr: SocketAddr::from(([127, 0, 0, 1], 8081)),
+                pubky_listen_socket: SocketAddr::from(([127, 0, 0, 1], 8082)),
                 stack: StackConfig::default(),
             };
 

--- a/examples/api/main.rs
+++ b/examples/api/main.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<(), DynError> {
     match opts.config {
         Some(path) => {
             let expanded_path = validate_and_expand_path(path)?;
-            NexusApi::start_from_path(expanded_path).await?
+            NexusApi::start_from_path(expanded_path).await?;
         }
         None => {
             let api_config = ApiConfig {
@@ -36,6 +36,10 @@ async fn main() -> Result<(), DynError> {
             NexusApiBuilder(api_context).start().await?;
         }
     }
+
+    tracing::info!("Press Ctrl+C to stop the Nexus API");
+    tokio::signal::ctrl_c().await?;
+    tracing::info!("Shutting down Nexus API");
 
     Ok(())
 }

--- a/examples/watcher/main.rs
+++ b/examples/watcher/main.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<(), DynError> {
     match opts.config {
         Some(path) => {
             let expanded_path = validate_and_expand_path(path)?;
-            NexusWatcher::start_from_path(&expanded_path).await?
+            NexusWatcher::start_from_path(expanded_path).await?
         }
         None => {
             let homeserver =

--- a/examples/watcher/main.rs
+++ b/examples/watcher/main.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<(), DynError> {
     match opts.config {
         Some(path) => {
             let expanded_path = validate_and_expand_path(path)?;
-            NexusWatcher::start_from_path(expanded_path).await?
+            NexusWatcher::start_from_path(&expanded_path).await?
         }
         None => {
             let homeserver =

--- a/nexus-common/Cargo.toml
+++ b/nexus-common/Cargo.toml
@@ -25,8 +25,12 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
-toml = "0.8.23"
+toml = "0.9.2"
 tracing = { workspace = true }
 tracing-log = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 utoipa = "5.4.0"
+
+[dev-dependencies]
+tempfile = { workspace = true }
+tokio-shared-rt = { workspace = true }

--- a/nexus-common/default.config.toml
+++ b/nexus-common/default.config.toml
@@ -2,6 +2,7 @@
 # Service name used for tracing, logging, and metrics in OpenTelemetry
 name = "nexusd.api"
 public_addr = "127.0.0.1:8080"
+pubky_listen_socket = "127.0.0.1:8081"
 
 [watcher]
 # Service name used for tracing, logging, and metrics in OpenTelemetry

--- a/nexus-common/src/config/api.rs
+++ b/nexus-common/src/config/api.rs
@@ -6,14 +6,16 @@ use std::{fmt::Debug, net::SocketAddr};
 
 pub const NAME: &str = "nexus.api";
 
-pub const DEFAULT_HOST: [u8; 4] = [127, 0, 0, 1];
-pub const DEFAULT_PORT: u16 = 8080;
+pub const DEFAULT_LOCAL_IP: [u8; 4] = [127, 0, 0, 1];
+pub const DEFAULT_ICANN_LOCAL_PORT: u16 = 8080;
+pub const DEFAULT_PUBKY_LOCAL_PORT: u16 = 8081;
 
 /// Configuration settings for the Nexus Watcher service
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ApiConfig {
     pub name: String,
     pub public_addr: SocketAddr,
+    pub pubky_listen_socket: SocketAddr,
     #[serde(default = "default_stack")]
     pub stack: StackConfig,
 }
@@ -22,7 +24,8 @@ impl Default for ApiConfig {
     fn default() -> Self {
         Self {
             name: String::from(NAME),
-            public_addr: SocketAddr::from((DEFAULT_HOST, DEFAULT_PORT)),
+            public_addr: SocketAddr::from((DEFAULT_LOCAL_IP, DEFAULT_ICANN_LOCAL_PORT)),
+            pubky_listen_socket: SocketAddr::from((DEFAULT_LOCAL_IP, DEFAULT_PUBKY_LOCAL_PORT)),
             stack: StackConfig::default(),
         }
     }
@@ -33,9 +36,8 @@ impl Default for ApiConfig {
 impl From<DaemonConfig> for ApiConfig {
     fn from(daemon_config: DaemonConfig) -> Self {
         ApiConfig {
-            name: daemon_config.api.name,
-            public_addr: daemon_config.api.public_addr,
             stack: daemon_config.stack,
+            ..daemon_config.api
         }
     }
 }

--- a/nexus-common/src/config/daemon.rs
+++ b/nexus-common/src/config/daemon.rs
@@ -42,7 +42,9 @@ impl DaemonConfig {
 
     /// Given a directory path, ensures the directory exists, writes a default
     /// [DaemonConfig] file if absent, then parses and returns the loaded config
-    pub async fn read_config_file(expanded_path: PathBuf) -> Result<DaemonConfig, DynError> {
+    pub async fn read_or_create_config_file(
+        expanded_path: PathBuf,
+    ) -> Result<DaemonConfig, DynError> {
         let config_file_path = Self::get_config_file_path(&expanded_path);
 
         if !config_file_path.exists() {

--- a/nexus-common/src/config/daemon.rs
+++ b/nexus-common/src/config/daemon.rs
@@ -1,9 +1,6 @@
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use std::{
-    fmt::Debug,
-    path::{Path, PathBuf},
-};
+use std::{fmt::Debug, path::PathBuf};
 use tracing::error;
 
 use crate::{file::CONFIG_FILE_NAME, types::DynError};
@@ -21,7 +18,7 @@ pub struct DaemonConfig {
 
 impl DaemonConfig {
     /// Returns the config file path in this directory
-    fn get_config_file_path(expanded_path: &Path) -> PathBuf {
+    fn get_config_file_path(expanded_path: &PathBuf) -> PathBuf {
         expanded_path.join(CONFIG_FILE_NAME)
     }
 
@@ -43,9 +40,9 @@ impl DaemonConfig {
     /// Given a directory path, ensures the directory exists, writes a default
     /// [DaemonConfig] file if absent, then parses and returns the loaded config
     pub async fn read_or_create_config_file(
-        expanded_path: PathBuf,
+        expanded_path: &PathBuf,
     ) -> Result<DaemonConfig, DynError> {
-        let config_file_path = Self::get_config_file_path(&expanded_path);
+        let config_file_path = Self::get_config_file_path(expanded_path);
 
         if !config_file_path.exists() {
             Self::write_default_config_file(&config_file_path)?;

--- a/nexus-common/src/config/daemon.rs
+++ b/nexus-common/src/config/daemon.rs
@@ -50,22 +50,11 @@ impl DaemonConfig {
         if !config_file_path.exists() {
             Self::write_default_config_file(&config_file_path)?;
         }
-        println!(
-            "nexusd reading the '{CONFIG_FILE_NAME}' file from '{}'",
-            expanded_path.display()
-        );
 
-        let config = <Self as ConfigLoader<DaemonConfig>>::load(config_file_path)
-            .await
-            .map_err(|e| {
-                error!(
-                    "Failed to load config file {:?}: {}",
-                    Self::get_config_file_path(&expanded_path),
-                    e
-                );
-                e
-            })?;
-        Ok(config)
+        println!("nexusd loading config file {}", config_file_path.display());
+        Self::load(&config_file_path).await.inspect_err(|e| {
+            error!("Failed to load config file: {e}");
+        })
     }
 }
 

--- a/nexus-common/src/config/daemon.rs
+++ b/nexus-common/src/config/daemon.rs
@@ -18,12 +18,12 @@ pub struct DaemonConfig {
 
 impl DaemonConfig {
     /// Returns the config file path in this directory
-    fn get_config_file_path(expanded_path: &PathBuf) -> PathBuf {
+    fn get_config_file_path(expanded_path: PathBuf) -> PathBuf {
         expanded_path.join(CONFIG_FILE_NAME)
     }
 
     /// Writes the default [DaemonConfig] config file into the specified path
-    fn write_default_config_file(config_file_path: &PathBuf) -> std::io::Result<()> {
+    fn write_default_config_file(config_file_path: PathBuf) -> std::io::Result<()> {
         // Make sure before write the file, the directory path exists
         if let Some(parent) = config_file_path.parent() {
             println!(
@@ -40,12 +40,12 @@ impl DaemonConfig {
     /// Given a directory path, ensures the directory exists, writes a default
     /// [DaemonConfig] file if absent, then parses and returns the loaded config
     pub async fn read_or_create_config_file(
-        expanded_path: &PathBuf,
+        expanded_path: PathBuf,
     ) -> Result<DaemonConfig, DynError> {
         let config_file_path = Self::get_config_file_path(expanded_path);
 
         if !config_file_path.exists() {
-            Self::write_default_config_file(&config_file_path)?;
+            Self::write_default_config_file(config_file_path.clone())?;
         }
 
         println!("nexusd loading config file {}", config_file_path.display());

--- a/nexus-common/src/config/file/mod.rs
+++ b/nexus-common/src/config/file/mod.rs
@@ -2,4 +2,4 @@ mod loader;
 pub(super) mod reader;
 
 pub use loader::ConfigLoader;
-pub use reader::{validate_and_expand_path, CONFIG_FILE_NAME, DEFAULT_HOME_DIR};
+pub use reader::{default_config_dir_path, validate_and_expand_path, CONFIG_FILE_NAME};

--- a/nexus-common/src/config/file/reader.rs
+++ b/nexus-common/src/config/file/reader.rs
@@ -3,10 +3,17 @@ use std::ffi::OsStr;
 use std::path::{Component, PathBuf};
 
 /// Path to default nexusd config file. Defaults to ~/.pubky-nexus
+///
+/// See [default_config_dir_path] to use this as [PathBuf]
 pub const DEFAULT_HOME_DIR: &str = ".pubky-nexus";
 pub(crate) const DEFAULT_CONFIG_TOML: &str = include_str!("../../../default.config.toml");
 /// The sole configuration file name recognized by nexus
 pub const CONFIG_FILE_NAME: &str = "config.toml";
+
+/// Returns [DEFAULT_HOME_DIR] as [PathBuf], relative to the home directory
+pub fn default_config_dir_path() -> PathBuf {
+    dirs::home_dir().unwrap_or_default().join(DEFAULT_HOME_DIR)
+}
 
 /// If the path starts with a "~", this expands the "~" to the full home directory path.
 ///

--- a/nexus-watcher/Cargo.toml
+++ b/nexus-watcher/Cargo.toml
@@ -24,7 +24,7 @@ tracing = { workspace = true }
 [dev-dependencies]
 anyhow = "1.0.98"
 httpc-test = "0.1.10"
-pubky-testnet = "0.5.1"
+pubky-testnet = { workspace = true }
 rand = "0.9.1"
 rand_distr = "0.5.1"
 tokio-shared-rt = "0.1"

--- a/nexus-watcher/Cargo.toml
+++ b/nexus-watcher/Cargo.toml
@@ -27,5 +27,5 @@ httpc-test = "0.1.10"
 pubky-testnet = { workspace = true }
 rand = "0.9.1"
 rand_distr = "0.5.1"
-tokio-shared-rt = "0.1"
+tokio-shared-rt = { workspace = true }
 reqwest = "0.12.22"

--- a/nexus-watcher/src/builder.rs
+++ b/nexus-watcher/src/builder.rs
@@ -100,7 +100,7 @@ impl NexusWatcher {
     /// Loads the [WatcherConfig] from [WATCHER_CONFIG_FILE_NAME] in the given path and starts the Nexus Watcher.
     ///
     /// If no [WatcherConfig] file is found, it defaults to [NexusWatcher::start_from_daemon].
-    pub async fn start_from_path(config_dir: &PathBuf) -> Result<(), DynError> {
+    pub async fn start_from_path(config_dir: PathBuf) -> Result<(), DynError> {
         match WatcherConfig::load(config_dir.join(WATCHER_CONFIG_FILE_NAME)).await {
             Ok(watcher_config) => NexusWatcherBuilder(watcher_config).start().await,
             Err(_) => NexusWatcher::start_from_daemon(config_dir).await,
@@ -110,7 +110,7 @@ impl NexusWatcher {
     /// Derives the [WatcherConfig] from [DaemonConfig] (nexusd service config), loads it and starts the Watcher.
     ///
     /// If a [DaemonConfig] is not found, a new one is created in the given path with the default contents.
-    pub async fn start_from_daemon(config_dir: &PathBuf) -> Result<(), DynError> {
+    pub async fn start_from_daemon(config_dir: PathBuf) -> Result<(), DynError> {
         let daemon_config = DaemonConfig::read_or_create_config_file(config_dir).await?;
         let watcher_config = WatcherConfig::from(daemon_config);
         NexusWatcherBuilder(watcher_config).start().await

--- a/nexus-watcher/src/builder.rs
+++ b/nexus-watcher/src/builder.rs
@@ -105,7 +105,7 @@ impl NexusWatcher {
             match WatcherConfig::load(config_dir.join(WATCHER_CONFIG_FILE_NAME)).await {
                 Ok(watcher_config) => watcher_config,
                 Err(_) => {
-                    let daemon_config = DaemonConfig::read_config_file(config_dir).await?;
+                    let daemon_config = DaemonConfig::read_or_create_config_file(config_dir).await?;
                     WatcherConfig::from(daemon_config)
                 }
             };
@@ -117,7 +117,7 @@ impl NexusWatcher {
     ///
     /// If a [DaemonConfig] is not found, a new one is created in the given path with the default contents.
     pub async fn start_from_daemon(config_dir: PathBuf) -> Result<(), DynError> {
-        let daemon_config = DaemonConfig::read_config_file(config_dir).await?;
+        let daemon_config = DaemonConfig::read_or_create_config_file(config_dir).await?;
         let watcher_config = WatcherConfig::from(daemon_config);
         NexusWatcherBuilder(watcher_config).start().await
     }

--- a/nexus-watcher/src/builder.rs
+++ b/nexus-watcher/src/builder.rs
@@ -100,23 +100,17 @@ impl NexusWatcher {
     /// Loads the [WatcherConfig] from [WATCHER_CONFIG_FILE_NAME] in the given path and starts the Nexus Watcher.
     ///
     /// If no [WatcherConfig] file is found, it defaults to [NexusWatcher::start_from_daemon].
-    pub async fn start_from_path(config_dir: PathBuf) -> Result<(), DynError> {
-        let watcher_config =
-            match WatcherConfig::load(config_dir.join(WATCHER_CONFIG_FILE_NAME)).await {
-                Ok(watcher_config) => watcher_config,
-                Err(_) => {
-                    let daemon_config = DaemonConfig::read_or_create_config_file(config_dir).await?;
-                    WatcherConfig::from(daemon_config)
-                }
-            };
-
-        NexusWatcherBuilder(watcher_config).start().await
+    pub async fn start_from_path(config_dir: &PathBuf) -> Result<(), DynError> {
+        match WatcherConfig::load(config_dir.join(WATCHER_CONFIG_FILE_NAME)).await {
+            Ok(watcher_config) => NexusWatcherBuilder(watcher_config).start().await,
+            Err(_) => NexusWatcher::start_from_daemon(config_dir).await,
+        }
     }
 
     /// Derives the [WatcherConfig] from [DaemonConfig] (nexusd service config), loads it and starts the Watcher.
     ///
     /// If a [DaemonConfig] is not found, a new one is created in the given path with the default contents.
-    pub async fn start_from_daemon(config_dir: PathBuf) -> Result<(), DynError> {
+    pub async fn start_from_daemon(config_dir: &PathBuf) -> Result<(), DynError> {
         let daemon_config = DaemonConfig::read_or_create_config_file(config_dir).await?;
         let watcher_config = WatcherConfig::from(daemon_config);
         NexusWatcherBuilder(watcher_config).start().await

--- a/nexus-webapi/Cargo.toml
+++ b/nexus-webapi/Cargo.toml
@@ -42,6 +42,7 @@ utoipa-swagger-ui = { version = "9.0.2", features = ["axum"] }
 anyhow = "1.0.98"
 criterion = { version = "0.6.0", features = ["async_tokio"] }
 httpc-test = "0.1.10"
+pubky-testnet = { workspace = true }
 tempfile = { workspace = true }
 tokio-shared-rt = "0.1"
 url = "2.5.4"

--- a/nexus-webapi/Cargo.toml
+++ b/nexus-webapi/Cargo.toml
@@ -42,6 +42,7 @@ utoipa-swagger-ui = { version = "9.0.2", features = ["axum"] }
 anyhow = "1.0.98"
 criterion = { version = "0.6.0", features = ["async_tokio"] }
 httpc-test = "0.1.10"
+tempfile = { workspace = true }
 tokio-shared-rt = "0.1"
 url = "2.5.4"
 

--- a/nexus-webapi/Cargo.toml
+++ b/nexus-webapi/Cargo.toml
@@ -11,7 +11,7 @@ build = "build.rs"
 [dependencies]
 async-trait = { workspace = true }
 axum = "0.8.4"
-axum-server = "0.7.2"
+axum-server = { version = "0.7.2", features = ["tls-rustls-no-provider"] }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 const_format = "0.2.34"

--- a/nexus-webapi/Cargo.toml
+++ b/nexus-webapi/Cargo.toml
@@ -16,6 +16,7 @@ chrono = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 const_format = "0.2.34"
 const-hex = { version = "1.14" }
+futures-util = "0.3.31"
 neo4rs = { workspace = true }
 once_cell = "1.21.3"
 opentelemetry = { workspace = true }

--- a/nexus-webapi/Cargo.toml
+++ b/nexus-webapi/Cargo.toml
@@ -15,6 +15,7 @@ axum-server = "0.7.2"
 chrono = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 const_format = "0.2.34"
+const-hex = { version = "1.14" }
 neo4rs = { workspace = true }
 once_cell = "1.21.3"
 opentelemetry = { workspace = true }
@@ -22,6 +23,7 @@ opentelemetry_sdk = { workspace = true }
 pubky-app-specs = { workspace = true }
 nexus-common = { version = "0.4.1", path = "../nexus-common" }
 deadpool-redis = "0.21.1"
+pkarr = { version = "3.8.0", default-features = false }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/nexus-webapi/Cargo.toml
+++ b/nexus-webapi/Cargo.toml
@@ -44,7 +44,7 @@ criterion = { version = "0.6.0", features = ["async_tokio"] }
 httpc-test = "0.1.10"
 pubky-testnet = { workspace = true }
 tempfile = { workspace = true }
-tokio-shared-rt = "0.1"
+tokio-shared-rt = { workspace = true }
 url = "2.5.4"
 
 [[bench]]

--- a/nexus-webapi/src/api_context.rs
+++ b/nexus-webapi/src/api_context.rs
@@ -34,6 +34,9 @@ impl ApiContextBuilder {
     }
 
     pub async fn try_build(&self) -> Result<ApiContext, DynError> {
+        // Ensure path to config dir exists, regardless of how the builder was initialized
+        std::fs::create_dir_all(self.config_dir.clone())?;
+
         let api_config = match &self.api_config {
             None => {
                 let dc = DaemonConfig::read_or_create_config_file(self.config_dir.clone()).await?;

--- a/nexus-webapi/src/api_context.rs
+++ b/nexus-webapi/src/api_context.rs
@@ -7,11 +7,16 @@ use pkarr::Keypair;
 pub struct ApiContext {
     pub(crate) api_config: ApiConfig,
     pub(crate) keypair: Keypair,
+
+    /// pkarr client builder in case we need to create more instances.
+    /// Comes ready with the correct bootstrap nodes and relays.
+    pub(crate) pkarr_builder: pkarr::ClientBuilder,
 }
 
 pub struct ApiContextBuilder {
     api_config: Option<ApiConfig>,
     config_dir: PathBuf,
+    pkarr_builder: Option<pkarr::ClientBuilder>,
 }
 
 impl ApiContextBuilder {
@@ -23,12 +28,19 @@ impl ApiContextBuilder {
         Self {
             api_config: None,
             config_dir: config_dir.clone(),
+            pkarr_builder: None,
         }
     }
 
     /// Sets a custom [ApiConfig], overriding the one that may be derived from a config file in the given dir
     pub fn api_config(mut self, api_config: ApiConfig) -> Self {
         self.api_config = Some(api_config);
+
+        self
+    }
+
+    pub fn pkarr_builder(mut self, pkarr_builder: pkarr::ClientBuilder) -> Self {
+        self.pkarr_builder = Some(pkarr_builder);
 
         self
     }
@@ -45,11 +57,17 @@ impl ApiContextBuilder {
             Some(ac) => ac.clone(),
         };
 
+        let pkarr_builder = self
+            .pkarr_builder
+            .clone()
+            .unwrap_or(pkarr::ClientBuilder::default());
+
         let keypair = self.read_or_create_keypair()?;
 
         Ok(ApiContext {
             api_config,
             keypair,
+            pkarr_builder,
         })
     }
 

--- a/nexus-webapi/src/api_context.rs
+++ b/nexus-webapi/src/api_context.rs
@@ -57,10 +57,7 @@ impl ApiContextBuilder {
             Some(ac) => ac.clone(),
         };
 
-        let pkarr_builder = self
-            .pkarr_builder
-            .clone()
-            .unwrap_or(pkarr::ClientBuilder::default());
+        let pkarr_builder = self.pkarr_builder.clone().unwrap_or_default();
 
         let keypair = self.read_or_create_keypair()?;
 

--- a/nexus-webapi/src/api_context.rs
+++ b/nexus-webapi/src/api_context.rs
@@ -16,10 +16,10 @@ pub struct ApiContextBuilder {
 
 impl ApiContextBuilder {
     pub fn from_default_config_dir() -> Self {
-        Self::from_config_dir(&default_config_dir_path())
+        Self::from_config_dir(default_config_dir_path())
     }
 
-    pub fn from_config_dir(config_dir: &PathBuf) -> Self {
+    pub fn from_config_dir(config_dir: PathBuf) -> Self {
         Self {
             api_config: None,
             config_dir: config_dir.clone(),
@@ -36,7 +36,7 @@ impl ApiContextBuilder {
     pub async fn try_build(&self) -> Result<ApiContext, DynError> {
         let api_config = match &self.api_config {
             None => {
-                let dc = DaemonConfig::read_or_create_config_file(&self.config_dir).await?;
+                let dc = DaemonConfig::read_or_create_config_file(self.config_dir.clone()).await?;
                 ApiConfig::from(dc)
             }
             Some(ac) => ac.clone(),
@@ -62,7 +62,7 @@ impl ApiContextBuilder {
         let secret_string = String::from_utf8_lossy(&secret).trim().to_string();
         let secret_bytes: [u8; 32] = const_hex::decode(secret_string)?
             .try_into()
-            .map_err(|_| format!("Failed to convert secret bytes into array of length 32"))?;
+            .map_err(|_| "Failed to convert secret bytes into array of length 32")?;
         let keypair = Keypair::from_secret_key(&secret_bytes);
         Ok(keypair)
     }

--- a/nexus-webapi/src/api_context.rs
+++ b/nexus-webapi/src/api_context.rs
@@ -1,0 +1,76 @@
+use std::path::PathBuf;
+
+use nexus_common::{file::default_config_dir_path, types::DynError, ApiConfig, DaemonConfig};
+use pkarr::Keypair;
+
+#[derive(Debug, Clone)]
+pub struct ApiContext {
+    pub(crate) api_config: ApiConfig,
+    pub(crate) keypair: Keypair,
+}
+
+pub struct ApiContextBuilder {
+    api_config: Option<ApiConfig>,
+    config_dir: PathBuf,
+}
+
+impl ApiContextBuilder {
+    pub fn from_default_config_dir() -> Self {
+        Self::from_config_dir(&default_config_dir_path())
+    }
+
+    pub fn from_config_dir(config_dir: &PathBuf) -> Self {
+        Self {
+            api_config: None,
+            config_dir: config_dir.clone(),
+        }
+    }
+
+    /// Sets a custom [ApiConfig], overriding the one that may be derived from a config file in the given dir
+    pub fn api_config(mut self, api_config: ApiConfig) -> Self {
+        self.api_config = Some(api_config);
+
+        self
+    }
+
+    pub async fn try_build(&self) -> Result<ApiContext, DynError> {
+        let api_config = match &self.api_config {
+            None => {
+                let dc = DaemonConfig::read_or_create_config_file(&self.config_dir).await?;
+                ApiConfig::from(dc)
+            }
+            Some(ac) => ac.clone(),
+        };
+
+        let keypair = self.read_or_create_keypair()?;
+
+        Ok(ApiContext {
+            api_config,
+            keypair,
+        })
+    }
+
+    /// Reads the secret file. Creates a new secret file if it doesn't exist.
+    fn read_or_create_keypair(&self) -> Result<Keypair, DynError> {
+        let secret_file_path = self.config_dir.join("secret");
+
+        if !secret_file_path.exists() {
+            self.write_keypair(&secret_file_path, &Keypair::random())?;
+        }
+
+        let secret = std::fs::read(secret_file_path)?;
+        let secret_string = String::from_utf8_lossy(&secret).trim().to_string();
+        let secret_bytes: [u8; 32] = const_hex::decode(secret_string)?
+            .try_into()
+            .map_err(|_| format!("Failed to convert secret bytes into array of length 32"))?;
+        let keypair = Keypair::from_secret_key(&secret_bytes);
+        Ok(keypair)
+    }
+
+    /// Writes the keypair to the secret file. If the file already exists, it will be overwritten.
+    fn write_keypair(&self, file_path: &PathBuf, keypair: &Keypair) -> Result<(), DynError> {
+        let secret = keypair.secret_key();
+        let hex_string = const_hex::encode(secret);
+        std::fs::write(file_path, hex_string).map_err(Into::into)
+    }
+}

--- a/nexus-webapi/src/builder.rs
+++ b/nexus-webapi/src/builder.rs
@@ -170,6 +170,9 @@ impl NexusApi {
         let pubky_socket = ctx.api_config.pubky_listen_socket;
         let pubky_listener = TcpListener::bind(pubky_socket)
             .inspect_err(|e| error!("Failed to bind to Pubky socket {pubky_socket:?}: {e}"))?;
+        let pubky_local_addr = pubky_listener
+            .local_addr()
+            .inspect_err(|e| error!("Failed to get local address after binding: {e})"))?;
         let pubky_handle = Handle::new();
 
         tokio::spawn(
@@ -180,7 +183,7 @@ impl NexusApi {
                 .inspect_err(|e| error!("Nexus API pubky TLS endpoint error: {e}")),
         );
 
-        Ok((pubky_handle, pubky_socket))
+        Ok((pubky_handle, pubky_local_addr))
     }
 
     /// Returns the public_key of this server

--- a/nexus-webapi/src/builder.rs
+++ b/nexus-webapi/src/builder.rs
@@ -106,7 +106,7 @@ impl NexusApi {
         let api_config = match ApiConfig::load(config_dir.join(API_CONFIG_FILE_NAME)).await {
             Ok(api_config) => api_config,
             Err(_) => {
-                let daemon_config = DaemonConfig::read_config_file(config_dir).await?;
+                let daemon_config = DaemonConfig::read_or_create_config_file(config_dir).await?;
                 ApiConfig::from(daemon_config)
             }
         };
@@ -116,7 +116,7 @@ impl NexusApi {
 
     /// Loads the configuration from nexusd service and starts the Nexus API
     pub async fn start_from_daemon(config_dir: PathBuf) -> Result<(), DynError> {
-        let daemon_config = DaemonConfig::read_config_file(config_dir).await?;
+        let daemon_config = DaemonConfig::read_or_create_config_file(config_dir).await?;
         let api_config = ApiConfig::from(daemon_config);
 
         NexusApiBuilder(api_config).start().await

--- a/nexus-webapi/src/builder.rs
+++ b/nexus-webapi/src/builder.rs
@@ -76,6 +76,8 @@ impl NexusApiBuilder {
 }
 
 pub struct NexusApi {
+    ctx: ApiContext,
+
     /// Local socket address used for the interface exposed via ICANN DNS
     pub icann_http_socket: SocketAddr,
     icann_http_handle: Handle,
@@ -127,6 +129,7 @@ impl NexusApi {
         info!("Nexus API listening on http://{}", ctx.keypair.public_key());
 
         Ok(NexusApi {
+            ctx,
             icann_http_socket,
             icann_http_handle,
             pubky_tls_socket,

--- a/nexus-webapi/src/builder.rs
+++ b/nexus-webapi/src/builder.rs
@@ -1,86 +1,80 @@
+use crate::api_context::{ApiContext, ApiContextBuilder};
 use crate::routes;
+
+use std::net::TcpListener;
+use std::time::Duration;
+use std::{fmt::Debug, net::SocketAddr, path::PathBuf};
+
 use axum_server::{Handle, Server};
 use nexus_common::db::DatabaseConfig;
 use nexus_common::file::ConfigLoader;
 use nexus_common::types::DynError;
-use nexus_common::{ApiConfig, DaemonConfig, StackManager};
-use nexus_common::{Level, StackConfig};
-use std::time::Duration;
-use std::{fmt::Debug, net::SocketAddr, path::PathBuf};
-use tokio::net::TcpListener;
+use nexus_common::Level;
+use nexus_common::{ApiConfig, StackManager};
 use tokio::signal;
 use tracing::{debug, error, info};
 
 pub const API_CONFIG_FILE_NAME: &str = "api-config.toml";
 
-#[derive(Debug, Default)]
-pub struct NexusApiBuilder(pub ApiConfig);
+#[derive(Debug)]
+pub struct NexusApiBuilder(pub ApiContext);
 
 impl NexusApiBuilder {
-    /// Creates a `NexusWatcherBuilder` instance with the given configuration and stack settings.
-    pub fn with_stack(mut config: ApiConfig, stack: &StackConfig) -> Self {
-        config.stack = stack.clone();
-        Self(config)
-    }
-
     /// Sets the service name for observability (tracing, logging, monitoring)
     pub fn name(&mut self, name: String) -> &mut Self {
-        self.0.name = name;
+        self.0.api_config.name = name;
 
         self
     }
 
     /// Configures the logging level for the service, determining verbosity and log output
     pub fn log_level(&mut self, log_level: Level) -> &mut Self {
-        self.0.stack.log_level = log_level;
+        self.0.api_config.stack.log_level = log_level;
 
         self
     }
 
     /// Sets the server's listening address for incoming connections
     pub fn public_addr(&mut self, addr: SocketAddr) -> &mut Self {
-        self.0.public_addr = addr;
+        self.0.api_config.public_addr = addr;
 
         self
     }
 
     /// Sets the directory for storing static files on the server
     pub fn files_path(&mut self, files_path: PathBuf) -> &mut Self {
-        self.0.stack.files_path = files_path;
+        self.0.api_config.stack.files_path = files_path;
 
         self
     }
 
     /// Sets the OpenTelemetry endpoint for tracing and monitoring
     pub fn otlp_endpoint(&mut self, otlp_endpoint: Option<String>) -> &mut Self {
-        self.0.stack.otlp_endpoint = otlp_endpoint;
+        self.0.api_config.stack.otlp_endpoint = otlp_endpoint;
 
         self
     }
 
     /// Sets the database configuration, including graph database and Redis settings
     pub fn db(&mut self, db: DatabaseConfig) -> &mut Self {
-        self.0.stack.db = db;
+        self.0.api_config.stack.db = db;
 
         self
     }
 
     /// Opens ddbb connections and initialises tracing layer (if provided in config)
     pub async fn init_stack(&self) -> Result<(), DynError> {
-        StackManager::setup(&self.0.name, &self.0.stack).await?;
-        Ok(())
+        StackManager::setup(&self.0.api_config.name, &self.0.api_config.stack).await
     }
 
     pub async fn start(self) -> Result<(), DynError> {
-        if let Err(e) = self.init_stack().await {
-            tracing::error!("Failed to initialize stack: {}", e);
-            return Err(e);
-        }
+        self.init_stack()
+            .await
+            .inspect_err(|e| tracing::error!("Failed to initialize stack: {e}"))?;
 
-        if let Err(e) = NexusApi::start(self.0, None).await {
-            tracing::error!("Failed to start Nexus API: {}", e);
-            return Err(e);
-        }
+        NexusApi::start(self.0, None)
+            .await
+            .inspect_err(|e| tracing::error!("Failed to start Nexus API: {e}"))?;
 
         Ok(())
     }
@@ -94,59 +88,57 @@ impl NexusApiBuilder {
 pub struct NexusApi {}
 
 impl NexusApi {
-    /// Creates a new instance with default configuration
-    pub fn builder() -> NexusApiBuilder {
-        NexusApiBuilder::default()
-    }
-
     /// Loads the [ApiConfig] from [API_CONFIG_FILE_NAME] in the given path and starts the Nexus API.
     ///
     /// If no [ApiConfig] file is found, it defaults to [NexusApi::start_from_daemon].
     pub async fn start_from_path(config_dir: PathBuf) -> Result<(), DynError> {
-        let api_config = match ApiConfig::load(config_dir.join(API_CONFIG_FILE_NAME)).await {
-            Ok(api_config) => api_config,
-            Err(_) => {
-                let daemon_config = DaemonConfig::read_or_create_config_file(config_dir).await?;
-                ApiConfig::from(daemon_config)
-            }
-        };
+        match ApiConfig::load(config_dir.join(API_CONFIG_FILE_NAME)).await {
+            Ok(api_config) => {
+                let api_context = ApiContextBuilder::from_config_dir(&config_dir)
+                    .api_config(api_config)
+                    .try_build()
+                    .await?;
 
-        NexusApiBuilder(api_config).start().await
+                NexusApiBuilder(api_context).start().await
+            }
+            Err(_) => NexusApi::start_from_daemon(config_dir).await,
+        }
     }
 
-    /// Loads the configuration from nexusd service and starts the Nexus API
+    /// Loads the [ApiConfig] from the [DaemonConfig] in the given path and starts the Nexus API.
     pub async fn start_from_daemon(config_dir: PathBuf) -> Result<(), DynError> {
-        let daemon_config = DaemonConfig::read_or_create_config_file(config_dir).await?;
-        let api_config = ApiConfig::from(daemon_config);
+        let api_context = ApiContextBuilder::from_config_dir(&config_dir)
+            .try_build()
+            .await?;
 
-        NexusApiBuilder(api_config).start().await
+        NexusApiBuilder(api_context).start().await
     }
 
     /// It sets up the necessary routes, binds to the specified address (if no
     /// listener is provided), and starts the Axum server
-    pub async fn start(config: ApiConfig, listener: Option<TcpListener>) -> Result<(), DynError> {
+    pub async fn start(ctx: ApiContext, listener: Option<TcpListener>) -> Result<(), DynError> {
         // Create all the routes of the API
-        let app = routes::routes(config.stack.files_path.clone());
-        debug!(?config, "Running NexusAPI with");
+        let app = routes::routes(ctx.api_config.stack.files_path.clone());
+        debug!(?ctx.api_config, "Running NexusAPI with config");
 
+        let public_addr = ctx.api_config.public_addr;
         let listener = match listener {
             Some(l) => l,
-            None => TcpListener::bind(config.public_addr).await.map_err(|e| {
-                error!("Failed to bind to {:?}: {}", config.public_addr, e);
-                e
-            })?,
+            None => TcpListener::bind(public_addr)
+                .inspect_err(|e| error!("Failed to bind to {public_addr:?}: {e}"))?,
         };
-        let addr = listener.local_addr().unwrap_or_else(|e| {
+        let local_addr = listener.local_addr().unwrap_or_else(|e| {
             panic!("Failed to get local address after binding: {e}");
         });
-        info!("Listening on {:?}", addr);
+        info!("Nexus API listening on {local_addr}");
 
-        let std_listener = listener.into_std()?;
+        // TODO Create server, init TLS, register shutdown handle
+        info!("Nexus API listening on http://{}", ctx.keypair.public_key());
 
         // Create a shutdown handle
         let handle = Handle::new();
 
-        let server = Server::from_tcp(std_listener)
+        let server = Server::from_tcp(listener)
             .handle(handle.clone()) // attach the handle
             .serve(app.into_make_service());
 

--- a/nexus-webapi/src/builder.rs
+++ b/nexus-webapi/src/builder.rs
@@ -94,7 +94,7 @@ impl NexusApi {
     pub async fn start_from_path(config_dir: PathBuf) -> Result<(), DynError> {
         match ApiConfig::load(config_dir.join(API_CONFIG_FILE_NAME)).await {
             Ok(api_config) => {
-                let api_context = ApiContextBuilder::from_config_dir(&config_dir)
+                let api_context = ApiContextBuilder::from_config_dir(config_dir)
                     .api_config(api_config)
                     .try_build()
                     .await?;
@@ -107,7 +107,7 @@ impl NexusApi {
 
     /// Loads the [ApiConfig] from the [DaemonConfig] in the given path and starts the Nexus API.
     pub async fn start_from_daemon(config_dir: PathBuf) -> Result<(), DynError> {
-        let api_context = ApiContextBuilder::from_config_dir(&config_dir)
+        let api_context = ApiContextBuilder::from_config_dir(config_dir)
             .try_build()
             .await?;
 

--- a/nexus-webapi/src/builder.rs
+++ b/nexus-webapi/src/builder.rs
@@ -199,11 +199,6 @@ impl NexusApi {
         self.ctx.keypair.public_key()
     }
 
-    /// Returns the `https://<server public key>` url
-    pub fn pubky_url(&self) -> String {
-        format!("https://{}", self.public_key())
-    }
-
     /// Get the URL of the icann http server.
     pub fn icann_http_url(&self) -> String {
         format!("http://{}", self.icann_http_socket)

--- a/nexus-webapi/src/key_republisher.rs
+++ b/nexus-webapi/src/key_republisher.rs
@@ -1,0 +1,112 @@
+use std::net::IpAddr;
+
+use nexus_common::types::DynError;
+use pkarr::dns::Name;
+use pkarr::errors::PublishError;
+use pkarr::{dns::rdata::SVCB, SignedPacket};
+
+use tokio::task::JoinHandle;
+use tokio::time::{interval, Duration};
+
+use crate::api_context::ApiContext;
+
+/// Republishes the Nexus API's pkarr packet to the DHT every hour.
+pub struct NexusApiKeyRepublisher {
+    join_handle: JoinHandle<()>,
+}
+
+impl NexusApiKeyRepublisher {
+    pub async fn start(context: &ApiContext, pubky_tls_port: u16) -> Result<Self, DynError> {
+        let signed_packet = create_signed_packet(context, pubky_tls_port)?;
+        let pkarr_client = context.pkarr_builder.build()?;
+        let join_handle = Self::start_periodic_republish(pkarr_client, &signed_packet).await?;
+        Ok(Self { join_handle })
+    }
+
+    async fn publish_once(
+        client: &pkarr::Client,
+        signed_packet: &SignedPacket,
+    ) -> Result<(), PublishError> {
+        let res = client.publish(signed_packet, None).await;
+        if let Err(e) = &res {
+            tracing::warn!("Failed to publish the Nexus API's pkarr packet to the DHT: {e}");
+        } else {
+            tracing::info!("Published the Nexus API's pkarr packet to the DHT.");
+        }
+        res
+    }
+
+    /// Start the periodic republish task which will republish the server packet to the DHT every hour.
+    ///
+    /// # Errors
+    /// - Throws an error if the initial publish fails.
+    /// - Throws an error if the periodic republish task is already running.
+    async fn start_periodic_republish(
+        client: pkarr::Client,
+        signed_packet: &SignedPacket,
+    ) -> Result<JoinHandle<()>, DynError> {
+        // Publish once to make sure the packet is published to the DHT before this
+        // function returns.
+        // Throws an error if the packet is not published to the DHT.
+        Self::publish_once(&client, signed_packet).await?;
+
+        // Start the periodic republish task.
+        let signed_packet = signed_packet.clone();
+        let handle = tokio::spawn(async move {
+            let mut interval = interval(Duration::from_secs(60 * 60)); // 1 hour in seconds
+            interval.tick().await; // This ticks immediatly. Wait for first interval before starting the loop.
+            loop {
+                interval.tick().await;
+                let _ = Self::publish_once(&client, &signed_packet).await;
+            }
+        });
+
+        Ok(handle)
+    }
+
+    /// Stop the periodic republish task.
+    pub fn stop(&self) {
+        self.join_handle.abort();
+    }
+}
+
+impl Drop for NexusApiKeyRepublisher {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+pub fn create_signed_packet(
+    context: &ApiContext,
+    local_pubky_tls_port: u16,
+) -> Result<SignedPacket, DynError> {
+    let root_name: Name = "."
+        .try_into()
+        .expect(". is the root domain and always valid");
+
+    let mut signed_packet_builder = SignedPacket::builder();
+
+    // TODO Getter / field for public IP
+    let public_ip = context.api_config.public_addr.ip();
+
+    let public_pubky_tls_port = local_pubky_tls_port;
+
+    // `SVCB(HTTPS)` record pointing to the pubky tls port and the public ip address
+    // This is what is used in all applications expect for browsers.
+    let mut svcb = SVCB::new(0, root_name.clone());
+    svcb.set_port(public_pubky_tls_port);
+    match &public_ip {
+        IpAddr::V4(ip) => {
+            svcb.set_ipv4hint([ip.to_bits()])?;
+        }
+        IpAddr::V6(ip) => {
+            svcb.set_ipv6hint([ip.to_bits()])?;
+        }
+    };
+    signed_packet_builder = signed_packet_builder.https(root_name.clone(), svcb, 60 * 60);
+
+    // `A` record to the public IP. This is used for regular browser connections.
+    signed_packet_builder = signed_packet_builder.address(root_name.clone(), public_ip, 60 * 60);
+
+    Ok(signed_packet_builder.build(&context.keypair)?)
+}

--- a/nexus-webapi/src/lib.rs
+++ b/nexus-webapi/src/lib.rs
@@ -43,6 +43,7 @@
 //!
 //! This project is licensed under the terms of the MIT License.
 
+pub mod api_context;
 mod builder;
 pub mod error;
 pub mod mock;

--- a/nexus-webapi/src/lib.rs
+++ b/nexus-webapi/src/lib.rs
@@ -46,6 +46,7 @@
 pub mod api_context;
 mod builder;
 pub mod error;
+mod key_republisher;
 pub mod mock;
 pub mod models;
 pub mod routes;

--- a/nexus-webapi/tests/endpoints/mod.rs
+++ b/nexus-webapi/tests/endpoints/mod.rs
@@ -1,4 +1,5 @@
-use crate::utils::host_url;
+use crate::utils::{host_url, server::TestServiceServer};
+
 use anyhow::Result;
 
 #[tokio_shared_rt::test(shared)]
@@ -40,6 +41,22 @@ async fn test_info_endpoint() -> Result<()> {
     println!("body: {body:?}");
     assert_eq!(body["name"], env!("CARGO_PKG_NAME"));
     assert_eq!(body["version"], env!("CARGO_PKG_VERSION"));
+
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_pkarr_endpoint() -> Result<()> {
+    let test_server = TestServiceServer::get_test_server().await;
+    let pubky_tls_dns_url = test_server.nexus_api.pubky_tls_dns_url();
+
+    let client = &test_server.testnet.pubky_client_builder().build()?;
+    let response = client
+        .get(format!("{pubky_tls_dns_url}/v0/info"))
+        .send()
+        .await?;
+
+    assert_eq!(response.status(), 200);
 
     Ok(())
 }

--- a/nexus-webapi/tests/utils/mod.rs
+++ b/nexus-webapi/tests/utils/mod.rs
@@ -1,15 +1,14 @@
 use axum::http::{Method, StatusCode};
 use serde_json::Value;
-use server::{TestServiceServer, SERVER_URL};
+use server::TestServiceServer;
 
 pub mod server;
 
-/// Instead of hardcoding the host, we have a function that returns it.
-pub async fn host_url() -> String {
-    // Ensure the server is running.
-    TestServiceServer::get_test_server().await;
-    // Get the URL that was stored when the server started.
-    SERVER_URL.get().expect("SERVER_URL should be set").clone()
+pub(crate) async fn host_url() -> String {
+    let test_server = TestServiceServer::get_test_server().await;
+
+    // Get the server URL, including OS-chosen port (e.g., "http://127.0.0.1:12345")
+    format!("http://{}", test_server.nexus_api.icann_http_socket)
 }
 
 // #######################################

--- a/nexus-webapi/tests/utils/mod.rs
+++ b/nexus-webapi/tests/utils/mod.rs
@@ -8,7 +8,7 @@ pub(crate) async fn host_url() -> String {
     let test_server = TestServiceServer::get_test_server().await;
 
     // Get the server URL, including OS-chosen port (e.g., "http://127.0.0.1:12345")
-    format!("http://{}", test_server.nexus_api.icann_http_socket)
+    test_server.nexus_api.icann_http_url()
 }
 
 // #######################################

--- a/nexus-webapi/tests/utils/server.rs
+++ b/nexus-webapi/tests/utils/server.rs
@@ -1,52 +1,45 @@
+use std::net::SocketAddr;
+
 use anyhow::Result;
 use nexus_common::{get_files_dir_test_pathbuf, ApiConfig};
-use nexus_webapi::{api_context::ApiContextBuilder, NexusApiBuilder};
-use std::{net::SocketAddr, sync::Arc};
-use tokio::sync::{Mutex, OnceCell};
+use nexus_webapi::{api_context::ApiContextBuilder, NexusApi, NexusApiBuilder};
+use tokio::sync::OnceCell;
 
 /// Util backend server for testing.
 /// Performs the same routine the main service server does.
 /// OnceCell is used to ensure the server is only started once.
-#[derive(Clone, Debug)]
 pub struct TestServiceServer {
-    pub initialized: bool,
+    pub nexus_api: NexusApi,
 }
 
-// Global variable to store the server URL.
-pub static SERVER_URL: OnceCell<String> = OnceCell::const_new();
-
-pub static TEST_SERVER: OnceCell<Arc<Mutex<TestServiceServer>>> = OnceCell::const_new();
+static TEST_SERVER: OnceCell<TestServiceServer> = OnceCell::const_new();
 
 impl TestServiceServer {
-    pub async fn get_test_server() -> Arc<Mutex<TestServiceServer>> {
-        // Start the server if it hasn't been started
+    pub async fn get_test_server() -> &'static TestServiceServer {
         TEST_SERVER
             .get_or_init(|| async {
-                Self::start_server().await.unwrap();
-                Arc::new(Mutex::new(TestServiceServer { initialized: true }))
+                let nexus_api = Self::start_server().await.unwrap();
+                TestServiceServer { nexus_api }
             })
             .await
-            .to_owned()
     }
 
-    async fn start_server() -> Result<()> {
+    async fn start_server() -> Result<NexusApi> {
+        let test_api_config = ApiConfig {
+            // When we define the sockets, use local port 0 so OS assigns an available port
+            public_addr: SocketAddr::from(([127, 0, 0, 1], 0)),
+            pubky_listen_socket: SocketAddr::from(([127, 0, 0, 1], 0)),
+            ..Default::default()
+        };
+
         let api_context = ApiContextBuilder::from_default_config_dir()
-            .api_config(ApiConfig::default())
+            .api_config(test_api_config)
             .try_build()
             .await
             .expect("Failed to create ApiContext");
-
-        let nexus_builder = NexusApiBuilder(api_context)
-            // Use local port 0 so OS assigns an available port
-            .public_addr(SocketAddr::from(([127, 0, 0, 1], 0)))
-            .files_path(get_files_dir_test_pathbuf());
-
+        let nexus_builder = NexusApiBuilder(api_context).files_path(get_files_dir_test_pathbuf());
         let nexus_api = nexus_builder.start().await.unwrap();
 
-        // Save the server URL, including OS-chosen port (e.g., "http://127.0.0.1:12345") in a global variable
-        let url = format!("http://{}", nexus_api.icann_http_socket);
-        SERVER_URL.set(url).expect("SERVER_URL already set");
-
-        Ok(())
+        Ok(nexus_api)
     }
 }

--- a/nexus-webapi/tests/utils/server.rs
+++ b/nexus-webapi/tests/utils/server.rs
@@ -32,7 +32,9 @@ impl TestServiceServer {
             ..Default::default()
         };
 
-        let api_context = ApiContextBuilder::from_default_config_dir()
+        // Every time we start a test server, use a new temp config dir, which is automatically removed after the tests
+        let temp_config_dir = tempfile::TempDir::new_in(".")?;
+        let api_context = ApiContextBuilder::from_config_dir(temp_config_dir.path().to_path_buf())
             .api_config(test_api_config)
             .try_build()
             .await

--- a/nexus-webapi/tests/utils/server.rs
+++ b/nexus-webapi/tests/utils/server.rs
@@ -44,7 +44,7 @@ impl TestServiceServer {
         let nexus_api = nexus_builder.start().await.unwrap();
 
         // Save the server URL, including OS-chosen port (e.g., "http://127.0.0.1:12345") in a global variable
-        let url = format!("http://{}", nexus_api.socket);
+        let url = format!("http://{}", nexus_api.icann_http_socket);
         SERVER_URL.set(url).expect("SERVER_URL already set");
 
         Ok(())

--- a/nexus-webapi/tests/utils/server.rs
+++ b/nexus-webapi/tests/utils/server.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use nexus_common::get_files_dir_test_pathbuf;
+use nexus_common::{get_files_dir_test_pathbuf, ApiConfig};
 use nexus_webapi::{api_context::ApiContextBuilder, NexusApiBuilder};
 use std::{
     net::{Ipv4Addr, TcpListener},
@@ -34,6 +34,7 @@ impl TestServiceServer {
 
     async fn start_server() -> Result<()> {
         let api_context = ApiContextBuilder::from_default_config_dir()
+            .api_config(ApiConfig::default())
             .try_build()
             .await
             .expect("Failed to create ApiContext");

--- a/nexusd/Cargo.toml
+++ b/nexusd/Cargo.toml
@@ -21,4 +21,4 @@ tracing = { workspace = true }
 tokio = { workspace = true }
 
 [dev-dependencies]
-tokio-shared-rt = "0.1"
+tokio-shared-rt = { workspace = true }

--- a/nexusd/src/cli.rs
+++ b/nexusd/src/cli.rs
@@ -1,5 +1,5 @@
 use clap::{Args, Parser, Subcommand};
-use nexus_common::file::{validate_and_expand_path, DEFAULT_HOME_DIR};
+use nexus_common::file::{default_config_dir_path, validate_and_expand_path};
 use nexus_webapi::mock::MockType;
 use std::path::PathBuf;
 
@@ -24,10 +24,6 @@ impl Cli {
             Some(command) => command,
         }
     }
-}
-
-fn default_config_dir_path() -> PathBuf {
-    dirs::home_dir().unwrap_or_default().join(DEFAULT_HOME_DIR)
 }
 
 /// Validate that the data_dir path is a directory.

--- a/nexusd/src/launcher.rs
+++ b/nexusd/src/launcher.rs
@@ -4,7 +4,7 @@ use nexus_watcher::NexusWatcherBuilder;
 use nexus_webapi::NexusApiBuilder;
 use serde::{Deserialize, Serialize};
 use std::{fmt::Debug, path::PathBuf};
-use tokio::join;
+use tokio::try_join;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DaemonLauncher {}
@@ -14,7 +14,8 @@ impl DaemonLauncher {
         let config = DaemonConfig::read_or_create_config_file(config_dir).await?;
         let nexus_webapi_builder = NexusApiBuilder::with_stack(config.api, &config.stack);
         let nexus_watcher_builder = NexusWatcherBuilder::with_stack(config.watcher, &config.stack);
-        let _ = join!(nexus_webapi_builder.start(), nexus_watcher_builder.start());
+
+        try_join!(nexus_webapi_builder.start(), nexus_watcher_builder.start())?;
         Ok(())
     }
 }

--- a/nexusd/src/launcher.rs
+++ b/nexusd/src/launcher.rs
@@ -10,8 +10,8 @@ use tokio::try_join;
 pub struct DaemonLauncher {}
 
 impl DaemonLauncher {
-    pub async fn start(config_dir: &PathBuf) -> Result<(), DynError> {
-        let api_context = ApiContextBuilder::from_config_dir(config_dir)
+    pub async fn start(config_dir: PathBuf) -> Result<(), DynError> {
+        let api_context = ApiContextBuilder::from_config_dir(config_dir.clone())
             .try_build()
             .await?;
         let nexus_webapi_builder = NexusApiBuilder(api_context);

--- a/nexusd/src/launcher.rs
+++ b/nexusd/src/launcher.rs
@@ -11,7 +11,7 @@ pub struct DaemonLauncher {}
 
 impl DaemonLauncher {
     pub async fn start(config_dir: PathBuf) -> Result<(), DynError> {
-        let config = DaemonConfig::read_config_file(config_dir).await?;
+        let config = DaemonConfig::read_or_create_config_file(config_dir).await?;
         let nexus_webapi_builder = NexusApiBuilder::with_stack(config.api, &config.stack);
         let nexus_watcher_builder = NexusWatcherBuilder::with_stack(config.watcher, &config.stack);
         let _ = join!(nexus_webapi_builder.start(), nexus_watcher_builder.start());

--- a/nexusd/src/launcher.rs
+++ b/nexusd/src/launcher.rs
@@ -1,7 +1,7 @@
 use nexus_common::types::DynError;
 use nexus_common::DaemonConfig;
 use nexus_watcher::NexusWatcherBuilder;
-use nexus_webapi::NexusApiBuilder;
+use nexus_webapi::{api_context::ApiContextBuilder, NexusApiBuilder};
 use serde::{Deserialize, Serialize};
 use std::{fmt::Debug, path::PathBuf};
 use tokio::try_join;
@@ -10,9 +10,13 @@ use tokio::try_join;
 pub struct DaemonLauncher {}
 
 impl DaemonLauncher {
-    pub async fn start(config_dir: PathBuf) -> Result<(), DynError> {
+    pub async fn start(config_dir: &PathBuf) -> Result<(), DynError> {
+        let api_context = ApiContextBuilder::from_config_dir(config_dir)
+            .try_build()
+            .await?;
+        let nexus_webapi_builder = NexusApiBuilder(api_context);
+
         let config = DaemonConfig::read_or_create_config_file(config_dir).await?;
-        let nexus_webapi_builder = NexusApiBuilder::with_stack(config.api, &config.stack);
         let nexus_watcher_builder = NexusWatcherBuilder::with_stack(config.watcher, &config.stack);
 
         try_join!(nexus_webapi_builder.start(), nexus_watcher_builder.start())?;

--- a/nexusd/src/main.rs
+++ b/nexusd/src/main.rs
@@ -31,9 +31,9 @@ async fn main() -> Result<(), DynError> {
             NexusApi::start_from_daemon(config_dir).await?
         }
         NexusCommands::Watcher(WatcherArgs { config_dir }) => {
-            NexusWatcher::start_from_daemon(config_dir).await?
+            NexusWatcher::start_from_daemon(&config_dir).await?
         }
-        NexusCommands::Run { config_dir } => DaemonLauncher::start(config_dir).await?,
+        NexusCommands::Run { config_dir } => DaemonLauncher::start(&config_dir).await?,
     }
     Ok(())
 }

--- a/nexusd/src/main.rs
+++ b/nexusd/src/main.rs
@@ -31,9 +31,9 @@ async fn main() -> Result<(), DynError> {
             NexusApi::start_from_daemon(config_dir).await?
         }
         NexusCommands::Watcher(WatcherArgs { config_dir }) => {
-            NexusWatcher::start_from_daemon(&config_dir).await?
+            NexusWatcher::start_from_daemon(config_dir).await?
         }
-        NexusCommands::Run { config_dir } => DaemonLauncher::start(&config_dir).await?,
+        NexusCommands::Run { config_dir } => DaemonLauncher::start(config_dir).await?,
     }
     Ok(())
 }

--- a/nexusd/src/main.rs
+++ b/nexusd/src/main.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<(), DynError> {
             },
         },
         NexusCommands::Api(ApiArgs { config_dir }) => {
-            NexusApi::start_from_daemon(config_dir).await?
+            NexusApi::start_from_daemon(config_dir).await?;
         }
         NexusCommands::Watcher(WatcherArgs { config_dir }) => {
             NexusWatcher::start_from_daemon(config_dir).await?


### PR DESCRIPTION
This PR bumps the `toml` dependency.

However, since their [changelog](https://github.com/toml-rs/toml/blob/main/crates/toml/CHANGELOG.md) includes:

> New TOML parser and writer which carries a risk for regressions

this PR also adds a parsing test, covering both writing and parsing, to ensure the crate behavior is unchanged.

Builds on top of #503. Supersedes #506.