### PR TITLE
feat(bootstrap): posts with file metadata

### DIFF
--- a/nexus-common/src/models/post/mod.rs
+++ b/nexus-common/src/models/post/mod.rs
@@ -1,5 +1,6 @@
 mod bookmark;
 mod counts;
+mod detailed;
 mod details;
 mod relationships;
 pub mod search;
@@ -8,6 +9,7 @@ mod view;
 
 pub use bookmark::Bookmark;
 pub use counts::PostCounts;
+pub use detailed::{PostStreamDetailed, PostViewDetailed};
 pub use details::PostDetails;
 pub use relationships::PostRelationships;
 pub use stream::{

--- a/nexus-webapi/benches/bootstrap.rs
+++ b/nexus-webapi/benches/bootstrap.rs
@@ -21,7 +21,7 @@ fn bench_bootstrap_user(c: &mut Criterion) {
         &user_id,
         |b, &id| {
             b.to_async(&rt).iter(|| async {
-                let user = Bootstrap::get_by_id(id, ViewType::Full).await.unwrap();
+                let user = Bootstrap::get_by_id(id, ViewType::Full, true).await.unwrap();
                 std::hint::black_box(user);
             });
         },

--- a/nexus-webapi/src/models/mod.rs
+++ b/nexus-webapi/src/models/mod.rs
@@ -1,5 +1,3 @@
 pub mod info;
-pub mod post;
 
 pub use info::ServerInfo;
-pub use post::{PostStreamDetailed, PostViewDetailed};

--- a/nexus-webapi/src/routes/v0/bootstrap.rs
+++ b/nexus-webapi/src/routes/v0/bootstrap.rs
@@ -33,7 +33,7 @@ pub async fn bootstrap_handler(
 ) -> Result<Json<Bootstrap>> {
     debug!("GET {BOOTSTRAP_ROUTE}, user_id:{}", user_id);
 
-    Ok(Json(Bootstrap::get_by_id(&user_id, ViewType::Full).await?))
+    Ok(Json(Bootstrap::get_by_id(&user_id, ViewType::Full, true).await?))
 }
 
 #[utoipa::path(

--- a/nexus-webapi/src/routes/v0/post/view.rs
+++ b/nexus-webapi/src/routes/v0/post/view.rs
@@ -1,4 +1,4 @@
-use crate::models::PostViewDetailed;
+use nexus_common::models::post::PostViewDetailed;
 use crate::routes::v0::endpoints::POST_ROUTE;
 use crate::{Error, Result};
 use axum::extract::{Path, Query};

--- a/nexus-webapi/src/routes/v0/stream/posts.rs
+++ b/nexus-webapi/src/routes/v0/stream/posts.rs
@@ -1,4 +1,4 @@
-use crate::models::PostStreamDetailed;
+use nexus_common::models::post::PostStreamDetailed;
 use crate::routes::v0::endpoints::{
     STREAM_POSTS_BY_IDS_ROUTE, STREAM_POSTS_ROUTE, STREAM_POST_KEYS_ROUTE,
 };

--- a/nexus-webapi/tests/post/from_post_views.rs
+++ b/nexus-webapi/tests/post/from_post_views.rs
@@ -1,7 +1,7 @@
 use crate::utils::server::TestServiceServer;
 use anyhow::Result;
 use nexus_common::models::post::PostView;
-use nexus_webapi::models::PostStreamDetailed;
+use nexus_common::models::post::PostStreamDetailed;
 
 // Cairo user and post N7Q2F5W8J0L3 from posts.cypher
 const CAIRO_USER: &str = super::CAIRO_USER;

--- a/nexus-webapi/tests/user/bootstrap.rs
+++ b/nexus-webapi/tests/user/bootstrap.rs
@@ -30,12 +30,12 @@ async fn test_bootstrap_user() -> Result<()> {
 
     // Assert post authors and taggers are included in the users list
     for post in user_bootstrap_respose.posts.0 {
-        let author_id = post.details.author;
+        let author_id = post.view.details.author;
         assert!(
             user_ids.contains(&author_id),
             "user_ids is missing author `{author_id}`"
         );
-        post.tags
+        post.view.tags
             .iter()
             .flat_map(|tags| tags.taggers.iter())
             .for_each(|tagger| {


### PR DESCRIPTION
## Summary

Enable the Bootstrap endpoint to return file attachment metadata alongside posts, so the frontend gets everything it needs in a single request instead of fetching file details separately.

### What it brings

Previously, the Bootstrap response returned `PostStream` (bare `PostView` objects) which only included attachment URIs as plain strings. To get actual file metadata, the frontend had to make additional requests to `/stream/posts/by_ids` with `include_attachment_metadata=true`.

Now, the Bootstrap response returns `PostStreamDetailed` — each post comes enriched with its `attachments_metadata` (a list of `FileDetails`) directly in the payload. This applies to both the main timeline posts and their replies.

When a post has no attachments, the `attachments_metadata` field is simply omitted from the JSON — no overhead, fully backward-compatible.

### Changes

#### New file

- `nexus-common/src/models/post/detailed.rs` — `PostViewDetailed`, `PostStreamDetailed`, and `fetch_attachment_metadata` helper, moved from `nexus-webapi` into `nexus-common` so they can be used by both the Bootstrap logic and the web API routes.

#### Deleted file

- `nexus-webapi/src/models/post.rs` — The types now live in `nexus-common`; consumers import directly.


## Pre-submission Checklist

> For tests to work you need a working neo4j and redis instance with the example dataset in `docker/db-graph`

- [ ] **Testing**: Implement and pass new tests for the new features/fixes, `cargo nextest run`.
- [ ] **Performance**: Ensure new code has relevant performance benchmarks, `cargo bench -p nexus-webapi`
