### PR TITLE
chore: use docker named volumes

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,8 +10,8 @@ services:
       # Mount the neo4j configuration file to container
       - .database/neo4j/conf:/conf:Z
       # Mount the data to container
-      - .database/neo4j/data:/data:Z
-      - .database/neo4j/logs:/logs:Z
+      - neo4j_data:/data
+      - neo4j_logs:/logs
       - ./test-graph:/test-graph:Z
     environment:
       NEO4J_initial_dbms_default__database: ${NEO4J_DB_NAME}
@@ -40,7 +40,7 @@ services:
     networks:
       - default
     volumes:
-      - .database/redis/data:/data:Z
+      - redis_data:/data
     restart: always
 
   redisinsight:
@@ -87,3 +87,8 @@ services:
     #   - default
     # restart: unless-stopped
     # network_mode: host
+
+volumes:
+  neo4j_data:
+  neo4j_logs:
+  redis_data:


### PR DESCRIPTION
Turns Redis and Neo4j bind mounts into named volumes.
This means all data stored by containers is kept within volumes managed by the Docker CLI.
For example, `docker compose down -v` will remove all graph/Redis data, leading to a clean dev environment.
Previously it required manual directory removal.