### PR TITLE
`nexus-api` tests: use unseeded `Testnet`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2363,7 +2363,7 @@ checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
 [[package]]
 name = "http-relay"
 version = "0.5.1"
-source = "git+https://github.com/pubky/pubky-core.git?branch=sdk_version_0.7.0#ec4e01d54395d7a894f2fa8674c8be8dbf4e6ad9"
+source = "git+https://github.com/ok300/pubky-core.git?branch=ok300-sdk-0.7.x-expose-testnet-unseeded#5a7e445f75b1fed5a5b7d25e31ebadc4357b2d11"
 dependencies = [
  "anyhow",
  "axum",
@@ -3869,7 +3869,7 @@ dependencies = [
 [[package]]
 name = "pkarr-republisher"
 version = "0.5.1"
-source = "git+https://github.com/pubky/pubky-core.git?branch=sdk_version_0.7.0#ec4e01d54395d7a894f2fa8674c8be8dbf4e6ad9"
+source = "git+https://github.com/ok300/pubky-core.git?branch=ok300-sdk-0.7.x-expose-testnet-unseeded#5a7e445f75b1fed5a5b7d25e31ebadc4357b2d11"
 dependencies = [
  "anyhow",
  "clap",
@@ -4154,7 +4154,7 @@ dependencies = [
 [[package]]
 name = "pubky"
 version = "0.7.0-rc.1"
-source = "git+https://github.com/pubky/pubky-core.git?branch=sdk_version_0.7.0#ec4e01d54395d7a894f2fa8674c8be8dbf4e6ad9"
+source = "git+https://github.com/ok300/pubky-core.git?branch=ok300-sdk-0.7.x-expose-testnet-unseeded#5a7e445f75b1fed5a5b7d25e31ebadc4357b2d11"
 dependencies = [
  "base64",
  "cookie",
@@ -4219,7 +4219,7 @@ dependencies = [
 [[package]]
 name = "pubky-common"
 version = "0.7.0-rc.1"
-source = "git+https://github.com/pubky/pubky-core.git?branch=sdk_version_0.7.0#ec4e01d54395d7a894f2fa8674c8be8dbf4e6ad9"
+source = "git+https://github.com/ok300/pubky-core.git?branch=ok300-sdk-0.7.x-expose-testnet-unseeded#5a7e445f75b1fed5a5b7d25e31ebadc4357b2d11"
 dependencies = [
  "argon2",
  "base32",
@@ -4240,7 +4240,7 @@ dependencies = [
 [[package]]
 name = "pubky-homeserver"
 version = "0.7.0-rc.1"
-source = "git+https://github.com/pubky/pubky-core.git?branch=sdk_version_0.7.0#ec4e01d54395d7a894f2fa8674c8be8dbf4e6ad9"
+source = "git+https://github.com/ok300/pubky-core.git?branch=ok300-sdk-0.7.x-expose-testnet-unseeded#5a7e445f75b1fed5a5b7d25e31ebadc4357b2d11"
 dependencies = [
  "anyhow",
  "async-dropper",
@@ -4303,7 +4303,7 @@ dependencies = [
 [[package]]
 name = "pubky-testnet"
 version = "0.7.0-rc.1"
-source = "git+https://github.com/pubky/pubky-core.git?branch=sdk_version_0.7.0#ec4e01d54395d7a894f2fa8674c8be8dbf4e6ad9"
+source = "git+https://github.com/ok300/pubky-core.git?branch=ok300-sdk-0.7.x-expose-testnet-unseeded#5a7e445f75b1fed5a5b7d25e31ebadc4357b2d11"
 dependencies = [
  "anyhow",
  "clap",
@@ -4342,7 +4342,7 @@ dependencies = [
 [[package]]
 name = "pubky_test_utils"
 version = "0.1.0"
-source = "git+https://github.com/pubky/pubky-core.git?branch=sdk_version_0.7.0#ec4e01d54395d7a894f2fa8674c8be8dbf4e6ad9"
+source = "git+https://github.com/ok300/pubky-core.git?branch=ok300-sdk-0.7.x-expose-testnet-unseeded#5a7e445f75b1fed5a5b7d25e31ebadc4357b2d11"
 dependencies = [
  "pubky_test_utils_drop_db_helper",
  "pubky_test_utils_macro",
@@ -4351,7 +4351,7 @@ dependencies = [
 [[package]]
 name = "pubky_test_utils_drop_db_helper"
 version = "0.1.0"
-source = "git+https://github.com/pubky/pubky-core.git?branch=sdk_version_0.7.0#ec4e01d54395d7a894f2fa8674c8be8dbf4e6ad9"
+source = "git+https://github.com/ok300/pubky-core.git?branch=ok300-sdk-0.7.x-expose-testnet-unseeded#5a7e445f75b1fed5a5b7d25e31ebadc4357b2d11"
 dependencies = [
  "sqlx",
 ]
@@ -4359,7 +4359,7 @@ dependencies = [
 [[package]]
 name = "pubky_test_utils_macro"
 version = "0.1.0"
-source = "git+https://github.com/pubky/pubky-core.git?branch=sdk_version_0.7.0#ec4e01d54395d7a894f2fa8674c8be8dbf4e6ad9"
+source = "git+https://github.com/ok300/pubky-core.git?branch=ok300-sdk-0.7.x-expose-testnet-unseeded#5a7e445f75b1fed5a5b7d25e31ebadc4357b2d11"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2363,7 +2363,7 @@ checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
 [[package]]
 name = "http-relay"
 version = "0.5.1"
-source = "git+https://github.com/ok300/pubky-core.git?branch=ok300-sdk-0.7.x-expose-testnet-unseeded#5a7e445f75b1fed5a5b7d25e31ebadc4357b2d11"
+source = "git+https://github.com/pubky/pubky-core.git?branch=sdk_version_0.7.0#ea5a27d40ede4c55a18332beb9c960f21162a4c7"
 dependencies = [
  "anyhow",
  "axum",
@@ -3109,7 +3109,7 @@ dependencies = [
  "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
  "opentelemetry_sdk 0.31.0",
- "pubky 0.7.0-rc.1",
+ "pubky 0.7.0-rc.3",
  "pubky-app-specs",
  "redis",
  "serde",
@@ -3149,7 +3149,7 @@ dependencies = [
  "neo4rs",
  "nexus-common",
  "opentelemetry 0.31.0",
- "pubky 0.7.0-rc.1",
+ "pubky 0.7.0-rc.3",
  "pubky-app-specs",
  "pubky-testnet",
  "rand 0.10.0",
@@ -3178,7 +3178,7 @@ dependencies = [
  "neo4rs",
  "nexus-common",
  "opentelemetry 0.31.0",
- "pubky 0.7.0-rc.1",
+ "pubky 0.7.0-rc.3",
  "pubky-app-specs",
  "pubky-testnet",
  "serde",
@@ -3869,7 +3869,7 @@ dependencies = [
 [[package]]
 name = "pkarr-republisher"
 version = "0.5.1"
-source = "git+https://github.com/ok300/pubky-core.git?branch=ok300-sdk-0.7.x-expose-testnet-unseeded#5a7e445f75b1fed5a5b7d25e31ebadc4357b2d11"
+source = "git+https://github.com/pubky/pubky-core.git?branch=sdk_version_0.7.0#ea5a27d40ede4c55a18332beb9c960f21162a4c7"
 dependencies = [
  "anyhow",
  "clap",
@@ -4153,8 +4153,8 @@ dependencies = [
 
 [[package]]
 name = "pubky"
-version = "0.7.0-rc.1"
-source = "git+https://github.com/ok300/pubky-core.git?branch=ok300-sdk-0.7.x-expose-testnet-unseeded#5a7e445f75b1fed5a5b7d25e31ebadc4357b2d11"
+version = "0.7.0-rc.3"
+source = "git+https://github.com/pubky/pubky-core.git?branch=sdk_version_0.7.0#ea5a27d40ede4c55a18332beb9c960f21162a4c7"
 dependencies = [
  "base64",
  "cookie",
@@ -4165,7 +4165,7 @@ dependencies = [
  "httpdate",
  "log",
  "pkarr 5.0.3",
- "pubky-common 0.7.0-rc.1",
+ "pubky-common 0.7.0-rc.3",
  "reqwest 0.13.2",
  "serde",
  "thiserror 2.0.18",
@@ -4218,8 +4218,8 @@ dependencies = [
 
 [[package]]
 name = "pubky-common"
-version = "0.7.0-rc.1"
-source = "git+https://github.com/ok300/pubky-core.git?branch=ok300-sdk-0.7.x-expose-testnet-unseeded#5a7e445f75b1fed5a5b7d25e31ebadc4357b2d11"
+version = "0.7.0-rc.3"
+source = "git+https://github.com/pubky/pubky-core.git?branch=sdk_version_0.7.0#ea5a27d40ede4c55a18332beb9c960f21162a4c7"
 dependencies = [
  "argon2",
  "base32",
@@ -4239,8 +4239,8 @@ dependencies = [
 
 [[package]]
 name = "pubky-homeserver"
-version = "0.7.0-rc.1"
-source = "git+https://github.com/ok300/pubky-core.git?branch=ok300-sdk-0.7.x-expose-testnet-unseeded#5a7e445f75b1fed5a5b7d25e31ebadc4357b2d11"
+version = "0.7.0-rc.3"
+source = "git+https://github.com/pubky/pubky-core.git?branch=sdk_version_0.7.0#ea5a27d40ede4c55a18332beb9c960f21162a4c7"
 dependencies = [
  "anyhow",
  "async-dropper",
@@ -4278,7 +4278,7 @@ dependencies = [
  "pkarr-republisher",
  "postcard",
  "prometheus",
- "pubky-common 0.7.0-rc.1",
+ "pubky-common 0.7.0-rc.3",
  "pubky_test_utils",
  "reqwest 0.13.2",
  "sea-query",
@@ -4302,8 +4302,8 @@ dependencies = [
 
 [[package]]
 name = "pubky-testnet"
-version = "0.7.0-rc.1"
-source = "git+https://github.com/ok300/pubky-core.git?branch=ok300-sdk-0.7.x-expose-testnet-unseeded#5a7e445f75b1fed5a5b7d25e31ebadc4357b2d11"
+version = "0.7.0-rc.3"
+source = "git+https://github.com/pubky/pubky-core.git?branch=sdk_version_0.7.0#ea5a27d40ede4c55a18332beb9c960f21162a4c7"
 dependencies = [
  "anyhow",
  "clap",
@@ -4313,8 +4313,8 @@ dependencies = [
  "once_cell",
  "pkarr 5.0.3",
  "pkarr-relay",
- "pubky 0.7.0-rc.1",
- "pubky-common 0.7.0-rc.1",
+ "pubky 0.7.0-rc.3",
+ "pubky-common 0.7.0-rc.3",
  "pubky-homeserver",
  "pubky_test_utils",
  "tempfile",
@@ -4342,7 +4342,7 @@ dependencies = [
 [[package]]
 name = "pubky_test_utils"
 version = "0.1.0"
-source = "git+https://github.com/ok300/pubky-core.git?branch=ok300-sdk-0.7.x-expose-testnet-unseeded#5a7e445f75b1fed5a5b7d25e31ebadc4357b2d11"
+source = "git+https://github.com/pubky/pubky-core.git?branch=sdk_version_0.7.0#ea5a27d40ede4c55a18332beb9c960f21162a4c7"
 dependencies = [
  "pubky_test_utils_drop_db_helper",
  "pubky_test_utils_macro",
@@ -4351,7 +4351,7 @@ dependencies = [
 [[package]]
 name = "pubky_test_utils_drop_db_helper"
 version = "0.1.0"
-source = "git+https://github.com/ok300/pubky-core.git?branch=ok300-sdk-0.7.x-expose-testnet-unseeded#5a7e445f75b1fed5a5b7d25e31ebadc4357b2d11"
+source = "git+https://github.com/pubky/pubky-core.git?branch=sdk_version_0.7.0#ea5a27d40ede4c55a18332beb9c960f21162a4c7"
 dependencies = [
  "sqlx",
 ]
@@ -4359,7 +4359,7 @@ dependencies = [
 [[package]]
 name = "pubky_test_utils_macro"
 version = "0.1.0"
-source = "git+https://github.com/ok300/pubky-core.git?branch=ok300-sdk-0.7.x-expose-testnet-unseeded#5a7e445f75b1fed5a5b7d25e31ebadc4357b2d11"
+source = "git+https://github.com/pubky/pubky-core.git?branch=sdk_version_0.7.0#ea5a27d40ede4c55a18332beb9c960f21162a4c7"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2363,7 +2363,7 @@ checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
 [[package]]
 name = "http-relay"
 version = "0.5.1"
-source = "git+https://github.com/pubky/pubky-core.git?tag=v0.7.0-rc.2#9bd80c23ab2d1ddf3b9a35e5645a4f468be8cbcf"
+source = "git+https://github.com/pubky/pubky-core.git?tag=v0.7.0-rc.3#ea5a27d40ede4c55a18332beb9c960f21162a4c7"
 dependencies = [
  "anyhow",
  "axum",
@@ -3869,7 +3869,7 @@ dependencies = [
 [[package]]
 name = "pkarr-republisher"
 version = "0.5.1"
-source = "git+https://github.com/pubky/pubky-core.git?tag=v0.7.0-rc.2#9bd80c23ab2d1ddf3b9a35e5645a4f468be8cbcf"
+source = "git+https://github.com/pubky/pubky-core.git?tag=v0.7.0-rc.3#ea5a27d40ede4c55a18332beb9c960f21162a4c7"
 dependencies = [
  "anyhow",
  "clap",
@@ -4153,8 +4153,8 @@ dependencies = [
 
 [[package]]
 name = "pubky"
-version = "0.7.0-rc.1"
-source = "git+https://github.com/pubky/pubky-core.git?tag=v0.7.0-rc.2#9bd80c23ab2d1ddf3b9a35e5645a4f468be8cbcf"
+version = "0.7.0-rc.3"
+source = "git+https://github.com/pubky/pubky-core.git?tag=v0.7.0-rc.3#ea5a27d40ede4c55a18332beb9c960f21162a4c7"
 dependencies = [
  "base64",
  "cookie",
@@ -4165,7 +4165,7 @@ dependencies = [
  "httpdate",
  "log",
  "pkarr 5.0.3",
- "pubky-common 0.6.0",
+ "pubky-common 0.7.0-rc.3",
  "reqwest 0.13.2",
  "serde",
  "thiserror 2.0.18",
@@ -4218,8 +4218,8 @@ dependencies = [
 
 [[package]]
 name = "pubky-common"
-version = "0.6.0"
-source = "git+https://github.com/pubky/pubky-core.git?tag=v0.7.0-rc.2#9bd80c23ab2d1ddf3b9a35e5645a4f468be8cbcf"
+version = "0.7.0-rc.3"
+source = "git+https://github.com/pubky/pubky-core.git?tag=v0.7.0-rc.3#ea5a27d40ede4c55a18332beb9c960f21162a4c7"
 dependencies = [
  "argon2",
  "base32",
@@ -4239,8 +4239,8 @@ dependencies = [
 
 [[package]]
 name = "pubky-homeserver"
-version = "0.6.0"
-source = "git+https://github.com/pubky/pubky-core.git?tag=v0.7.0-rc.2#9bd80c23ab2d1ddf3b9a35e5645a4f468be8cbcf"
+version = "0.7.0-rc.3"
+source = "git+https://github.com/pubky/pubky-core.git?tag=v0.7.0-rc.3#ea5a27d40ede4c55a18332beb9c960f21162a4c7"
 dependencies = [
  "anyhow",
  "async-dropper",
@@ -4278,7 +4278,7 @@ dependencies = [
  "pkarr-republisher",
  "postcard",
  "prometheus",
- "pubky-common 0.6.0",
+ "pubky-common 0.7.0-rc.3",
  "pubky_test_utils",
  "reqwest 0.13.2",
  "sea-query",
@@ -4302,8 +4302,8 @@ dependencies = [
 
 [[package]]
 name = "pubky-testnet"
-version = "0.7.2"
-source = "git+https://github.com/pubky/pubky-core.git?tag=v0.7.0-rc.2#9bd80c23ab2d1ddf3b9a35e5645a4f468be8cbcf"
+version = "0.7.0-rc.3"
+source = "git+https://github.com/pubky/pubky-core.git?tag=v0.7.0-rc.3#ea5a27d40ede4c55a18332beb9c960f21162a4c7"
 dependencies = [
  "anyhow",
  "clap",
@@ -4313,8 +4313,8 @@ dependencies = [
  "once_cell",
  "pkarr 5.0.3",
  "pkarr-relay",
- "pubky 0.7.0-rc.1",
- "pubky-common 0.6.0",
+ "pubky 0.7.0-rc.3",
+ "pubky-common 0.7.0-rc.3",
  "pubky-homeserver",
  "pubky_test_utils",
  "tempfile",
@@ -4342,7 +4342,7 @@ dependencies = [
 [[package]]
 name = "pubky_test_utils"
 version = "0.1.0"
-source = "git+https://github.com/pubky/pubky-core.git?tag=v0.7.0-rc.2#9bd80c23ab2d1ddf3b9a35e5645a4f468be8cbcf"
+source = "git+https://github.com/pubky/pubky-core.git?tag=v0.7.0-rc.3#ea5a27d40ede4c55a18332beb9c960f21162a4c7"
 dependencies = [
  "pubky_test_utils_drop_db_helper",
  "pubky_test_utils_macro",
@@ -4351,7 +4351,7 @@ dependencies = [
 [[package]]
 name = "pubky_test_utils_drop_db_helper"
 version = "0.1.0"
-source = "git+https://github.com/pubky/pubky-core.git?tag=v0.7.0-rc.2#9bd80c23ab2d1ddf3b9a35e5645a4f468be8cbcf"
+source = "git+https://github.com/pubky/pubky-core.git?tag=v0.7.0-rc.3#ea5a27d40ede4c55a18332beb9c960f21162a4c7"
 dependencies = [
  "sqlx",
 ]
@@ -4359,7 +4359,7 @@ dependencies = [
 [[package]]
 name = "pubky_test_utils_macro"
 version = "0.1.0"
-source = "git+https://github.com/pubky/pubky-core.git?tag=v0.7.0-rc.2#9bd80c23ab2d1ddf3b9a35e5645a4f468be8cbcf"
+source = "git+https://github.com/pubky/pubky-core.git?tag=v0.7.0-rc.3#ea5a27d40ede4c55a18332beb9c960f21162a4c7"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,11 @@ neo4rs = "0.8.0"
 opentelemetry = "0.31"
 opentelemetry_sdk = { version = "0.31", features = ["rt-tokio"] }
 # pubky = "0.5.4"
-pubky = { git = "https://github.com/pubky/pubky-core.git", package = "pubky", branch = "sdk_version_0.7.0" }
+pubky = { git = "https://github.com/ok300/pubky-core.git", package = "pubky", branch = "ok300-sdk-0.7.x-expose-testnet-unseeded" }
 # pubky-app-specs = { version = "0.4.0", features = ["openapi"] }
 pubky-app-specs = { git = "https://github.com/pubky/pubky-app-specs", rev = "8b05c5fe7ad4df9a3cb39005e5019f99a5e5036d", features = ["openapi"] }
 # pubky-testnet = "0.5.4"
-pubky-testnet = { git = "https://github.com/pubky/pubky-core.git", package = "pubky-testnet", branch = "sdk_version_0.7.0" }
+pubky-testnet = { git = "https://github.com/ok300/pubky-core.git", package = "pubky-testnet", branch = "ok300-sdk-0.7.x-expose-testnet-unseeded" }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.149"
 tempfile = "3.25"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,11 @@ neo4rs = "0.8.0"
 opentelemetry = "0.31"
 opentelemetry_sdk = { version = "0.31", features = ["rt-tokio"] }
 # pubky = "0.5.4"
-pubky = { git = "https://github.com/pubky/pubky-core.git", package = "pubky", tag = "v0.7.0-rc.2" }
+pubky = { git = "https://github.com/pubky/pubky-core.git", package = "pubky", tag = "v0.7.0-rc.3" }
 # pubky-app-specs = { version = "0.4.0", features = ["openapi"] }
 pubky-app-specs = { git = "https://github.com/pubky/pubky-app-specs", rev = "8b05c5fe7ad4df9a3cb39005e5019f99a5e5036d", features = ["openapi"] }
 # pubky-testnet = "0.5.4"
-pubky-testnet = { git = "https://github.com/pubky/pubky-core.git", package = "pubky-testnet", tag = "v0.7.0-rc.2" }
+pubky-testnet = { git = "https://github.com/pubky/pubky-core.git", package = "pubky-testnet", tag = "v0.7.0-rc.3" }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.149"
 tempfile = "3.25"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,11 @@ neo4rs = "0.8.0"
 opentelemetry = "0.31"
 opentelemetry_sdk = { version = "0.31", features = ["rt-tokio"] }
 # pubky = "0.5.4"
-pubky = { git = "https://github.com/ok300/pubky-core.git", package = "pubky", branch = "ok300-sdk-0.7.x-expose-testnet-unseeded" }
+pubky = { git = "https://github.com/pubky/pubky-core.git", package = "pubky", branch = "sdk_version_0.7.0" }
 # pubky-app-specs = { version = "0.4.0", features = ["openapi"] }
 pubky-app-specs = { git = "https://github.com/pubky/pubky-app-specs", rev = "8b05c5fe7ad4df9a3cb39005e5019f99a5e5036d", features = ["openapi"] }
 # pubky-testnet = "0.5.4"
-pubky-testnet = { git = "https://github.com/ok300/pubky-core.git", package = "pubky-testnet", branch = "ok300-sdk-0.7.x-expose-testnet-unseeded" }
+pubky-testnet = { git = "https://github.com/pubky/pubky-core.git", package = "pubky-testnet", branch = "sdk_version_0.7.0" }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.149"
 tempfile = "3.25"

--- a/nexus-webapi/tests/utils/server.rs
+++ b/nexus-webapi/tests/utils/server.rs
@@ -19,7 +19,7 @@ impl TestServiceServer {
     pub async fn get_test_server() -> &'static TestServiceServer {
         TEST_SERVER
             .get_or_init(|| async {
-                let testnet = pubky_testnet::Testnet::new().await.unwrap();
+                let testnet = pubky_testnet::Testnet::new_unseeded().await.unwrap();
                 let nexus_api = Self::start_server(&testnet).await.unwrap();
                 TestServiceServer { nexus_api, testnet }
             })


### PR DESCRIPTION
This PR uses an unseeded `Testnet`, made available in https://github.com/pubky/mainline/pull/78

Depends on:
- [x] https://github.com/pubky/pubky-core/pull/329