### PR TITLE
Bump neo4j to 5.26.19

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -24,6 +24,8 @@ services:
       NEO4J_server_memory_pagecache_size: 1G
       NEO4J_server_memory_heap_initial__size: 2G
       NEO4J_server_memory_heap_max__size: 2G
+      # Disable telemetry, see https://neo4j.com/docs/operations-manual/current/configuration/configuration-settings/#config_client.allow_telemetry
+      NEO4J_client_allow__telemetry: false
       # NEO4J_apoc_uuid_enabled: false
 
 


### PR DESCRIPTION
This PR bumps `neo4j` from 5.26.7 (released 05.2025) to the latest 5.26.19. The changelog is available [here](https://github.com/neo4j/neo4j/wiki/Neo4j-5.26-changelog).

It stays on the 5.26 LTS branch but brings the latest fixes and improvements.
