### PR TITLE
chore: disable neo4j telemetry

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -24,7 +24,11 @@ services:
       NEO4J_server_memory_pagecache_size: 1G
       NEO4J_server_memory_heap_initial__size: 2G
       NEO4J_server_memory_heap_max__size: 2G
-      # Disable telemetry, see https://neo4j.com/docs/operations-manual/current/configuration/configuration-settings/#config_client.allow_telemetry
+      # Disable telemetry (server-side)
+      # https://neo4j.com/docs/operations-manual/current/configuration/configuration-settings/#config_dbms.usage_report.enabled
+      NEO4J_dbms_usage__report_enabled: false
+      # Disable telemetry (client-side)
+      # https://neo4j.com/docs/operations-manual/current/configuration/configuration-settings/#config_client.allow_telemetry
       NEO4J_client_allow__telemetry: false
       # NEO4J_apoc_uuid_enabled: false
 


### PR DESCRIPTION
When neo4j container starts locally, its console contains:

```
2026-02-20 18:54:43.183+0000 INFO  Anonymous Usage Data is being sent to Neo4j, see https://neo4j.com/docs/usage-data/
```

This PR disables neo4j telemetry on client-side (browser), as well as server-side (container).