### PR TITLE
Remove misuse of `EventProcessorError::ShutdownRequested`

### DIFF
--- a/nexus-common/src/models/homeserver.rs
+++ b/nexus-common/src/models/homeserver.rs
@@ -27,8 +27,11 @@ impl Homeserver {
     }
 
     /// Creates a new homeserver instance with the specified cursor
-    pub fn from_cursor(id: PubkyId, cursor: String) -> Self {
-        Homeserver { id, cursor }
+    pub fn from_cursor<T: Into<String>>(id: PubkyId, cursor: T) -> Self {
+        Homeserver {
+            id,
+            cursor: cursor.into(),
+        }
     }
 
     /// Stores this homeserver in the graph.

--- a/nexus-watcher/src/events/errors.rs
+++ b/nexus-watcher/src/events/errors.rs
@@ -21,9 +21,6 @@ pub enum EventProcessorError {
     /// The Pubky client could not resolve the pubky
     #[error("PubkyClientError: {message}")]
     PubkyClientError { message: String },
-    /// Graceful shutdown requested (not a failure; used to stop the event processor)
-    #[error("ShutdownRequested: Graceful shutdown requested")]
-    ShutdownRequested,
 }
 
 impl EventProcessorError {

--- a/nexus-watcher/src/events/processor_factory.rs
+++ b/nexus-watcher/src/events/processor_factory.rs
@@ -44,6 +44,10 @@ impl TEventProcessorFactory for EventProcessorFactory {
         Duration::from_secs(PROCESSING_TIMEOUT_SECS)
     }
 
+    fn shutdown_rx(&self) -> Receiver<bool> {
+        self.shutdown_rx.clone()
+    }
+
     /// Creates and returns a new event processor instance for the specified homeserver
     async fn build(&self, homeserver_id: String) -> Result<Arc<dyn TEventProcessor>, DynError> {
         let homeserver_id = PubkyId::try_from(&homeserver_id)?;

--- a/nexus-watcher/src/events/traits/tevent_processor.rs
+++ b/nexus-watcher/src/events/traits/tevent_processor.rs
@@ -20,13 +20,7 @@ use nexus_common::types::DynError;
 ///   different processor implementations
 #[async_trait::async_trait]
 pub trait TEventProcessor: Send + Sync {
-    /// Runs the event processor asynchronously, consuming the processor instance.
-    ///
-    /// # Parameters
-    /// * `self` - The processor instance, consumed by this method (takes ownership)
-    /// * `shutdown_rx` - A watch channel receiver that signals when the processor should
-    ///   shut down. The processor should check this channel regularly and terminate
-    ///   when it receives a shutdown signal.
+    /// Runs the event processor asynchronously.
     ///
     /// Returns `Ok(())` on a clean exit, or `Err(DynError)` on failure.
     async fn run(self: Arc<Self>) -> Result<(), DynError>;

--- a/nexus-watcher/tests/service/event_processing_multiple_homeservers.rs
+++ b/nexus-watcher/tests/service/event_processing_multiple_homeservers.rs
@@ -34,7 +34,7 @@ async fn test_multiple_homeserver_event_processing() -> Result<()> {
     )
     .await;
 
-    let factory = MockEventProcessorFactory::new(event_processor_hashmap, None);
+    let factory = MockEventProcessorFactory::new(event_processor_hashmap, None, shutdown_rx);
 
     let result = factory.run_all().await.unwrap();
 
@@ -63,7 +63,11 @@ async fn test_multi_hs_event_processing_with_timeout() -> Result<()> {
         .await;
     }
 
-    let factory = MockEventProcessorFactory::new(event_processor_hashmap, EVENT_PROCESSOR_TIMEOUT);
+    let factory = MockEventProcessorFactory::new(
+        event_processor_hashmap,
+        EVENT_PROCESSOR_TIMEOUT,
+        shutdown_rx,
+    );
 
     let result = factory.run_all().await.unwrap();
 

--- a/nexus-watcher/tests/service/mock_event_processor.rs
+++ b/nexus-watcher/tests/service/mock_event_processor.rs
@@ -20,7 +20,7 @@ const TIMEOUT: Duration = Duration::from_secs(2);
 async fn test_mock_event_processors() -> Result<(), DynError> {
     let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
     let mock_processors = create_mock_event_processors(shutdown_rx.clone());
-    let factory = MockEventProcessorFactory::new(mock_processors, Some(TIMEOUT));
+    let factory = MockEventProcessorFactory::new(mock_processors, Some(TIMEOUT), shutdown_rx);
 
     // Test successful event processor
     let processor = factory.build(HS_IDS[0].to_string()).await?;

--- a/nexus-watcher/tests/service/utils/processor.rs
+++ b/nexus-watcher/tests/service/utils/processor.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use crate::service::utils::MockEventProcessorResult;
 use nexus_common::types::DynError;
-use nexus_watcher::events::errors::EventProcessorError;
 use nexus_watcher::events::TEventProcessor;
 use tokio::sync::watch::Receiver;
 use tokio::time::Duration;
@@ -17,25 +16,16 @@ pub struct MockEventProcessor {
 #[async_trait::async_trait]
 impl TEventProcessor for MockEventProcessor {
     async fn run(self: Arc<Self>) -> Result<(), DynError> {
-        // If shutdown was already requested, exit immediately so callers can count it
-        if *self.shutdown_rx.borrow() {
-            return Err(EventProcessorError::ShutdownRequested.into());
-        }
-
         // Simulate a timeout/long-running work if needed, but be responsive to shutdown
+        // This simulates the processing of event lines, which can take a while but can be interrupted by the shutdown signal
         if let Some(timeout) = self.timeout {
             let mut shutdown_rx = self.shutdown_rx.clone();
             tokio::select! {
                 _ = tokio::time::sleep(timeout) => {},
                 _ = shutdown_rx.changed() => {
-                    return Err(EventProcessorError::ShutdownRequested.into());
+                    return Ok(());
                 }
             }
-        }
-
-        // Check again before returning a result
-        if *self.shutdown_rx.borrow() {
-            return Err(EventProcessorError::ShutdownRequested.into());
         }
 
         match &self.processor_status {


### PR DESCRIPTION
The `EventProcessorError::ShutdownRequested` was (mis)used as a way to signal which event processor runs were interrupted by a shutdown signal. The number of such processor runs was tallied in `skipped_homeservers`, returned by `run_all`.

On further reflection, counting the skipped processor runs may not be a good idea, because the value is imprecise. If the signal is received during `run_all`, this causes the loop to exit _now_, which means it cannot "look ahead" to count the HSs that will be skipped this run. In other words, `skipped_homeservers` contained "processor runs skipped until the signal was received", not "all skipped processor runs" as the name implies.

This PR
- removed the `ShutdownRequested` pseudo-error
- changed `skipped_homeservers` into `count_error`, showing the total number of processor runs so far that failed with an error.
- fixed a signal test
  - before: the factory's `run_all` continued looping over processors, building and running new ones, not checking if the signal was received in the meantime
  - after: `run_all` checks the signal before building / running any new processor

For the test fix, the factory now exposes `shutdown_rx()`, which is used to read the shutdown signal in the `run_all` loop.