### PR TITLE
Allow other container runtimes, like `podman`

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,11 +133,13 @@ The manager will automatically handle migrations in the appropriate order, progr
 
 ## 🧪 Running Tests
 
-Running tests requires setting up mock data (`docker/test-graph/mocks`) into Neo4j and Redis
+Running tests requires setting up mock data (`docker/test-graph/mocks`) into Neo4j and Redis.
 
-Use the `db` command to load the mock data
+Use the `db` command to load the mock data:
 
 ```bash
+# If you're using podman instead of docker, set this env variable before importing mock data
+# export CONTAINER_RUNTIME=podman
 cargo run -p nexusd -- db mock
 ```
 
@@ -148,7 +150,7 @@ cargo nextest run -p nexus-common --no-fail-fast
 
 cargo nextest run -p nexus-webapi --no-fail-fast
 
-# nexus tests need the Postgres Connection URL as env variable, adjust it as needed
+# nexus-watcher tests need the Postgres Connection URL as env variable, adjust it as needed
 # export TEST_PUBKY_CONNECTION_STRING=postgres://test_user:test_pass@localhost:5432/postgres?pubky-test=true
 cargo nextest run -p nexus-watcher --no-fail-fast
 ```

--- a/nexus-webapi/src/mock.rs
+++ b/nexus-webapi/src/mock.rs
@@ -86,8 +86,12 @@ impl MockDb {
 
     async fn sync_graph() {
         Self::drop_graph().await;
-        // Run the run-queries.sh script on the Docker host using docker exec
-        tokio::process::Command::new("docker")
+
+        // Allow other runtimes like podman, but default to docker
+        let container_runtime = std::env::var("CONTAINER_RUNTIME").unwrap_or("docker".to_string());
+
+        // Run the run-queries.sh script inside the neo4j container using docker exec
+        tokio::process::Command::new(&container_runtime)
             .args(["exec", "neo4j", "bash", "/test-graph/run-queries.sh"])
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())


### PR DESCRIPTION
This PR adds support for running Nexus with `podman` instead of `docker`.

More specifically, it allows importing the mock data for tests with either of the two container runtimes. Everything else already also works with `podman` (setting up the containers based on `docker-compose.yml`, running them, etc).