### PR TITLE
refactor: extract periodic task loop into reusable `run_periodic_tasks`

### DIFF
--- a/nexus-watcher/src/service/mod.rs
+++ b/nexus-watcher/src/service/mod.rs
@@ -12,6 +12,7 @@ pub use processor_runner::EventProcessorRunner;
 pub(crate) use task_runner::{run_periodic_tasks, PeriodicTask};
 pub use traits::{TEventProcessor, TEventProcessorRunner};
 
+use crate::service::task_runner::task_results_into_result;
 use crate::NexusWatcherBuilder;
 use nexus_common::file::ConfigLoader;
 use nexus_common::models::homeserver::Homeserver;
@@ -103,11 +104,8 @@ impl NexusWatcher {
         ];
 
         let task_results = run_periodic_tasks(tasks, shutdown_rx).await;
-        for task_result in task_results {
-            info!(task = task_result.name, outcome = ?task_result.outcome, "Task exited");
-        }
 
         info!("Nexus Watcher shut down gracefully");
-        Ok(())
+        task_results_into_result(task_results)
     }
 }

--- a/nexus-watcher/src/service/task_runner.rs
+++ b/nexus-watcher/src/service/task_runner.rs
@@ -146,8 +146,8 @@ pub(crate) enum TaskOutcome {
 /// Result of running a single periodic task.
 #[derive(Debug, Clone)]
 pub(crate) struct TaskResult {
-    pub name: String,
-    pub outcome: TaskOutcome,
+    name: String,
+    outcome: TaskOutcome,
 }
 
 impl TaskResult {
@@ -163,6 +163,20 @@ impl TaskResult {
             name: name.into(),
             outcome: TaskOutcome::Panicked,
         }
+    }
+}
+
+/// Converts a list of task results into a `Result`, returning `Err` if any task panicked.
+pub(crate) fn task_results_into_result(results: Vec<TaskResult>) -> Result<(), DynError> {
+    let panicked: Vec<String> = results
+        .into_iter()
+        .filter(|r| r.outcome == TaskOutcome::Panicked)
+        .map(|r| r.name)
+        .collect();
+
+    match panicked.is_empty() {
+        true => Ok(()),
+        false => Err(format!("Task(s) panicked: {}", panicked.join(", ")).into()),
     }
 }
 
@@ -328,6 +342,36 @@ mod tests {
             "expected at most 5 ticks (skip behaviour), but got {ticks}"
         );
         assert!(ticks >= 1, "task should have ticked at least once");
+    }
+
+    #[test]
+    fn test_task_results_into_result_no_panics() {
+        let results = vec![
+            TaskResult::completed("task-a"),
+            TaskResult::completed("task-b"),
+        ];
+        assert!(task_results_into_result(results).is_ok());
+    }
+
+    #[test]
+    fn test_task_results_into_result_with_panic() {
+        let results = vec![
+            TaskResult::panicked("task-a"),
+            TaskResult::completed("task-b"),
+        ];
+        let err = task_results_into_result(results).unwrap_err();
+        assert!(err.to_string().contains("task-a"));
+    }
+
+    #[test]
+    fn test_task_results_into_result_all_panicked() {
+        let results = vec![
+            TaskResult::panicked("task-a"),
+            TaskResult::panicked("task-b"),
+        ];
+        let err = task_results_into_result(results).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("task-a") && msg.contains("task-b"));
     }
 
     /// Verify that a fast task whose execution time is well below the


### PR DESCRIPTION
This PR simplifies and modularizes `NexusWatcher::start` as follows:
- the various parallel tasks are instantiated via `PeriodicTask::new`
- the vector of `PeriodicTask` is given as arg to `run_periodic_tasks`
- `run_periodic_tasks` spawns the tasks each in their own thread, registers the shutdown signal + the interval `tick()` + the cancellation signal

The cancellation signal is used by `run_periodic_tasks` to detect when a task has panicked. It then triggers a graceful shutdown from all other parallel running tasks.

This PR also uses the `MissedTickBehavior::Skip` for the `run_periodic_tasks` threads.

---

This PR is an alternative implementation for #757 and #760.