### PR TITLE
Bump redis version

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       # NEO4J_apoc_uuid_enabled: false
 
   redis:
-    image: redis:8.0.5-alpine
+    image: redis:8.0.6-alpine
     container_name: redis
     ports:
       - 127.0.0.1:6379:6379


### PR DESCRIPTION
This PR bumps the Redis minor version (`8.0.5` to `8.0.6`).

This brings a security fix.

See changelog: https://raw.githubusercontent.com/redis/redis/8.0/00-RELEASENOTES