### PR TITLE
fix: adjust log verbosity

### DIFF
--- a/nexus-watcher/src/service/mod.rs
+++ b/nexus-watcher/src/service/mod.rs
@@ -86,8 +86,9 @@ impl NexusWatcher {
                     break;
                 }
                 _ = interval.tick() => {
-                    info!("Indexing homeservers…");
-                    _ = ev_processor_runner.run_all()
+                    debug!("Indexing homeservers…");
+                    _ = ev_processor_runner
+                        .run_all()
                         .await
                         .inspect_err(|e| error!("Failed to start event processors run: {e}"));
                 }

--- a/nexus-watcher/src/service/processor.rs
+++ b/nexus-watcher/src/service/processor.rs
@@ -42,7 +42,7 @@ impl TEventProcessor for EventProcessor {
         };
 
         match maybe_event_lines {
-            None => info!("No new events"),
+            None => debug!("No new events"),
             Some(event_lines) => {
                 info!("Processing {} event lines", event_lines.len());
                 self.process_event_lines(event_lines).await?;

--- a/nexus-watcher/src/service/stats.rs
+++ b/nexus-watcher/src/service/stats.rs
@@ -58,6 +58,11 @@ impl RunAllProcessorsStats {
     pub fn count_timeout(&self) -> usize {
         self.count(ProcessorRunStatus::Timeout)
     }
+
+    /// Number of homeservers where processing failed to start
+    pub fn count_failed_to_build(&self) -> usize {
+        self.count(ProcessorRunStatus::FailedToBuild)
+    }
 }
 
 /// Wrapper around `RunAllProcessorsStats` which indicates they've been processed

--- a/nexus-webapi/src/routes/static/avatar.rs
+++ b/nexus-webapi/src/routes/static/avatar.rs
@@ -9,7 +9,7 @@ use nexus_common::media::FileVariant;
 use nexus_common::models::file::Blob;
 use nexus_common::models::{file::FileDetails, traits::Collection, user::UserDetails};
 use tower_http::services::fs::ServeFileSystemResponseBody;
-use tracing::{error, info};
+use tracing::{debug, error};
 use utoipa::OpenApi;
 
 use super::endpoints::USER_AVATAR_ROUTE;
@@ -33,7 +33,7 @@ pub async fn user_avatar_handler(
     State(app_state): State<AppState>,
     request: Request,
 ) -> Result<Response<ServeFileSystemResponseBody>> {
-    info!("GET {USER_AVATAR_ROUTE} user_id:{}", user_id);
+    debug!("GET {USER_AVATAR_ROUTE} user_id:{}", user_id);
 
     let file_path: &PathBuf = &app_state.files_path;
 

--- a/nexus-webapi/src/routes/v0/bootstrap.rs
+++ b/nexus-webapi/src/routes/v0/bootstrap.rs
@@ -10,7 +10,7 @@ use axum::Router;
 use nexus_common::models::bootstrap::{Bootstrap, ViewType};
 use nexus_common::models::homeserver::Homeserver;
 use pubky_app_specs::PubkyId;
-use tracing::info;
+use tracing::debug;
 use utoipa::OpenApi;
 
 #[utoipa::path(
@@ -32,7 +32,7 @@ pub async fn bootstrap_handler(
     // TODO: Might need a param like "ViewType". There might be too much data to include in the first go, especially for mobile
     //Query(query): Query<Pub>,
 ) -> Result<Json<Bootstrap>> {
-    info!("GET {BOOTSTRAP_ROUTE}, user_id:{}", user_id);
+    debug!("GET {BOOTSTRAP_ROUTE}, user_id:{}", user_id);
 
     match Bootstrap::get_by_id(&user_id, ViewType::Full).await {
         Ok(Some(result)) => Ok(Json(result)),
@@ -55,7 +55,7 @@ pub async fn bootstrap_handler(
     )
 )]
 pub async fn put_homeserver_handler(Path(user_id): Path<String>) -> Result<()> {
-    info!("PUT {PUT_HOMESERVER_ROUTE}, user_id:{user_id}");
+    debug!("PUT {PUT_HOMESERVER_ROUTE}, user_id:{user_id}");
 
     PubkyId::try_from(&user_id)
         .map_err(|e| Error::invalid_input(&format!("Invalid user PK: {e}")))?;

--- a/nexus-webapi/src/routes/v0/file/details.rs
+++ b/nexus-webapi/src/routes/v0/file/details.rs
@@ -5,7 +5,7 @@ use axum::Json;
 use nexus_common::models::file::FileDetails;
 use nexus_common::models::file::FileUrls;
 use nexus_common::models::traits::Collection;
-use tracing::info;
+use tracing::debug;
 use utoipa::OpenApi;
 
 #[utoipa::path(
@@ -23,7 +23,7 @@ use utoipa::OpenApi;
     )
 )]
 pub async fn file_details_handler(Path(file_uri): Path<String>) -> Result<Json<FileDetails>> {
-    info!("GET {FILE_ROUTE} file_uri:{}", file_uri);
+    debug!("GET {FILE_ROUTE} file_uri:{}", file_uri);
 
     let file_key = FileDetails::file_key_from_uri(&file_uri);
     let result = FileDetails::get_by_ids(

--- a/nexus-webapi/src/routes/v0/file/list.rs
+++ b/nexus-webapi/src/routes/v0/file/list.rs
@@ -4,7 +4,7 @@ use axum::Json;
 use nexus_common::models::file::FileDetails;
 use nexus_common::models::traits::Collection;
 use serde::Deserialize;
-use tracing::info;
+use tracing::debug;
 use utoipa::{OpenApi, ToSchema};
 
 #[derive(Deserialize, ToSchema)]
@@ -26,7 +26,7 @@ pub struct FilesByIdsBody {
 pub async fn file_details_by_uris_handler(
     Json(body): Json<FilesByIdsBody>,
 ) -> Result<Json<Vec<FileDetails>>> {
-    info!("GET {FILE_LIST_ROUTE} uris:{:?}", body.uris);
+    debug!("GET {FILE_LIST_ROUTE} uris:{:?}", body.uris);
 
     let keys: Vec<Vec<String>> = body
         .uris

--- a/nexus-webapi/src/routes/v0/notification/list.rs
+++ b/nexus-webapi/src/routes/v0/notification/list.rs
@@ -5,7 +5,7 @@ use axum::extract::{Path, Query};
 use axum::Json;
 use nexus_common::models::notification::{Notification, NotificationBody, PostChangedSource};
 use nexus_common::types::Pagination;
-use tracing::info;
+use tracing::debug;
 use utoipa::OpenApi;
 
 #[utoipa::path(
@@ -31,7 +31,7 @@ pub async fn list_notifications_handler(
     Path(user_id): axum::extract::Path<String>,
     Query(pagination): Query<Pagination>,
 ) -> Result<Json<Vec<Notification>>> {
-    info!("GET {NOTIFICATION_ROUTE} for user_id: {}", user_id);
+    debug!("GET {NOTIFICATION_ROUTE} for user_id: {}", user_id);
 
     match Notification::get_by_id(&user_id, pagination).await {
         Ok(notifications) => json_array_or_no_content(notifications, "notifications"),

--- a/nexus-webapi/src/routes/v0/post/bookmark.rs
+++ b/nexus-webapi/src/routes/v0/post/bookmark.rs
@@ -4,7 +4,7 @@ use axum::extract::{Path, Query};
 use axum::Json;
 use nexus_common::models::post::Bookmark;
 use serde::Deserialize;
-use tracing::info;
+use tracing::debug;
 use utoipa::OpenApi;
 
 #[derive(Deserialize)]
@@ -32,7 +32,7 @@ pub async fn post_bookmark_handler(
     Path((author_id, post_id)): Path<(String, String)>,
     Query(query): Query<PostQuery>,
 ) -> Result<Json<Bookmark>> {
-    info!(
+    debug!(
         "GET {POST_BOOKMARK_ROUTE} author_id:{}, post_id:{}, viewer_id:{}",
         author_id,
         post_id,

--- a/nexus-webapi/src/routes/v0/post/counts.rs
+++ b/nexus-webapi/src/routes/v0/post/counts.rs
@@ -3,7 +3,7 @@ use crate::{Error, Result};
 use axum::extract::Path;
 use axum::Json;
 use nexus_common::models::post::PostCounts;
-use tracing::info;
+use tracing::debug;
 use utoipa::OpenApi;
 
 #[utoipa::path(
@@ -24,7 +24,7 @@ use utoipa::OpenApi;
 pub async fn post_counts_handler(
     Path((author_id, post_id)): Path<(String, String)>,
 ) -> Result<Json<PostCounts>> {
-    info!(
+    debug!(
         "GET {POST_COUNTS_ROUTE} author_id:{}, post_id:{}",
         author_id, post_id
     );

--- a/nexus-webapi/src/routes/v0/post/details.rs
+++ b/nexus-webapi/src/routes/v0/post/details.rs
@@ -4,7 +4,7 @@ use axum::extract::Path;
 use axum::Json;
 use nexus_common::models::post::PostDetails;
 use pubky_app_specs::PubkyAppPostKind;
-use tracing::info;
+use tracing::debug;
 use utoipa::OpenApi;
 
 #[utoipa::path(
@@ -25,7 +25,7 @@ use utoipa::OpenApi;
 pub async fn post_details_handler(
     Path((author_id, post_id)): Path<(String, String)>,
 ) -> Result<Json<PostDetails>> {
-    info!(
+    debug!(
         "GET {POST_DETAILS_ROUTE} author_id:{}, post_id:{}",
         author_id, post_id
     );

--- a/nexus-webapi/src/routes/v0/post/tags.rs
+++ b/nexus-webapi/src/routes/v0/post/tags.rs
@@ -7,7 +7,7 @@ use axum::Json;
 use nexus_common::models::tag::post::TagPost;
 use nexus_common::models::tag::traits::{TagCollection, TaggersCollection};
 use nexus_common::models::tag::TagDetails;
-use tracing::info;
+use tracing::debug;
 use utoipa::OpenApi;
 
 #[utoipa::path(
@@ -33,7 +33,7 @@ pub async fn post_tags_handler(
     Path((author_id, post_id)): Path<(String, String)>,
     Query(query): Query<TagsQuery>,
 ) -> Result<Json<Vec<TagDetails>>> {
-    info!(
+    debug!(
         "GET {POST_TAGS_ROUTE} author_id:{}, post_id: {}, skip_tags:{:?}, limit_tags:{:?}, limit_taggers:{:?}",
         author_id, post_id, query.limit_tags, query.skip_tags, query.limit_taggers
     );
@@ -77,7 +77,7 @@ pub async fn post_taggers_handler(
     Path((author_id, post_id, label)): Path<(String, String, String)>,
     Query(taggers_query): Query<TaggersQuery>,
 ) -> Result<Json<TaggersInfoResponse>> {
-    info!(
+    debug!(
         "GET {POST_TAGGERS_ROUTE} author_id:{}, post_id: {}, label: {}, viewer_id:{:?}, skip:{:?}, limit:{:?}",
         author_id, post_id, label, taggers_query.tags_query.viewer_id, taggers_query.pagination.skip, taggers_query.pagination.limit
     );

--- a/nexus-webapi/src/routes/v0/post/view.rs
+++ b/nexus-webapi/src/routes/v0/post/view.rs
@@ -6,7 +6,7 @@ use axum::Json;
 use nexus_common::models::post::{PostRelationships, PostView};
 use nexus_common::models::tag::post::TagPost;
 use nexus_common::models::tag::TagDetails;
-use tracing::info;
+use tracing::debug;
 use utoipa::OpenApi;
 
 #[utoipa::path(
@@ -31,7 +31,7 @@ pub async fn post_view_handler(
     Path((author_id, post_id)): Path<(String, String)>,
     Query(query): Query<TagsQuery>,
 ) -> Result<Json<PostView>> {
-    info!(
+    debug!(
         "GET {POST_ROUTE} author_id:{}, post_id:{}, viewer_id:{}, limit_tags:{:?}, limit_taggers:{:?}",
         author_id,
         post_id,

--- a/nexus-webapi/src/routes/v0/search/posts.rs
+++ b/nexus-webapi/src/routes/v0/search/posts.rs
@@ -7,7 +7,7 @@ use nexus_common::models::post::search::PostsByTagSearch;
 use nexus_common::types::Pagination;
 use nexus_common::types::StreamSorting;
 use serde::Deserialize;
-use tracing::info;
+use tracing::debug;
 use utoipa::OpenApi;
 
 #[derive(Deserialize)]
@@ -44,7 +44,7 @@ pub async fn search_posts_by_tag_handler(
     let sorting = query.sorting;
     let mut pagination = query.pagination;
 
-    info!(
+    debug!(
         "GET {SEARCH_POSTS_BY_TAG_ROUTE} tag:{}, sort_by: {:?}, start: {:?}, end: {:?}, skip: {:?}, limit: {:?}",
         tag, sorting, pagination.start, pagination.end, pagination.skip, pagination.limit
     );

--- a/nexus-webapi/src/routes/v0/search/tags.rs
+++ b/nexus-webapi/src/routes/v0/search/tags.rs
@@ -9,7 +9,7 @@ use nexus_common::types::Pagination;
 use pubky_app_specs::traits::Validatable;
 use pubky_app_specs::PubkyAppTag;
 use serde::Deserialize;
-use tracing::info;
+use tracing::debug;
 use utoipa::OpenApi;
 
 #[derive(Deserialize)]
@@ -44,7 +44,7 @@ pub async fn search_tags_by_prefix_handler(
     pagination.skip.get_or_insert_default();
     pagination.limit.get_or_insert(20);
 
-    info!(
+    debug!(
         "GET {SEARCH_TAGS_BY_PREFIX_ROUTE} validated_prefix:{}, skip: {:?}, limit: {:?}",
         validated_prefix, pagination.skip, pagination.limit
     );

--- a/nexus-webapi/src/routes/v0/search/users.rs
+++ b/nexus-webapi/src/routes/v0/search/users.rs
@@ -6,7 +6,7 @@ use axum::Json;
 use nexus_common::models::user::UserSearch;
 use nexus_common::types::Pagination;
 use serde::Deserialize;
-use tracing::info;
+use tracing::debug;
 use utoipa::OpenApi;
 
 #[derive(Deserialize)]
@@ -41,7 +41,7 @@ pub async fn search_users_by_name_handler(
         return Err(Error::invalid_input("Username cannot be empty"));
     }
 
-    info!("GET {SEARCH_USERS_BY_NAME_ROUTE} username:{}", username);
+    debug!("GET {SEARCH_USERS_BY_NAME_ROUTE} username:{}", username);
 
     let skip = query.pagination.skip.unwrap_or(0);
     let limit = query.pagination.limit.unwrap_or(200);
@@ -83,7 +83,7 @@ pub async fn search_users_by_id_handler(
         )));
     }
 
-    info!("GET {SEARCH_USERS_BY_ID_ROUTE} ID:{}", id_prefix);
+    debug!("GET {SEARCH_USERS_BY_ID_ROUTE} ID:{}", id_prefix);
 
     let skip = query.pagination.skip.unwrap_or(0);
     let limit = query.pagination.limit.unwrap_or(200);

--- a/nexus-webapi/src/routes/v0/stream/posts.rs
+++ b/nexus-webapi/src/routes/v0/stream/posts.rs
@@ -11,7 +11,7 @@ use nexus_common::{
 };
 use pubky_app_specs::PubkyAppPostKind;
 use serde::{de, Deserialize, Deserializer};
-use tracing::info;
+use tracing::debug;
 use utoipa::{OpenApi, ToSchema};
 
 const MAX_TAGS: usize = 5;
@@ -112,7 +112,7 @@ Ensure that you provide the necessary parameters based on the selected `source`.
 pub async fn stream_posts_handler(
     Query(mut query): Query<PostStreamQuery>,
 ) -> AppResult<Json<PostStream>> {
-    info!("GET {STREAM_POSTS_ROUTE}");
+    debug!("GET {STREAM_POSTS_ROUTE}");
 
     query.initialize_defaults();
     query.validate_tags()?;
@@ -173,7 +173,7 @@ Ensure that you provide the necessary parameters based on the selected `source`.
 pub async fn stream_post_keys_handler(
     Query(mut query): Query<PostStreamQuery>,
 ) -> AppResult<Json<PostKeyStream>> {
-    info!("GET {STREAM_POST_KEYS_ROUTE}");
+    debug!("GET {STREAM_POST_KEYS_ROUTE}");
 
     query.initialize_defaults();
     query.validate_tags()?;
@@ -221,7 +221,7 @@ pub struct PostStreamByIdsRequest {
 pub async fn stream_posts_by_ids_handler(
     Json(request): Json<PostStreamByIdsRequest>,
 ) -> AppResult<Json<PostStream>> {
-    info!(
+    debug!(
         "POST {} post_ids size {:?}",
         STREAM_POSTS_BY_IDS_ROUTE,
         request.post_ids.len()

--- a/nexus-webapi/src/routes/v0/stream/users.rs
+++ b/nexus-webapi/src/routes/v0/stream/users.rs
@@ -8,7 +8,7 @@ use axum::Json;
 use nexus_common::models::user::{UserIdStream, UserStream, UserStreamInput, UserStreamSource};
 use nexus_common::types::{Pagination, StreamReach, Timeframe};
 use serde::Deserialize;
-use tracing::info;
+use tracing::debug;
 use utoipa::{OpenApi, ToSchema};
 
 #[derive(Deserialize)]
@@ -61,7 +61,7 @@ Ensure that you provide the necessary parameters based on the selected `source`.
 pub async fn stream_users_handler(
     Query(query): Query<UserStreamQuery>,
 ) -> Result<Json<UserStream>> {
-    info!(
+    debug!(
         "GET {STREAM_USERS_ROUTE} viewer_id: {:?} source: {:?}",
         query.viewer_id, query.source
     );
@@ -117,7 +117,7 @@ Ensure that you provide the necessary parameters based on the selected `source`.
 pub async fn stream_user_ids_handler(
     Query(query): Query<UserStreamQuery>,
 ) -> Result<Json<UserIdStream>> {
-    info!(
+    debug!(
         "GET {STREAM_USER_IDS_ROUTE} viewer_id: {:?} source: {:?}",
         query.viewer_id, query.source
     );
@@ -189,7 +189,7 @@ pub async fn stream_username_search_handler(
     let skip = query.pagination.skip.unwrap_or(0);
     let limit = query.pagination.limit.unwrap_or(20);
 
-    info!(
+    debug!(
         "GET {STREAM_USERS_USERNAME_SEARCH_ROUTE}?username={}",
         username
     );
@@ -240,7 +240,7 @@ pub struct UserStreamByIdsRequest {
 pub async fn stream_users_by_ids_handler(
     Json(request): Json<UserStreamByIdsRequest>,
 ) -> Result<Json<UserStream>> {
-    info!(
+    debug!(
         "POST {} user_ids: {:?}",
         STREAM_USERS_BY_IDS_ROUTE, request.user_ids
     );

--- a/nexus-webapi/src/routes/v0/tag/global.rs
+++ b/nexus-webapi/src/routes/v0/tag/global.rs
@@ -9,7 +9,7 @@ use nexus_common::models::tag::Taggers as TaggersType;
 use nexus_common::types::routes::HotTagsInputDTO;
 use nexus_common::types::{Pagination, StreamReach, Timeframe};
 use serde::Deserialize;
-use tracing::{error, info};
+use tracing::{debug, error};
 use utoipa::OpenApi;
 
 #[derive(Deserialize, Debug)]
@@ -54,7 +54,7 @@ pub async fn tag_taggers_handler(
     Path(label): Path<String>,
     Query(query): Query<TagTaggersQuery>,
 ) -> Result<Json<TaggersType>> {
-    info!(
+    debug!(
         "GET {TAG_TAGGERS_ROUTE} label:{}, query: {:?}",
         label, query
     );
@@ -106,7 +106,7 @@ pub async fn tag_taggers_handler(
     )
 )]
 pub async fn hot_tags_handler(Query(query): Query<HotTagsQuery>) -> Result<Json<HotTags>> {
-    info!("GET {TAGS_HOT_ROUTE}, query: {:?}", query);
+    debug!("GET {TAGS_HOT_ROUTE}, query: {:?}", query);
 
     // Check if user_id and reach are provided together
     if query.user_id.is_some() ^ query.reach.is_some() {

--- a/nexus-webapi/src/routes/v0/tag/view.rs
+++ b/nexus-webapi/src/routes/v0/tag/view.rs
@@ -3,7 +3,7 @@ use crate::{Error, Result};
 use axum::extract::Path;
 use axum::Json;
 use nexus_common::models::tag::view::TagView;
-use tracing::info;
+use tracing::debug;
 use utoipa::OpenApi;
 
 #[utoipa::path(
@@ -24,7 +24,7 @@ use utoipa::OpenApi;
 pub async fn tag_view_handler(
     Path((tagger_id, tag_id)): Path<(String, String)>,
 ) -> Result<Json<TagView>> {
-    info!("GET {TAG_ROUTE} tagger_id:{}, tag_id:{}", tagger_id, tag_id);
+    debug!("GET {TAG_ROUTE} tagger_id:{}, tag_id:{}", tagger_id, tag_id);
 
     match TagView::get_by_tagger_and_id(&tagger_id, &tag_id).await {
         Ok(Some(tag)) => Ok(Json(tag)),

--- a/nexus-webapi/src/routes/v0/user/counts.rs
+++ b/nexus-webapi/src/routes/v0/user/counts.rs
@@ -3,7 +3,7 @@ use crate::{Error, Result};
 use axum::extract::Path;
 use axum::Json;
 use nexus_common::models::user::UserCounts;
-use tracing::info;
+use tracing::debug;
 use utoipa::OpenApi;
 
 #[utoipa::path(
@@ -21,7 +21,7 @@ use utoipa::OpenApi;
     )
 )]
 pub async fn user_counts_handler(Path(user_id): Path<String>) -> Result<Json<UserCounts>> {
-    info!("GET {USER_COUNTS_ROUTE} user_id:{}", user_id);
+    debug!("GET {USER_COUNTS_ROUTE} user_id:{}", user_id);
 
     match UserCounts::get_by_id(&user_id).await {
         Ok(Some(counts)) => Ok(Json(counts)),

--- a/nexus-webapi/src/routes/v0/user/details.rs
+++ b/nexus-webapi/src/routes/v0/user/details.rs
@@ -4,7 +4,7 @@ use axum::extract::Path;
 use axum::Json;
 use nexus_common::models::user::UserDetails;
 use pubky_app_specs::{PubkyAppUserLink, PubkyId};
-use tracing::info;
+use tracing::debug;
 use utoipa::OpenApi;
 
 #[utoipa::path(
@@ -22,7 +22,7 @@ use utoipa::OpenApi;
     )
 )]
 pub async fn user_details_handler(Path(user_id): Path<String>) -> Result<Json<UserDetails>> {
-    info!("GET {USER_DETAILS_ROUTE} user_id:{}", user_id);
+    debug!("GET {USER_DETAILS_ROUTE} user_id:{}", user_id);
 
     match UserDetails::get_by_id(&user_id).await {
         Ok(Some(details)) => Ok(Json(details)),

--- a/nexus-webapi/src/routes/v0/user/follows.rs
+++ b/nexus-webapi/src/routes/v0/user/follows.rs
@@ -6,7 +6,7 @@ use axum::extract::{Path, Query};
 use axum::Json;
 use nexus_common::models::follow::{Followers, Following, Friends, UserFollows};
 use nexus_common::types::Pagination;
-use tracing::info;
+use tracing::debug;
 use utoipa::OpenApi;
 
 #[utoipa::path(
@@ -29,7 +29,7 @@ pub async fn user_followers_handler(
     Path(user_id): Path<String>,
     Query(query): Query<Pagination>,
 ) -> Result<Json<Followers>> {
-    info!("GET {USER_FOLLOWERS_ROUTE} user_id:{}", user_id);
+    debug!("GET {USER_FOLLOWERS_ROUTE} user_id:{}", user_id);
 
     let skip = query.skip.unwrap_or(0);
     let limit = query.limit.unwrap_or(200);
@@ -61,7 +61,7 @@ pub async fn user_following_handler(
     Path(user_id): Path<String>,
     Query(query): Query<Pagination>,
 ) -> Result<Json<Following>> {
-    info!("GET {USER_FOLLOWING_ROUTE} user_id:{}", user_id);
+    debug!("GET {USER_FOLLOWING_ROUTE} user_id:{}", user_id);
 
     let skip = query.skip.unwrap_or(0);
     let limit = query.limit.unwrap_or(200);
@@ -93,7 +93,7 @@ pub async fn user_friends_handler(
     Path(user_id): Path<String>,
     Query(query): Query<Pagination>,
 ) -> Result<Json<Friends>> {
-    info!("GET {USER_FRIENDS_ROUTE} user_id:{}", user_id);
+    debug!("GET {USER_FRIENDS_ROUTE} user_id:{}", user_id);
 
     let skip = query.skip.unwrap_or(0);
     let limit = query.limit.unwrap_or(200);

--- a/nexus-webapi/src/routes/v0/user/muted.rs
+++ b/nexus-webapi/src/routes/v0/user/muted.rs
@@ -4,7 +4,7 @@ use axum::extract::{Path, Query};
 use axum::Json;
 use nexus_common::models::user::Muted;
 use nexus_common::types::Pagination;
-use tracing::info;
+use tracing::debug;
 use utoipa::OpenApi;
 
 #[utoipa::path(
@@ -27,7 +27,7 @@ pub async fn user_muted_handler(
     Path(user_id): Path<String>,
     Query(query): Query<Pagination>,
 ) -> Result<Json<Muted>> {
-    info!("GET {USER_MUTED_ROUTE} user_id:{}", user_id);
+    debug!("GET {USER_MUTED_ROUTE} user_id:{}", user_id);
 
     let skip = query.skip.unwrap_or(0);
     let limit = query.limit.unwrap_or(200);

--- a/nexus-webapi/src/routes/v0/user/relationship.rs
+++ b/nexus-webapi/src/routes/v0/user/relationship.rs
@@ -3,7 +3,7 @@ use crate::{Error, Result};
 use axum::extract::Path;
 use axum::Json;
 use nexus_common::models::user::Relationship;
-use tracing::info;
+use tracing::debug;
 use utoipa::OpenApi;
 
 #[utoipa::path(
@@ -24,7 +24,7 @@ use utoipa::OpenApi;
 pub async fn user_relationship_handler(
     Path((user_id, viewer_id)): Path<(String, String)>,
 ) -> Result<Json<Relationship>> {
-    info!(
+    debug!(
         "GET {RELATIONSHIP_ROUTE} user_id:{}, viewer_id:{}",
         user_id, viewer_id
     );

--- a/nexus-webapi/src/routes/v0/user/tags.rs
+++ b/nexus-webapi/src/routes/v0/user/tags.rs
@@ -9,7 +9,7 @@ use nexus_common::models::tag::user::TagUser;
 use nexus_common::models::tag::TagDetails;
 use nexus_common::types::Pagination;
 use serde::Deserialize;
-use tracing::info;
+use tracing::debug;
 use utoipa::OpenApi;
 
 #[utoipa::path(
@@ -36,7 +36,7 @@ pub async fn user_tags_handler(
     Path(user_id): Path<String>,
     Query(query): Query<TagsQuery>,
 ) -> Result<Json<Vec<TagDetails>>> {
-    info!(
+    debug!(
         "GET {USER_TAGS_ROUTE} user_id:{}, skip_tags:{:?}, limit_tags:{:?}, limit_taggers:{:?}, viewer_id:{:?}, depth:{:?}",
         user_id, query.skip_tags, query.limit_tags, query.limit_taggers, query.viewer_id, query.depth
     );
@@ -92,7 +92,7 @@ pub async fn user_taggers_handler(
         tags_query,
     }): Query<TaggersQuery>,
 ) -> Result<Json<TaggersInfoResponse>> {
-    info!(
+    debug!(
         "GET {USER_TAGGERS_ROUTE} user_id:{}, label: {}, skip:{:?}, limit:{:?}, viewer_id:{:?}, depth:{:?}",
         user_id, label, pagination.skip, pagination.limit, tags_query.viewer_id, tags_query.depth
     );

--- a/nexus-webapi/src/routes/v0/user/view.rs
+++ b/nexus-webapi/src/routes/v0/user/view.rs
@@ -5,7 +5,7 @@ use axum::Json;
 use nexus_common::models::tag::TagDetails;
 use nexus_common::models::user::UserView;
 use serde::Deserialize;
-use tracing::info;
+use tracing::debug;
 use utoipa::OpenApi;
 
 #[derive(Deserialize)]
@@ -34,7 +34,7 @@ pub async fn user_view_handler(
     Path(user_id): Path<String>,
     Query(query): Query<ProfileQuery>,
 ) -> Result<Json<UserView>> {
-    info!(
+    debug!(
         "GET {USER_ROUTE} user_id:{}, viewer_id:{:?}, depth: {:?}",
         user_id, query.viewer_id, query.depth
     );


### PR DESCRIPTION
This PR attempts to fix some concerns about "too much logging" by QA team.

## nexus-watcher

**Findings**
- High-frequency polling logs (every 100–500 ms) in e2e tests, staging and prod were emitted at the `INFO` level (`Indexing homeservers…`, `No new events`), flooding logs without adding actionable signal.
- Per-homeserver run summaries were logged at `INFO` on every interval, even when runs were clean, producing repetitive noise.
- Error and retry paths already log at appropriate levels.

**Changes**
- Downgraded repetitive loop logs to `DEBUG` while keeping shutdown and processing summaries for actual work at `INFO`/`WARN`.
- Made per-homeserver run details `DEBUG`-only and emit `WARN` summaries only when a run shows failures, keeping successful cycles quiet.

## nexus-webapi

**Findings**
- Handlers logged every request at `INFO`, creating excessive noise under normal traffic and duplicating tracing middleware visibility.
- Request logs rarely added context beyond the route, making them low-value at high volume.

**Changes**
- Shifted request-entry logs in route handlers from `INFO` to `DEBUG` to reduce chatter while retaining visibility when elevated detail is needed.