### PR TITLE
fix(watcher): handle non-success responses when processing PUT events

### DIFF
--- a/nexus-watcher/src/events/mod.rs
+++ b/nexus-watcher/src/events/mod.rs
@@ -103,14 +103,13 @@ impl Event {
     pub async fn handle_put_event(self, moderation: Arc<Moderation>) -> Result<(), DynError> {
         debug!("Handling PUT event for URI: {}", self.uri);
 
-        let mut response;
-        {
+        let response = {
             let pubky_client =
                 PubkyClient::get().map_err(|e| EventProcessorError::PubkyClientError {
                     message: e.to_string(),
                 })?;
 
-            response = match pubky_client.get(&self.uri).send().await {
+            match pubky_client.get(&self.uri).send().await {
                 Ok(response) => response,
                 Err(e) => {
                     return Err(EventProcessorError::PubkyClientError {
@@ -118,8 +117,8 @@ impl Event {
                     }
                     .into())
                 }
-            };
-        } // drop the pubky_client lock
+            }
+        }; // drop the pubky_client lock
 
         if !response.status().is_success() {
             let status = response.status();


### PR DESCRIPTION
## Summary
- prevent PUT event handling from parsing error responses by checking HTTP status before decoding blobs
- return clearer PubkyClientError messages that include status code and response body when fetches fail