### PR TITLE
Update User Tags endpoint: Swagger annotation should indicate a list of objects instead of single object in response type 200 OK

### DIFF
--- a/nexus-webapi/src/routes/v0/user/tags.rs
+++ b/nexus-webapi/src/routes/v0/user/tags.rs
@@ -25,7 +25,7 @@ use utoipa::OpenApi;
         ("depth" = Option<usize>, Query, description = "User trusted network depth, user following users distance. Numbers bigger than 4, will be ignored")
     ),
     responses(
-        (status = 200, description = "User tags", body = TagDetails),
+        (status = 200, description = "User tags", body = Vec<TagDetails>),
         (status = 404, description = "User not found"),
         (status = 500, description = "Internal server error")
     )


### PR DESCRIPTION
Update two remaining endpoints, so that they don't throw error 404 if no result is found, but instead they return an empty list.