### PR TITLE
Fix HS persistence: explicitly check existence in graph

### DIFF
--- a/nexus-common/src/models/homeserver.rs
+++ b/nexus-common/src/models/homeserver.rs
@@ -82,9 +82,9 @@ impl Homeserver {
         }
     }
 
-    /// Verifies if homeserver exists, or persists it if missing
+    /// Verifies if homeserver exists in the graph, or persists it if missing
     pub async fn persist_if_unknown(homeserver_id: PubkyId) -> Result<(), DynError> {
-        if Self::get_by_id(homeserver_id.clone()).await?.is_none() {
+        if Self::get_from_graph(&homeserver_id).await?.is_none() {
             info!("Persisting new homeserver: {homeserver_id}");
             let homeserver = Homeserver::new(homeserver_id);
             homeserver.put_to_graph().await?;


### PR DESCRIPTION
This PR fixes an edge case, where a HS was not persisted in the Neo4j graph if it already existed in the Redis cache.

Locally, this was never seen because both the graph and the index were cleared in tandem. However as this was deployed on Staging, the index already contained the default HS, at the same time when the graph got the new `Homeserver` entity in the schema. This lead to the situation that the default HS (from `config.toml`) was present in the index, but not in the graph.

The PR fixes this by updating `Homeserver::persist_if_unknown` to explicitly do a lookup in the graph and bypass `get_by_id`, which first does a lookup in the Redis cache.