### PR TITLE
chore: same test order in readme and ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,10 +76,10 @@ jobs:
       - name: Run nexus-common unit tests
         run: cargo nextest run -p nexus-common --no-fail-fast
 
-      # This test suite uses the TEST_PUBKY_CONNECTION_STRING env variable
       - name: Run API integration tests
         run: cargo nextest run -p nexus-webapi --no-fail-fast
 
+      # This test suite uses the TEST_PUBKY_CONNECTION_STRING env variable
       - name: Run WATCHER integration tests
         run: cargo nextest run -p nexus-watcher --no-fail-fast
 

--- a/README.md
+++ b/README.md
@@ -146,10 +146,10 @@ Then to run the tests:
 ```bash
 cargo nextest run -p nexus-common --no-fail-fast
 
-# webapi tests need the Postgres Connection URL as env variable, adjust it as needed
-export TEST_PUBKY_CONNECTION_STRING=postgres://test_user:test_pass@localhost:5432/postgres?pubky-test=true
 cargo nextest run -p nexus-webapi --no-fail-fast
 
+# nexus tests need the Postgres Connection URL as env variable, adjust it as needed
+# export TEST_PUBKY_CONNECTION_STRING=postgres://test_user:test_pass@localhost:5432/postgres?pubky-test=true
 cargo nextest run -p nexus-watcher --no-fail-fast
 ```
 


### PR DESCRIPTION
This change reflects test order defined in github actions. 

`nexus-webapi` tests share the same  state as `nexus-watcher` tests, if env is not cleaned up between runs then following errors appear:

```
  stderr ───

    thread 'tags::hot::test_global_hot_tags_with_today_timeframe' (953172) panicked at nexus-webapi/tests/tags/hot.rs:52:5:
    assertion `left == right` failed
      left: Number(4)
     right: 3
```

```
  stderr ───

    thread 'stream::user::influencers::test_global_influencers_with_today_timeframe' (952936) panicked at nexus-webapi/tests/stream/user/influencers.rs:143:9:
    Expected user ID not found: omynbjw4ksjc4at5gretyoatw1g5h53tkee5z55fh69sng1d3jpy
    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This state dependency doesn't cause problems in current CI setup (yet). 
This PR doesn't fix underlying problem and it should be corrected in separate PR if needed. 