### PR TITLE
fix: connection string and `README.md` links

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ cp .env-sample .env
 docker compose up -d
 ```
 
-3. Optionally, populate the Neo4j database with initial mock data. Follow [Running Tests](#running-tests) section about setting up mock data.
+3. Optionally, populate the Neo4j database with initial mock data. Follow [Running Tests](#-running-tests) section about setting up mock data.
 
 4. Run the Nexus service:
 
@@ -148,7 +148,7 @@ cargo nextest run -p nexus-common --no-fail-fast
 cargo nextest run -p nexus-watcher --no-fail-fast
 
 # webapi tests need the Postgres Connection URL as env variable, adjust it as needed
-export TEST_PUBKY_CONNECTION_STRING=postgres://postgres:postgres@localhost:5432/postgres?pubky-test=true
+export TEST_PUBKY_CONNECTION_STRING=postgres://test_user:test_pass@localhost:5432/postgres?pubky-test=true
 cargo nextest run -p nexus-webapi --no-fail-fast
 ```
 
@@ -171,7 +171,7 @@ cargo bench -p nexus-webapi --bench user
 
 ## ⚠️ Troubleshooting
 
-If tests or the development environment seem out of sync, follow the [Running Tests](#running-tests) steps to reload the mock data.
+If tests or the development environment seem out of sync, follow the [Running Tests](#-running-tests) steps to reload the mock data.
 
 ## 🤝 Contributing
 


### PR DESCRIPTION
Changes `TEST_PUBKY_CONNECTION_STRING` to use the default values from `docker/.env-sample`.
This configuration should now work out of the box without adjusting the connection string.

fixes: #695 