### PR TITLE
chore: upgrade Redis from Stack 7.2 to Redis 8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ cargo run -p nexusd -- api
 
 5. **Access Redis and Neo4j UIs and Swagger endpoint**:
    - Swagger UI: [http://localhost:8080/swagger-ui](http://localhost:8080/swagger-ui)
-   - Redis Insight: [http://localhost:8001/redis-stack/browser](http://localhost:8001/redis-stack/browser)
+   - Redis Insight: [http://localhost:5540](http://localhost:5540)
    - Neo4J Browser: [http://localhost:7474/browser/](http://localhost:7474/browser/)
 
 ## 📈 Observability

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -29,16 +29,24 @@ services:
       # NEO4J_apoc_uuid_enabled: false
 
   redis:
-    image: redis/redis-stack:7.2.0-v11
+    image: redis:8
     container_name: redis
     ports:
       - "127.0.0.1:6379:6379"
-      - "127.0.0.1:8001:8001"
     networks:
       - default
     volumes:
       - .database/redis/data:/data:Z
     restart: always
+
+  redisinsight:
+    image: redis/redisinsight:latest
+    container_name: redisinsight
+    ports:
+      - "127.0.0.1:5540:5540"
+    networks:
+      - default
+    restart: unless-stopped
 
   # Only used for tests that involve homeservers
   postgres:


### PR DESCRIPTION
  ## Summary

  - Upgrade dev docker-compose Redis image from `redis/redis-stack:7.2.0-v11` to `redis:8`
  - Redis 8.0 includes all former Stack modules (RedisJSON, RediSearch, etc.) built-in, no separate Stack image needed
  - Add separate `redisinsight` container (no longer bundled in base image), accessible on port `5540`
  - Update README Redis Insight URL accordingly

  ## License

  Redis 8.0 is tri-licensed (RSALv2 / SSPLv1 / AGPLv3). We choose **AGPLv3** (the only OSI-approved option). Since pubky-nexus uses Redis as an unmodified backend over the standard protocol, the AGPLv3 copyleft does not affect our MIT license.

  ## DevOps action required on `pubky-stack`

  This PR only updates the **nexus dev/CI docker-compose**. The following still need upgrading separately:

  ### 1. Stack-level docker-compose (`pubky-stack/docker/docker-compose.yml`)
  - `nexus-redis` service still uses `redis/redis-stack:7.2.0-v11`
  - Change to `redis:8`, remove port `8001`, we need to add separate `redisinsight` container
  - The mounted `redis.conf` directory is currently empty, verify if a config is needed for Redis 8

  ### 2. Staging/Production Redis VMs
  - Staging: `10.0.0.20`
  - Production: `10.1.0.9`
  - These run Redis as standalone processes (not via docker-compose)
  - **Upgrade procedure**: back up RDB data first (Redis 8 RDB files are not backward-compatible), then upgrade Redis to 8.0 on each VM
  - No config changes needed for nexusd, it connects via `redis://$REDIS_HOST:6379` unchanged

  ### Migration risk
  - **Low**: pubky-nexus only uses RedisJSON (`JSON.SET`/`JSON.GET`), which works identically in Redis 8.0
  - No RediSearch, TimeSeries, or Bloom usage
  - No ACL configuration
  - RDB format is forward-compatible (8.0 reads older RDB files)


Redis Insight Working
<img width="1844" height="987" alt="Screenshot from 2026-02-19 15-30-30" src="https://github.com/user-attachments/assets/700e0334-3349-4925-9b3c-6772e00975ed" />

  ## Test plan
  - [x] CI passes with `redis:8` image
  - [x] Verify RedisInsight accessible at `http://localhost:5540`
  - [ ] DevOps: upgrade staging Redis VM, run smoke tests
  - [ ] DevOps: upgrade production Redis VM after staging validation
