### PR TITLE
feat(bootstrap): posts with file metadata

### DIFF
--- a/docker/test-graph/mocks/posts.cypher
+++ b/docker/test-graph/mocks/posts.cypher
@@ -174,7 +174,7 @@ MERGE (p:Post {id: "MLOW1TGL5BKH2"}) SET p.content = "VIDEO post, mkv B", p.kind
 MATCH (u:User {id: $cairo}), (p:Post {id: "MLOW1TGL5BKH2"}) MERGE (u)-[:AUTHORED]->(p);
 MERGE (p:Post {id: "MLOW1TGL5BKH3"}) SET p.content = "VIDEO post, mkv C", p.kind = "video", p.indexed_at = 1980477299310;
 MATCH (u:User {id: $cairo}), (p:Post {id: "MLOW1TGL5BKH3"}) MERGE (u)-[:AUTHORED]->(p);
-MERGE (p:Post {id: "MLOW1TGL5BKH4"}) SET p.content = "VIDEO post, mkv D", p.kind = "video", p.indexed_at = 1980477299320;
+MERGE (p:Post {id: "MLOW1TGL5BKH4"}) SET p.content = "VIDEO post, mkv D", p.kind = "video", p.indexed_at = 1980477299320, p.attachments = ["pubky://f5tcy5gtgzshipr6pag6cn9uski3s8tjare7wd3n7enmyokgjk1o/pub/pubky.app/files/2ZK3A1B2C3D40", "pubky://f5tcy5gtgzshipr6pag6cn9uski3s8tjare7wd3n7enmyokgjk1o/pub/pubky.app/files/2ZK3E5F6G7H80"];
 MATCH (u:User {id: $bogota}), (p:Post {id: "MLOW1TGL5BKH4"}) MERGE (u)-[:AUTHORED]->(p);
 MERGE (p:Post {id: "MLOW1TGL5BKH5"}) SET p.content = "VIDEO post, mkv E", p.kind = "video", p.indexed_at = 1980477299330;
 MATCH (u:User {id: $cairo}), (p:Post {id: "MLOW1TGL5BKH5"}) MERGE (u)-[:AUTHORED]->(p);

--- a/nexus-common/src/db/graph/queries/put.rs
+++ b/nexus-common/src/db/graph/queries/put.rs
@@ -79,7 +79,7 @@ pub fn create_post(
         .param("content", post.content.to_string())
         .param("indexed_at", post.indexed_at)
         .param("kind", kind.trim_matches('"'))
-        .param("attachments", post.attachments.clone().unwrap_or(vec![]));
+        .param("attachments", post.attachments.clone().unwrap_or_default());
 
     // Handle "replied" relationship
     cypher_query = add_relationship_params(

--- a/nexus-webapi/tests/user/bootstrap.rs
+++ b/nexus-webapi/tests/user/bootstrap.rs
@@ -4,11 +4,15 @@ use crate::utils::get_request;
 use anyhow::Result;
 use nexus_common::models::bootstrap::Bootstrap;
 use nexus_common::models::notification::Notification;
+use nexus_common::models::notification::NotificationBody;
 
 #[tokio_shared_rt::test(shared)]
 async fn test_bootstrap_user() -> Result<()> {
     let user_id = "zdbg13k5gh4tfz9qz11quohrxetgqxs7awandu8h57147xddcuhy";
     let follower_id = "pxnu33x7jtpx9ar1ytsi4yxbp6a5o36gwhffs8zoxmbuptici1jy";
+
+    // Init TestService, incl. DBs, before using redis connection
+    crate::utils::server::TestServiceServer::get_test_server().await;
 
     // Create test notifications for the user
     Notification::new_follow(follower_id, user_id, false)
@@ -35,13 +39,31 @@ async fn test_bootstrap_user() -> Result<()> {
         .collect();
 
     // Assert post authors are included in the users list
-    for post in user_bootstrap_respose.posts.0 {
-        let author_id = post.details.author;
+    for post in &user_bootstrap_respose.posts.0 {
+        let author_id = &post.details.author;
         assert!(
-            user_ids.contains(&author_id),
+            user_ids.contains(author_id),
             "user_ids is missing author `{author_id}`"
         );
     }
+
+    // MLOW1TGL5BKH4 has 2 attachments pointing to Cairo's files
+    assert!(
+        !user_bootstrap_respose.files.is_empty(),
+        "Bootstrap should contain file metadata for post attachments"
+    );
+    assert_eq!(
+        user_bootstrap_respose.files.len(),
+        2,
+        "Expected 2 file details from MLOW1TGL5BKH4 attachments"
+    );
+    let file_ids: HashSet<String> = user_bootstrap_respose
+        .files
+        .iter()
+        .map(|f| f.id.clone())
+        .collect();
+    assert!(file_ids.contains("2ZK3A1B2C3D40"));
+    assert!(file_ids.contains("2ZK3E5F6G7H80"));
 
     // Assert notifications count for indexed user
     assert_eq!(
@@ -53,7 +75,7 @@ async fn test_bootstrap_user() -> Result<()> {
     // Verify the notification is a follow notification
     if let Some(notification) = user_bootstrap_respose.notifications.first() {
         match &notification.body {
-            nexus_common::models::notification::NotificationBody::Follow { followed_by } => {
+            NotificationBody::Follow { followed_by } => {
                 assert_eq!(
                     followed_by, follower_id,
                     "Follow notification should be from the correct user"
@@ -96,6 +118,21 @@ async fn test_bootstrap_user_not_indexed() -> Result<()> {
         user_bootstrap_response.notifications.len(),
         0,
         "Non-indexed users should not have notifications"
+    );
+
+    // Files count should match the unique attachment URIs found in the post stream
+    let expected_uris: HashSet<String> = user_bootstrap_response
+        .posts
+        .0
+        .iter()
+        .filter_map(|p| p.details.attachments.as_ref())
+        .flatten()
+        .cloned()
+        .collect();
+    assert_eq!(
+        user_bootstrap_response.files.len(),
+        expected_uris.len(),
+        "Files count should match the number of unique attachment URIs in posts"
     );
 
     Ok(())


### PR DESCRIPTION
## Sumarise

Previously, the Bootstrap response returned `PostStream` (bare `PostView` objects) which only included attachment URIs as plain strings. To get actual file metadata (dimensions, content type, size, etc.), the frontend had to make **additional requests** to the files endpoint

Now, the Bootstrap response returns `files` directly in the payload. This applies to both the main timeline posts and their replies.

## Pre-submission Checklist

> For tests to work you need a working neo4j and redis instance with the example dataset in `docker/db-graph`

- [ ] **Testing**: Implement and pass new tests for the new features/fixes, `cargo nextest run`.
- [ ] **Performance**: Ensure new code has relevant performance benchmarks, `cargo bench -p nexus-webapi`
