### PR TITLE
feat(watcher): allow any testnet hostname

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,17 +734,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "console_log"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8aed40e4edbf4d3b4431ab260b63fdc40f5780a4766824329ea0f1eefe3c0f"
-dependencies = [
- "log",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1022,6 +1011,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "dav-server"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1325ec68fa2627b069d06d5096d6109da5ebf46d45099e01e2dc59a4bcc4641e"
+dependencies = [
+ "bytes",
+ "derivative",
+ "dyn-clone",
+ "futures-channel",
+ "futures-util",
+ "headers",
+ "htmlescape",
+ "http",
+ "http-body",
+ "http-body-util",
+ "lazy_static",
+ "libc",
+ "log",
+ "lru 0.14.0",
+ "mime_guess",
+ "parking_lot",
+ "percent-encoding",
+ "pin-project",
+ "pin-utils",
+ "reflink-copy",
+ "regex",
+ "time",
+ "tokio",
+ "url",
+ "uuid",
+ "xml-rs",
+ "xmltree",
+]
+
+[[package]]
+name = "dav-server-opendalfs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5305e1e00d258d119aae1e1fbdee3a704cf66b632b4f1a6d384d65531d84c35c"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "dav-server",
+ "futures",
+ "opendal 0.54.0",
+]
+
+[[package]]
 name = "deadpool"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,6 +1129,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1520,7 +1568,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -1577,19 +1625,6 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "gloo-utils"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
-dependencies = [
- "js-sys",
- "serde",
- "serde_json",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -1794,6 +1829,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f558a64ac9af88b5ba400d99b579451af0d39c6d360980045b91aac966d705e2"
 
 [[package]]
+name = "htmlescape"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
+
+[[package]]
 name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1836,8 +1877,7 @@ checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
 [[package]]
 name = "http-relay"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42593e99cc11615a459454e0278f89d31b0501af077322dd29f0b0832470294c"
+source = "git+https://github.com/pubky/pubky-core?branch=feat%2Fconfigurable-testnet-host#5f835a45751778fd97687f6664e94cc2b9e9e8a1"
 dependencies = [
  "anyhow",
  "axum",
@@ -2359,6 +2399,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
 
 [[package]]
+name = "lru"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f8cc7106155f10bdf99a6f379688f543ad6596a415375b36a59a054ceda1198"
+dependencies = [
+ "hashbrown 0.15.3",
+]
+
+[[package]]
 name = "mainline"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2371,7 +2420,7 @@ dependencies = [
  "flume",
  "futures-lite",
  "getrandom 0.2.16",
- "lru",
+ "lru 0.13.0",
  "serde",
  "serde_bencode",
  "serde_bytes",
@@ -2782,6 +2831,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "opendal"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb9838d0575c6dbaf3fcec7255af8d5771996d4af900bbb6fa9a314dec00a1a"
+dependencies = [
+ "anyhow",
+ "backon",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "futures",
+ "getrandom 0.2.16",
+ "http",
+ "http-body",
+ "log",
+ "md-5",
+ "percent-encoding",
+ "quick-xml",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3100,7 +3175,7 @@ dependencies = [
  "getrandom 0.2.16",
  "heed",
  "log",
- "lru",
+ "lru 0.13.0",
  "mainline",
  "ntimestamp",
  "page_size",
@@ -3149,8 +3224,7 @@ dependencies = [
 [[package]]
 name = "pkarr-republisher"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552e84a5f8c1120b49ea38a95dd835d10b5a5ee7b6e8fad69ece426a82b0e3b0"
+source = "git+https://github.com/pubky/pubky-core?branch=feat%2Fconfigurable-testnet-host#5f835a45751778fd97687f6664e94cc2b9e9e8a1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3326,37 +3400,25 @@ checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 [[package]]
 name = "pubky"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "992e2ba6c36d80012177466d7b3417c93831c68ee7908506c9be1754e7312fdf"
+source = "git+https://github.com/pubky/pubky-core?branch=feat%2Fconfigurable-testnet-host#5f835a45751778fd97687f6664e94cc2b9e9e8a1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
  "bytes",
- "cfg_aliases",
- "console_log",
  "cookie",
  "cookie_store",
  "flume",
  "futures-lite",
  "futures-util",
- "getrandom 0.2.16",
- "getrandom 0.3.2",
- "gloo-timers",
- "js-sys",
  "log",
  "pkarr",
  "pubky-common",
  "reqwest",
- "serde",
- "serde-wasm-bindgen 0.4.5",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
- "tsify",
  "url",
- "wasm-bindgen",
  "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]
@@ -3370,7 +3432,7 @@ dependencies = [
  "js-sys",
  "mime",
  "serde",
- "serde-wasm-bindgen 0.6.5",
+ "serde-wasm-bindgen",
  "serde_json",
  "url",
  "utoipa",
@@ -3381,8 +3443,7 @@ dependencies = [
 [[package]]
 name = "pubky-common"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68fe0df38341348d8b885ed182b19e0c9d66dac1b3af1c92becba97f64854245"
+source = "git+https://github.com/pubky/pubky-core?branch=feat%2Fconfigurable-testnet-host#5f835a45751778fd97687f6664e94cc2b9e9e8a1"
 dependencies = [
  "argon2",
  "base32",
@@ -3402,8 +3463,7 @@ dependencies = [
 [[package]]
 name = "pubky-homeserver"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26d043aa17283cfa0e36683bf31c757b10ccd521c38d27bfdcfde088c6564ed"
+source = "git+https://github.com/pubky/pubky-core?branch=feat%2Fconfigurable-testnet-host#5f835a45751778fd97687f6664e94cc2b9e9e8a1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3414,6 +3474,8 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "clap",
+ "dav-server",
+ "dav-server-opendalfs",
  "dirs",
  "dyn-clone",
  "fast-glob",
@@ -3426,7 +3488,7 @@ dependencies = [
  "httpdate",
  "infer",
  "mime_guess",
- "opendal",
+ "opendal 0.53.3",
  "page_size",
  "percent-encoding",
  "pkarr",
@@ -3452,8 +3514,7 @@ dependencies = [
 [[package]]
 name = "pubky-testnet"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc9d07601d9867b7cf41155bdbda31550325deea49970d7126506a1102bb04a9"
+source = "git+https://github.com/pubky/pubky-core?branch=feat%2Fconfigurable-testnet-host#5f835a45751778fd97687f6664e94cc2b9e9e8a1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3742,6 +3803,18 @@ dependencies = [
  "getrandom 0.2.16",
  "libredox",
  "thiserror 2.0.12",
+]
+
+[[package]]
+name = "reflink-copy"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c81d000a2c524133cc00d2f92f019d399e57906c3b7119271a2495354fe895"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rustix",
+ "windows 0.61.1",
 ]
 
 [[package]]
@@ -4126,17 +4199,6 @@ dependencies = [
 
 [[package]]
 name = "serde-wasm-bindgen"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b4c031cd0d9014307d82b8abf653c0290fbdaeb4c02d00c63cf52f728628bf"
-dependencies = [
- "js-sys",
- "serde",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "serde-wasm-bindgen"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
@@ -4170,17 +4232,6 @@ name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "serde_derive_internals"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4954,31 +5005,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "tsify"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ec91b85e6c6592ed28636cb1dd1fac377ecbbeb170ff1d79f97aac5e38926d"
-dependencies = [
- "gloo-utils",
- "serde",
- "serde_json",
- "tsify-macros",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "tsify-macros"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a324606929ad11628a19206d7853807481dcaecd6c08be70a235930b8241955"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn 2.0.101",
-]
-
-[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5323,6 +5349,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5ee8f3d025738cb02bad7868bbb5f8a6327501e870bf51f1b455b0a2454a419"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.61.0",
+ "windows-future",
+ "windows-link",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.0",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5346,6 +5394,16 @@ dependencies = [
  "windows-link",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a1d6bbefcb7b60acd19828e1bc965da6fcf18a7e39490c5f8be71e54a19ba32"
+dependencies = [
+ "windows-core 0.61.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -5397,6 +5455,16 @@ name = "windows-link"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.0",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-registry"
@@ -5557,6 +5625,21 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "xml-rs"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fd8403733700263c6eb89f192880191f1b83e332f7a20371ddcf421c4a337c7"
+
+[[package]]
+name = "xmltree"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b619f8c85654798007fb10afa5125590b43b088c225a25fc2fec100a9fad0fc6"
+dependencies = [
+ "xml-rs",
+]
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ clap = "4.5.41"
 neo4rs = "0.8.0"
 opentelemetry = "0.30"
 opentelemetry_sdk = { version = "0.30", features = ["rt-tokio"] }
-pubky = "0.5.1"
+pubky = { git = "https://github.com/pubky/pubky-core", branch = "feat/configurable-testnet-host" }
 pubky-app-specs = { version = "0.3.5", features = ["openapi"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.141"

--- a/examples/watcher/main.rs
+++ b/examples/watcher/main.rs
@@ -38,6 +38,7 @@ async fn main() -> Result<(), DynError> {
             let config = WatcherConfig {
                 name: String::from("nexusd.watcher"),
                 testnet: false,
+                testnet_host: "not-needed".to_string(),
                 homeserver,
                 events_limit: 100,
                 watcher_sleep: 5000,

--- a/nexus-common/default.config.toml
+++ b/nexus-common/default.config.toml
@@ -7,6 +7,8 @@ public_addr = "127.0.0.1:8080"
 # Service name used for tracing, logging, and metrics in OpenTelemetry
 name = "nexusd.watcher"
 testnet = false
+# testnet host, if undefined, will default to `localhost`
+# testnet_host = "localhost"
 # Synonym homeserver pubky
 homeserver = "8um71us3fyw6h8wbcxb5ar3rwusy1a6u49956ikzojg3gcwd1dty"
 events_limit = 50

--- a/nexus-common/src/config/watcher.rs
+++ b/nexus-common/src/config/watcher.rs
@@ -8,6 +8,7 @@ use std::fmt::Debug;
 pub const NAME: &str = "nexus.watcher";
 
 pub const TESTNET: bool = false;
+pub const DEFAULT_TESTNET_HOST: &str = "localhost";
 // Testnet homeserver key
 pub const HOMESERVER_PUBKY: &str = "8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo";
 // Maximum number of events to fetch at once from a homeserver
@@ -31,6 +32,7 @@ pub const MODERATED_TAGS: [&str; 6] = [
 pub struct WatcherConfig {
     pub name: String,
     pub testnet: bool,
+    pub testnet_host: String,
     pub homeserver: PubkyId,
     pub events_limit: u32,
     pub watcher_sleep: u64,
@@ -51,9 +53,10 @@ impl Default for WatcherConfig {
         let moderation_id = PubkyId::try_from(MODERATION_ID)
             .expect("Hardcoded moderation should be a valid pubky id");
         Self {
-            name: String::from(NAME),
+            name: NAME.to_string(),
             stack: StackConfig::default(),
             testnet: TESTNET,
+            testnet_host: DEFAULT_TESTNET_HOST.to_string(),
             homeserver,
             events_limit: EVENTS_LIMIT,
             watcher_sleep: WATCHER_SLEEP,
@@ -68,14 +71,8 @@ impl Default for WatcherConfig {
 impl From<DaemonConfig> for WatcherConfig {
     fn from(daemon_config: DaemonConfig) -> Self {
         WatcherConfig {
-            name: daemon_config.watcher.name,
-            testnet: daemon_config.watcher.testnet,
-            homeserver: daemon_config.watcher.homeserver,
-            events_limit: daemon_config.watcher.events_limit,
-            watcher_sleep: daemon_config.watcher.watcher_sleep,
             stack: daemon_config.stack,
-            moderation_id: daemon_config.watcher.moderation_id,
-            moderated_tags: daemon_config.watcher.moderated_tags,
+            ..daemon_config.watcher
         }
     }
 }

--- a/nexus-common/src/db/connectors/pubky.rs
+++ b/nexus-common/src/db/connectors/pubky.rs
@@ -18,19 +18,27 @@ pub enum PubkyClientError {
 pub struct PubkyClient;
 
 impl PubkyClient {
-    pub async fn initialise(testnet: bool) -> Result<(), PubkyClientError> {
+    /// Initializes the `PubkyClient`.
+    ///
+    /// - For mainnet, pass `None`.
+    /// - For testnet, pass `Some(hostname)` (e.g., "localhost" or "homeserver").
+    pub async fn initialise(testnet_host: Option<&str>) -> Result<(), PubkyClientError> {
         PUBKY_CLIENT_SINGLETON
             .get_or_try_init(|| async {
                 debug!(
                     "Initialising PubkyClient in {} mode",
-                    if testnet { "testnet" } else { "mainnet" }
+                    if let Some(host) = testnet_host {
+                        format!("testnet with host '{}'", host)
+                    } else {
+                        "mainnet".to_string()
+                    }
                 );
-                let client = match testnet {
-                    true => Client::builder()
-                        .testnet()
+                let client = match testnet_host {
+                    Some(host) => Client::builder()
+                        .testnet_with_host(host)
                         .build()
                         .map_err(|e| PubkyClientError::ClientError(e.to_string()))?,
-                    false => Client::builder()
+                    None => Client::builder()
                         .build()
                         .map_err(|e| PubkyClientError::ClientError(e.to_string()))?,
                 };

--- a/nexus-watcher/Cargo.toml
+++ b/nexus-watcher/Cargo.toml
@@ -24,7 +24,7 @@ tracing = { workspace = true }
 [dev-dependencies]
 anyhow = "1.0.98"
 httpc-test = "0.1.10"
-pubky-testnet = "0.5.1"
+pubky-testnet = { git = "https://github.com/pubky/pubky-core", branch = "feat/configurable-testnet-host" }
 rand = "0.9.2"
 rand_distr = "0.5.1"
 tokio-shared-rt = "0.1"

--- a/nexus-watcher/src/builder.rs
+++ b/nexus-watcher/src/builder.rs
@@ -72,7 +72,12 @@ impl NexusWatcherBuilder {
     /// Opens ddbb connections and initialises tracing layer (if provided in config)
     pub async fn init_stack(&self) -> Result<(), DynError> {
         StackManager::setup(&self.0.name, &self.0.stack).await?;
-        let _ = PubkyClient::initialise(self.0.testnet).await;
+        let testnet_host = if self.0.testnet {
+            Some(self.0.testnet_host.as_str())
+        } else {
+            None
+        };
+        let _ = PubkyClient::initialise(testnet_host).await;
         Ok(())
     }
 


### PR DESCRIPTION
# Pre-submission Checklist
This PR  uses latest https://github.com/pubky/pubky-core/pull/189 pubky-client and should allow setting custom `hostnames` for testnet enabled Nexus. This is needed for the dockerized stack to run on platforms other than Linux.

> For tests to work you need a working neo4j and redis instance with the example dataset in `docker/db-graph`

- [ ] **Testing**: Implement and pass new tests for the new features/fixes, `cargo nextest run`.
- [ ] **Performance**: Ensure new code has relevant performance benchmarks, `cargo bench -p nexus-webapi`
