### PR TITLE
Add test case for event processors which panic

### DIFF
--- a/nexus-watcher/tests/service/event_processing_multiple_homeservers.rs
+++ b/nexus-watcher/tests/service/event_processing_multiple_homeservers.rs
@@ -42,6 +42,8 @@ async fn test_multiple_homeserver_event_processing() -> Result<()> {
 
     assert_eq!(result.count_ok, 3);
     assert_eq!(result.count_error, 1);
+    assert_eq!(result.count_panic, 0);
+    assert_eq!(result.count_timeout, 0);
 
     Ok(())
 }
@@ -72,6 +74,8 @@ async fn test_multi_hs_event_processing_with_timeout() -> Result<()> {
 
     assert_eq!(result.count_ok, 1); // 1 success
     assert_eq!(result.count_timeout, 2); // 2 failures due to timeout
+    assert_eq!(result.count_error, 0);
+    assert_eq!(result.count_panic, 0);
 
     Ok(())
 }

--- a/nexus-watcher/tests/service/event_processing_multiple_homeservers.rs
+++ b/nexus-watcher/tests/service/event_processing_multiple_homeservers.rs
@@ -1,6 +1,6 @@
 use crate::service::utils::{
-    create_random_homeservers_and_persist, error_result, setup, success_result,
-    MockEventProcessorFactory,
+    create_random_homeservers_and_persist, setup, MockEventProcessorFactory,
+    MockEventProcessorResult,
 };
 use anyhow::Result;
 use nexus_watcher::service::TEventProcessorFactory;
@@ -14,7 +14,7 @@ async fn test_multiple_homeserver_event_processing() -> Result<()> {
 
     // Create 3 random homeservers with success result
     for _ in 0..3 {
-        let processor_status = success_result("success from homeserver");
+        let processor_status = MockEventProcessorResult::Success("Success from HS".into());
         create_random_homeservers_and_persist(
             &mut event_processor_list,
             None,
@@ -26,7 +26,7 @@ async fn test_multiple_homeserver_event_processing() -> Result<()> {
     }
 
     // Create 1 random homeserver with error result
-    let processor_status = error_result("PubkyClient: timeout from homeserver");
+    let processor_status = MockEventProcessorResult::Error("PubkyClient: timeout from HS".into());
     create_random_homeservers_and_persist(
         &mut event_processor_list,
         None,
@@ -57,7 +57,7 @@ async fn test_multi_hs_event_processing_with_timeout() -> Result<()> {
 
     // Create 3 random homeservers with timeout limit
     for index in 0..3 {
-        let processor_status = success_result("success from homeserver");
+        let processor_status = MockEventProcessorResult::Success("Success from HS".into());
         create_random_homeservers_and_persist(
             &mut event_processor_list,
             Some(Duration::from_secs(index * 2)),

--- a/nexus-watcher/tests/service/event_processing_multiple_homeservers.rs
+++ b/nexus-watcher/tests/service/event_processing_multiple_homeservers.rs
@@ -14,7 +14,7 @@ async fn test_multiple_homeserver_event_processing() -> Result<()> {
 
     // Create 3 random homeservers with success result
     for _ in 0..3 {
-        let processor_status = MockEventProcessorResult::Success("Success from HS".into());
+        let processor_status = MockEventProcessorResult::Success;
         create_random_homeservers_and_persist(
             &mut event_processor_list,
             None,
@@ -57,7 +57,7 @@ async fn test_multi_hs_event_processing_with_timeout() -> Result<()> {
 
     // Create 3 random homeservers with timeout limit
     for index in 0..3 {
-        let processor_status = MockEventProcessorResult::Success("Success from HS".into());
+        let processor_status = MockEventProcessorResult::Success;
         create_random_homeservers_and_persist(
             &mut event_processor_list,
             Some(Duration::from_secs(index * 2)),

--- a/nexus-watcher/tests/service/signal.rs
+++ b/nexus-watcher/tests/service/signal.rs
@@ -15,7 +15,7 @@ async fn test_shutdown_signal() -> Result<()> {
 
     // Create 3 random homeservers with timeout limit
     for index in 0..3 {
-        let processor_status = MockEventProcessorResult::Success("Success from HS".into());
+        let processor_status = MockEventProcessorResult::Success;
         create_random_homeservers_and_persist(
             &mut event_processor_list,
             Some(Duration::from_secs(index * 2)),

--- a/nexus-watcher/tests/service/signal.rs
+++ b/nexus-watcher/tests/service/signal.rs
@@ -42,6 +42,8 @@ async fn test_shutdown_signal() -> Result<()> {
     // We triggered the shutdown signal 1s after start
     assert_eq!(result.count_ok, 2); // 2 processors run without errors (of the 3, the 3rd one didn't even start)
     assert_eq!(result.count_error, 0); // no processors fail, because no erratic or unexpected behavior was triggered
+    assert_eq!(result.count_panic, 0);
+    assert_eq!(result.count_timeout, 0);
 
     Ok(())
 }

--- a/nexus-watcher/tests/service/signal.rs
+++ b/nexus-watcher/tests/service/signal.rs
@@ -1,5 +1,6 @@
 use crate::service::utils::{
-    create_random_homeservers_and_persist, setup, success_result, MockEventProcessorFactory,
+    create_random_homeservers_and_persist, setup, MockEventProcessorFactory,
+    MockEventProcessorResult,
 };
 use anyhow::Result;
 use nexus_watcher::service::TEventProcessorFactory;
@@ -14,7 +15,7 @@ async fn test_shutdown_signal() -> Result<()> {
 
     // Create 3 random homeservers with timeout limit
     for index in 0..3 {
-        let processor_status = success_result("success from homeserver");
+        let processor_status = MockEventProcessorResult::Success("Success from HS".into());
         create_random_homeservers_and_persist(
             &mut event_processor_list,
             Some(Duration::from_secs(index * 2)),

--- a/nexus-watcher/tests/service/utils/mod.rs
+++ b/nexus-watcher/tests/service/utils/mod.rs
@@ -7,21 +7,5 @@ pub use processor::{
     create_mock_event_processors, create_random_homeservers_and_persist, MockEventProcessor,
 };
 pub use processor_factory::MockEventProcessorFactory;
-pub use setup::{setup, HS_IDS};
-
 pub use result::MockEventProcessorResult;
-
-/// Create a success result type
-pub fn success_result(message: &str) -> MockEventProcessorResult {
-    MockEventProcessorResult::Success(message.to_string())
-}
-
-/// Create an error result type
-pub fn error_result(message: &str) -> MockEventProcessorResult {
-    MockEventProcessorResult::Error(message.to_string().into())
-}
-
-/// Create a panic result type
-pub fn _panic_result() -> MockEventProcessorResult {
-    MockEventProcessorResult::Panic()
-}
+pub use setup::{setup, HS_IDS};

--- a/nexus-watcher/tests/service/utils/processor.rs
+++ b/nexus-watcher/tests/service/utils/processor.rs
@@ -43,9 +43,9 @@ impl TEventProcessor for MockEventProcessor {
         }
 
         match &self.processor_status {
-            MockEventProcessorResult::Success(_) => Ok(()),
+            MockEventProcessorResult::Success => Ok(()),
             MockEventProcessorResult::Error(e) => Err(format!("{e}").into()),
-            MockEventProcessorResult::Panic() => panic!("Event processor panicked: unknown error"),
+            MockEventProcessorResult::Panic => panic!("Event processor panicked: unknown error"),
         }
     }
 }
@@ -83,11 +83,11 @@ pub fn create_mock_event_processors(
 ) -> Vec<MockEventProcessor> {
     use MockEventProcessorResult::*;
     [
-        (HS_IDS[0], None, Success("Success finished!".into())),
+        (HS_IDS[0], None, Success),
         (HS_IDS[1], None, Error("Event processor error!".into())),
-        (HS_IDS[2], None, Panic()),
-        (HS_IDS[3], Some(3), Success("Success finished!".into())),
-        (HS_IDS[4], Some(1), Success("Success finished!".into())),
+        (HS_IDS[2], None, Panic),
+        (HS_IDS[3], Some(3), Success),
+        (HS_IDS[4], Some(1), Success),
     ]
     .into_iter()
     .map(

--- a/nexus-watcher/tests/service/utils/result.rs
+++ b/nexus-watcher/tests/service/utils/result.rs
@@ -2,22 +2,7 @@ use nexus_common::types::DynError;
 
 /// Result of a homeserver event processing
 pub enum MockEventProcessorResult {
-    Success(String),
+    Success,
     Error(DynError),
-    Panic(),
-}
-
-impl Clone for MockEventProcessorResult {
-    /// Useful native function for testing environment
-    fn clone(&self) -> Self {
-        match self {
-            MockEventProcessorResult::Success(msg) => {
-                MockEventProcessorResult::Success(msg.clone())
-            }
-            MockEventProcessorResult::Error(err) => {
-                MockEventProcessorResult::Error(err.to_string().into())
-            }
-            MockEventProcessorResult::Panic() => MockEventProcessorResult::Panic(),
-        }
-    }
+    Panic,
 }


### PR DESCRIPTION
This PR adds a test case for event processors which panic.

It also refactors and simplifies a few test utils related to the event processor result.