### PR TITLE
Update exposed API ingestion endpoint: ask for user PK instead of HS PK

### DIFF
--- a/nexus-common/src/homeserver_manager.rs
+++ b/nexus-common/src/homeserver_manager.rs
@@ -1,7 +1,8 @@
-use nexus_common::db::PubkyClient;
-use nexus_common::models::homeserver::Homeserver;
-use nexus_common::models::user::UserDetails;
-use nexus_common::types::DynError;
+use crate::db::PubkyClient;
+use crate::models::homeserver::Homeserver;
+use crate::models::user::UserDetails;
+use crate::types::DynError;
+
 use pubky::PublicKey;
 use pubky_app_specs::{ParsedUri, PubkyId};
 

--- a/nexus-common/src/lib.rs
+++ b/nexus-common/src/lib.rs
@@ -15,6 +15,7 @@
 
 mod config;
 pub mod db;
+mod homeserver_manager;
 pub mod media;
 pub mod models;
 mod stack;
@@ -22,4 +23,5 @@ pub mod types;
 pub mod utils;
 
 pub use config::*;
+pub use homeserver_manager::HomeserverManager;
 pub use stack::*;

--- a/nexus-watcher/src/events/handlers/follow.rs
+++ b/nexus-watcher/src/events/handlers/follow.rs
@@ -1,14 +1,14 @@
 use crate::events::errors::EventProcessorError;
 use crate::events::retry::event::RetryEvent;
 use crate::handle_indexing_results;
-use crate::service::HomeserverManager;
+
 use nexus_common::db::kv::JsonAction;
 use nexus_common::db::OperationOutcome;
 use nexus_common::models::follow::{Followers, Following, Friends, UserFollows};
 use nexus_common::models::notification::Notification;
 use nexus_common::models::user::UserCounts;
-
 use nexus_common::types::DynError;
+use nexus_common::HomeserverManager;
 use pubky_app_specs::{user_uri_builder, PubkyId};
 use tracing::debug;
 

--- a/nexus-watcher/src/events/handlers/post.rs
+++ b/nexus-watcher/src/events/handlers/post.rs
@@ -1,7 +1,6 @@
 use crate::events::errors::EventProcessorError;
 use crate::events::retry::event::RetryEvent;
 use crate::handle_indexing_results;
-use crate::service::HomeserverManager;
 use nexus_common::db::kv::{JsonAction, ScoreAction};
 use nexus_common::db::queries::get::post_is_safe_to_delete;
 use nexus_common::db::{exec_single_row, execute_graph_operation, OperationOutcome};
@@ -12,6 +11,7 @@ use nexus_common::models::post::{
 };
 use nexus_common::models::user::UserCounts;
 use nexus_common::types::DynError;
+use nexus_common::HomeserverManager;
 use pubky_app_specs::{
     post_uri_builder, user_uri_builder, ParsedUri, PubkyAppPost, PubkyAppPostKind, PubkyId,
     Resource,

--- a/nexus-watcher/src/events/handlers/tag.rs
+++ b/nexus-watcher/src/events/handlers/tag.rs
@@ -1,7 +1,6 @@
 use crate::events::errors::EventProcessorError;
 use crate::events::retry::event::RetryEvent;
 use crate::handle_indexing_results;
-use crate::service::HomeserverManager;
 use chrono::Utc;
 use nexus_common::db::kv::{JsonAction, ScoreAction};
 use nexus_common::db::OperationOutcome;
@@ -14,6 +13,7 @@ use nexus_common::models::tag::traits::{TagCollection, TaggersCollection};
 use nexus_common::models::tag::user::TagUser;
 use nexus_common::models::user::UserCounts;
 use nexus_common::types::DynError;
+use nexus_common::HomeserverManager;
 use pubky_app_specs::{user_uri_builder, ParsedUri, PubkyAppTag, PubkyId, Resource};
 use tracing::debug;
 

--- a/nexus-watcher/src/service/mod.rs
+++ b/nexus-watcher/src/service/mod.rs
@@ -1,5 +1,4 @@
 mod constants;
-mod homeserver;
 mod processor;
 mod processor_factory;
 mod stats;
@@ -7,7 +6,6 @@ mod traits;
 
 /// Module exports
 pub use constants::{PROCESSING_TIMEOUT_SECS, WATCHER_CONFIG_FILE_NAME};
-pub use homeserver::HomeserverManager;
 pub use processor::EventProcessor;
 pub use processor_factory::EventProcessorFactory;
 pub use traits::{TEventProcessor, TEventProcessorFactory};

--- a/nexus-webapi/src/routes/v0/bootstrap.rs
+++ b/nexus-webapi/src/routes/v0/bootstrap.rs
@@ -8,7 +8,7 @@ use axum::routing::{get, put};
 use axum::Json;
 use axum::Router;
 use nexus_common::models::bootstrap::{Bootstrap, ViewType};
-use nexus_common::models::homeserver::Homeserver;
+use nexus_common::HomeserverManager;
 use pubky_app_specs::PubkyId;
 use tracing::info;
 use utoipa::OpenApi;
@@ -44,36 +44,25 @@ pub async fn bootstrap_handler(
 #[utoipa::path(
     put,
     path = PUT_HOMESERVER_ROUTE,
-    description = "Start monitoring Pubky App data on a new homeserver",
+    description = "Ingest (start monitoring all events of) the Homeserver on which this User PK stores data at this time",
     tag = "Bootstrap",
     params(
-        ("homeserver_pk" = String, Path, description = "Homeserver PK")
+        ("user_pk" = String, Path, description = "User PK")
     ),
     responses(
         (status = 200, description = "Successfully added new homeserver"),
         (status = 500, description = "Internal server error")
     )
 )]
-pub async fn put_homeserver_handler(Path(homeserver_pk): Path<String>) -> Result<()> {
-    info!("PUT {PUT_HOMESERVER_ROUTE}, homeserver_pk:{homeserver_pk}");
+pub async fn put_homeserver_handler(Path(user_pk): Path<String>) -> Result<()> {
+    info!("PUT {PUT_HOMESERVER_ROUTE}, user_pk:{user_pk}");
 
-    let hs = PubkyId::try_from(&homeserver_pk)
-        .map(Homeserver::new)
-        .map_err(|e| Error::invalid_input(&format!("Invalid homeserver PK: {e}")))?;
+    PubkyId::try_from(&user_pk)
+        .map_err(|e| Error::invalid_input(&format!("Invalid user PK: {e}")))?;
 
-    // Before saving to graph, check if it exists (indexed)
-    match Homeserver::get_from_index(&homeserver_pk).await {
-        Err(e) => Err(Error::internal(e)),
-        Ok(Some(_)) => Err(Error::invalid_input("Homeserver is already known")),
-        Ok(None) => {
-            hs.put_to_graph()
-                .await
-                .map_err(|_| Error::invalid_input("Failed to store homeserver to graph"))?;
-            hs.put_to_index()
-                .await
-                .map_err(|_| Error::invalid_input("Failed to add homeserver to index"))
-        }
-    }
+    HomeserverManager::maybe_ingest_for_user(&user_pk)
+        .await
+        .map_err(Error::internal)
 }
 
 #[derive(OpenApi)]

--- a/nexus-webapi/src/routes/v0/endpoints.rs
+++ b/nexus-webapi/src/routes/v0/endpoints.rs
@@ -68,4 +68,4 @@ pub const NOTIFICATION_ROUTE: &str = concatcp!(USER_ROUTE, "/notifications");
 
 // -- BOOTSTRAP endpoints -
 pub const BOOTSTRAP_ROUTE: &str = concatcp!(VERSION_ROUTE, "/bootstrap/{user_id}");
-pub const PUT_HOMESERVER_ROUTE: &str = concatcp!(VERSION_ROUTE, "/homeserver/add/{homeserver_pk}");
+pub const PUT_HOMESERVER_ROUTE: &str = concatcp!(VERSION_ROUTE, "/ingest/{user_pk}");


### PR DESCRIPTION
This PR changes the logic of the exposed PUT endpoint:
- before, it asked for a Homeserver PK, to cause the ingestion of that HS
- now, it asks for a User PK, which internally causes the ingestion of that user's HS

The ingestion logic (check if HS is known, construct client, lookup, etc) re-uses the existing `HomeserverManager::maybe_ingest_for_user` , which is also used when ingesting the HS of referenced users in posts.

To make this possible, the `HomeserverManager` was moved from `nexus-watcher` to `nexus-common`.