### PR TITLE
Simplify HS lookup query

### DIFF
--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -249,7 +249,6 @@ pub fn get_all_homeservers() -> Query {
     query(
         "MATCH (hs:Homeserver)
         WITH collect(hs.id) AS homeservers_list
-        WHERE size(homeservers_list) > 0
         RETURN homeservers_list",
     )
 }

--- a/nexus-common/src/models/homeserver.rs
+++ b/nexus-common/src/models/homeserver.rs
@@ -84,16 +84,17 @@ impl Homeserver {
         Ok(())
     }
 
-    /// Retrieves all homeservers from the graph
+    /// Retrieves all homeservers from the graph.
+    ///
+    /// # Returns
+    /// A list of all known homeserver IDs.
+    ///
+    /// # Errors
+    /// Throws an error if no homeservers are found.
     pub async fn get_all_from_graph() -> Result<Vec<String>, DynError> {
         let query = queries::get::get_all_homeservers();
-        let homeservers: Option<Vec<String>> =
-            fetch_key_from_graph(query, "homeservers_list").await?;
-
-        if homeservers.is_none() {
-            return Err("No homeservers found in graph".into());
-        }
-        Ok(homeservers.unwrap())
+        let homeservers = fetch_key_from_graph(query, "homeservers_list").await?;
+        homeservers.ok_or("No homeservers found in graph".into())
     }
 }
 


### PR DESCRIPTION
This PR keeps the query consistent with the other queries, by allowing it to return an empty list.

The check in the caller is updated, so that an empty list results in an error.