### PR TITLE
fix: `put_index_list` de-duplicates when appending to list

### DIFF
--- a/nexus-common/src/db/kv/traits.rs
+++ b/nexus-common/src/db/kv/traits.rs
@@ -244,15 +244,12 @@ pub trait RedisOps: Serialize + DeserializeOwned + Send + Sync {
         let prefix = Self::prefix().await;
         let key = key_parts.join(":");
 
-        // TODO: Unsafe. If re-indexed it will duplicate follower/following list entries.
-        // Need reading, matching out the duplicates then storing. Inneficient.
-        // Needs mode safety for double-write.
-
         // Directly use the string representations of items without additional serialization
         let collection = self.as_ref();
         let values: Vec<&str> = collection.iter().map(|item| item.as_ref()).collect();
 
         // Store the values in the Redis list
+        // Note: lists::put uses LREM + RPUSH to prevent duplicates during re-indexing
         lists::put(&prefix, &key, &values).await
     }
 


### PR DESCRIPTION
This PR addresses a TODO in `put_index_list` which mentioned the method only inserts and doesn't check for duplicates.

The fix is a modification to `lists::put` to use `LREM + RPUSH` pattern in a pipeline to prevent duplicate entries.

For each value being added:
1. `LREM` removes all existing occurrences from the list (count=0 removes all)
2. `RPUSH` appends the value to the end of the list

Note: If a value already exists, it will be removed from its original position and re-added at the end of the list.
