### PR TITLE
fix(webapi): tag view endpoint to return tagged resource URI

### DIFF
--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -932,8 +932,15 @@ pub fn recommend_users(user_id: &str, limit: usize) -> neo4rs::Query {
 pub fn get_tag_by_tagger_and_id(tagger_id: &str, tag_id: &str) -> neo4rs::Query {
     query(
         "
-        MATCH (tagger:User { id: $tagger_id})-[tag:TAGGED {id: $tag_id }]->()
-        RETURN tag.id as id, tag.indexed_at as indexed_at, tag.label as label
+        MATCH (tagger:User { id: $tagger_id})-[tag:TAGGED {id: $tag_id }]->(tagged)
+        OPTIONAL MATCH (author:User)-[:AUTHORED]->(tagged)
+        RETURN
+            labels(tagged) as tagged_labels,
+            tagged.id as tagged_id,
+            author.id as author_id,
+            tag.id as id,
+            tag.indexed_at as indexed_at,
+            tag.label as label
         ",
     )
     .param("tagger_id", tagger_id)

--- a/nexus-webapi/tests/tags/view.rs
+++ b/nexus-webapi/tests/tags/view.rs
@@ -1,10 +1,12 @@
 use anyhow::Result;
 use axum::http::StatusCode;
+use pubky_app_specs::post_uri_builder;
 
 use crate::utils::{get_request, invalid_get_request};
 
 const PUBKY_TAGGER_ID: &str = "78guxwtzgtgpskij51om7t66awmqxznr6p7ogonfohoags6ahc5y";
 const PUBKY_TAG_ID: &str = "2Z1N8QBQK9EG0";
+const PUBKY_TAGGED_POST_ID: &str = "2Z1N8QBERF700";
 const INVALID_PUBKY_TAGGER_ID: &str = "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
 const INVALID_PUBKY_TAG_ID: &str = "0000000000000";
 
@@ -24,7 +26,11 @@ async fn test_tag_view() -> Result<()> {
 
     assert!(body.is_object());
 
-    assert_eq!(body["tag_uri"], "pubky://78guxwtzgtgpskij51om7t66awmqxznr6p7ogonfohoags6ahc5y/pub/pubky.app/tags/2Z1N8QBQK9EG0");
+    let expected_post_uri = post_uri_builder(
+        PUBKY_TAGGER_ID.to_string(),
+        PUBKY_TAGGED_POST_ID.to_string(),
+    );
+    assert_eq!(body["uri"], expected_post_uri);
     assert_eq!(body["indexed_at"], 1724134095000_i64);
     assert_eq!(body["label"], "anti");
 


### PR DESCRIPTION
- return tagged resource URIs from the tag view query including tagged node metadata
- update TagView to build user/post URIs and error on unsupported tagged resources
- adjust tag view integration test to expect the tagged object URI