### PR TITLE
Explicitly specify loopback IP when exposing container ports

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,8 +4,8 @@ services:
     container_name: neo4j
     restart: unless-stopped
     ports:
-      - 7474:7474
-      - 7687:7687
+      - 127.0.0.1:7474:7474
+      - 127.0.0.1:7687:7687
     volumes:
       # Mount the neo4j configuration file to container    
       - .database/neo4j/conf:/conf:Z
@@ -33,8 +33,8 @@ services:
     image: redis/redis-stack:7.2.0-v11
     container_name: redis
     ports:
-      - "6379:6379"
-      - "8001:8001"
+      - "127.0.0.1:6379:6379"
+      - "127.0.0.1:8001:8001"
     networks:
       - default
     volumes:
@@ -51,7 +51,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
     ports:
-      - "${POSTGRES_PORT:-5432}:5432"
+      - "127.0.0.1:${POSTGRES_PORT:-5432}:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
       interval: 5s
@@ -66,8 +66,8 @@ services:
       # This ensures the Jaeger container also listens for OTLP signals
       # COLLECTOR_OTLP_ENABLED: "true"
     # ports:
-    #   - "16686:16686"    # Jaeger UI
-    #   - "4317:4317"      # OTLP/gRPC
+    #   - "127.0.0.1:16686:16686"    # Jaeger UI
+    #   - "127.0.0.1:4317:4317"      # OTLP/gRPC
     #   - "4318:4318"      # OTLP/HTTP
     # networks:
     #   - default


### PR DESCRIPTION
The common way ports are exposed in docker `8001:8001` is actually equivalent to `0.0.0.0:8001:8001`, which binds the port to all of the host's IPs.

Since docker bypasses local firewalls like `ufw` and `iptables` (https://github.com/docker/for-linux/issues/690) , a user that would follow our docs to setup a Nexus instance on a VPS VM will inadvertently expose each container's mapped ports to the internet.

To follow security best practices, this PR switches to a port notation that explicitly binds it to the host's loopback IP.

Related to https://github.com/pubky/pubky-core/pull/288