### PR TITLE
Bump `pubky-app-specs`, use new URI builder utilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,9 +1384,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
@@ -2113,9 +2113,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -3003,9 +3003,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
@@ -3370,9 +3370,9 @@ dependencies = [
 
 [[package]]
 name = "pubky-app-specs"
-version = "0.3.5"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1a959e3635b64772f48812728c27172a2269117f16741c5ef49378369b3db60"
+checksum = "6a5319eb520494294699fde304b08d821f8bbb9b8437551cad8b005c07afd172"
 dependencies = [
  "base32",
  "blake3",
@@ -5060,9 +5060,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ neo4rs = "0.8.0"
 opentelemetry = "0.30"
 opentelemetry_sdk = { version = "0.30", features = ["rt-tokio"] }
 pubky = "0.5.4"
-pubky-app-specs = { version = "0.3.5", features = ["openapi"] }
+pubky-app-specs = { version = "0.4.0", features = ["openapi"] }
 pubky-testnet = "0.5.4"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.145"

--- a/nexus-common/src/models/notification/mod.rs
+++ b/nexus-common/src/models/notification/mod.rs
@@ -4,6 +4,7 @@ use crate::types::DynError;
 use crate::types::Pagination;
 use chrono::Utc;
 use neo4rs::Row;
+use pubky_app_specs::{bookmark_uri_builder, post_uri_builder, tag_uri_builder};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
@@ -247,7 +248,7 @@ impl Notification {
         }
         let body = NotificationBody::Mention {
             mentioned_by: user_id.to_string(),
-            post_uri: format!("pubky://{user_id}/pub/pubky.app/posts/{post_id}"),
+            post_uri: post_uri_builder(user_id.to_string(), post_id.to_string()),
         };
         let notification = Notification::new(body);
         notification.put_to_index(mentioned_id).await?;
@@ -319,7 +320,7 @@ impl Notification {
                 Box::new(|row: &Row| {
                     let replier_id: &str = row.get("replier_id").unwrap_or_default();
                     let reply_id: &str = row.get("reply_id").unwrap_or_default();
-                    let linked_uri = format!("pubky://{replier_id}/pub/pubky.app/posts/{reply_id}");
+                    let linked_uri = post_uri_builder(replier_id.into(), reply_id.into());
                     (replier_id.to_string(), linked_uri)
                 }),
             ),
@@ -329,7 +330,7 @@ impl Notification {
                 Box::new(|row: &Row| {
                     let tagger_id: &str = row.get("tagger_id").unwrap_or_default();
                     let tag_id: &str = row.get("tag_id").unwrap_or_default();
-                    let linked_uri = format!("pubky://{tagger_id}/pub/pubky.app/tags/{tag_id}");
+                    let linked_uri = tag_uri_builder(tagger_id.into(), tag_id.into());
                     (tagger_id.to_string(), linked_uri)
                 }),
             ),
@@ -339,8 +340,7 @@ impl Notification {
                 Box::new(|row: &Row| {
                     let bookmarker_id: &str = row.get("bookmarker_id").unwrap_or_default();
                     let bookmark_id: &str = row.get("bookmark_id").unwrap_or_default();
-                    let linked_uri =
-                        format!("pubky://{bookmarker_id}/pub/pubky.app/bookmarks/{bookmark_id}");
+                    let linked_uri = bookmark_uri_builder(bookmarker_id.into(), bookmark_id.into());
                     (bookmarker_id.to_string(), linked_uri)
                 }),
             ),
@@ -350,8 +350,7 @@ impl Notification {
                 Box::new(|row: &Row| {
                     let reposter_id: &str = row.get("reposter_id").unwrap_or_default();
                     let repost_id: &str = row.get("repost_id").unwrap_or_default();
-                    let linked_uri =
-                        format!("pubky://{reposter_id}/pub/pubky.app/posts/{repost_id}");
+                    let linked_uri = post_uri_builder(reposter_id.into(), repost_id.into());
                     (reposter_id.to_string(), linked_uri)
                 }),
             ),

--- a/nexus-common/src/models/post/details.rs
+++ b/nexus-common/src/models/post/details.rs
@@ -5,7 +5,7 @@ use crate::db::{
 };
 use crate::types::DynError;
 use chrono::Utc;
-use pubky_app_specs::{PubkyAppPost, PubkyAppPostKind, PubkyId};
+use pubky_app_specs::{post_uri_builder, PubkyAppPost, PubkyAppPostKind, PubkyId};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
@@ -113,7 +113,7 @@ impl PostDetails {
         post_id: &String,
     ) -> Result<Self, DynError> {
         Ok(PostDetails {
-            uri: format!("pubky://{author_id}/pub/pubky.app/posts/{post_id}"),
+            uri: post_uri_builder(author_id.to_string(), post_id.into()),
             content: homeserver_post.content,
             id: post_id.clone(),
             indexed_at: Utc::now().timestamp_millis(),

--- a/nexus-common/src/models/post/relationships.rs
+++ b/nexus-common/src/models/post/relationships.rs
@@ -1,6 +1,6 @@
 use crate::db::{fetch_row_from_graph, queries, RedisOps};
 use crate::types::DynError;
-use pubky_app_specs::{PubkyAppPost, PubkyAppPostKind};
+use pubky_app_specs::{post_uri_builder, PubkyAppPost, PubkyAppPostKind};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
@@ -66,15 +66,11 @@ impl PostRelationships {
         let mentioned: Vec<String> = row.get("mentioned_user_ids").unwrap_or(Vec::new());
 
         let replied = match (replied_author_id, replied_post_id) {
-            (Some(author_id), Some(post_id)) => {
-                Some(format!("pubky://{author_id}/pub/pubky.app/posts/{post_id}"))
-            }
+            (Some(author_id), Some(post_id)) => Some(post_uri_builder(author_id, post_id)),
             _ => None,
         };
         let reposted = match (reposted_author_id, reposted_post_id) {
-            (Some(author_id), Some(post_id)) => {
-                Some(format!("pubky://{author_id}/pub/pubky.app/posts/{post_id}"))
-            }
+            (Some(author_id), Some(post_id)) => Some(post_uri_builder(author_id, post_id)),
             _ => None,
         };
         Ok(Some(Self {

--- a/nexus-common/src/models/tag/view.rs
+++ b/nexus-common/src/models/tag/view.rs
@@ -1,3 +1,4 @@
+use pubky_app_specs::tag_uri_builder;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
@@ -28,7 +29,7 @@ impl TagView {
         };
 
         Ok(Some(Self {
-            tag_uri: format!("pubky://{}/pub/pubky.app/tags/{}", tagger_id, tag_id),
+            tag_uri: tag_uri_builder(tagger_id.into(), tag_id.into()),
             label: row.get("label")?,
             indexed_at: row.get("indexed_at")?,
         }))

--- a/nexus-watcher/src/events/handlers/post.rs
+++ b/nexus-watcher/src/events/handlers/post.rs
@@ -12,7 +12,8 @@ use nexus_common::models::post::{
 use nexus_common::models::user::UserCounts;
 use nexus_common::types::DynError;
 use pubky_app_specs::{
-    user_uri_builder, ParsedUri, PubkyAppPost, PubkyAppPostKind, PubkyId, Resource,
+    post_uri_builder, user_uri_builder, ParsedUri, PubkyAppPost, PubkyAppPostKind, PubkyId,
+    Resource,
 };
 use tracing::debug;
 
@@ -226,7 +227,7 @@ async fn sync_edit(
     post_details: PostDetails,
 ) -> Result<(), DynError> {
     // Construct the URI of the post that changed
-    let changed_uri = format!("pubky://{author_id}/pub/pubky.app/posts/{post_id}");
+    let changed_uri = post_uri_builder(author_id.to_string(), post_id.clone());
 
     // Update content of PostDetails!
     if let Err(e) = post_details.put_to_index(&author_id, None, true).await {
@@ -333,7 +334,7 @@ pub async fn del(author_id: PubkyId, post_id: String) -> Result<(), DynError> {
 }
 
 pub async fn sync_del(author_id: PubkyId, post_id: String) -> Result<(), DynError> {
-    let deleted_uri = format!("pubky://{author_id}/pub/pubky.app/posts/{post_id}");
+    let deleted_uri = post_uri_builder(author_id.to_string(), post_id.clone());
 
     let post_relationships = PostRelationships::get_by_id(&author_id, &post_id).await?;
     // If the post is reply, cannot delete from the main feeds

--- a/nexus-watcher/tests/event_processor/bookmarks/del.rs
+++ b/nexus-watcher/tests/event_processor/bookmarks/del.rs
@@ -4,7 +4,10 @@ use crate::event_processor::utils::watcher::WatcherTest;
 use anyhow::Result;
 use nexus_common::models::post::{Bookmark, PostStream};
 use pubky::Keypair;
-use pubky_app_specs::{traits::HashId, PubkyAppBookmark, PubkyAppPost, PubkyAppUser};
+use pubky_app_specs::{
+    bookmark_uri_builder, post_uri_builder, traits::HashId, PubkyAppBookmark, PubkyAppPost,
+    PubkyAppUser,
+};
 
 #[tokio_shared_rt::test(shared)]
 async fn test_homeserver_unbookmark() -> Result<()> {
@@ -43,11 +46,11 @@ async fn test_homeserver_unbookmark() -> Result<()> {
 
     // Step 3: Add a bookmark to the post. Before create a new user
     let bookmark = PubkyAppBookmark {
-        uri: format!("pubky://{author_id}/pub/pubky.app/posts/{post_id}"),
+        uri: post_uri_builder(author_id.clone(), post_id.clone()),
         created_at: chrono::Utc::now().timestamp_millis(),
     };
     let bookmark_id = bookmark.create_id();
-    let bookmark_url = format!("pubky://{bookmarker_id}/pub/pubky.app/bookmarks/{bookmark_id}");
+    let bookmark_url = bookmark_uri_builder(bookmarker_id.clone(), bookmark_id);
 
     // Put bookmark
     test.put(&bookmark_url, bookmark).await.unwrap();

--- a/nexus-watcher/tests/event_processor/bookmarks/fail_index.rs
+++ b/nexus-watcher/tests/event_processor/bookmarks/fail_index.rs
@@ -1,7 +1,10 @@
 use crate::event_processor::utils::watcher::{retrieve_and_handle_event_line, WatcherTest};
 use anyhow::Result;
 use pubky::Keypair;
-use pubky_app_specs::{traits::HashId, PubkyAppBookmark, PubkyAppPost, PubkyAppUser};
+use pubky_app_specs::{
+    bookmark_uri_builder, post_uri_builder, traits::HashId, PubkyAppBookmark, PubkyAppPost,
+    PubkyAppUser,
+};
 use tracing::error;
 
 /// The user profile is stored in the homeserver. Missing the author that creates the bookmark
@@ -38,13 +41,13 @@ async fn test_homeserver_bookmark_without_user() -> Result<()> {
 
     // Create a bookmark content
     let bookmark = PubkyAppBookmark {
-        uri: format!("pubky://{author_id}/pub/pubky.app/posts/{post_id}"),
+        uri: post_uri_builder(author_id, post_id),
         created_at: chrono::Utc::now().timestamp_millis(),
     };
 
     // Create the bookmark of the shadow user
     let bookmark_id = bookmark.create_id();
-    let bookmark_url = format!("pubky://{shadow_user_id}/pub/pubky.app/bookmarks/{bookmark_id}");
+    let bookmark_url = bookmark_uri_builder(shadow_user_id, bookmark_id);
 
     // Switch OFF the event processor to simulate the pending events to index
     test = test.remove_event_processing().await;

--- a/nexus-watcher/tests/event_processor/bookmarks/raw.rs
+++ b/nexus-watcher/tests/event_processor/bookmarks/raw.rs
@@ -4,7 +4,10 @@ use crate::event_processor::utils::watcher::WatcherTest;
 use anyhow::Result;
 use nexus_common::models::post::{Bookmark, PostStream};
 use pubky::Keypair;
-use pubky_app_specs::{traits::HashId, PubkyAppBookmark, PubkyAppPost, PubkyAppUser};
+use pubky_app_specs::{
+    bookmark_uri_builder, post_uri_builder, traits::HashId, PubkyAppBookmark, PubkyAppPost,
+    PubkyAppUser,
+};
 
 #[tokio_shared_rt::test(shared)]
 async fn test_homeserver_bookmark() -> Result<()> {
@@ -33,11 +36,11 @@ async fn test_homeserver_bookmark() -> Result<()> {
 
     // Step 3: Add a bookmark to the post. Before create a new user
     let bookmark = PubkyAppBookmark {
-        uri: format!("pubky://{user_id}/pub/pubky.app/posts/{post_id}"),
+        uri: post_uri_builder(user_id.clone(), post_id.clone()),
         created_at: chrono::Utc::now().timestamp_millis(),
     };
     let bookmark_id = bookmark.create_id();
-    let bookmark_url = format!("pubky://{user_id}/pub/pubky.app/bookmarks/{bookmark_id}");
+    let bookmark_url = bookmark_uri_builder(user_id.clone(), bookmark_id.clone());
 
     // Put bookmark
     test.put(&bookmark_url, bookmark).await.unwrap();

--- a/nexus-watcher/tests/event_processor/bookmarks/retry_bookmark.rs
+++ b/nexus-watcher/tests/event_processor/bookmarks/retry_bookmark.rs
@@ -2,7 +2,9 @@ use crate::event_processor::utils::watcher::{assert_eventually_exists, WatcherTe
 use anyhow::Result;
 use nexus_watcher::events::{errors::EventProcessorError, retry::event::RetryEvent, EventType};
 use pubky::Keypair;
-use pubky_app_specs::{traits::HashId, PubkyAppBookmark, PubkyAppUser};
+use pubky_app_specs::{
+    bookmark_uri_builder, post_uri_builder, traits::HashId, PubkyAppBookmark, PubkyAppUser,
+};
 
 /// The user profile is stored in the homeserver. Missing the post to connect the bookmark
 #[tokio_shared_rt::test(shared)]
@@ -23,7 +25,7 @@ async fn test_homeserver_bookmark_cannot_index() -> Result<()> {
     let fake_post_id = "0032QB10HCRHG";
     let fake_user_id = "ba3e8qeby33uq9cughpxdf7bew9etn1eq8bc3yhwg7p1f54yaozy";
     // Create parent post uri
-    let post_uri = format!("pubky://{fake_user_id}/pub/pubky.app/posts/{fake_post_id}");
+    let post_uri = post_uri_builder(fake_user_id.into(), fake_post_id.into());
 
     // Create a bookmark content
     let bookmark = PubkyAppBookmark {
@@ -33,7 +35,7 @@ async fn test_homeserver_bookmark_cannot_index() -> Result<()> {
 
     // Create the bookmark of the shadow user
     let bookmark_id = bookmark.create_id();
-    let bookmark_url = format!("pubky://{user_id}/pub/pubky.app/bookmarks/{bookmark_id}");
+    let bookmark_url = bookmark_uri_builder(user_id.into(), bookmark_id);
     // PUT bookmark
     test.put(&bookmark_url, bookmark).await?;
 

--- a/nexus-watcher/tests/event_processor/bookmarks/viewer.rs
+++ b/nexus-watcher/tests/event_processor/bookmarks/viewer.rs
@@ -3,7 +3,10 @@ use crate::event_processor::utils::watcher::WatcherTest;
 use anyhow::Result;
 use nexus_common::models::post::PostStream;
 use pubky::Keypair;
-use pubky_app_specs::{traits::HashId, PubkyAppBookmark, PubkyAppPost, PubkyAppUser};
+use pubky_app_specs::{
+    bookmark_uri_builder, post_uri_builder, traits::HashId, PubkyAppBookmark, PubkyAppPost,
+    PubkyAppUser,
+};
 
 #[tokio_shared_rt::test(shared)]
 async fn test_homeserver_viewer_bookmark() -> Result<()> {
@@ -43,11 +46,11 @@ async fn test_homeserver_viewer_bookmark() -> Result<()> {
     let viewer_id = test.create_user(&viewer_keypair, &viewer_user).await?;
 
     let bookmark = PubkyAppBookmark {
-        uri: format!("pubky://{user_id}/pub/pubky.app/posts/{post_id}"),
+        uri: post_uri_builder(user_id.clone(), post_id.clone()),
         created_at: chrono::Utc::now().timestamp_millis(),
     };
     let bookmark_id = bookmark.create_id();
-    let bookmark_url = format!("pubky://{viewer_id}/pub/pubky.app/bookmarks/{bookmark_id}");
+    let bookmark_url = bookmark_uri_builder(viewer_id.clone(), bookmark_id.clone());
 
     // Put bookmark
     test.put(&bookmark_url, bookmark).await.unwrap();

--- a/nexus-watcher/tests/event_processor/files/create.rs
+++ b/nexus-watcher/tests/event_processor/files/create.rs
@@ -3,8 +3,8 @@ use anyhow::Result;
 use chrono::Utc;
 use nexus_common::models::{file::FileDetails, traits::Collection};
 use pubky::Keypair;
-use pubky_app_specs::traits::{HasIdPath, HashId};
-use pubky_app_specs::{PubkyAppBlob, PubkyAppFile, PubkyAppUser};
+use pubky_app_specs::traits::HashId;
+use pubky_app_specs::{blob_uri_builder, PubkyAppBlob, PubkyAppFile, PubkyAppUser};
 use std::path::Path;
 
 #[tokio_shared_rt::test(shared)]
@@ -26,7 +26,7 @@ async fn test_put_pubkyapp_file() -> Result<()> {
     let blob_data = "Hello World!".to_string();
     let blob = PubkyAppBlob::new(blob_data.as_bytes().to_vec());
     let blob_id = blob.create_id();
-    let blob_url = format!("pubky://{}{}", user_id, blob.create_path(&blob_id));
+    let blob_url = blob_uri_builder(user_id.clone(), blob_id);
 
     test.create_file_from_body(blob_url.as_str(), blob.0.clone())
         .await?;

--- a/nexus-watcher/tests/event_processor/files/delete.rs
+++ b/nexus-watcher/tests/event_processor/files/delete.rs
@@ -3,10 +3,7 @@ use anyhow::Result;
 use chrono::Utc;
 use nexus_common::models::{file::FileDetails, traits::Collection};
 use pubky::Keypair;
-use pubky_app_specs::{
-    traits::{HasIdPath, HashId},
-    PubkyAppBlob, PubkyAppFile, PubkyAppUser,
-};
+use pubky_app_specs::{blob_uri_builder, traits::HashId, PubkyAppBlob, PubkyAppFile, PubkyAppUser};
 use std::path::Path;
 
 #[tokio_shared_rt::test(shared)]
@@ -28,7 +25,7 @@ async fn test_delete_pubkyapp_file() -> Result<()> {
     let blob_data = "Hello World!".to_string();
     let blob = PubkyAppBlob::new(blob_data.as_bytes().to_vec());
     let blob_id = blob.create_id();
-    let blob_url = format!("pubky://{}{}", user_id, blob.create_path(&blob_id));
+    let blob_url = blob_uri_builder(user_id.clone(), blob_id);
 
     test.create_file_from_body(blob_url.as_str(), blob.0.clone())
         .await?;

--- a/nexus-watcher/tests/event_processor/follows/retry_follow.rs
+++ b/nexus-watcher/tests/event_processor/follows/retry_follow.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use nexus_watcher::events::errors::EventProcessorError;
 use nexus_watcher::events::{retry::event::RetryEvent, EventType};
 use pubky::Keypair;
-use pubky_app_specs::{user_uri_builder, PubkyAppUser};
+use pubky_app_specs::{follow_uri_builder, user_uri_builder, PubkyAppUser};
 
 /// The user profile is stored in the homeserver. Missing the followee to connect with follower
 #[tokio_shared_rt::test(shared)]
@@ -28,7 +28,7 @@ async fn test_homeserver_follow_cannot_index() -> Result<()> {
 
     test.create_follow(&follower_id, &followee_id).await?;
 
-    let follow_url = format!("pubky://{follower_id}/pub/pubky.app/follows/{followee_id}");
+    let follow_url = follow_uri_builder(follower_id, followee_id.clone());
 
     let index_key = format!(
         "{}:{}",

--- a/nexus-watcher/tests/event_processor/mutes/retry_mute.rs
+++ b/nexus-watcher/tests/event_processor/mutes/retry_mute.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use nexus_watcher::events::errors::EventProcessorError;
 use nexus_watcher::events::{retry::event::RetryEvent, EventType};
 use pubky::Keypair;
-use pubky_app_specs::{user_uri_builder, PubkyAppUser};
+use pubky_app_specs::{mute_uri_builder, user_uri_builder, PubkyAppUser};
 /// The user profile is stored in the homeserver. Missing the mutee to connect with muter
 #[tokio_shared_rt::test(shared)]
 async fn test_homeserver_mute_cannot_index() -> Result<()> {
@@ -28,7 +28,7 @@ async fn test_homeserver_mute_cannot_index() -> Result<()> {
     // Mute the user
     test.create_mute(&muter_id, &mutee_id).await?;
 
-    let mute_url = format!("pubky://{muter_id}/pub/pubky.app/mutes/{mutee_id}");
+    let mute_url = mute_uri_builder(muter_id, mutee_id.clone());
 
     let index_key = format!(
         "{}:{}",

--- a/nexus-watcher/tests/event_processor/network/counts.rs
+++ b/nexus-watcher/tests/event_processor/network/counts.rs
@@ -8,6 +8,7 @@ use nexus_common::{
 };
 use pubky::Keypair;
 use pubky_app_specs::{
+    bookmark_uri_builder, follow_uri_builder, mute_uri_builder, post_uri_builder, tag_uri_builder,
     traits::HashId, PubkyAppBookmark, PubkyAppMute, PubkyAppPost, PubkyAppPostKind, PubkyAppTag,
     PubkyAppUser,
 };
@@ -136,8 +137,7 @@ async fn test_large_network_scenario_counts() -> Result<()> {
                     let mute = PubkyAppMute {
                         created_at: chrono::Utc::now().timestamp_millis(),
                     };
-                    let mute_url =
-                        format!("pubky://{user_id}/pub/pubky.app/mutes/{target_user_id}");
+                    let mute_url = mute_uri_builder(user_id.into(), target_user_id.into());
                     pubky_client
                         .put(mute_url.as_str())
                         .json(&mute)
@@ -160,15 +160,11 @@ async fn test_large_network_scenario_counts() -> Result<()> {
                 let target_post_id = &user_posts[&target_user_id.clone()][post_index];
 
                 let bookmark = PubkyAppBookmark {
-                    uri: format!("pubky://{target_user_id}/pub/pubky.app/posts/{target_post_id}"),
+                    uri: post_uri_builder(target_user_id.into(), target_post_id.into()),
                     created_at: chrono::Utc::now().timestamp_millis(),
                 };
 
-                let bookmark_url = format!(
-                    "pubky://{}/pub/pubky.app/bookmarks/{}",
-                    user_id,
-                    bookmark.create_id()
-                );
+                let bookmark_url = bookmark_uri_builder(user_id.into(), bookmark.create_id());
 
                 test.put(&bookmark_url, &bookmark).await?;
                 total_bookmarks += 1;
@@ -188,12 +184,12 @@ async fn test_large_network_scenario_counts() -> Result<()> {
 
                 let tag_label = format!("tag{}", rng.random_range(0..100)); // FAILs tag labels are repeated, the same, the counts do not match graph vs index. Graph does not duplicate tag, but index counts do increase.
                 let tag = PubkyAppTag {
-                    uri: format!("pubky://{target_user_id}/pub/pubky.app/posts/{target_post_id}"),
+                    uri: post_uri_builder(target_user_id.into(), target_post_id.into()),
                     label: tag_label.clone(),
                     created_at: chrono::Utc::now().timestamp_millis(),
                 };
 
-                let tag_url = format!("pubky://{}/pub/pubky.app/tags/{}", user_id, tag.create_id());
+                let tag_url = tag_uri_builder(user_id.into(), tag.create_id());
 
                 test.put(&tag_url, &tag).await?;
                 total_tags += 1;
@@ -229,8 +225,7 @@ async fn test_large_network_scenario_counts() -> Result<()> {
             let target_index = rng.random_range(0..following.len());
             let target_user_id = &following[target_index];
             if unfollowed.insert(target_user_id.clone()) {
-                let follow_uri =
-                    format!("pubky://{user_id}/pub/pubky.app/follows/{target_user_id}");
+                let follow_uri = follow_uri_builder(user_id.into(), target_user_id.into());
                 test.del(&follow_uri).await?;
                 following_set.remove(target_user_id);
                 total_unfollows += 1;
@@ -255,7 +250,7 @@ async fn test_large_network_scenario_counts() -> Result<()> {
             let target_index = rng.random_range(0..muted.len());
             let target_user_id = &muted[target_index];
             if unmuted.insert(target_user_id.clone()) {
-                let mute_uri = format!("pubky://{user_id}/pub/pubky.app/mutes/{target_user_id}");
+                let mute_uri = mute_uri_builder(user_id.into(), target_user_id.into());
                 pubky_client.delete(mute_uri.as_str()).send().await?;
                 mute_set.remove(target_user_id);
                 _total_unmutes += 1;

--- a/nexus-watcher/tests/event_processor/posts/attachments.rs
+++ b/nexus-watcher/tests/event_processor/posts/attachments.rs
@@ -4,8 +4,8 @@ use anyhow::Result;
 use chrono::Utc;
 use pubky::Keypair;
 use pubky_app_specs::{
-    traits::{HasIdPath, HashId},
-    PubkyAppBlob, PubkyAppFile, PubkyAppPost, PubkyAppPostKind, PubkyAppUser,
+    blob_uri_builder, traits::HashId, PubkyAppBlob, PubkyAppFile, PubkyAppPost, PubkyAppPostKind,
+    PubkyAppUser,
 };
 
 #[tokio_shared_rt::test(shared)]
@@ -26,7 +26,7 @@ async fn test_homeserver_post_attachments() -> Result<()> {
     let blob_data = "Hello World!".to_string();
     let blob = PubkyAppBlob::new(blob_data.as_bytes().to_vec());
     let blob_id = blob.create_id();
-    let blob_url = format!("pubky://{}{}", user_id, blob.create_path(&blob_id));
+    let blob_url = blob_uri_builder(user_id.clone(), blob_id);
 
     test.create_file_from_body(blob_url.as_str(), blob.0.clone())
         .await?;

--- a/nexus-watcher/tests/event_processor/posts/del_bookmarked_notification.rs
+++ b/nexus-watcher/tests/event_processor/posts/del_bookmarked_notification.rs
@@ -6,7 +6,8 @@ use nexus_common::{
 };
 use pubky::Keypair;
 use pubky_app_specs::{
-    traits::HashId, PubkyAppBookmark, PubkyAppPost, PubkyAppPostKind, PubkyAppUser,
+    bookmark_uri_builder, post_uri_builder, traits::HashId, PubkyAppBookmark, PubkyAppPost,
+    PubkyAppPostKind, PubkyAppUser,
 };
 
 #[tokio_shared_rt::test(shared)]
@@ -47,14 +48,10 @@ async fn test_delete_bookmarked_post_notification() -> Result<()> {
 
     // User B bookmarks User A's post
     let bookmark = PubkyAppBookmark {
-        uri: format!("pubky://{user_a_id}/pub/pubky.app/posts/{post_id}"),
+        uri: post_uri_builder(user_a_id.clone(), post_id.clone()),
         created_at: 0,
     };
-    let bookmark_url = format!(
-        "pubky://{}/pub/pubky.app/bookmarks/{}",
-        user_b_id,
-        bookmark.create_id()
-    );
+    let bookmark_url = bookmark_uri_builder(user_b_id.clone(), bookmark.create_id());
     test.put(&bookmark_url, bookmark).await?;
 
     // User A deletes their post

--- a/nexus-watcher/tests/event_processor/posts/del_reply_notification.rs
+++ b/nexus-watcher/tests/event_processor/posts/del_reply_notification.rs
@@ -5,7 +5,7 @@ use nexus_common::{
     types::Pagination,
 };
 use pubky::Keypair;
-use pubky_app_specs::{PubkyAppPost, PubkyAppPostKind, PubkyAppUser};
+use pubky_app_specs::{post_uri_builder, PubkyAppPost, PubkyAppPostKind, PubkyAppUser};
 
 #[tokio_shared_rt::test(shared)]
 async fn test_delete_post_that_replied_notification() -> Result<()> {
@@ -47,7 +47,7 @@ async fn test_delete_post_that_replied_notification() -> Result<()> {
     let reply = PubkyAppPost {
         content: "User's post to be deleted".to_string(),
         kind: PubkyAppPostKind::Short,
-        parent: Some(format!("pubky://{poster_id}/pub/pubky.app/posts/{post_id}")),
+        parent: Some(post_uri_builder(poster_id.clone(), post_id.clone())),
         embed: None,
         attachments: None,
     };

--- a/nexus-watcher/tests/event_processor/posts/del_reply_parent_notification.rs
+++ b/nexus-watcher/tests/event_processor/posts/del_reply_parent_notification.rs
@@ -5,7 +5,7 @@ use nexus_common::{
     types::Pagination,
 };
 use pubky::Keypair;
-use pubky_app_specs::{PubkyAppPost, PubkyAppPostKind, PubkyAppUser};
+use pubky_app_specs::{post_uri_builder, PubkyAppPost, PubkyAppPostKind, PubkyAppUser};
 
 #[tokio_shared_rt::test(shared)]
 async fn test_delete_parent_post_notification() -> Result<()> {
@@ -47,7 +47,7 @@ async fn test_delete_parent_post_notification() -> Result<()> {
     let reply = PubkyAppPost {
         content: "Reply by User B".to_string(),
         kind: PubkyAppPostKind::Short,
-        parent: Some(format!("pubky://{user_a_id}/pub/pubky.app/posts/{post_id}")),
+        parent: Some(post_uri_builder(user_a_id.clone(), post_id.clone())),
         embed: None,
         attachments: None,
     };

--- a/nexus-watcher/tests/event_processor/posts/del_repost_notification.rs
+++ b/nexus-watcher/tests/event_processor/posts/del_repost_notification.rs
@@ -5,7 +5,9 @@ use nexus_common::{
     types::Pagination,
 };
 use pubky::Keypair;
-use pubky_app_specs::{PubkyAppPost, PubkyAppPostEmbed, PubkyAppPostKind, PubkyAppUser};
+use pubky_app_specs::{
+    post_uri_builder, PubkyAppPost, PubkyAppPostEmbed, PubkyAppPostKind, PubkyAppUser,
+};
 
 #[tokio_shared_rt::test(shared)]
 async fn test_delete_post_that_reposted_notification() -> Result<()> {
@@ -50,7 +52,7 @@ async fn test_delete_post_that_reposted_notification() -> Result<()> {
         parent: None,
         embed: Some(PubkyAppPostEmbed {
             kind: PubkyAppPostKind::Short,
-            uri: format!("pubky://{poster_id}/pub/pubky.app/posts/{post_id}"),
+            uri: post_uri_builder(poster_id.clone(), post_id.clone()),
         }),
         attachments: None,
     };

--- a/nexus-watcher/tests/event_processor/posts/del_reposted_notification.rs
+++ b/nexus-watcher/tests/event_processor/posts/del_reposted_notification.rs
@@ -5,7 +5,9 @@ use nexus_common::{
     types::Pagination,
 };
 use pubky::Keypair;
-use pubky_app_specs::{PubkyAppPost, PubkyAppPostEmbed, PubkyAppPostKind, PubkyAppUser};
+use pubky_app_specs::{
+    post_uri_builder, PubkyAppPost, PubkyAppPostEmbed, PubkyAppPostKind, PubkyAppUser,
+};
 
 #[tokio_shared_rt::test(shared)]
 async fn test_delete_reposted_post_notification() -> Result<()> {
@@ -50,7 +52,7 @@ async fn test_delete_reposted_post_notification() -> Result<()> {
         parent: None,
         embed: Some(PubkyAppPostEmbed {
             kind: PubkyAppPostKind::Short,
-            uri: format!("pubky://{user_a_id}/pub/pubky.app/posts/{post_id}"),
+            uri: post_uri_builder(user_a_id.clone(), post_id.clone()),
         }),
         attachments: None,
     };

--- a/nexus-watcher/tests/event_processor/posts/del_tagged_notification.rs
+++ b/nexus-watcher/tests/event_processor/posts/del_tagged_notification.rs
@@ -6,7 +6,9 @@ use nexus_common::{
     types::Pagination,
 };
 use pubky::Keypair;
-use pubky_app_specs::{traits::HashId, PubkyAppPost, PubkyAppTag, PubkyAppUser};
+use pubky_app_specs::{
+    post_uri_builder, tag_uri_builder, traits::HashId, PubkyAppPost, PubkyAppTag, PubkyAppUser,
+};
 
 #[tokio_shared_rt::test(shared)]
 async fn test_delete_tagged_post_notification() -> Result<()> {
@@ -47,12 +49,12 @@ async fn test_delete_tagged_post_notification() -> Result<()> {
     // User B tags User A's post
     let label = "merkle_tree";
     let tag = PubkyAppTag {
-        uri: format!("pubky://{user_a_id}/pub/pubky.app/posts/{post_id}"),
+        uri: post_uri_builder(user_a_id.clone(), post_id.clone()),
         label: label.to_string(),
         created_at: Utc::now().timestamp_millis(),
     };
     let tag_id = tag.create_id();
-    let tag_url = format!("pubky://{user_b_id}/pub/pubky.app/tags/{tag_id}");
+    let tag_url = tag_uri_builder(user_b_id.clone(), tag_id);
 
     // Put tag
     test.put(&tag_url, tag).await?;

--- a/nexus-watcher/tests/event_processor/posts/del_with_attachments.rs
+++ b/nexus-watcher/tests/event_processor/posts/del_with_attachments.rs
@@ -7,8 +7,8 @@ use chrono::Utc;
 use nexus_common::models::{file::FileDetails, traits::Collection};
 use pubky::Keypair;
 use pubky_app_specs::{
-    traits::{HasIdPath, HashId},
-    PubkyAppBlob, PubkyAppFile, PubkyAppPost, PubkyAppPostKind, PubkyAppUser,
+    blob_uri_builder, traits::HashId, PubkyAppBlob, PubkyAppFile, PubkyAppPost, PubkyAppPostKind,
+    PubkyAppUser,
 };
 
 #[tokio_shared_rt::test(shared)]
@@ -33,7 +33,7 @@ async fn test_homeserver_del_post_with_attachments() -> Result<()> {
         let blob_data = format!("DEL me, im part of attachment of file {}", i + 1);
         let blob = PubkyAppBlob::new(blob_data.as_bytes().to_vec());
         let blob_id = blob.create_id();
-        let blob_url = format!("pubky://{}{}", user_id, blob.create_path(&blob_id));
+        let blob_url = blob_uri_builder(user_id.clone(), blob_id);
 
         test.create_file_from_body(blob_url.as_str(), blob.0.clone())
             .await?;

--- a/nexus-watcher/tests/event_processor/posts/del_with_relations.rs
+++ b/nexus-watcher/tests/event_processor/posts/del_with_relations.rs
@@ -3,7 +3,10 @@ use anyhow::Result;
 use chrono::Utc;
 use nexus_common::models::post::{PostCounts, PostDetails, PostView};
 use pubky::Keypair;
-use pubky_app_specs::{traits::HashId, PubkyAppPost, PubkyAppPostKind, PubkyAppTag, PubkyAppUser};
+use pubky_app_specs::{
+    post_uri_builder, tag_uri_builder, traits::HashId, PubkyAppPost, PubkyAppPostKind, PubkyAppTag,
+    PubkyAppUser,
+};
 
 #[tokio_shared_rt::test(shared)]
 async fn test_delete_post_with_relationships() -> Result<()> {
@@ -32,11 +35,11 @@ async fn test_delete_post_with_relationships() -> Result<()> {
 
     // Create a tag
     let tag = PubkyAppTag {
-        uri: format!("pubky://{user_id}/pub/pubky.app/posts/{post_id}"),
+        uri: post_uri_builder(user_id.clone(), post_id.clone()),
         label: "funny".to_string(),
         created_at: Utc::now().timestamp_millis(),
     };
-    let tag_url = format!("pubky://{}/pub/pubky.app/tags/{}", user_id, tag.create_id());
+    let tag_url = tag_uri_builder(user_id.clone(), tag.create_id());
 
     // Put tag
     test.put(&tag_url, tag).await?;

--- a/nexus-watcher/tests/event_processor/posts/del_without_relations.rs
+++ b/nexus-watcher/tests/event_processor/posts/del_without_relations.rs
@@ -10,7 +10,9 @@ use nexus_common::{
     },
 };
 use pubky::Keypair;
-use pubky_app_specs::{PubkyAppPost, PubkyAppPostEmbed, PubkyAppPostKind, PubkyAppUser};
+use pubky_app_specs::{
+    post_uri_builder, PubkyAppPost, PubkyAppPostEmbed, PubkyAppPostKind, PubkyAppUser,
+};
 
 use super::utils::{
     check_member_global_timeline_user_post, check_member_total_engagement_user_posts,
@@ -154,7 +156,7 @@ async fn test_delete_post_that_reposted() -> Result<()> {
         parent: None,
         embed: Some(PubkyAppPostEmbed {
             kind: PubkyAppPostKind::Short,
-            uri: format!("pubky://{user_id}/pub/pubky.app/posts/{post_id}"),
+            uri: post_uri_builder(user_id.clone(), post_id.clone()),
         }),
         attachments: None,
     };
@@ -282,7 +284,7 @@ async fn test_delete_post_that_replied() -> Result<()> {
     let reply = PubkyAppPost {
         content: "Watcher:PostDeleteReplied:User:Reply".to_string(),
         kind: PubkyAppPostKind::Short,
-        parent: Some(format!("pubky://{user_id}/pub/pubky.app/posts/{post_id}")),
+        parent: Some(post_uri_builder(user_id.clone(), post_id.clone())),
         embed: None,
         attachments: None,
     };

--- a/nexus-watcher/tests/event_processor/posts/edit_bookmarked_notification.rs
+++ b/nexus-watcher/tests/event_processor/posts/edit_bookmarked_notification.rs
@@ -6,7 +6,8 @@ use nexus_common::{
 };
 use pubky::Keypair;
 use pubky_app_specs::{
-    traits::HashId, PubkyAppBookmark, PubkyAppPost, PubkyAppPostKind, PubkyAppUser,
+    bookmark_uri_builder, post_uri_builder, traits::HashId, PubkyAppBookmark, PubkyAppPost,
+    PubkyAppPostKind, PubkyAppUser,
 };
 
 #[tokio_shared_rt::test(shared)]
@@ -47,19 +48,15 @@ async fn test_edit_bookmarked_post_notification() -> Result<()> {
 
     // User B bookmarks User A's post
     let bookmark = PubkyAppBookmark {
-        uri: format!("pubky://{user_a_id}/pub/pubky.app/posts/{post_id}"),
+        uri: post_uri_builder(user_a_id.clone(), post_id.clone()),
         created_at: 0,
     };
-    let bookmark_url = format!(
-        "pubky://{}/pub/pubky.app/bookmarks/{}",
-        user_b_id,
-        bookmark.create_id()
-    );
+    let bookmark_url = bookmark_uri_builder(user_b_id.clone(), bookmark.create_id());
     test.put(&bookmark_url, bookmark).await?;
 
     // User A edits their post
     post.content = "Edited post by User A".to_string();
-    let edited_url = format!("pubky://{user_a_id}/pub/pubky.app/posts/{post_id}");
+    let edited_url = post_uri_builder(user_a_id.clone(), post_id.clone());
 
     // Overwrite existing post in the homeserver for the edited one
     test.put(edited_url.as_str(), &post).await?;

--- a/nexus-watcher/tests/event_processor/posts/edit_reply_parent_notification.rs
+++ b/nexus-watcher/tests/event_processor/posts/edit_reply_parent_notification.rs
@@ -5,7 +5,7 @@ use nexus_common::{
     types::Pagination,
 };
 use pubky::Keypair;
-use pubky_app_specs::{PubkyAppPost, PubkyAppPostKind, PubkyAppUser};
+use pubky_app_specs::{post_uri_builder, PubkyAppPost, PubkyAppPostKind, PubkyAppUser};
 
 #[tokio_shared_rt::test(shared)]
 async fn test_edit_parent_post_notification() -> Result<()> {
@@ -47,7 +47,7 @@ async fn test_edit_parent_post_notification() -> Result<()> {
     let reply = PubkyAppPost {
         content: "Reply by User B".to_string(),
         kind: PubkyAppPostKind::Short,
-        parent: Some(format!("pubky://{user_a_id}/pub/pubky.app/posts/{post_id}")),
+        parent: Some(post_uri_builder(user_a_id.clone(), post_id.clone())),
         embed: None,
         attachments: None,
     };
@@ -55,7 +55,7 @@ async fn test_edit_parent_post_notification() -> Result<()> {
 
     // User A edits their original post
     post.content = "Edited post by User A".to_string();
-    let edited_url = format!("pubky://{user_a_id}/pub/pubky.app/posts/{post_id}");
+    let edited_url = post_uri_builder(user_a_id.clone(), post_id.clone());
 
     // Overwrite existing post in the homeserver with the edited one
     test.put(edited_url.as_str(), &post).await?;

--- a/nexus-watcher/tests/event_processor/posts/edit_reposted_notification.rs
+++ b/nexus-watcher/tests/event_processor/posts/edit_reposted_notification.rs
@@ -5,7 +5,9 @@ use nexus_common::{
     types::Pagination,
 };
 use pubky::Keypair;
-use pubky_app_specs::{PubkyAppPost, PubkyAppPostEmbed, PubkyAppPostKind, PubkyAppUser};
+use pubky_app_specs::{
+    post_uri_builder, PubkyAppPost, PubkyAppPostEmbed, PubkyAppPostKind, PubkyAppUser,
+};
 
 #[tokio_shared_rt::test(shared)]
 async fn test_edit_reposted_post_notification() -> Result<()> {
@@ -50,7 +52,7 @@ async fn test_edit_reposted_post_notification() -> Result<()> {
         parent: None,
         embed: Some(PubkyAppPostEmbed {
             kind: PubkyAppPostKind::Short,
-            uri: format!("pubky://{user_a_id}/pub/pubky.app/posts/{post_id}"),
+            uri: post_uri_builder(user_a_id.clone(), post_id.clone()),
         }),
         attachments: None,
     };
@@ -58,7 +60,7 @@ async fn test_edit_reposted_post_notification() -> Result<()> {
 
     // User A edits their post
     post.content = "Edited post by User A".to_string();
-    let edited_url = format!("pubky://{user_a_id}/pub/pubky.app/posts/{post_id}");
+    let edited_url = post_uri_builder(user_a_id.clone(), post_id.clone());
 
     // Overwrite existing post in the homeserver for the edited one
     test.put(edited_url.as_str(), &post).await?;

--- a/nexus-watcher/tests/event_processor/posts/edit_tagged_notification.rs
+++ b/nexus-watcher/tests/event_processor/posts/edit_tagged_notification.rs
@@ -6,7 +6,9 @@ use nexus_common::{
     types::Pagination,
 };
 use pubky::Keypair;
-use pubky_app_specs::{traits::HashId, PubkyAppPost, PubkyAppTag, PubkyAppUser};
+use pubky_app_specs::{
+    post_uri_builder, tag_uri_builder, traits::HashId, PubkyAppPost, PubkyAppTag, PubkyAppUser,
+};
 
 #[tokio_shared_rt::test(shared)]
 async fn test_edit_tagged_post_notification() -> Result<()> {
@@ -47,19 +49,19 @@ async fn test_edit_tagged_post_notification() -> Result<()> {
     // User B tags User A's post
     let label = "merkle_tree";
     let tag = PubkyAppTag {
-        uri: format!("pubky://{user_a_id}/pub/pubky.app/posts/{post_id}"),
+        uri: post_uri_builder(user_a_id.clone(), post_id.clone()),
         label: label.to_string(),
         created_at: Utc::now().timestamp_millis(),
     };
     let tag_id = tag.create_id();
-    let tag_url = format!("pubky://{user_b_id}/pub/pubky.app/tags/{tag_id}");
+    let tag_url = tag_uri_builder(user_b_id.clone(), tag_id);
 
     // Put tag
     test.put(&tag_url, tag).await?;
 
     // User A edits their post
     post.content = "Edited post by User A".to_string();
-    let edited_url = format!("pubky://{user_a_id}/pub/pubky.app/posts/{post_id}");
+    let edited_url = post_uri_builder(user_a_id.clone(), post_id.clone());
 
     // Overwrite existing post in the homeserver with the edited one
     test.put(edited_url.as_str(), &post).await?;

--- a/nexus-watcher/tests/event_processor/posts/engagement.rs
+++ b/nexus-watcher/tests/event_processor/posts/engagement.rs
@@ -2,7 +2,9 @@ use super::utils::check_member_total_engagement_user_posts;
 use crate::event_processor::utils::watcher::WatcherTest;
 use anyhow::Result;
 use pubky::Keypair;
-use pubky_app_specs::{PubkyAppPost, PubkyAppPostEmbed, PubkyAppPostKind, PubkyAppUser};
+use pubky_app_specs::{
+    post_uri_builder, PubkyAppPost, PubkyAppPostEmbed, PubkyAppPostKind, PubkyAppUser,
+};
 
 #[tokio_shared_rt::test(shared)]
 async fn test_homeserver_post_engagement() -> Result<()> {
@@ -53,12 +55,12 @@ async fn test_homeserver_post_engagement() -> Result<()> {
     let bob_id = test.create_user(&bob_user_keypair, &bob_user).await?;
 
     // Bob replies to popular alice post
-    let parent_uri = format!("pubky://{alice_id}/pub/pubky.app/posts/{alice_post_id}");
+    let alice_post_uri = post_uri_builder(alice_id.clone(), alice_post_id.clone());
 
     let reply = PubkyAppPost {
         content: "Watcher:PostInfluencer:Bob:Reply".to_string(),
         kind: PubkyAppPostKind::Short,
-        parent: Some(parent_uri.clone()),
+        parent: Some(alice_post_uri.clone()),
         embed: None,
         attachments: None,
     };
@@ -66,15 +68,13 @@ async fn test_homeserver_post_engagement() -> Result<()> {
     let _reply_id = test.create_post(&bob_id, &reply).await?;
 
     // Create repost of alice post
-    let post_uri = format!("pubky://{alice_id}/pub/pubky.app/posts/{alice_post_id}");
-
     let repost = PubkyAppPost {
         content: "Watcher:PostInfluencer:Bob:Repost".to_string(),
         kind: PubkyAppPostKind::Short,
         parent: None,
         embed: Some(PubkyAppPostEmbed {
             kind: PubkyAppPostKind::Short,
-            uri: post_uri.clone(),
+            uri: alice_post_uri.clone(),
         }),
         attachments: None,
     };

--- a/nexus-watcher/tests/event_processor/posts/fail_reply.rs
+++ b/nexus-watcher/tests/event_processor/posts/fail_reply.rs
@@ -2,7 +2,7 @@ use crate::event_processor::utils::watcher::{retrieve_and_handle_event_line, Wat
 use anyhow::Result;
 use nexus_common::types::DynError;
 use pubky::Keypair;
-use pubky_app_specs::{PubkyAppPost, PubkyAppPostKind, PubkyAppUser};
+use pubky_app_specs::{post_uri_builder, PubkyAppPost, PubkyAppPostKind, PubkyAppUser};
 use tracing::error;
 
 /// The user profile is stored in the homeserver and synched in the graph, but the posts just exist in the homeserver
@@ -34,7 +34,7 @@ async fn test_homeserver_post_reply_without_post_parent() -> Result<(), DynError
     let post_id = test.create_post(&author_id, &post).await?;
 
     // Create reply
-    let parent_uri = format!("pubky://{author_id}/pub/pubky.app/posts/{post_id}");
+    let parent_uri = post_uri_builder(author_id.clone(), post_id);
 
     let reply = PubkyAppPost {
         content: "Watcher:PostReplyFail:Author:Reply".to_string(),
@@ -47,7 +47,8 @@ async fn test_homeserver_post_reply_without_post_parent() -> Result<(), DynError
     let reply_id = test.create_post(&author_id, &reply).await?;
 
     // Create raw event line to retrieve the content from the homeserver
-    let post_event = format!("PUT pubky://{author_id}/pub/pubky.app/posts/{reply_id}");
+    let reply_uri = post_uri_builder(author_id.clone(), reply_id);
+    let post_event = format!("PUT {reply_uri}");
 
     // Simulate the event processor to handle the event.
     // If the event processor were activated, the test would not catch the missing dependency

--- a/nexus-watcher/tests/event_processor/posts/fail_repost.rs
+++ b/nexus-watcher/tests/event_processor/posts/fail_repost.rs
@@ -2,7 +2,9 @@ use crate::event_processor::utils::watcher::{retrieve_and_handle_event_line, Wat
 use anyhow::Result;
 use nexus_common::types::DynError;
 use pubky::Keypair;
-use pubky_app_specs::{PubkyAppPost, PubkyAppPostEmbed, PubkyAppPostKind, PubkyAppUser};
+use pubky_app_specs::{
+    post_uri_builder, PubkyAppPost, PubkyAppPostEmbed, PubkyAppPostKind, PubkyAppUser,
+};
 use tracing::error;
 
 /// The user profile is stored in the homeserver and synched in the graph, but the posts just exist in the homeserver
@@ -54,15 +56,15 @@ async fn test_homeserver_post_repost_without_post_parent() -> Result<(), DynErro
         parent: None,
         embed: Some(PubkyAppPostEmbed {
             kind: PubkyAppPostKind::Short,
-            uri: format!("pubky://{post_author_id}/pub/pubky.app/posts/{post_id}"),
+            uri: post_uri_builder(post_author_id, post_id),
         }),
         attachments: None,
     };
     let repost_id = test.create_post(&repost_author_id, &repost).await?;
 
     // Create raw event line to retrieve the content from the homeserver
-    let post_homeserver_uri =
-        format!("PUT pubky://{repost_author_id}/pub/pubky.app/posts/{repost_id}");
+    let repost_uri = post_uri_builder(repost_author_id, repost_id);
+    let post_homeserver_uri = format!("PUT {repost_uri}");
 
     // Simulate the event processor to handle the event.
     // If the event processor were activated, the test would not catch the missing dependency

--- a/nexus-watcher/tests/event_processor/posts/influencer.rs
+++ b/nexus-watcher/tests/event_processor/posts/influencer.rs
@@ -4,7 +4,9 @@ use crate::{
 };
 use anyhow::Result;
 use pubky::Keypair;
-use pubky_app_specs::{PubkyAppPost, PubkyAppPostEmbed, PubkyAppPostKind, PubkyAppUser};
+use pubky_app_specs::{
+    post_uri_builder, PubkyAppPost, PubkyAppPostEmbed, PubkyAppPostKind, PubkyAppUser,
+};
 
 #[tokio_shared_rt::test(shared)]
 async fn test_homeserver_post_influencer() -> Result<()> {
@@ -60,27 +62,25 @@ async fn test_homeserver_post_influencer() -> Result<()> {
     assert_eq!(influencer_score.unwrap(), 1);
 
     // Bob replies to popular alice post
-    let parent_uri = format!("pubky://{alice_id}/pub/pubky.app/posts/{alice_post_id}");
+    let alice_post_uri = post_uri_builder(alice_id.clone(), alice_post_id.clone());
 
     let reply = PubkyAppPost {
         content: "Watcher:PostInfluencer:Bob:Reply".to_string(),
         kind: PubkyAppPostKind::Short,
-        parent: Some(parent_uri.clone()),
+        parent: Some(alice_post_uri.clone()),
         attachments: None,
         embed: None,
     };
     let _reply_id = test.create_post(&bob_id, &reply).await?;
 
     // Create repost of alice post
-    let post_uri = format!("pubky://{alice_id}/pub/pubky.app/posts/{alice_post_id}");
-
     let repost = PubkyAppPost {
         content: "Watcher:PostInfluencer:Bob:Repost".to_string(),
         kind: PubkyAppPostKind::Short,
         parent: None,
         embed: Some(PubkyAppPostEmbed {
             kind: PubkyAppPostKind::Short,
-            uri: post_uri.clone(),
+            uri: alice_post_uri.clone(),
         }),
         attachments: None,
     };

--- a/nexus-watcher/tests/event_processor/posts/moderated.rs
+++ b/nexus-watcher/tests/event_processor/posts/moderated.rs
@@ -4,7 +4,10 @@ use crate::{
 use anyhow::Result;
 use chrono::Utc;
 use pubky::{recovery_file, Keypair};
-use pubky_app_specs::{traits::HashId, PubkyAppPost, PubkyAppPostKind, PubkyAppTag, PubkyAppUser};
+use pubky_app_specs::{
+    post_uri_builder, tag_uri_builder, traits::HashId, PubkyAppPost, PubkyAppPostKind, PubkyAppTag,
+    PubkyAppUser,
+};
 use tokio::fs;
 
 #[tokio_shared_rt::test(shared)]
@@ -46,15 +49,11 @@ async fn test_moderated_post_lifecycle() -> Result<()> {
     let moderator_id = test.create_user(&moderator_key, &user).await?;
 
     let tag = PubkyAppTag {
-        uri: format!("pubky://{user_id}/pub/pubky.app/posts/{post_id}"),
+        uri: post_uri_builder(user_id.clone(), post_id.clone()),
         label: "label_to_moderate".to_string(),
         created_at: Utc::now().timestamp_millis(),
     };
-    let tag_url = format!(
-        "pubky://{}/pub/pubky.app/tags/{}",
-        moderator_id,
-        tag.create_id()
-    );
+    let tag_url = tag_uri_builder(moderator_id, tag.create_id());
     // Put tag
     test.put(&tag_url, tag).await?;
 

--- a/nexus-watcher/tests/event_processor/posts/reply.rs
+++ b/nexus-watcher/tests/event_processor/posts/reply.rs
@@ -11,7 +11,7 @@ use nexus_common::{
     models::post::{PostDetails, PostRelationships, PostStream},
 };
 use pubky::Keypair;
-use pubky_app_specs::{PubkyAppPost, PubkyAppPostKind, PubkyAppUser};
+use pubky_app_specs::{post_uri_builder, PubkyAppPost, PubkyAppPostKind, PubkyAppUser};
 
 #[tokio_shared_rt::test(shared)]
 async fn test_homeserver_post_reply() -> Result<()> {
@@ -40,7 +40,7 @@ async fn test_homeserver_post_reply() -> Result<()> {
     let parent_post_id = test.create_post(&user_id, &parent_post).await?;
 
     // Create reply uri
-    let parent_uri = format!("pubky://{user_id}/pub/pubky.app/posts/{parent_post_id}");
+    let parent_uri = post_uri_builder(user_id.clone(), parent_post_id.clone());
 
     let reply_post = PubkyAppPost {
         content: "Watcher:PostReply:User:Reply".to_string(),

--- a/nexus-watcher/tests/event_processor/posts/reply_notification.rs
+++ b/nexus-watcher/tests/event_processor/posts/reply_notification.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use nexus_common::models::notification::{Notification, NotificationBody};
 use nexus_common::types::Pagination;
 use pubky::Keypair;
-use pubky_app_specs::{PubkyAppPost, PubkyAppPostKind, PubkyAppUser};
+use pubky_app_specs::{post_uri_builder, PubkyAppPost, PubkyAppPostKind, PubkyAppUser};
 
 #[tokio_shared_rt::test(shared)]
 async fn test_homeserver_post_reply_notification() -> Result<()> {
@@ -32,7 +32,7 @@ async fn test_homeserver_post_reply_notification() -> Result<()> {
 
     let alice_post_id = test.create_post(&alice_id, &parent_post).await?;
 
-    let parent_uri = format!("pubky://{alice_id}/pub/pubky.app/posts/{alice_post_id}");
+    let parent_uri = post_uri_builder(alice_id.clone(), alice_post_id.clone());
 
     let reply_post = PubkyAppPost {
         content: "Watcher:PostReplyNotification:Alice:Reply".to_string(),

--- a/nexus-watcher/tests/event_processor/posts/reply_repost.rs
+++ b/nexus-watcher/tests/event_processor/posts/reply_repost.rs
@@ -3,7 +3,9 @@ use crate::event_processor::users::utils::find_user_counts;
 use crate::event_processor::utils::watcher::WatcherTest;
 use anyhow::Result;
 use pubky::Keypair;
-use pubky_app_specs::{PubkyAppPost, PubkyAppPostEmbed, PubkyAppPostKind, PubkyAppUser};
+use pubky_app_specs::{
+    post_uri_builder, PubkyAppPost, PubkyAppPostEmbed, PubkyAppPostKind, PubkyAppUser,
+};
 
 #[tokio_shared_rt::test(shared)]
 async fn test_homeserver_reply_repost() -> Result<()> {
@@ -33,7 +35,7 @@ async fn test_homeserver_reply_repost() -> Result<()> {
     let parent_post_id = test.create_post(&user_id, &parent_post).await?;
 
     // Create reply
-    let parent_uri = format!("pubky://{user_id}/pub/pubky.app/posts/{parent_post_id}");
+    let parent_uri = post_uri_builder(user_id.clone(), parent_post_id.clone());
 
     let reply = PubkyAppPost {
         content: "Watcher:ReplyRepost:User:Reply".to_string(),
@@ -46,15 +48,13 @@ async fn test_homeserver_reply_repost() -> Result<()> {
     let reply_id = test.create_post(&user_id, &reply).await?;
 
     // Create repost
-    let post_uri = format!("pubky://{user_id}/pub/pubky.app/posts/{parent_post_id}");
-
     let repost = PubkyAppPost {
         content: "Watcher:ReplyRepost:User:Repost".to_string(),
         kind: PubkyAppPostKind::Short,
         parent: None,
         embed: Some(PubkyAppPostEmbed {
             kind: PubkyAppPostKind::Short,
-            uri: post_uri.clone(),
+            uri: parent_uri.clone(),
         }),
         attachments: None,
     };

--- a/nexus-watcher/tests/event_processor/posts/repost.rs
+++ b/nexus-watcher/tests/event_processor/posts/repost.rs
@@ -11,7 +11,9 @@ use nexus_common::{
     models::post::{PostDetails, PostRelationships},
 };
 use pubky::Keypair;
-use pubky_app_specs::{PubkyAppPost, PubkyAppPostEmbed, PubkyAppPostKind, PubkyAppUser};
+use pubky_app_specs::{
+    post_uri_builder, PubkyAppPost, PubkyAppPostEmbed, PubkyAppPostKind, PubkyAppUser,
+};
 
 #[tokio_shared_rt::test(shared)]
 async fn test_homeserver_post_repost() -> Result<()> {
@@ -40,7 +42,7 @@ async fn test_homeserver_post_repost() -> Result<()> {
     let parent_post_id = test.create_post(&user_id, &parent_post).await?;
 
     // Create repost uri
-    let parent_uri = format!("pubky://{user_id}/pub/pubky.app/posts/{parent_post_id}");
+    let parent_uri = post_uri_builder(user_id.clone(), parent_post_id.clone());
 
     let repost = PubkyAppPost {
         content: "Watcher:PostReply:User:Repost".to_string(),

--- a/nexus-watcher/tests/event_processor/posts/repost_notification.rs
+++ b/nexus-watcher/tests/event_processor/posts/repost_notification.rs
@@ -4,7 +4,9 @@ use anyhow::Result;
 use nexus_common::models::notification::{Notification, NotificationBody};
 use nexus_common::types::Pagination;
 use pubky::Keypair;
-use pubky_app_specs::{PubkyAppPost, PubkyAppPostEmbed, PubkyAppPostKind, PubkyAppUser};
+use pubky_app_specs::{
+    post_uri_builder, PubkyAppPost, PubkyAppPostEmbed, PubkyAppPostKind, PubkyAppUser,
+};
 
 #[tokio_shared_rt::test(shared)]
 async fn test_homeserver_post_repost_notification() -> Result<()> {
@@ -32,7 +34,7 @@ async fn test_homeserver_post_repost_notification() -> Result<()> {
 
     let alice_post_id = test.create_post(&alice_id, &parent_post).await?;
 
-    let parent_uri = format!("pubky://{alice_id}/pub/pubky.app/posts/{alice_post_id}");
+    let parent_uri = post_uri_builder(alice_id.clone(), alice_post_id.clone());
 
     let alice_repost = PubkyAppPost {
         content: "Watcher:PostRepostNotification:Alice:Reply".to_string(),

--- a/nexus-watcher/tests/event_processor/posts/retry_all.rs
+++ b/nexus-watcher/tests/event_processor/posts/retry_all.rs
@@ -3,7 +3,9 @@ use anyhow::Result;
 use nexus_watcher::events::errors::EventProcessorError;
 use nexus_watcher::events::{retry::event::RetryEvent, EventType};
 use pubky::Keypair;
-use pubky_app_specs::{PubkyAppPost, PubkyAppPostEmbed, PubkyAppPostKind, PubkyAppUser};
+use pubky_app_specs::{
+    post_uri_builder, PubkyAppPost, PubkyAppPostEmbed, PubkyAppPostKind, PubkyAppUser,
+};
 /// The user profile is stored in the homeserver. Missing the post to connect the new one
 #[tokio_shared_rt::test(shared)]
 async fn test_homeserver_post_with_reply_repost_cannot_index() -> Result<()> {
@@ -25,8 +27,8 @@ async fn test_homeserver_post_with_reply_repost_cannot_index() -> Result<()> {
     let reply_fake_post_id = "0032QB10HCRHG";
     let repost_fake_post_id = "0032QB10HP6JJ";
     // Create parent post uri
-    let reply_uri = format!("pubky://{user_id}/pub/pubky.app/posts/{reply_fake_post_id}");
-    let repost_uri = format!("pubky://{user_id}/pub/pubky.app/posts/{repost_fake_post_id}");
+    let reply_uri = post_uri_builder(user_id.clone(), reply_fake_post_id.into());
+    let repost_uri = post_uri_builder(user_id.clone(), repost_fake_post_id.into());
 
     let repost_reply_post = PubkyAppPost {
         content: "Watcher:IndexFail:PostRepost:User:Reply".to_string(),
@@ -41,7 +43,7 @@ async fn test_homeserver_post_with_reply_repost_cannot_index() -> Result<()> {
 
     let repost_reply_post_id = test.create_post(&user_id, &repost_reply_post).await?;
 
-    let repost_reply_url = format!("pubky://{user_id}/pub/pubky.app/posts/{repost_reply_post_id}");
+    let repost_reply_url = post_uri_builder(user_id, repost_reply_post_id);
 
     let index_key = format!(
         "{}:{}",

--- a/nexus-watcher/tests/event_processor/posts/retry_post.rs
+++ b/nexus-watcher/tests/event_processor/posts/retry_post.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use nexus_watcher::events::errors::EventProcessorError;
 use nexus_watcher::events::{retry::event::RetryEvent, EventType};
 use pubky::Keypair;
-use pubky_app_specs::{PubkyAppPost, PubkyAppPostKind};
+use pubky_app_specs::{post_uri_builder, PubkyAppPost, PubkyAppPostKind};
 
 /// The user profile is stored in the homeserver. Missing the author to connect the post
 #[tokio_shared_rt::test(shared)]
@@ -27,7 +27,7 @@ async fn test_homeserver_post_cannot_index() -> Result<()> {
 
     let post_id = test.create_post(&user_id, &post).await?;
 
-    let post_url = format!("pubky://{user_id}/pub/pubky.app/posts/{post_id}");
+    let post_url = post_uri_builder(user_id.clone(), post_id);
 
     let index_key = format!(
         "{}:{}",

--- a/nexus-watcher/tests/event_processor/posts/retry_reply.rs
+++ b/nexus-watcher/tests/event_processor/posts/retry_reply.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use nexus_watcher::events::errors::EventProcessorError;
 use nexus_watcher::events::{retry::event::RetryEvent, EventType};
 use pubky::Keypair;
-use pubky_app_specs::{PubkyAppPost, PubkyAppPostKind, PubkyAppUser};
+use pubky_app_specs::{post_uri_builder, PubkyAppPost, PubkyAppPostKind, PubkyAppUser};
 
 /// The user profile is stored in the homeserver. Missing the post to connect the new one
 #[tokio_shared_rt::test(shared)]
@@ -25,7 +25,7 @@ async fn test_homeserver_post_reply_cannot_index() -> Result<()> {
     // Use a placeholder parent post ID to intentionally avoid resolving it in the graph database
     let parent_fake_post_id = "0032QB10HCRHG";
     // Create parent post uri
-    let dependency_uri = format!("pubky://{user_id}/pub/pubky.app/posts/{parent_fake_post_id}");
+    let dependency_uri = post_uri_builder(user_id.clone(), parent_fake_post_id.into());
 
     let reply_post = PubkyAppPost {
         content: "Watcher:IndexFail:PostReply:User:Reply".to_string(),
@@ -37,7 +37,7 @@ async fn test_homeserver_post_reply_cannot_index() -> Result<()> {
 
     let reply_id = test.create_post(&user_id, &reply_post).await?;
 
-    let reply_url = format!("pubky://{user_id}/pub/pubky.app/posts/{reply_id}");
+    let reply_url = post_uri_builder(user_id, reply_id);
 
     let index_key = format!(
         "{}:{}",

--- a/nexus-watcher/tests/event_processor/posts/retry_repost.rs
+++ b/nexus-watcher/tests/event_processor/posts/retry_repost.rs
@@ -3,7 +3,9 @@ use anyhow::Result;
 use nexus_watcher::events::errors::EventProcessorError;
 use nexus_watcher::events::{retry::event::RetryEvent, EventType};
 use pubky::Keypair;
-use pubky_app_specs::{PubkyAppPost, PubkyAppPostEmbed, PubkyAppPostKind, PubkyAppUser};
+use pubky_app_specs::{
+    post_uri_builder, PubkyAppPost, PubkyAppPostEmbed, PubkyAppPostKind, PubkyAppUser,
+};
 
 /// The user profile is stored in the homeserver. Missing the post to connect the new one
 #[tokio_shared_rt::test(shared)]
@@ -25,7 +27,7 @@ async fn test_homeserver_post_repost_cannot_index() -> Result<()> {
     // Use a placeholder parent post ID to intentionally avoid resolving it in the graph database
     let repost_fake_post_id = "0032QB10HCRHG";
     // Create parent post uri
-    let dependency_uri = format!("pubky://{user_id}/pub/pubky.app/posts/{repost_fake_post_id}");
+    let dependency_uri = post_uri_builder(user_id.clone(), repost_fake_post_id.into());
 
     let repost_post = PubkyAppPost {
         content: "Watcher:IndexFail:PostRepost:User:Reply".to_string(),
@@ -40,7 +42,7 @@ async fn test_homeserver_post_repost_cannot_index() -> Result<()> {
 
     let repost_id = test.create_post(&user_id, &repost_post).await?;
 
-    let repost_url = format!("pubky://{user_id}/pub/pubky.app/posts/{repost_id}");
+    let repost_url = post_uri_builder(user_id, repost_id);
 
     let index_key = format!(
         "{}:{}",

--- a/nexus-watcher/tests/event_processor/posts/utils.rs
+++ b/nexus-watcher/tests/event_processor/posts/utils.rs
@@ -8,6 +8,7 @@ use nexus_common::{
         POST_TOTAL_ENGAGEMENT_KEY_PARTS,
     },
 };
+use pubky_app_specs::post_uri_builder;
 
 pub async fn find_post_counts(user_id: &str, post_id: &str) -> PostCounts {
     PostCounts::get_from_index(user_id, post_id)
@@ -94,10 +95,8 @@ pub async fn find_reply_relationship_parent_uri(user_id: &str, post_id: &str) ->
             1,
             "Reply relationship does not exist in the graph"
         );
-        return Ok(format!(
-            "pubky://{}/pub/pubky.app/posts/{}",
-            relationship[0].0, relationship[0].1
-        ));
+        let uri = post_uri_builder(relationship[0].0.clone(), relationship[0].1.clone());
+        return Ok(uri);
     }
     anyhow::bail!("Post relationship not found in Nexus graph");
 }
@@ -113,10 +112,8 @@ pub async fn find_repost_relationship_parent_uri(user_id: &str, post_id: &str) -
             1,
             "Reply relationship does not exist in the graph"
         );
-        return Ok(format!(
-            "pubky://{}/pub/pubky.app/posts/{}",
-            relationship[0].0, relationship[0].1
-        ));
+        let uri = post_uri_builder(relationship[0].0.clone(), relationship[0].1.clone());
+        return Ok(uri);
     }
     anyhow::bail!("Post relationship not found in Nexus graph");
 }

--- a/nexus-watcher/tests/event_processor/tags/fail_index.rs
+++ b/nexus-watcher/tests/event_processor/tags/fail_index.rs
@@ -2,7 +2,9 @@ use crate::event_processor::utils::watcher::{retrieve_and_handle_event_line, Wat
 use anyhow::Result;
 use chrono::Utc;
 use pubky::Keypair;
-use pubky_app_specs::{traits::HashId, PubkyAppPost, PubkyAppTag, PubkyAppUser};
+use pubky_app_specs::{
+    post_uri_builder, tag_uri_builder, traits::HashId, PubkyAppPost, PubkyAppTag, PubkyAppUser,
+};
 use tracing::error;
 
 #[tokio_shared_rt::test(shared)]
@@ -44,11 +46,7 @@ async fn test_homeserver_tag_cannot_add_while_index() -> Result<()> {
     };
 
     let tag_blob = serde_json::to_vec(&tag)?;
-    let tag_url = format!(
-        "pubky://{}/pub/pubky.app/tags/{}",
-        shadow_user_id,
-        tag.create_id()
-    );
+    let tag_url = tag_uri_builder(shadow_user_id.clone(), tag.create_id());
 
     // PUT user tag
     test.put(tag_url.as_str(), tag_blob).await?;
@@ -88,16 +86,12 @@ async fn test_homeserver_tag_cannot_add_while_index() -> Result<()> {
     let label = "merkle_tree";
 
     let tag = PubkyAppTag {
-        uri: format!("pubky://{tagged_user_id}/pub/pubky.app/posts/{post_id}"),
+        uri: post_uri_builder(tagged_user_id, post_id),
         label: label.to_string(),
         created_at: Utc::now().timestamp_millis(),
     };
     let tag_blob = serde_json::to_vec(&tag)?;
-    let tag_url = format!(
-        "pubky://{}/pub/pubky.app/tags/{}",
-        shadow_user_id,
-        tag.create_id()
-    );
+    let tag_url = tag_uri_builder(shadow_user_id, tag.create_id());
     // PUT post tag
     test.put(&tag_url, tag_blob).await?;
 

--- a/nexus-watcher/tests/event_processor/tags/multi_user.rs
+++ b/nexus-watcher/tests/event_processor/tags/multi_user.rs
@@ -12,6 +12,7 @@ use nexus_common::{
     types::Pagination,
 };
 use pubky::Keypair;
+use pubky_app_specs::tag_uri_builder;
 use pubky_app_specs::{traits::HashId, PubkyAppTag, PubkyAppUser};
 
 #[tokio_shared_rt::test(shared)]
@@ -53,11 +54,7 @@ async fn test_homeserver_multi_user_tags() -> Result<()> {
             label: label_wind.to_string(),
             created_at: Utc::now().timestamp_millis(),
         };
-        let tag_url = format!(
-            "pubky://{}/pub/pubky.app/tags/{}",
-            tagger_id,
-            tag.create_id()
-        );
+        let tag_url = tag_uri_builder(tagger_id.clone(), tag.create_id());
         // Put tag
         test.put(&tag_url, tag).await?;
         tag_urls.push(tag_url)
@@ -71,11 +68,7 @@ async fn test_homeserver_multi_user_tags() -> Result<()> {
             label: label_earth.to_string(),
             created_at: Utc::now().timestamp_millis(),
         };
-        let tag_url = format!(
-            "pubky://{}/pub/pubky.app/tags/{}",
-            tagger_id,
-            tag.create_id()
-        );
+        let tag_url = tag_uri_builder(tagger_id.clone(), tag.create_id());
         // Put tag
         test.put(&tag_url, tag).await?;
         tag_urls.push(tag_url)

--- a/nexus-watcher/tests/event_processor/tags/post_del.rs
+++ b/nexus-watcher/tests/event_processor/tags/post_del.rs
@@ -10,6 +10,7 @@ use chrono::Utc;
 use nexus_common::models::tag::post::TagPost;
 use nexus_common::models::tag::traits::{TagCollection, TaggersCollection};
 use pubky::Keypair;
+use pubky_app_specs::{post_uri_builder, tag_uri_builder};
 use pubky_app_specs::{traits::HashId, PubkyAppPost, PubkyAppTag, PubkyAppUser};
 
 #[tokio_shared_rt::test(shared)]
@@ -54,15 +55,11 @@ async fn test_homeserver_del_tag_post() -> Result<()> {
     let label = "antonymous";
 
     let tag = PubkyAppTag {
-        uri: format!("pubky://{author_user_id}/pub/pubky.app/posts/{post_id}"),
+        uri: post_uri_builder(author_user_id.clone(), post_id.clone()),
         label: label.to_string(),
         created_at: Utc::now().timestamp_millis(),
     };
-    let tag_url = format!(
-        "pubky://{}/pub/pubky.app/tags/{}",
-        tagger_user_id,
-        tag.create_id()
-    );
+    let tag_url = tag_uri_builder(tagger_user_id.clone(), tag.create_id());
 
     // Step 3: Creat & Delete the tag
     test.put(&tag_url, tag).await?;

--- a/nexus-watcher/tests/event_processor/tags/post_multi_user.rs
+++ b/nexus-watcher/tests/event_processor/tags/post_multi_user.rs
@@ -20,6 +20,7 @@ use nexus_common::{
     types::Pagination,
 };
 use pubky::Keypair;
+use pubky_app_specs::{post_uri_builder, tag_uri_builder};
 use pubky_app_specs::{traits::HashId, PubkyAppPost, PubkyAppTag, PubkyAppUser};
 
 #[tokio_shared_rt::test(shared)]
@@ -68,15 +69,11 @@ async fn test_homeserver_multi_user_posts_tags() -> Result<()> {
 
     for tagger_id in water_taggers {
         let tag = PubkyAppTag {
-            uri: format!("pubky://{author_id}/pub/pubky.app/posts/{post_id}"),
+            uri: post_uri_builder(author_id.clone(), post_id.clone()),
             label: label_water.to_string(),
             created_at: Utc::now().timestamp_millis(),
         };
-        let tag_url = format!(
-            "pubky://{}/pub/pubky.app/tags/{}",
-            tagger_id,
-            tag.create_id()
-        );
+        let tag_url = tag_uri_builder(tagger_id.clone(), tag.create_id());
         // Put tag
         test.put(&tag_url, tag).await?;
         tag_urls.push(tag_url)
@@ -86,15 +83,11 @@ async fn test_homeserver_multi_user_posts_tags() -> Result<()> {
 
     for tagger_id in fire_taggers {
         let tag = PubkyAppTag {
-            uri: format!("pubky://{author_id}/pub/pubky.app/posts/{post_id}"),
+            uri: post_uri_builder(author_id.clone(), post_id.clone()),
             label: label_fire.to_string(),
             created_at: Utc::now().timestamp_millis(),
         };
-        let tag_url = format!(
-            "pubky://{}/pub/pubky.app/tags/{}",
-            tagger_id,
-            tag.create_id()
-        );
+        let tag_url = tag_uri_builder(tagger_id.clone(), tag.create_id());
         // Put tag
         test.put(&tag_url, tag).await?;
         tag_urls.push(tag_url)

--- a/nexus-watcher/tests/event_processor/tags/post_notification.rs
+++ b/nexus-watcher/tests/event_processor/tags/post_notification.rs
@@ -7,7 +7,9 @@ use nexus_common::{
     types::Pagination,
 };
 use pubky::Keypair;
-use pubky_app_specs::{traits::HashId, PubkyAppPost, PubkyAppTag, PubkyAppUser};
+use pubky_app_specs::{
+    post_uri_builder, tag_uri_builder, traits::HashId, PubkyAppPost, PubkyAppTag, PubkyAppUser,
+};
 
 #[tokio_shared_rt::test(shared)]
 async fn test_homeserver_tag_post_notification() -> Result<()> {
@@ -52,16 +54,12 @@ async fn test_homeserver_tag_post_notification() -> Result<()> {
     let label = "interesting";
 
     let tag = PubkyAppTag {
-        uri: format!("pubky://{author_id}/pub/pubky.app/posts/{post_id}"),
+        uri: post_uri_builder(author_id.clone(), post_id.clone()),
         label: label.to_string(),
         created_at: Utc::now().timestamp_millis(),
     };
 
-    let tag_url = format!(
-        "pubky://{}/pub/pubky.app/tags/{}",
-        tagger_id,
-        tag.create_id()
-    );
+    let tag_url = tag_uri_builder(tagger_id.clone(), tag.create_id());
 
     // Put tag
     test.put(tag_url.as_str(), tag).await?;

--- a/nexus-watcher/tests/event_processor/tags/post_put.rs
+++ b/nexus-watcher/tests/event_processor/tags/post_put.rs
@@ -13,6 +13,7 @@ use nexus_common::models::tag::post::TagPost;
 use nexus_common::models::tag::traits::TagCollection;
 use nexus_common::types::Pagination;
 use pubky::Keypair;
+use pubky_app_specs::{post_uri_builder, tag_uri_builder};
 use pubky_app_specs::{traits::HashId, PubkyAppPost, PubkyAppTag, PubkyAppUser};
 
 #[tokio_shared_rt::test(shared)]
@@ -45,15 +46,11 @@ async fn test_homeserver_put_tag_post() -> Result<()> {
     let label = "merkle_tree";
 
     let tag = PubkyAppTag {
-        uri: format!("pubky://{tagger_user_id}/pub/pubky.app/posts/{post_id}"),
+        uri: post_uri_builder(tagger_user_id.clone(), post_id.clone()),
         label: label.to_string(),
         created_at: Utc::now().timestamp_millis(),
     };
-    let tag_url = format!(
-        "pubky://{}/pub/pubky.app/tags/{}",
-        tagger_user_id,
-        tag.create_id()
-    );
+    let tag_url = tag_uri_builder(tagger_user_id.clone(), tag.create_id());
 
     // Put tag
     test.put(&tag_url, tag).await?;
@@ -184,15 +181,11 @@ async fn test_homeserver_put_tag_post_unique_count() -> Result<()> {
 
     let label = "tag-183";
     let tag = PubkyAppTag {
-        uri: format!("pubky://{tagger_user_id}/pub/pubky.app/posts/{post_id}"),
+        uri: post_uri_builder(tagger_user_id.clone(), post_id.clone()),
         label: label.to_string(),
         created_at: Utc::now().timestamp_millis(),
     };
-    let tag_url = format!(
-        "pubky://{}/pub/pubky.app/tags/{}",
-        tagger_user_id,
-        tag.create_id()
-    );
+    let tag_url = tag_uri_builder(tagger_user_id.clone(), tag.create_id());
 
     // Step 1: Put tag (tag post)
     test.put(&tag_url, tag.clone()).await?;
@@ -242,11 +235,7 @@ async fn test_homeserver_put_tag_user_unique_count() -> Result<()> {
         label: label.to_string(),
         created_at: Utc::now().timestamp_millis(),
     };
-    let tag_url = format!(
-        "pubky://{}/pub/pubky.app/tags/{}",
-        tagger_user_id,
-        tag.create_id()
-    );
+    let tag_url = tag_uri_builder(tagger_user_id.clone(), tag.create_id());
 
     // Step 1: Put tag (tag user)
     test.put(&tag_url, tag.clone()).await?;

--- a/nexus-watcher/tests/event_processor/tags/retry_post_tag.rs
+++ b/nexus-watcher/tests/event_processor/tags/retry_post_tag.rs
@@ -4,6 +4,7 @@ use chrono::Utc;
 use nexus_watcher::events::errors::EventProcessorError;
 use nexus_watcher::events::{retry::event::RetryEvent, EventType};
 use pubky::Keypair;
+use pubky_app_specs::{post_uri_builder, tag_uri_builder};
 use pubky_app_specs::{traits::HashId, PubkyAppTag, PubkyAppUser};
 
 #[tokio_shared_rt::test(shared)]
@@ -34,10 +35,7 @@ async fn test_homeserver_post_tag_event_to_queue() -> Result<()> {
     // => Create user tag
     let label = "peak_limit";
 
-    let dependency_uri = format!(
-        "pubky://{author_id}/pub/pubky.app/posts/{}",
-        "0032Q4SFBFD4G"
-    );
+    let dependency_uri = post_uri_builder(author_id, "0032Q4SFBFD4G".into());
 
     // Create a tag in a fake post
     let tag = PubkyAppTag {
@@ -45,10 +43,7 @@ async fn test_homeserver_post_tag_event_to_queue() -> Result<()> {
         label: label.to_string(),
         created_at: Utc::now().timestamp_millis(),
     };
-    let tag_url = format!(
-        "pubky://{tagger_user_id}/pub/pubky.app/tags/{}",
-        tag.create_id()
-    );
+    let tag_url = tag_uri_builder(tagger_user_id, tag.create_id());
 
     // PUT user tag
     // That operation is going to write the event in the pending events queue, so block a bit the thread

--- a/nexus-watcher/tests/event_processor/tags/retry_user_tag.rs
+++ b/nexus-watcher/tests/event_processor/tags/retry_user_tag.rs
@@ -4,6 +4,7 @@ use chrono::Utc;
 use nexus_watcher::events::errors::EventProcessorError;
 use nexus_watcher::events::{retry::event::RetryEvent, EventType};
 use pubky::Keypair;
+use pubky_app_specs::tag_uri_builder;
 use pubky_app_specs::{traits::HashId, PubkyAppTag, PubkyAppUser};
 
 #[tokio_shared_rt::test(shared)]
@@ -35,11 +36,7 @@ async fn test_homeserver_user_tag_event_to_queue() -> Result<()> {
         label: label.to_string(),
         created_at: Utc::now().timestamp_millis(),
     };
-    let tag_url = format!(
-        "pubky://{}/pub/pubky.app/tags/{}",
-        tagger_user_id,
-        tag.create_id()
-    );
+    let tag_url = tag_uri_builder(tagger_user_id, tag.create_id());
 
     // PUT user tag
     // That operation is going to write the event in the pending events queue, so block a bit the thread

--- a/nexus-watcher/tests/event_processor/tags/user_notification.rs
+++ b/nexus-watcher/tests/event_processor/tags/user_notification.rs
@@ -6,7 +6,7 @@ use nexus_common::{
     types::Pagination,
 };
 use pubky::Keypair;
-use pubky_app_specs::{traits::HashId, PubkyAppTag, PubkyAppUser};
+use pubky_app_specs::{tag_uri_builder, traits::HashId, PubkyAppTag, PubkyAppUser};
 
 #[tokio_shared_rt::test(shared)]
 async fn test_homeserver_put_tag_user_notification() -> Result<()> {
@@ -44,11 +44,7 @@ async fn test_homeserver_put_tag_user_notification() -> Result<()> {
         label: label.to_string(),
         created_at: Utc::now().timestamp_millis(),
     };
-    let tag_url = format!(
-        "pubky://{}/pub/pubky.app/tags/{}",
-        tagger_user_id,
-        tag.create_id()
-    );
+    let tag_url = tag_uri_builder(tagger_user_id.clone(), tag.create_id());
 
     // Put tag
     test.put(tag_url.as_str(), tag).await?;

--- a/nexus-watcher/tests/event_processor/tags/user_to_self_put.rs
+++ b/nexus-watcher/tests/event_processor/tags/user_to_self_put.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 use chrono::Utc;
 use nexus_common::models::tag::{traits::TagCollection, user::TagUser};
 use pubky::Keypair;
-use pubky_app_specs::{traits::HashId, PubkyAppTag, PubkyAppUser};
+use pubky_app_specs::{tag_uri_builder, traits::HashId, PubkyAppTag, PubkyAppUser};
 
 #[tokio_shared_rt::test(shared)]
 async fn test_homeserver_put_tag_user_self() -> Result<()> {
@@ -34,7 +34,7 @@ async fn test_homeserver_put_tag_user_self() -> Result<()> {
         created_at: Utc::now().timestamp_millis(),
     };
 
-    let tag_url = format!("pubky://{}/pub/pubky.app/tags/{}", user_id, tag.create_id());
+    let tag_url = tag_uri_builder(user_id.clone(), tag.create_id());
 
     // Put tag
     test.put(tag_url.as_str(), tag).await?;

--- a/nexus-watcher/tests/event_processor/tags/user_to_user_del.rs
+++ b/nexus-watcher/tests/event_processor/tags/user_to_user_del.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 use chrono::Utc;
 use nexus_common::models::tag::{traits::TagCollection, user::TagUser};
 use pubky::Keypair;
-use pubky_app_specs::{traits::HashId, PubkyAppTag, PubkyAppUser};
+use pubky_app_specs::{tag_uri_builder, traits::HashId, PubkyAppTag, PubkyAppUser};
 
 #[tokio_shared_rt::test(shared)]
 async fn test_homeserver_del_tag_to_another_user() -> Result<()> {
@@ -45,11 +45,7 @@ async fn test_homeserver_del_tag_to_another_user() -> Result<()> {
         created_at: Utc::now().timestamp_millis(),
     };
 
-    let tag_url = format!(
-        "pubky://{}/pub/pubky.app/tags/{}",
-        tagger_user_id,
-        tag.create_id()
-    );
+    let tag_url = tag_uri_builder(tagger_user_id.clone(), tag.create_id());
 
     // Put tag
     test.put(tag_url.as_str(), tag).await?;

--- a/nexus-watcher/tests/event_processor/tags/user_to_user_put.rs
+++ b/nexus-watcher/tests/event_processor/tags/user_to_user_put.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 use chrono::Utc;
 use nexus_common::models::tag::{traits::TagCollection, user::TagUser};
 use pubky::Keypair;
-use pubky_app_specs::{traits::HashId, PubkyAppTag, PubkyAppUser};
+use pubky_app_specs::{tag_uri_builder, traits::HashId, PubkyAppTag, PubkyAppUser};
 
 #[tokio_shared_rt::test(shared)]
 async fn test_homeserver_put_tag_user_another() -> Result<()> {
@@ -45,11 +45,7 @@ async fn test_homeserver_put_tag_user_another() -> Result<()> {
         created_at: Utc::now().timestamp_millis(),
     };
 
-    let tag_url = format!(
-        "pubky://{}/pub/pubky.app/tags/{}",
-        tagger_user_id,
-        tag.create_id()
-    );
+    let tag_url = tag_uri_builder(tagger_user_id.clone(), tag.create_id());
 
     // PUT post tag
     test.put(tag_url.as_str(), tag).await?;

--- a/nexus-watcher/tests/event_processor/users/del_with_relations.rs
+++ b/nexus-watcher/tests/event_processor/users/del_with_relations.rs
@@ -7,8 +7,8 @@ use chrono::Utc;
 use nexus_common::models::user::{UserCounts, UserStream, UserView};
 use pubky::Keypair;
 use pubky_app_specs::{
-    traits::{HasIdPath, HashId},
-    PubkyAppBlob, PubkyAppFile, PubkyAppPost, PubkyAppPostKind, PubkyAppUser, PubkyAppUserLink,
+    blob_uri_builder, traits::HashId, PubkyAppBlob, PubkyAppFile, PubkyAppPost, PubkyAppPostKind,
+    PubkyAppUser, PubkyAppUserLink,
 };
 
 #[tokio_shared_rt::test(shared)]
@@ -120,7 +120,7 @@ async fn test_delete_user_with_relationships() -> Result<()> {
     let blob_data = "Image bytes blob".to_string();
     let blob = PubkyAppBlob::new(blob_data.as_bytes().to_vec());
     let blob_id = blob.create_id();
-    let blob_url = format!("pubky://{}{}", user_with_id, blob.create_path(&blob_id));
+    let blob_url = blob_uri_builder(user_with_id.clone(), blob_id);
 
     test.create_file_from_body(blob_url.as_str(), blob.0.clone())
         .await?;

--- a/nexus-watcher/tests/event_processor/users/moderated.rs
+++ b/nexus-watcher/tests/event_processor/users/moderated.rs
@@ -6,7 +6,7 @@ use crate::{
 use anyhow::Result;
 use chrono::Utc;
 use pubky::{recovery_file, Keypair};
-use pubky_app_specs::{traits::HashId, PubkyAppTag, PubkyAppUser};
+use pubky_app_specs::{tag_uri_builder, traits::HashId, PubkyAppTag, PubkyAppUser};
 use tokio::fs;
 
 #[tokio_shared_rt::test(shared)]
@@ -41,11 +41,7 @@ async fn test_moderated_user_lifecycle() -> Result<()> {
         label: "label_to_moderate".to_string(),
         created_at: Utc::now().timestamp_millis(),
     };
-    let tag_url = format!(
-        "pubky://{}/pub/pubky.app/tags/{}",
-        moderator_id,
-        tag.create_id()
-    );
+    let tag_url = tag_uri_builder(moderator_id, tag.create_id());
     test.put(&tag_url, tag.clone()).await?;
 
     // 5. Confirm the user no longer exists
@@ -72,11 +68,7 @@ async fn test_moderated_user_lifecycle() -> Result<()> {
         label: "tagging_myself".to_string(),
         created_at: Utc::now().timestamp_millis(),
     };
-    let selftag_url = format!(
-        "pubky://{}/pub/pubky.app/tags/{}",
-        target_id,
-        self_tag.create_id()
-    );
+    let selftag_url = tag_uri_builder(target_id.clone(), self_tag.create_id());
     test.put(&selftag_url, self_tag).await?;
 
     // 8. Tag the target user with the moderation label

--- a/nexus-watcher/tests/event_processor/users/raw.rs
+++ b/nexus-watcher/tests/event_processor/users/raw.rs
@@ -10,7 +10,7 @@ use nexus_common::{
     models::user::{UserCounts, UserSearch, USER_NAME_KEY_PARTS},
 };
 use pubky::Keypair;
-use pubky_app_specs::{PubkyAppUser, PubkyAppUserLink};
+use pubky_app_specs::{file_uri_builder, PubkyAppUser, PubkyAppUserLink};
 
 #[tokio_shared_rt::test(shared)]
 async fn test_homeserver_user_put_event() -> Result<()> {
@@ -20,7 +20,10 @@ async fn test_homeserver_user_put_event() -> Result<()> {
 
     let user = PubkyAppUser {
         bio: Some("test_homeserver_user_event".to_string()),
-        image: Some("pubky://4snwyct86m383rsduhw5xgcxpw7c63j3pq8x4ycqikxgik8y64ro/pub/pubky.app/files/003286NSMY490".to_string()),
+        image: Some(file_uri_builder(
+            "4snwyct86m383rsduhw5xgcxpw7c63j3pq8x4ycqikxgik8y64ro".into(),
+            "003286NSMY490".into(),
+        )),
         links: Some(vec![PubkyAppUserLink {
             title: "User Event".to_string(),
             url: "pubky://watcher.nexus".to_string(),

--- a/nexus-watcher/tests/event_processor/utils/watcher.rs
+++ b/nexus-watcher/tests/event_processor/utils/watcher.rs
@@ -9,7 +9,9 @@ use nexus_watcher::events::retry::event::RetryEvent;
 use nexus_watcher::events::Event;
 use nexus_watcher::NexusWatcher;
 use pubky::Keypair;
-use pubky_app_specs::PubkyId;
+use pubky_app_specs::{
+    file_uri_builder, follow_uri_builder, mute_uri_builder, post_uri_builder, PubkyId,
+};
 use pubky_app_specs::{
     traits::TimestampId, PubkyAppFile, PubkyAppFollow, PubkyAppPost, PubkyAppUser,
 };
@@ -171,7 +173,7 @@ impl WatcherTest {
 
     pub async fn create_post(&mut self, user_id: &str, post: &PubkyAppPost) -> Result<String> {
         let post_id = post.create_id();
-        let url = format!("pubky://{user_id}/pub/pubky.app/posts/{post_id}");
+        let url = post_uri_builder(user_id.into(), post_id.clone());
         // Write the post in the pubky.app repository
         PubkyClient::get()
             .unwrap()
@@ -197,7 +199,7 @@ impl WatcherTest {
     }
 
     pub async fn cleanup_post(&mut self, user_id: &str, post_id: &str) -> Result<()> {
-        let url = format!("pubky://{user_id}/pub/pubky.app/posts/{post_id}");
+        let url = post_uri_builder(user_id.into(), post_id.into());
         PubkyClient::get()
             .unwrap()
             .delete(url.as_str())
@@ -213,7 +215,7 @@ impl WatcherTest {
         file: &PubkyAppFile,
     ) -> Result<(String, String)> {
         let file_id = file.create_id();
-        let url = format!("pubky://{user_id}/pub/pubky.app/files/{file_id}");
+        let url = file_uri_builder(user_id.into(), file_id.clone());
         PubkyClient::get()
             .unwrap()
             .put(url.as_str())
@@ -240,7 +242,7 @@ impl WatcherTest {
     }
 
     pub async fn cleanup_file(&mut self, user_id: &str, file_id: &str) -> Result<()> {
-        let url = format!("pubky://{user_id}/pub/pubky.app/files/{file_id}");
+        let url = file_uri_builder(user_id.into(), file_id.into());
         PubkyClient::get()
             .unwrap()
             .delete(url.as_str())
@@ -254,7 +256,7 @@ impl WatcherTest {
         let follow_relationship = PubkyAppFollow {
             created_at: Utc::now().timestamp_millis(),
         };
-        let follow_url = format!("pubky://{follower_id}/pub/pubky.app/follows/{followee_id}");
+        let follow_url = follow_uri_builder(follower_id.into(), followee_id.into());
         PubkyClient::get()
             .unwrap()
             .put(follow_url.as_str())
@@ -270,7 +272,7 @@ impl WatcherTest {
         let mute_relationship = PubkyAppFollow {
             created_at: Utc::now().timestamp_millis(),
         };
-        let mute_url = format!("pubky://{muter_id}/pub/pubky.app/mutes/{mutee_id}");
+        let mute_url = mute_uri_builder(muter_id.into(), mutee_id.into());
         PubkyClient::get()
             .unwrap()
             .put(mute_url.as_str())

--- a/nexus-webapi/tests/files/by_ids.rs
+++ b/nexus-webapi/tests/files/by_ids.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use pubky_app_specs::file_uri_builder;
 use serde_json::json;
 
 use crate::utils::post_request;
@@ -7,11 +8,11 @@ use crate::utils::post_request;
 async fn test_files_by_ids() -> Result<()> {
     let test_file_id = "2ZK2H8P2T5NG0";
     let test_file_user = "y4euc58gnmxun9wo87gwmanu6kztt9pgw1zz1yp1azp7trrsjamy";
-    let test_file_uri = format!("pubky://{test_file_user}/pub/pubky.app/files/{test_file_id}");
+    let test_file_uri = file_uri_builder(test_file_user.into(), test_file_id.into());
 
     let test_file_id2 = "2ZK1VCJN4YE00";
     let test_file_user2 = "sfgetccnq7s3h57a7imf6n7k5fqxus33yg85f1ndhnrnofjdmhjy";
-    let test_file_uri2 = format!("pubky://{test_file_user2}/pub/pubky.app/files/{test_file_id2}");
+    let test_file_uri2 = file_uri_builder(test_file_user2.into(), test_file_id2.into());
 
     let json_body = post_request(
         "/v0/files/by_ids",

--- a/nexus-webapi/tests/files/details.rs
+++ b/nexus-webapi/tests/files/details.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use pubky_app_specs::file_uri_builder;
 
 use crate::utils::get_request;
 
@@ -7,7 +8,7 @@ async fn test_file_details() -> Result<()> {
     let test_file_id = "2ZK2H8P2T5NG0";
     let test_file_user = "y4euc58gnmxun9wo87gwmanu6kztt9pgw1zz1yp1azp7trrsjamy";
 
-    let test_file_uri = format!("pubky://{test_file_user}/pub/pubky.app/files/{test_file_id}");
+    let test_file_uri = file_uri_builder(test_file_user.into(), test_file_id.into());
 
     let json_body = get_request(
         format!(


### PR DESCRIPTION
This PR bumps the `pubky-app-specs` dependency and replaces hardcoded URIs with `xyz_uri_builder` utils.