### PR TITLE
Change from `Box<dyn TEventProcessor>` to `Arc`

### DIFF
--- a/nexus-watcher/src/events/processor.rs
+++ b/nexus-watcher/src/events/processor.rs
@@ -28,7 +28,7 @@ impl TEventProcessor for EventProcessor {
     /// Runs the event processor. Polls events from the homeserver and processes them.
     /// # Returns:
     /// - `Result<(), DynError>`: The result of the event processing
-    async fn run(self: Box<Self>) -> Result<(), DynError> {
+    async fn run(self: Arc<Self>) -> Result<(), DynError> {
         let lines = {
             let tracer = global::tracer(self.tracer_name.clone());
             let span = tracer.start("Polling Events");

--- a/nexus-watcher/src/events/processor_factory.rs
+++ b/nexus-watcher/src/events/processor_factory.rs
@@ -45,15 +45,14 @@ impl TEventProcessorFactory for EventProcessorFactory {
     }
 
     /// Creates and returns a new event processor instance for the specified homeserver
-    /// The ownership of the event processor is transferred to the caller
-    async fn build(&self, homeserver_id: String) -> Result<Box<dyn TEventProcessor>, DynError> {
-        let homeserver_id = PubkyId::try_from(&homeserver_id).map_err(DynError::from)?;
+    async fn build(&self, homeserver_id: String) -> Result<Arc<dyn TEventProcessor>, DynError> {
+        let homeserver_id = PubkyId::try_from(&homeserver_id)?;
         let homeserver = Homeserver::get_by_id(homeserver_id)
             .await?
             .ok_or("Homeserver not found")?;
 
         // Create a new event processor instance with the specified homeserver
-        Ok(Box::new(EventProcessor {
+        Ok(Arc::new(EventProcessor {
             homeserver,
             limit: self.limit,
             files_path: self.files_path.clone(),

--- a/nexus-watcher/src/events/traits/tevent_processor.rs
+++ b/nexus-watcher/src/events/traits/tevent_processor.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use nexus_common::types::DynError;
 
 /// Asynchronous event processor interface for the Watcher service.
@@ -27,5 +29,5 @@ pub trait TEventProcessor: Send + Sync {
     ///   when it receives a shutdown signal.
     ///
     /// Returns `Ok(())` on a clean exit, or `Err(DynError)` on failure.
-    async fn run(self: Box<Self>) -> Result<(), DynError>;
+    async fn run(self: Arc<Self>) -> Result<(), DynError>;
 }

--- a/nexus-watcher/src/events/traits/tevent_processor_factory.rs
+++ b/nexus-watcher/src/events/traits/tevent_processor_factory.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use crate::events::{errors::EventProcessorError, TEventProcessor};
 use nexus_common::{models::homeserver::Homeserver, types::DynError};
@@ -46,9 +46,8 @@ pub trait TEventProcessorFactory: Send + Sync {
     /// Returns `Ok(Box<dyn TEventProcessor>)` containing the newly created processor
     /// instance on success, or `Err(DynError)` if processor creation fails.
     ///
-    /// The returned processor is fully configured and ready to be executed with its
-    /// `run` method. Ownership of the processor is transferred to the caller.
-    async fn build(&self, homeserver_id: String) -> Result<Box<dyn TEventProcessor>, DynError>;
+    /// The returned processor is fully configured and ready to be executed with its `run` method.
+    async fn build(&self, homeserver_id: String) -> Result<Arc<dyn TEventProcessor>, DynError>;
 
     /// Runs event processors for all homeservers retrieved from the graph.
     ///

--- a/nexus-watcher/tests/service/event_processing_multiple_homeservers.rs
+++ b/nexus-watcher/tests/service/event_processing_multiple_homeservers.rs
@@ -10,21 +10,31 @@ use std::time::Duration;
 async fn test_multiple_homeserver_event_processing() -> Result<()> {
     // Initialize the test
     let mut event_processor_hashmap = setup().await?;
+    let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
 
     // Create 3 random homeservers with success result
     for _ in 0..3 {
         let processor_status = success_result("success from homeserver");
-        create_random_homeservers_and_persist(&mut event_processor_hashmap, None, processor_status)
-            .await;
+        create_random_homeservers_and_persist(
+            &mut event_processor_hashmap,
+            None,
+            processor_status,
+            shutdown_rx.clone(),
+        )
+        .await;
     }
 
     // Create 1 random homeserver with error result
     let processor_status = error_result("PubkyClient: timeout from homeserver");
-    create_random_homeservers_and_persist(&mut event_processor_hashmap, None, processor_status)
-        .await;
+    create_random_homeservers_and_persist(
+        &mut event_processor_hashmap,
+        None,
+        processor_status,
+        shutdown_rx.clone(),
+    )
+    .await;
 
-    let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
-    let factory = MockEventProcessorFactory::new(event_processor_hashmap, None, shutdown_rx);
+    let factory = MockEventProcessorFactory::new(event_processor_hashmap, None);
 
     let result = factory.run_all().await.unwrap();
 
@@ -39,6 +49,7 @@ async fn test_multi_hs_event_processing_with_timeout() -> Result<()> {
     const EVENT_PROCESSOR_TIMEOUT: Option<Duration> = Some(Duration::from_secs(1));
     // Initialize the test
     let mut event_processor_hashmap = setup().await?;
+    let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
 
     // Create 3 random homeservers with timeout limit
     for index in 0..3 {
@@ -47,16 +58,12 @@ async fn test_multi_hs_event_processing_with_timeout() -> Result<()> {
             &mut event_processor_hashmap,
             Some(Duration::from_secs(index * 2)),
             processor_status,
+            shutdown_rx.clone(),
         )
         .await;
     }
 
-    let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
-    let factory = MockEventProcessorFactory::new(
-        event_processor_hashmap,
-        EVENT_PROCESSOR_TIMEOUT,
-        shutdown_rx,
-    );
+    let factory = MockEventProcessorFactory::new(event_processor_hashmap, EVENT_PROCESSOR_TIMEOUT);
 
     let result = factory.run_all().await.unwrap();
 

--- a/nexus-watcher/tests/service/mock_event_processor.rs
+++ b/nexus-watcher/tests/service/mock_event_processor.rs
@@ -20,7 +20,7 @@ const TIMEOUT: Duration = Duration::from_secs(2);
 async fn test_mock_event_processors() -> Result<(), DynError> {
     let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
     let mock_processors = create_mock_event_processors(shutdown_rx.clone());
-    let factory = MockEventProcessorFactory::new(mock_processors, Some(TIMEOUT), shutdown_rx);
+    let factory = MockEventProcessorFactory::new(mock_processors, Some(TIMEOUT));
 
     // Test successful event processor
     let processor = factory.build(HS_IDS[0].to_string()).await?;

--- a/nexus-watcher/tests/service/signal.rs
+++ b/nexus-watcher/tests/service/signal.rs
@@ -10,27 +10,27 @@ use tokio::time::sleep;
 async fn test_shutdown_signal() -> Result<()> {
     // Initialize the test
     let mut event_processor_hashmap = setup().await?;
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
 
     // Create 3 random homeservers with timeout limit
     for index in 0..3 {
         let processor_status = success_result("success from homeserver");
-        create_random_homeservers_and_persist(&mut event_processor_hashmap, Some(Duration::from_secs(index * 2)), processor_status)
-            .await;
+        create_random_homeservers_and_persist(
+            &mut event_processor_hashmap,
+            Some(Duration::from_secs(index * 2)),
+            processor_status,
+            shutdown_rx.clone(),
+        )
+        .await;
     }
 
-    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
-    let factory = MockEventProcessorFactory::new(
-        event_processor_hashmap,
-        None,
-        shutdown_rx,
-    );
+    let factory = MockEventProcessorFactory::new(event_processor_hashmap, None);
 
     // Schedule Ctrl-C simulation after 1s
     tokio::spawn({
         let shutdown_tx = shutdown_tx.clone();
         async move {
             sleep(Duration::from_secs(1)).await;
-            // simulate Ctrl-C
             let _ = shutdown_tx.send(true);
         }
     });

--- a/nexus-watcher/tests/service/utils/mod.rs
+++ b/nexus-watcher/tests/service/utils/mod.rs
@@ -7,11 +7,12 @@ pub use processor::MockEventProcessor;
 pub use processor_factory::MockEventProcessorFactory;
 pub use setup::setup;
 
-use nexus_common::{models::homeserver::Homeserver, utils::create_shutdown_rx};
+use nexus_common::models::homeserver::Homeserver;
 use pubky::Keypair;
 use pubky_app_specs::PubkyId;
 pub use result::MockEventProcessorResult;
 use std::{collections::HashMap, time::Duration};
+use tokio::sync::watch::Receiver;
 
 /// Create a success result type
 pub fn success_result(message: &str) -> MockEventProcessorResult {
@@ -33,6 +34,7 @@ pub async fn create_random_homeservers_and_persist(
     event_processor_hashmap: &mut HashMap<String, MockEventProcessor>,
     timeout: Option<Duration>,
     processor_status: MockEventProcessorResult,
+    shutdown_rx: Receiver<bool>,
 ) {
     let homeserver_keypair = Keypair::random();
     let homeserver_public_key = homeserver_keypair.public_key().to_z32();
@@ -44,7 +46,7 @@ pub async fn create_random_homeservers_and_persist(
         homeserver_id: homeserver_public_key.clone(),
         timeout,
         processor_status,
-        shutdown_rx: create_shutdown_rx(),
+        shutdown_rx,
     };
     event_processor_hashmap.insert(homeserver_public_key.clone(), event_processor);
 }


### PR DESCRIPTION
This PR uses `Arc` instead of `Box`, which simplifies the ownership management for the event processors.

It also removes the need for `&mut self` in some of the methods.

Due to how `shutdown_rx` is used, this change also brings:
- removing `shutdown_rx` from the `MockEventProcessorFactory`, because it's not used by the factory itself
  - it is used by the real factory when building the event processors, but the mock one takes pre-built processors on initialization
- `create_random_homeservers_and_persist` now asks for `shutdown_rx` as arg instead of creating a new random one, which forces the caller to use the same `shutdown_rx` across all mock event processors, which emulates the behavior of the real event processor