### PR TITLE
Update dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,6 @@ updates:
       day: "sunday"
     commit-message:
       prefix: "deps"
-    open-pull-requests-limit: 10
     rebase-strategy: "auto"
     groups:
       cargo-dependencies:


### PR DESCRIPTION
This PR consolidates all cargo dependency updates into a single weekly PR instead of creating individual PRs per dependency.