### PR TITLE
`MockEventProcessor`: rename `timeout` to `sleep_duration`

### DIFF
--- a/nexus-watcher/tests/service/mock_event_processor.rs
+++ b/nexus-watcher/tests/service/mock_event_processor.rs
@@ -63,10 +63,10 @@ fn create_mock_event_processors(
         (HS_IDS[4], Some(1), Success("Success finished!".into())),
     ]
     .into_iter()
-    .map(|(id, timeout_sec, status)| {
+    .map(|(id, sleep_duration_sec, status)| {
         let processor = MockEventProcessor {
             homeserver_id: id.to_string(),
-            timeout: timeout_sec.map(Duration::from_secs),
+            sleep_duration: sleep_duration_sec.map(Duration::from_secs),
             processor_status: status,
             shutdown_rx: shutdown_rx.clone(),
         };

--- a/nexus-watcher/tests/service/utils/mod.rs
+++ b/nexus-watcher/tests/service/utils/mod.rs
@@ -32,7 +32,7 @@ pub fn _panic_result() -> MockEventProcessorResult {
 // Create a random homeserver and add it to the event processor hashmap
 pub async fn create_random_homeservers_and_persist(
     event_processor_hashmap: &mut HashMap<String, MockEventProcessor>,
-    timeout: Option<Duration>,
+    sleep_duration: Option<Duration>,
     processor_status: MockEventProcessorResult,
     shutdown_rx: Receiver<bool>,
 ) {
@@ -44,7 +44,7 @@ pub async fn create_random_homeservers_and_persist(
 
     let event_processor = MockEventProcessor {
         homeserver_id: homeserver_public_key.clone(),
-        timeout,
+        sleep_duration,
         processor_status,
         shutdown_rx,
     };


### PR DESCRIPTION
This helps distinguish between
- actual timeout: max duration a task can take, after which it's terminated with `Err`
- sleep duration: amount of time a test task will simulate busy activity, after which it returns `Ok`