### PR TITLE
Correctly handle and track panicks in event processor runs

### DIFF
--- a/nexus-watcher/src/service/constants.rs
+++ b/nexus-watcher/src/service/constants.rs
@@ -1,4 +1,5 @@
 /// Name of the watcher config file
 pub const WATCHER_CONFIG_FILE_NAME: &str = "watcher-config.toml";
 ///  Per-homeserver hard timeout (seconds)
+// TODO: Set timeout maybe from the config file
 pub const PROCESSING_TIMEOUT_SECS: u64 = 3_600;

--- a/nexus-watcher/src/service/processor.rs
+++ b/nexus-watcher/src/service/processor.rs
@@ -7,6 +7,7 @@ use nexus_common::models::homeserver::Homeserver;
 use nexus_common::types::DynError;
 use opentelemetry::trace::{FutureExt, Span, TraceContextExt, Tracer};
 use opentelemetry::{global, Context, KeyValue};
+use pubky_app_specs::PubkyId;
 use std::error::Error;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -24,7 +25,11 @@ pub struct EventProcessor {
 
 #[async_trait::async_trait]
 impl TEventProcessor for EventProcessor {
-    async fn run(self: Arc<Self>) -> Result<(), DynError> {
+    fn get_homeserver_id(&self) -> PubkyId {
+        self.homeserver.id.clone()
+    }
+
+    async fn run_internal(self: Arc<Self>) -> Result<(), DynError> {
         let maybe_event_lines = {
             let tracer = global::tracer(self.tracer_name.clone());
             let span = tracer.start("Polling Events");

--- a/nexus-watcher/src/service/processor_factory.rs
+++ b/nexus-watcher/src/service/processor_factory.rs
@@ -1,14 +1,12 @@
 use crate::events::Moderation;
 use crate::service::processor::EventProcessor;
 use crate::service::traits::{TEventProcessor, TEventProcessorFactory};
-use crate::service::PROCESSING_TIMEOUT_SECS;
 use nexus_common::models::homeserver::Homeserver;
 use nexus_common::types::DynError;
 use nexus_common::WatcherConfig;
 use pubky_app_specs::PubkyId;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Duration;
 use tokio::sync::watch::Receiver;
 
 /// This implements the creation logic for [`EventProcessor`] objects
@@ -41,12 +39,6 @@ impl EventProcessorFactory {
 
 #[async_trait::async_trait]
 impl TEventProcessorFactory for EventProcessorFactory {
-    /// Returns the timeout for the event processor
-    fn timeout(&self) -> Duration {
-        // TODO: Set timeout maybe from the config file
-        Duration::from_secs(PROCESSING_TIMEOUT_SECS)
-    }
-
     fn shutdown_rx(&self) -> Receiver<bool> {
         self.shutdown_rx.clone()
     }

--- a/nexus-watcher/src/service/traits/tevent_processor.rs
+++ b/nexus-watcher/src/service/traits/tevent_processor.rs
@@ -18,6 +18,10 @@ impl RunError {
     pub fn is_panic(&self) -> bool {
         matches!(self, RunError::Panicked)
     }
+
+    pub fn is_timeout(&self) -> bool {
+        matches!(self, RunError::TimedOut)
+    }
 }
 
 impl Display for RunError {

--- a/nexus-watcher/src/service/traits/tevent_processor.rs
+++ b/nexus-watcher/src/service/traits/tevent_processor.rs
@@ -47,7 +47,7 @@ pub trait TEventProcessor: Send + Sync + 'static {
     async fn run(self: Arc<Self>) -> Result<(), RunError> {
         let hs_id = self.get_homeserver_id().to_string();
         let timeout = self
-            .timeout()
+            .custom_timeout()
             .unwrap_or(Duration::from_secs(PROCESSING_TIMEOUT_SECS));
 
         let handle = tokio::spawn(self.run_internal());
@@ -78,10 +78,10 @@ pub trait TEventProcessor: Send + Sync + 'static {
     /// Returns `Ok(())` on a clean exit, or `Err(DynError)` on failure.
     async fn run_internal(self: Arc<Self>) -> Result<(), DynError>;
 
-    /// Optional custom timeout for this event processor execution.
+    /// Optional custom timeout for this event processor.
     ///
     /// If not set, the [`PROCESSING_TIMEOUT_SECS`] is applied.
-    fn timeout(&self) -> Option<Duration> {
+    fn custom_timeout(&self) -> Option<Duration> {
         None
     }
 }

--- a/nexus-watcher/src/service/traits/tevent_processor.rs
+++ b/nexus-watcher/src/service/traits/tevent_processor.rs
@@ -1,15 +1,35 @@
-use std::sync::Arc;
+use std::{fmt::Display, sync::Arc, time::Duration};
 
 use nexus_common::types::DynError;
+use pubky_app_specs::PubkyId;
+use tracing::error;
+
+use crate::service::PROCESSING_TIMEOUT_SECS;
+
+/// Possible error types of an event processor run
+#[derive(Debug)]
+pub enum RunError {
+    Internal(DynError),
+    Panicked,
+    TimedOut,
+}
+
+impl RunError {
+    pub fn is_panic(&self) -> bool {
+        matches!(self, RunError::Panicked)
+    }
+}
+
+impl Display for RunError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self)
+    }
+}
 
 /// Asynchronous event processor interface for the Watcher service.
 ///
 /// This trait represents a component that can process events asynchronously and can be
 /// gracefully shut down through a watch channel.
-///
-/// # Thread Safety
-/// Implementors must be `Send + Sync` to ensure they can be safely used across thread
-/// boundaries, which is crucial for asynchronous event processing.
 ///
 /// # Implementation Notes
 /// - Implementors should regularly check the `shutdown_rx` channel for shutdown signals
@@ -17,9 +37,53 @@ use nexus_common::types::DynError;
 /// - The method returns a `DynError` to allow for flexible error handling across
 ///   different processor implementations
 #[async_trait::async_trait]
-pub trait TEventProcessor: Send + Sync {
+pub trait TEventProcessor: Send + Sync + 'static {
+    fn get_homeserver_id(&self) -> PubkyId;
+
+    async fn run(self: Arc<Self>) -> Result<(), RunError> {
+        let hs_id = self.get_homeserver_id().to_string();
+        let timeout = self
+            .timeout()
+            .unwrap_or(Duration::from_secs(PROCESSING_TIMEOUT_SECS));
+
+        let handle = tokio::spawn(self.run_internal());
+
+        let join_result = tokio::time::timeout(timeout, handle)
+            .await
+            .inspect_err(|_| error!("Event processor timed out for {hs_id}"))
+            .map_err(|_| RunError::TimedOut)?;
+
+        match join_result {
+            Ok(run_internal_result) => match run_internal_result {
+                Ok(_) => Ok(()),
+                Err(e) => {
+                    error!("Event processor failed for {hs_id}: {e:?}");
+                    Err(RunError::Internal(e))
+                }
+            },
+
+            Err(join_error) => {
+                // The JoinError can be:
+                // - join_error.is_panic() => panic by the inner future
+                // - join_error.is_cancelled() => inner future was abruptly interrupted, for example
+                //   - JoinHandle::abort() is called on the handle
+                //   - the Tokio runtime is shut down
+
+                error!("JoinError while running event processor for {hs_id}: {join_error:?}");
+                Err(RunError::Panicked)
+            }
+        }
+    }
+
     /// Runs the event processor asynchronously.
     ///
     /// Returns `Ok(())` on a clean exit, or `Err(DynError)` on failure.
-    async fn run(self: Arc<Self>) -> Result<(), DynError>;
+    async fn run_internal(self: Arc<Self>) -> Result<(), DynError>;
+
+    /// Optional custom timeout for this event processor execution.
+    ///
+    /// If not set, the [`PROCESSING_TIMEOUT_SECS`] is applied.
+    fn timeout(&self) -> Option<Duration> {
+        None
+    }
 }

--- a/nexus-watcher/src/service/traits/tevent_processor_factory.rs
+++ b/nexus-watcher/src/service/traits/tevent_processor_factory.rs
@@ -115,7 +115,7 @@ pub trait TEventProcessorFactory {
     /// - The processor cannot be built for the given homeserver
     /// - The processor fails during execution
     /// - The processor times out
-    async fn run(&self, hs_id: String) -> Result<(), RunError> {
+    async fn run_single(&self, hs_id: String) -> Result<(), RunError> {
         let Ok(event_processor) = self.build(hs_id.clone()).await else {
             error!("Failed to build event processor for homeserver: {}", hs_id);
             // TODO This is not an accurate Err, as RunError indicates the run started, but this happens before run()

--- a/nexus-watcher/src/service/traits/tevent_processor_factory.rs
+++ b/nexus-watcher/src/service/traits/tevent_processor_factory.rs
@@ -1,23 +1,31 @@
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
 use nexus_common::types::DynError;
-use tokio::{sync::watch::Receiver, time::timeout};
+use tokio::sync::watch::Receiver;
 use tracing::{error, info};
 
-use crate::service::traits::TEventProcessor;
+use crate::service::traits::{tevent_processor::RunError, TEventProcessor};
+
+#[derive(Default)]
+pub struct RunAllProcessorsStats {
+    /// Number of homeservers where processing were successful
+    pub count_ok: u16,
+    /// Number of homeservers where processing failed with Err
+    pub count_error: u16,
+    /// Number of homeservers where processing panicked
+    pub count_panic: u16,
+    /// Number of homeservers where processing timed out
+    pub count_timeout: u16,
+}
 
 /// The type that describes the result of an event processor run
-type RunAllProcessorsResult = Result<(u64, u64), DynError>;
+type RunAllProcessorsResult = Result<RunAllProcessorsStats, DynError>;
 
 /// Asynchronous factory for creating event processors in the Watcher service.
 ///
 /// This trait represents a component responsible for creating event processor instances
 /// for specific homeservers. It provides a standardized way to instantiate processors
 /// with the appropriate configuration and dependencies.
-///
-/// # Thread Safety
-/// Implementors must be `Send + Sync` to ensure they can be safely used across thread
-/// boundaries, which is essential for asynchronous factory operations.
 ///
 /// # Implementation Notes
 /// - The `build` method should create and return a fully configured event processor
@@ -29,13 +37,7 @@ type RunAllProcessorsResult = Result<(u64, u64), DynError>;
 /// - Implementors should ensure that created processors are properly isolated and
 ///   don't share mutable state unless explicitly intended
 #[async_trait::async_trait]
-pub trait TEventProcessorFactory: Send + Sync {
-    /// Returns the timeout duration for event processor execution.
-    ///
-    /// This timeout is applied to individual event processor `run()` operations
-    /// to prevent hanging or long-running processors from blocking the system
-    fn timeout(&self) -> Duration;
-
+pub trait TEventProcessorFactory {
     /// Returns the shutdown signal receiver
     fn shutdown_rx(&self) -> Receiver<bool>;
 
@@ -75,40 +77,33 @@ pub trait TEventProcessorFactory: Send + Sync {
     async fn run_all(&self) -> RunAllProcessorsResult {
         let hs_ids = self.homeservers_by_priority().await;
 
-        // Initialize counters for the number of homeservers that were processed successfully and those that failed
-        let mut count_ok = 0;
-        let mut count_error = 0;
+        let mut run_stats = RunAllProcessorsStats::default();
 
         for hs_id in hs_ids {
             if *self.shutdown_rx().borrow() {
                 info!("Shutdown detected in homeserver {hs_id}, exiting run_all loop");
-                return Ok((count_ok, count_error));
+                return Ok(run_stats);
             }
+
+            // TODO Re-use run() below, instead of separate build/run for each processor
 
             let Ok(event_processor) = self.build(hs_id.clone()).await else {
                 error!("Failed to build event processor for homeserver: {}", hs_id);
                 continue;
             };
-            match timeout(self.timeout(), event_processor.run()).await {
-                Ok(Ok(_)) => count_ok += 1,
-                Ok(Err(e)) => {
-                    error!("Event processor failed for {}: {:?}", hs_id, e);
-                    count_error += 1;
-                }
-                Err(_) => {
-                    error!("Event processor timed out for {}", hs_id);
-                    count_error += 1;
-                }
+
+            match event_processor.run().await {
+                Ok(_) => run_stats.count_ok += 1,
+                Err(RunError::Internal(_)) => run_stats.count_error += 1,
+                Err(RunError::Panicked) => run_stats.count_panic += 1,
+                Err(RunError::TimedOut) => run_stats.count_timeout += 1,
             }
         }
 
-        Ok((count_ok, count_error))
+        Ok(run_stats)
     }
 
-    /// Runs an event processor for a specific homeserver.
-    ///
-    /// This method creates an event processor for the specified homeserver ID and
-    /// executes it with timeout protection
+    /// Creates and runs an event processor for a specific homeserver.
     ///
     /// # Parameters
     /// * `hs_id` - The homeserver identifier as a string. Must be a valid PubkyId
@@ -120,27 +115,15 @@ pub trait TEventProcessorFactory: Send + Sync {
     /// - The processor cannot be built for the given homeserver
     /// - The processor fails during execution
     /// - The processor times out
-    async fn run(&self, hs_id: String) -> Result<(), DynError> {
+    async fn run(&self, hs_id: String) -> Result<(), RunError> {
         let Ok(event_processor) = self.build(hs_id.clone()).await else {
             error!("Failed to build event processor for homeserver: {}", hs_id);
-            return Err(DynError::from(format!(
+            // TODO This is not an accurate Err, as RunError indicates the run started, but this happens before run()
+            return Err(RunError::Internal(DynError::from(format!(
                 "Failed to build event processor for homeserver: {hs_id}",
-            )));
+            ))));
         };
-        match timeout(self.timeout(), event_processor.run()).await {
-            Ok(Ok(_)) => Ok(()),
-            Ok(Err(e)) => {
-                error!("Event processor failed for {}: {:?}", hs_id, e);
-                return Err(DynError::from(format!(
-                    "Event processor failed for {hs_id}: {e:?}",
-                )));
-            }
-            Err(_) => {
-                error!("Event processor timed out for {}", hs_id);
-                return Err(DynError::from(format!(
-                    "Event processor timed out for {hs_id}"
-                )));
-            }
-        }
+
+        event_processor.run().await
     }
 }

--- a/nexus-watcher/src/service/traits/tevent_processor_factory.rs
+++ b/nexus-watcher/src/service/traits/tevent_processor_factory.rs
@@ -85,8 +85,6 @@ pub trait TEventProcessorFactory {
                 return Ok(run_stats);
             }
 
-            // TODO Re-use run() below, instead of separate build/run for each processor
-
             let Ok(event_processor) = self.build(hs_id.clone()).await else {
                 error!("Failed to build event processor for homeserver: {}", hs_id);
                 continue;
@@ -101,29 +99,5 @@ pub trait TEventProcessorFactory {
         }
 
         Ok(run_stats)
-    }
-
-    /// Creates and runs an event processor for a specific homeserver.
-    ///
-    /// # Parameters
-    /// * `hs_id` - The homeserver identifier as a string. Must be a valid PubkyId
-    ///   that exists in the system and can be processed by the factory.
-    ///
-    /// # Returns
-    /// Returns `Ok(())` if the processor completes successfully within the timeout,
-    /// or `Err(DynError)` if:
-    /// - The processor cannot be built for the given homeserver
-    /// - The processor fails during execution
-    /// - The processor times out
-    async fn run_single(&self, hs_id: String) -> Result<(), RunError> {
-        let Ok(event_processor) = self.build(hs_id.clone()).await else {
-            error!("Failed to build event processor for homeserver: {}", hs_id);
-            // TODO This is not an accurate Err, as RunError indicates the run started, but this happens before run()
-            return Err(RunError::Internal(DynError::from(format!(
-                "Failed to build event processor for homeserver: {hs_id}",
-            ))));
-        };
-
-        event_processor.run().await
     }
 }

--- a/nexus-watcher/tests/event_processor/network/counts.rs
+++ b/nexus-watcher/tests/event_processor/network/counts.rs
@@ -267,8 +267,13 @@ async fn test_large_network_scenario_counts() -> Result<()> {
     if !PROCESS_EVENTS_ONE_BY_ONE {
         for _ in 1..=100 {
             // Run the event processor
+            // We do this because earlier, the factory's event processing has been turned off temporarily
+            // but at this point we are ready to run the event processing
             test.event_processor_factory
-                .run_single(test.homeserver_id.clone())
+                .build(test.homeserver_id.clone())
+                .await
+                .map_err(|e| anyhow!(e))?
+                .run()
                 .await
                 .map_err(|e| anyhow!(e))?;
         }

--- a/nexus-watcher/tests/event_processor/network/counts.rs
+++ b/nexus-watcher/tests/event_processor/network/counts.rs
@@ -268,7 +268,7 @@ async fn test_large_network_scenario_counts() -> Result<()> {
         for _ in 1..=100 {
             // Run the event processor
             test.event_processor_factory
-                .run(test.homeserver_id.clone())
+                .run_single(test.homeserver_id.clone())
                 .await
                 .map_err(|e| anyhow!(e))?;
         }

--- a/nexus-watcher/tests/event_processor/tags/fail_index.rs
+++ b/nexus-watcher/tests/event_processor/tags/fail_index.rs
@@ -75,7 +75,7 @@ async fn test_homeserver_tag_cannot_add_while_index() -> Result<()> {
 
     // Build the event processor and run it to sync all the previous events with the event processor
     test.event_processor_factory
-        .run(test.homeserver_id.clone())
+        .run_single(test.homeserver_id.clone())
         .await
         .map_err(|e| anyhow!(e))?;
 

--- a/nexus-watcher/tests/event_processor/tags/fail_index.rs
+++ b/nexus-watcher/tests/event_processor/tags/fail_index.rs
@@ -74,8 +74,13 @@ async fn test_homeserver_tag_cannot_add_while_index() -> Result<()> {
     );
 
     // Build the event processor and run it to sync all the previous events with the event processor
+    // We do this because earlier, the factory's event processing has been turned off temporarily
+    // but at this point we are ready to run the event processing
     test.event_processor_factory
-        .run_single(test.homeserver_id.clone())
+        .build(test.homeserver_id.clone())
+        .await
+        .map_err(|e| anyhow!(e))?
+        .run()
         .await
         .map_err(|e| anyhow!(e))?;
 

--- a/nexus-watcher/tests/service/event_processor_prioritization.rs
+++ b/nexus-watcher/tests/service/event_processor_prioritization.rs
@@ -43,14 +43,13 @@ async fn test_mock_event_processor_factory_default_homeserver_prioritization(
     // Initialize the test
     setup().await?;
 
-    let event_processors = create_mock_event_processors(tokio::sync::watch::channel(false).1)
+    let event_processors = create_mock_event_processors(None, tokio::sync::watch::channel(false).1)
         .into_iter()
         .map(|processor| Arc::new(processor))
         .collect();
 
     let factory = MockEventProcessorFactory {
         event_processors,
-        timeout: None,
         shutdown_rx: tokio::sync::watch::channel(false).1,
     };
 

--- a/nexus-watcher/tests/service/mock_event_processor.rs
+++ b/nexus-watcher/tests/service/mock_event_processor.rs
@@ -12,30 +12,28 @@ async fn test_mock_event_processors() -> Result<(), DynError> {
     let factory = MockEventProcessorFactory::new(mock_processors, shutdown_rx);
 
     // Test successful event processor
-    let processor = factory.build(HS_IDS[0].to_string()).await?;
-    assert!(processor.run().await.is_ok());
+    let ev_processor_0 = factory.build(HS_IDS[0].to_string()).await?;
+    assert!(ev_processor_0.run().await.is_ok());
 
     // Test error event processor
-    let processor = factory.build(HS_IDS[1].to_string()).await?;
-    assert!(processor.run().await.is_err());
+    let ev_processor_1 = factory.build(HS_IDS[1].to_string()).await?;
+    assert!(ev_processor_1.run().await.is_err());
 
     // Test panic event processor
-    let processor = factory.build(HS_IDS[2].to_string()).await?;
-    let res = processor.run().await;
-    assert!(res.is_err() && res.unwrap_err().is_panic());
+    let ev_processor_2 = factory.build(HS_IDS[2].to_string()).await?;
+    let ev_processor_2_res = ev_processor_2.run().await;
+    assert!(ev_processor_2_res.is_err() && ev_processor_2_res.unwrap_err().is_panic());
 
     // Test timeout scenarios
-    let processor = factory.build(HS_IDS[3].to_string()).await?;
-    match processor.run().await {
-        Ok(_) => return Err(format!("Event processor should timeout after {TIMEOUT:?}s"))?,
-        Err(_) => {}
-    };
+    let ev_processor_3 = factory.build(HS_IDS[3].to_string()).await?;
+    let ev_processor_3_res = ev_processor_3.run().await;
+    assert!(ev_processor_3_res.is_err() && ev_processor_3_res.unwrap_err().is_timeout());
 
-    let processor = factory.build(HS_IDS[4].to_string()).await?;
-    match processor.run().await {
-        Ok(_) => {}
-        Err(_) => return Err(format!("Event processor should not timeout"))?,
-    };
+    let ev_processor_4 = factory.build(HS_IDS[4].to_string()).await?;
+    assert!(
+        ev_processor_4.run().await.is_ok(),
+        "Event processor should not timeout"
+    );
 
     Ok(())
 }

--- a/nexus-watcher/tests/service/signal.rs
+++ b/nexus-watcher/tests/service/signal.rs
@@ -19,12 +19,13 @@ async fn test_shutdown_signal() -> Result<()> {
             &mut event_processor_list,
             Some(Duration::from_secs(index * 2)),
             processor_status,
+            None,
             shutdown_rx.clone(),
         )
         .await;
     }
 
-    let factory = MockEventProcessorFactory::new(event_processor_list, None, shutdown_rx);
+    let factory = MockEventProcessorFactory::new(event_processor_list, shutdown_rx);
 
     // Schedule Ctrl-C simulation after 1s
     tokio::spawn({
@@ -39,8 +40,8 @@ async fn test_shutdown_signal() -> Result<()> {
 
     // We created 3 HSs, each with different execution durations (0s, 2s, 4s)
     // We triggered the shutdown signal 1s after start
-    assert_eq!(result.0, 2); // 2 processors run without errors (of the 3, the 3rd one didn't even start)
-    assert_eq!(result.1, 0); // no processors fail, because no erratic or unexpected behavior was triggered
+    assert_eq!(result.count_ok, 2); // 2 processors run without errors (of the 3, the 3rd one didn't even start)
+    assert_eq!(result.count_error, 0); // no processors fail, because no erratic or unexpected behavior was triggered
 
     Ok(())
 }

--- a/nexus-watcher/tests/service/utils/processor.rs
+++ b/nexus-watcher/tests/service/utils/processor.rs
@@ -10,16 +10,27 @@ use tokio::sync::watch::Receiver;
 use tokio::time::Duration;
 
 pub struct MockEventProcessor {
-    pub homeserver_id: String,
+    pub homeserver_id: PubkyId,
+    /// Desired event processor status. In other words, the type of execution that `run` should simulate.
     pub processor_status: MockEventProcessorResult,
     /// If set, this mock processor will return successfully after waiting for this amount of time
     pub sleep_duration: Option<Duration>,
+    /// A custom timeout for this event processor. If set, it overrides the globally defined one.
+    pub timeout: Option<Duration>,
     pub shutdown_rx: Receiver<bool>,
 }
 
 #[async_trait::async_trait]
 impl TEventProcessor for MockEventProcessor {
-    async fn run(self: Arc<Self>) -> Result<(), DynError> {
+    fn get_homeserver_id(&self) -> PubkyId {
+        self.homeserver_id.clone()
+    }
+
+    fn timeout(&self) -> Option<Duration> {
+        self.timeout
+    }
+
+    async fn run_internal(self: Arc<Self>) -> Result<(), DynError> {
         // Simulate a long-running task if needed, but be responsive to shutdown
         // This simulates the processing of event lines, which can take a while but can be interrupted by the shutdown signal
         if let Some(sleep_duration) = self.sleep_duration {
@@ -45,26 +56,30 @@ pub async fn create_random_homeservers_and_persist(
     event_processor_list: &mut Vec<MockEventProcessor>,
     sleep_duration: Option<Duration>,
     processor_status: MockEventProcessorResult,
+    timeout: Option<Duration>,
     shutdown_rx: Receiver<bool>,
 ) {
     let homeserver_keypair = Keypair::random();
     let homeserver_public_key = homeserver_keypair.public_key().to_z32();
 
-    let config_hs = PubkyId::try_from(homeserver_public_key.as_str()).unwrap();
-    Homeserver::persist_if_unknown(config_hs).await.unwrap();
+    let homeserver_id = PubkyId::try_from(homeserver_public_key.as_str()).unwrap();
+    Homeserver::persist_if_unknown(homeserver_id.clone())
+        .await
+        .unwrap();
 
     let event_processor = MockEventProcessor {
-        homeserver_id: homeserver_public_key.clone(),
+        homeserver_id,
         sleep_duration,
         processor_status,
+        timeout,
         shutdown_rx,
     };
     event_processor_list.push(event_processor);
 }
 
-
 /// Create a list of mock event processors
 pub fn create_mock_event_processors(
+    timeout: Option<Duration>,
     shutdown_rx: Receiver<bool>,
 ) -> Vec<MockEventProcessor> {
     use MockEventProcessorResult::*;
@@ -76,13 +91,14 @@ pub fn create_mock_event_processors(
         (HS_IDS[4], Some(1), Success("Success finished!".into())),
     ]
     .into_iter()
-    .map(|(homeserver_id, sleep_duration_sec, status)| {
-        MockEventProcessor {
-            homeserver_id: homeserver_id.to_string(),
+    .map(
+        |(homeserver_id, sleep_duration_sec, status)| MockEventProcessor {
+            homeserver_id: PubkyId::try_from(homeserver_id).unwrap(),
             sleep_duration: sleep_duration_sec.map(Duration::from_secs),
             processor_status: status,
+            timeout: timeout.clone(),
             shutdown_rx: shutdown_rx.clone(),
-        }
-    })
+        },
+    )
     .collect()
 }


### PR DESCRIPTION
This PR makes sure that any individual processor run which panics will not stop the wrapper `run_all`. This allows the indexer to continue indexing undisturbed.

To achieve this,`TEventProcessor` was changed as follows:
- `run` has a trait default implementation which internally calls `run_internal` and checks for timeout, panic or errors
- `run_internal` is the raw event processor run. For `EventProcessor`, it deals with fetching and processing events. For `MockEventProcessor`, it simulates a certain run behavior. Note that both the mock and the real implementation are subject to the same timeout and panic checks in `run`.
- got various utilities, like `timeout()` (moved from the factory) and `get_homeserver_id()`