### PR TITLE
ci: install imagemagick while waiting for container services to start

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,14 +46,14 @@ jobs:
         with:
           tool: cargo-nextest
 
-      - name: Install ImageMagick
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq imagemagick
-
       - name: Set up Docker Compose
         working-directory: docker
         run: docker compose --env-file .env-sample up -d
+
+      # Install imagemagick after docker containers are started and before waiting for services to be up
+      # This ensures services are starting up during this step, saving time in the "wait for services" step
+      - name: Install ImageMagick
+        run: sudo apt-get install -y -qq imagemagick
 
       - name: Wait for services to be ready
         run: |


### PR DESCRIPTION
This PR sandwiches the "Install ImageMagick" CI step between starting the docker containers and waiting for the container services to be up. This allows these 2 steps to happen in parallel, reducing the time waited for docker services.

Duration of CI step "Waiting for services to be ready":
- before this: 10 - 20 sec
- after this: 0 sec