### PR TITLE
Event indexing: fix edge-case when reindexing skips attachments

### DIFF
--- a/nexus-common/src/models/file/blob.rs
+++ b/nexus-common/src/models/file/blob.rs
@@ -77,3 +77,56 @@ impl Blob {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pubky_app_specs::PubkyAppBlob;
+    use tokio::io::AsyncReadExt;
+
+    #[tokio_shared_rt::test(shared)]
+    async fn test_put_to_static_creates_new_file() {
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let files_path = tmp_dir.path().join("user1").join("file1");
+        let blob = PubkyAppBlob::new(b"hello world".to_vec());
+
+        Blob::put_to_static("main".to_string(), files_path.clone(), &blob)
+            .await
+            .expect("put_to_static should succeed for a new file");
+
+        let mut content = Vec::new();
+        File::open(files_path.join("main"))
+            .await
+            .unwrap()
+            .read_to_end(&mut content)
+            .await
+            .unwrap();
+        assert_eq!(content, b"hello world");
+    }
+
+    #[tokio_shared_rt::test(shared)]
+    async fn test_put_to_static_overwrites_existing_file() {
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let files_path = tmp_dir.path().join("user1").join("file1");
+        let blob1 = PubkyAppBlob::new(b"first write".to_vec());
+
+        Blob::put_to_static("main".to_string(), files_path.clone(), &blob1)
+            .await
+            .expect("first put_to_static should succeed");
+
+        // Calling put_to_static again simulates re-indexing when the file already exists on disk
+        let blob2 = PubkyAppBlob::new(b"second write".to_vec());
+        Blob::put_to_static("main".to_string(), files_path.clone(), &blob2)
+            .await
+            .expect("put_to_static should succeed even when file already exists (re-indexing)");
+
+        let mut content = Vec::new();
+        File::open(files_path.join("main"))
+            .await
+            .unwrap()
+            .read_to_end(&mut content)
+            .await
+            .unwrap();
+        assert_eq!(content, b"second write");
+    }
+}


### PR DESCRIPTION
This PR introduces a fix for event indexing, whereby saving attachment files to disk would throw an error causing them to not be added to the DB if those attachment files already existed on disk. This typically happens in local dev environments, or during re-indexing.

The PR also adds tests.

Below is an LLM description of the fix:

---

During re-indexing (e.g. against a clear DB), `Blob::put_to_static` uses `File::create_new` which errors when the file already exists on disk. This error propagates up and short-circuits `sync_put`, so the Graph and Redis insertions never execute.

- Replace `File::create_new` with `File::create` in `nexus-common/src/models/file/blob.rs` to allow overwriting existing files
- Add unit tests for `Blob::put_to_static` covering both new file creation and the re-indexing overwrite scenario

```rust
// Before: fails if file exists, aborting the entire sync_put flow
let mut static_file = File::create_new(file_path).await?;

// After: creates or overwrites, allowing DB insertions to proceed
let mut static_file = File::create(file_path).await?;
```
