### PR TITLE
Bump postgres test dependency to 18

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -43,6 +43,7 @@ services:
   # Only used for tests that involve homeservers
   postgres:
     image: postgres:18-alpine
+    container_name: postgres
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}


### PR DESCRIPTION
This PR pulls in the Postgres version bump ( https://github.com/pubky/pubky-core/pull/289 ) .