### PR TITLE
fix: force ephemeral DHT port for testnet_with_host (avoid 6881 collision)

### DIFF
--- a/nexus-common/src/db/connectors/pubky.rs
+++ b/nexus-common/src/db/connectors/pubky.rs
@@ -35,6 +35,7 @@ impl PubkyConnector {
                     Some(host) => PubkyHttpClient::builder()
                         .testnet_with_host(host)
                         // Force pkarr/mainline DHT to bind an ephemeral local port instead of default behavior
+                        // We do this to prevent the client DHT from competing with `StaticTestnet` for port 6881
                         .pkarr(|p| p.dht(|d| d.port(0)))
                         .build(),
                     None => PubkyHttpClient::new(),


### PR DESCRIPTION
# Pre-submission Checklist

> For tests to work you need a working neo4j and redis instance with the example dataset in `docker/db-graph`

- [ ] **Testing**: Implement and pass new tests for the new features/fixes, `cargo nextest run`.
- [ ] **Performance**: Ensure new code has relevant performance benchmarks, `cargo bench -p nexus-webapi`

----

## Summary

Fixes the `testnet_with_host` DHT port-collision issue where clients could opportunistically bind UDP `6881`, conflicting with the static bootstrap node.

## What changed

- In `PubkyConnector::initialise` testnet path, keep host-aware config via:
  - `PubkyHttpClient::builder().testnet_with_host(host)`
- Force pkarr/mainline DHT to bind an ephemeral local port instead of default behavior:
  - `.pkarr(|p| p.dht(|d| d.port(0)))`

## Why

When DHT port is left implicit, mainline may try `6881` first. If Nexus starts before `StaticTestnet`, it can grab that port and prevent the bootstrap node from starting. Explicitly setting `port(0)` avoids competing for `6881` while preserving normal testnet host/relay/bootstrap behavior.