### PR TITLE
Consolidate and bump `tokio` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4668,9 +4668,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.47.0"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43864ed400b6043a4757a25c7a64a8efde741aed79a056a2fb348a406701bb35"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,6 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.142"
 tempfile = { version = "3.20" }
 thiserror = "2.0.12"
-tokio = { version = "1.47.0", features = ["full"] }
+tokio = { version = "1.47.1", features = ["full"] }
 tokio-shared-rt = "0.1"
 tracing = "0.1.41"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -13,7 +13,7 @@ path = "./watcher/main.rs"
 
 [dependencies]
 anyhow = "1.0.95"
-tokio = { version = "1.47.0", features = ["full"] }
+tokio = { workspace = true }
 nexus-common = { path = "../nexus-common" }
 nexus-webapi = { path = "../nexus-webapi" }
 nexus-watcher = { path = "../nexus-watcher" }


### PR DESCRIPTION
This PR bumps `tokio` at workspace level and updates `examples/Cargo.toml` to re-use it.