### PR TITLE
docker: fix SELinux permissions for redis, neo4j volumes

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,11 +8,11 @@ services:
       - 7687:7687
     volumes:
       # Mount the neo4j configuration file to container    
-      - .database/neo4j/conf:/conf
+      - .database/neo4j/conf:/conf:Z
       # Mount the data to container
-      - .database/neo4j/data:/data
-      - .database/neo4j/logs:/logs
-      - ./test-graph:/test-graph
+      - .database/neo4j/data:/data:Z
+      - .database/neo4j/logs:/logs:Z
+      - ./test-graph:/test-graph:Z
     environment:
       NEO4J_initial_dbms_default__database: ${NEO4J_DB_NAME}
       # IMPORTANT: If you change the auth params and you have already created the config files, will not take effect
@@ -38,7 +38,7 @@ services:
     networks:
       - default
     volumes:
-      - .database/redis/data:/data
+      - .database/redis/data:/data:Z
     restart: always
 
 


### PR DESCRIPTION
This PR adds the `:Z` suffix to the container volume mount paths, which fixes permission issues when the containers are deployed on a SELinux host (Fedora, RHEL, etc). Without this, neo4j and redis cannot access the mounted volumes because SELinux denies them access to the mapped local folders.

For all other host environments (macOS, Windows, non-SELinux linux), this new suffix has no effect.