### PR TITLE
Remove `expect()` from non-test code path

### DIFF
--- a/nexus-watcher/src/events/traits/tevent_processor_factory.rs
+++ b/nexus-watcher/src/events/traits/tevent_processor_factory.rs
@@ -62,7 +62,7 @@ pub trait TEventProcessorFactory: Send + Sync {
     async fn run_all(&self) -> ProcessorResultType {
         let hs_ids = Homeserver::get_all_from_graph()
             .await
-            .expect("No Homeserver IDs found in graph");
+            .inspect_err(|e| error!("{e}"))?;
 
         let mut processed_homeservers = 0;
         let mut skipped_homeservers = 0;


### PR DESCRIPTION
This PR removes the `expect()` call, which would panic and interrupt the main execution thread calling `run_all`, whose direct caller is `NexusWatcher::start`.

`expect()` is replaced with `inspect_err()` which only prints the error message in case of error. The error in case of no homeservers is already thrown by `get_all_from_graph`, here we only print that error message instead of creating a new one.