### PR TITLE
ci: speed up tests by caching workspace crates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,8 @@ jobs:
         with:
           shared-key: "test"
           cache-on-failure: true
+          # Cache workspace crates (members), as they are time-consuming to re-build on each PR
+          cache-workspace-crates: true
 
       - uses: taiki-e/install-action@v2
         with:


### PR DESCRIPTION
This PR sets the `Swatinem/rust-cache` flag `cache-workspace-crates: true`, which ensures workspace members are cached as well.

CI tests duration in case of a cache hit:
- before this: 10 - 11 mins
- after this: 7 - 8 mins