### PR TITLE
Rename `prioritize_default_homeserver()` -> `homeservers_by_priority()`

### DIFF
--- a/nexus-watcher/src/service/processor_factory.rs
+++ b/nexus-watcher/src/service/processor_factory.rs
@@ -56,7 +56,7 @@ impl TEventProcessorFactory for EventProcessorFactory {
     }
 
     /// Returns homeserver IDs with the default homeserver prioritized at index 0
-    async fn prioritize_default_homeserver(&self) -> Vec<String> {
+    async fn homeservers_by_priority(&self) -> Vec<String> {
         let mut hs_ids = Homeserver::get_all_from_graph()
             .await
             .expect("No Homeserver IDs found in graph");

--- a/nexus-watcher/src/service/traits/tevent_processor_factory.rs
+++ b/nexus-watcher/src/service/traits/tevent_processor_factory.rs
@@ -43,10 +43,10 @@ pub trait TEventProcessorFactory: Send + Sync {
     /// This is used to prioritize the default homeserver when processing multiple homeservers.
     fn default_homeserver(&self) -> &str;
 
-    /// Returns the homeserver IDs relevant for this run.
+    /// Returns the homeserver IDs relevant for this run, ordered by their priority.
     ///
     /// Contains all homeserver IDs from the graph, with the default homeserver prioritized at index 0.
-    async fn prioritize_default_homeserver(&self) -> Vec<String>;
+    async fn homeservers_by_priority(&self) -> Vec<String>;
 
     /// Creates and returns a new event processor instance for the specified homeserver.
     ///
@@ -73,7 +73,7 @@ pub trait TEventProcessorFactory: Send + Sync {
     /// - `count_ok`: Number of homeservers where processing returned Ok
     /// - `count_error`: Number of homeservers where processing failed with Err
     async fn run_all(&self) -> RunAllProcessorsResult {
-        let hs_ids = self.prioritize_default_homeserver().await;
+        let hs_ids = self.homeservers_by_priority().await;
 
         // Initialize counters for the number of homeservers that were processed successfully and those that failed
         let mut count_ok = 0;

--- a/nexus-watcher/tests/service/event_processor_prioritization.rs
+++ b/nexus-watcher/tests/service/event_processor_prioritization.rs
@@ -31,7 +31,7 @@ async fn test_event_processor_factory_default_homeserver_prioritization() -> Res
     }
 
     // Prioritize the default homeserver
-    let hs_ids = factory.prioritize_default_homeserver().await;
+    let hs_ids = factory.homeservers_by_priority().await;
     assert_eq!(hs_ids[0], HS_IDS[3]);
 
     Ok(())
@@ -61,7 +61,7 @@ async fn test_mock_event_processor_factory_default_homeserver_prioritization(
     }
 
     // Prioritize the default homeserver
-    let hs_ids = factory.prioritize_default_homeserver().await;
+    let hs_ids = factory.homeservers_by_priority().await;
     assert_eq!(hs_ids[0], HS_IDS[0]);
 
     Ok(())

--- a/nexus-watcher/tests/service/utils/processor_factory.rs
+++ b/nexus-watcher/tests/service/utils/processor_factory.rs
@@ -56,7 +56,7 @@ impl TEventProcessorFactory for MockEventProcessorFactory {
     }
 
     /// Returns homeserver IDs with the insert order of the event processors
-    async fn prioritize_default_homeserver(&self) -> Vec<String> {
+    async fn homeservers_by_priority(&self) -> Vec<String> {
         let persistedhs_ids = Homeserver::get_all_from_graph()
             .await
             .expect("No Homeserver IDs found in graph");


### PR DESCRIPTION
This PR renames `prioritize_default_homeserver()` to `homeservers_by_priority()`, as it implies a more general ordering in addition to placing the default one first.