### PR TITLE
Better separate use of `GraphError`, `RedisError`

### DIFF
--- a/nexus-common/src/models/event/mod.rs
+++ b/nexus-common/src/models/event/mod.rs
@@ -1,7 +1,6 @@
 mod errors;
 
-use crate::db::RedisOps;
-use crate::models::error::ModelResult;
+use crate::db::{kv::RedisResult, RedisOps};
 use pubky_app_specs::{ParsedUri, Resource};
 use serde::{Deserialize, Serialize};
 use std::{fmt, path::PathBuf};
@@ -96,14 +95,14 @@ impl Event {
     }
 
     /// Stores event line in Redis as part of the events list.
-    pub async fn store_event(&self) -> ModelResult<()> {
-        self.put_index_list(&["Events"]).await.map_err(Into::into)
+    pub async fn store_event(&self) -> RedisResult<()> {
+        self.put_index_list(&["Events"]).await
     }
 
     pub async fn get_events_from_redis(
         cursor: Option<usize>,
         limit: usize,
-    ) -> ModelResult<(Vec<String>, usize)> {
+    ) -> RedisResult<(Vec<String>, usize)> {
         let start = cursor.unwrap_or(0);
         let result = Event::try_from_index_list(&["Events"], Some(start), Some(limit)).await;
 

--- a/nexus-common/src/models/follow/traits.rs
+++ b/nexus-common/src/models/follow/traits.rs
@@ -1,6 +1,6 @@
 use crate::db::kv::RedisResult;
 use crate::db::{
-    execute_graph_operation, fetch_row_from_graph, queries, OperationOutcome, RedisOps,
+    execute_graph_operation, fetch_row_from_graph, queries, GraphResult, OperationOutcome, RedisOps,
 };
 use crate::models::error::ModelResult;
 use async_trait::async_trait;
@@ -11,10 +11,10 @@ use neo4rs::Query;
 pub trait UserFollows: Sized + RedisOps + AsRef<[String]> + Default {
     fn from_vec(vec: Vec<String>) -> Self;
 
-    async fn put_to_graph(follower_id: &str, followee_id: &str) -> ModelResult<OperationOutcome> {
+    async fn put_to_graph(follower_id: &str, followee_id: &str) -> GraphResult<OperationOutcome> {
         let indexed_at = Utc::now().timestamp_millis();
         let query = queries::put::create_follow(follower_id, followee_id, indexed_at);
-        execute_graph_operation(query).await.map_err(Into::into)
+        execute_graph_operation(query).await
     }
 
     async fn get_by_id(
@@ -39,7 +39,7 @@ pub trait UserFollows: Sized + RedisOps + AsRef<[String]> + Default {
         user_id: &str,
         skip: Option<usize>,
         limit: Option<usize>,
-    ) -> ModelResult<Option<Self>> {
+    ) -> GraphResult<Option<Self>> {
         let query = Self::get_query(user_id, skip, limit);
         let maybe_row = fetch_row_from_graph(query).await?;
 
@@ -85,9 +85,9 @@ pub trait UserFollows: Sized + RedisOps + AsRef<[String]> + Default {
         Ok(())
     }
 
-    async fn del_from_graph(follower_id: &str, followee_id: &str) -> ModelResult<OperationOutcome> {
+    async fn del_from_graph(follower_id: &str, followee_id: &str) -> GraphResult<OperationOutcome> {
         let query = queries::del::delete_follow(follower_id, followee_id);
-        execute_graph_operation(query).await.map_err(Into::into)
+        execute_graph_operation(query).await
     }
 
     async fn del_from_index(&self, user_id: &str) -> RedisResult<()> {

--- a/nexus-common/src/models/post/relationships.rs
+++ b/nexus-common/src/models/post/relationships.rs
@@ -1,5 +1,5 @@
 use crate::db::kv::RedisResult;
-use crate::db::{fetch_row_from_graph, queries, RedisOps};
+use crate::db::{fetch_row_from_graph, queries, GraphResult, RedisOps};
 use crate::models::error::ModelResult;
 use pubky_app_specs::{post_uri_builder, ParsedUri, PubkyAppPost, PubkyAppPostKind, PubkyId};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -76,7 +76,7 @@ impl PostRelationships {
     pub async fn get_from_graph(
         author_id: &str,
         post_id: &str,
-    ) -> ModelResult<Option<PostRelationships>> {
+    ) -> GraphResult<Option<PostRelationships>> {
         let query = queries::get::post_relationships(author_id, post_id);
         let maybe_row = fetch_row_from_graph(query).await?;
 
@@ -126,9 +126,8 @@ impl PostRelationships {
         self.put_index_json(&[author_id, post_id], None, None).await
     }
 
-    pub async fn delete(author_id: &str, post_id: &str) -> ModelResult<()> {
-        Self::remove_from_index_multiple_json(&[&[author_id, post_id]]).await?;
-        Ok(())
+    pub async fn delete(author_id: &str, post_id: &str) -> RedisResult<()> {
+        Self::remove_from_index_multiple_json(&[&[author_id, post_id]]).await
     }
 
     pub async fn reindex(author_id: &str, post_id: &str) -> ModelResult<()> {

--- a/nexus-common/src/models/tag/search.rs
+++ b/nexus-common/src/models/tag/search.rs
@@ -27,7 +27,7 @@ impl TagSearch {
     pub async fn get_by_label(
         label_prefix: &str,
         pagination: &Pagination,
-    ) -> ModelResult<Option<Vec<TagSearch>>> {
+    ) -> RedisResult<Option<Vec<TagSearch>>> {
         let label_prefix_lowercase = label_prefix.to_lowercase();
         let min_inclusive = format!("[{label_prefix_lowercase}");
 
@@ -45,7 +45,6 @@ impl TagSearch {
         )
         .await
         .map(|opt| opt.map(|list| list.into_iter().map(TagSearch).collect()))
-        .map_err(Into::into)
     }
 
     pub async fn put_to_index(tag_labels: &[String]) -> RedisResult<()> {

--- a/nexus-common/src/models/tag/traits/taggers.rs
+++ b/nexus-common/src/models/tag/traits/taggers.rs
@@ -1,6 +1,5 @@
 use crate::db::kv::RedisResult;
 use crate::db::RedisOps;
-use crate::models::error::ModelResult;
 use crate::models::tag::Taggers;
 use crate::types::Pagination;
 use async_trait::async_trait;
@@ -41,7 +40,7 @@ where
         pagination: Pagination,
         viewer_id: Option<&str>,
         depth: Option<u8>,
-    ) -> ModelResult<TaggersTuple> {
+    ) -> RedisResult<TaggersTuple> {
         // Set default params for pagination
         let skip = pagination.skip.unwrap_or(0);
         let limit = pagination.limit.unwrap_or(40);
@@ -57,9 +56,7 @@ where
             key_parts = Self::create_label_index(user_id, extra_param, label, false);
         }
 
-        async { Self::get_from_index(key_parts, viewer_id, Some(skip), Some(limit), prefix).await }
-            .await
-            .map_err(Into::into)
+        Self::get_from_index(key_parts, viewer_id, Some(skip), Some(limit), prefix).await
     }
 
     async fn get_from_index(
@@ -106,11 +103,11 @@ where
         author_id: &str,
         extra_param: Option<&str>,
         tag_label: &str,
-    ) -> ModelResult<()> {
+    ) -> RedisResult<()> {
         let key = match extra_param {
             Some(post_id) => vec![author_id, post_id, tag_label],
             None => vec![author_id, tag_label],
         };
-        self.remove_from_index_set(&key).await.map_err(Into::into)
+        self.remove_from_index_set(&key).await
     }
 }

--- a/nexus-common/src/models/user/counts.rs
+++ b/nexus-common/src/models/user/counts.rs
@@ -1,5 +1,5 @@
 use crate::db::kv::{JsonAction, RedisResult};
-use crate::db::{fetch_row_from_graph, queries, RedisOps};
+use crate::db::{fetch_row_from_graph, queries, GraphResult, RedisOps};
 use crate::models::error::ModelResult;
 use crate::models::tag::user::USER_TAGS_KEY_PARTS;
 use serde::{Deserialize, Serialize};
@@ -43,7 +43,7 @@ impl UserCounts {
     }
 
     /// Retrieves the counts from Neo4j.
-    pub async fn get_from_graph(user_id: &str) -> ModelResult<Option<UserCounts>> {
+    pub async fn get_from_graph(user_id: &str) -> GraphResult<Option<UserCounts>> {
         let query = queries::get::user_counts(user_id);
         let maybe_row = fetch_row_from_graph(query).await?;
 
@@ -76,9 +76,8 @@ impl UserCounts {
         author_id: &str,
         field: &str,
         action: JsonAction,
-    ) -> ModelResult<()> {
-        Self::modify_json_field(&[author_id], field, action).await?;
-        Ok(())
+    ) -> RedisResult<()> {
+        Self::modify_json_field(&[author_id], field, action).await
     }
 
     /// Updates a user's counts index field and conditionally updates ranking sets
@@ -141,11 +140,9 @@ impl UserCounts {
         Ok(())
     }
 
-    pub async fn delete(user_id: &str) -> ModelResult<()> {
+    pub async fn delete(user_id: &str) -> RedisResult<()> {
         // Delete user_details on Redis
-        Self::remove_from_index_multiple_json(&[&[user_id]]).await?;
-
-        Ok(())
+        Self::remove_from_index_multiple_json(&[&[user_id]]).await
     }
 
     /// Increments a field in a user's counts by 1.

--- a/nexus-common/src/models/user/muted.rs
+++ b/nexus-common/src/models/user/muted.rs
@@ -1,6 +1,6 @@
 use crate::db::kv::RedisResult;
 use crate::db::{
-    execute_graph_operation, fetch_row_from_graph, queries, OperationOutcome, RedisOps,
+    execute_graph_operation, fetch_row_from_graph, queries, GraphResult, OperationOutcome, RedisOps,
 };
 use crate::models::error::ModelResult;
 use async_trait::async_trait;
@@ -55,7 +55,7 @@ impl Muted {
         user_id: &str,
         skip: Option<usize>,
         limit: Option<usize>,
-    ) -> ModelResult<Option<Self>> {
+    ) -> GraphResult<Option<Self>> {
         let query = queries::get::get_user_muted(user_id, skip, limit);
         let maybe_row = fetch_row_from_graph(query).await?;
 
@@ -80,10 +80,10 @@ impl Muted {
         Self::put_index_set(&[user_id], &user_list_ref, None, None).await
     }
 
-    pub async fn put_to_graph(user_id: &str, muted_id: &str) -> ModelResult<OperationOutcome> {
+    pub async fn put_to_graph(user_id: &str, muted_id: &str) -> GraphResult<OperationOutcome> {
         let indexed_at = Utc::now().timestamp_millis();
         let query = queries::put::create_mute(user_id, muted_id, indexed_at);
-        execute_graph_operation(query).await.map_err(Into::into)
+        execute_graph_operation(query).await
     }
 
     pub async fn reindex(user_id: &str) -> ModelResult<()> {
@@ -97,9 +97,9 @@ impl Muted {
         Ok(())
     }
 
-    pub async fn del_from_graph(user_id: &str, muted_id: &str) -> ModelResult<OperationOutcome> {
+    pub async fn del_from_graph(user_id: &str, muted_id: &str) -> GraphResult<OperationOutcome> {
         let query = queries::del::delete_mute(user_id, muted_id);
-        execute_graph_operation(query).await.map_err(Into::into)
+        execute_graph_operation(query).await
     }
 
     pub async fn del_from_index(&self, user_id: &str) -> RedisResult<()> {

--- a/nexus-common/src/models/user/search.rs
+++ b/nexus-common/src/models/user/search.rs
@@ -2,7 +2,6 @@ use super::{UserDetails, USER_DELETED_SENTINEL};
 use crate::db::kv::RedisResult;
 use crate::db::RedisOps;
 use crate::models::create_zero_score_tuples;
-use crate::models::error::ModelResult;
 use crate::models::traits::Collection;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -21,7 +20,7 @@ impl UserSearch {
         name_prefix: &str,
         skip: Option<usize>,
         limit: Option<usize>,
-    ) -> ModelResult<Option<Self>> {
+    ) -> RedisResult<Option<Self>> {
         // Perform the lexicographical range search
         let elements = Self::get_from_index_name(name_prefix, skip, limit).await?;
 
@@ -45,7 +44,7 @@ impl UserSearch {
         id_prefix: &str,
         skip: Option<usize>,
         limit: Option<usize>,
-    ) -> ModelResult<Option<Self>> {
+    ) -> RedisResult<Option<Self>> {
         // Perform the lexicographical range search
         let elements = Self::get_from_index_id(id_prefix, skip, limit).await?;
 
@@ -149,7 +148,6 @@ impl UserSearch {
                 .collect::<Vec<&str>>(),
         )
         .await?;
-        Self::remove_from_index_sorted_set(None, &USER_ID_KEY_PARTS, user_ids).await?;
-        Ok(())
+        Self::remove_from_index_sorted_set(None, &USER_ID_KEY_PARTS, user_ids).await
     }
 }

--- a/nexus-webapi/src/error.rs
+++ b/nexus-webapi/src/error.rs
@@ -2,6 +2,7 @@ use axum::http::header::InvalidHeaderValue;
 use axum::http::uri::InvalidUri;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
+use nexus_common::db::kv::RedisError;
 use nexus_common::models::error::ModelError;
 use nexus_common::types::DynError;
 use std::io;
@@ -41,6 +42,14 @@ impl Error {
 
 impl From<ModelError> for Error {
     fn from(source: ModelError) -> Self {
+        Error::InternalServerError {
+            source: source.into(),
+        }
+    }
+}
+
+impl From<RedisError> for Error {
+    fn from(source: RedisError) -> Self {
         Error::InternalServerError {
             source: source.into(),
         }


### PR DESCRIPTION
This PR better separates the use of:
- `RedisError`: in return types of methods that deal exclusively with Redis (the index), like caching calls or redis ops
- `GraphError`: in return types of methods that deal exclusively with Neo4j (the graph), like graph operations and lookups