### PR TITLE
test: Use unseeded testnets for `nexus-watcher` tests

### DIFF
--- a/nexus-watcher/tests/event_processor/utils/watcher.rs
+++ b/nexus-watcher/tests/event_processor/utils/watcher.rs
@@ -112,8 +112,7 @@ impl WatcherTest {
 
         // WARNING: testnet initialization is time expensive, we only init one per process
         // TODO: Maybe we should create a single testnet network (singleton and push there more homeservers)
-        // This can be further sped up by using Testnet::new_unseeded() with pubky-testnet 0.7.x
-        let mut testnet = Testnet::new().await?;
+        let mut testnet = Testnet::new_unseeded().await?;
         testnet.create_http_relay().await?;
 
         // Create a random homeserver with a random public key


### PR DESCRIPTION
This PR uses an unseeded `Testnet` in `nexus-watcher` tests.

Builds on top of #726