### PR TITLE
deps: bump `pubky-app-specs` to 0.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4135,8 +4135,9 @@ dependencies = [
 
 [[package]]
 name = "pubky-app-specs"
-version = "0.4.0"
-source = "git+https://github.com/pubky/pubky-app-specs?rev=8b05c5fe7ad4df9a3cb39005e5019f99a5e5036d#8b05c5fe7ad4df9a3cb39005e5019f99a5e5036d"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "768489143c50693e617f2efd6b2498be0c8b0ac6280b4ba59067a3afc8b01477"
 dependencies = [
  "base32",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,7 @@ opentelemetry = "0.31"
 opentelemetry_sdk = { version = "0.31", features = ["rt-tokio"] }
 # pubky = "0.5.4"
 pubky = { git = "https://github.com/pubky/pubky-core.git", package = "pubky", rev = "0ec564d746236f46553ef56888a3aef9c1096f55" }
-# pubky-app-specs = { version = "0.4.0", features = ["openapi"] }
-pubky-app-specs = { git = "https://github.com/pubky/pubky-app-specs", rev = "8b05c5fe7ad4df9a3cb39005e5019f99a5e5036d", features = ["openapi"] }
+pubky-app-specs = { version = "0.4.3", features = ["openapi"] }
 # pubky-testnet = "0.5.4"
 pubky-testnet = { git = "https://github.com/pubky/pubky-core.git", package = "pubky-testnet", rev = "0ec564d746236f46553ef56888a3aef9c1096f55" }
 serde = { version = "1.0.219", features = ["derive"] }

--- a/nexus-watcher/tests/event_processor/posts/attachments.rs
+++ b/nexus-watcher/tests/event_processor/posts/attachments.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use chrono::Utc;
 use pubky::Keypair;
 use pubky_app_specs::{
-    blob_uri_builder,
+    blob_uri_builder, file_uri_builder,
     traits::{HasIdPath, HashId},
     PubkyAppBlob, PubkyAppFile, PubkyAppPost, PubkyAppPostKind, PubkyAppUser,
 };
@@ -41,11 +41,11 @@ async fn test_homeserver_post_attachments() -> Result<()> {
         size: blob.0.len(),
         created_at: Utc::now().timestamp_millis(),
     };
-    let (file_id, file_path) = test.create_file(&user_kp, &file).await?;
+    let (file_id, _file_path) = test.create_file(&user_kp, &file).await?;
 
     assert_file_details(&user_id, &file_id, &blob_absolute_url, &file).await;
 
-    let post_attachments = Some(vec![file_path.to_string()]);
+    let post_attachments = Some(vec![file_uri_builder(user_id.clone(), file_id.clone())]);
     let post = PubkyAppPost {
         content: "Watcher:PostEvent:Post".to_string(),
         kind: PubkyAppPostKind::Short,

--- a/nexus-watcher/tests/event_processor/posts/del_with_attachments.rs
+++ b/nexus-watcher/tests/event_processor/posts/del_with_attachments.rs
@@ -7,6 +7,7 @@ use chrono::Utc;
 use nexus_common::models::{file::FileDetails, traits::Collection};
 use pubky::Keypair;
 use pubky_app_specs::{
+    blob_uri_builder, file_uri_builder,
     traits::{HasIdPath, HashId},
     PubkyAppBlob, PubkyAppFile, PubkyAppPost, PubkyAppPostKind, PubkyAppUser,
 };
@@ -34,6 +35,7 @@ async fn test_homeserver_del_post_with_attachments() -> Result<()> {
         let blob = PubkyAppBlob::new(blob_data.as_bytes().to_vec());
         let blob_id = blob.create_id();
         let blob_relative_url = PubkyAppBlob::create_path(&blob_id);
+        let blob_absolute_url = blob_uri_builder(user_id.clone(), blob_id);
 
         test.create_file_from_body(&user_kp, blob_relative_url.as_str(), blob.0.clone())
             .await?;
@@ -42,7 +44,7 @@ async fn test_homeserver_del_post_with_attachments() -> Result<()> {
         let file = PubkyAppFile {
             name: format!("post_attachment_DEL-{i}"),
             content_type: "text/plain".to_string(),
-            src: blob_relative_url.clone(),
+            src: blob_absolute_url.clone(),
             size: blob.0.len(),
             created_at: Utc::now().timestamp_millis(),
         };
@@ -51,7 +53,10 @@ async fn test_homeserver_del_post_with_attachments() -> Result<()> {
         file_ids.push(file_id);
     }
 
-    let post_attachments: Vec<String> = file_paths.iter().map(|p| p.to_string()).collect();
+    let post_attachments: Vec<String> = file_ids
+        .iter()
+        .map(|id| file_uri_builder(user_id.clone(), id.clone()))
+        .collect();
     let post = PubkyAppPost {
         content: "Watcher:DelWithAttachmentEvent:Post".to_string(),
         kind: PubkyAppPostKind::Short,


### PR DESCRIPTION
This PR bumps `pubky-app-specs` to the latest published version 0.4.3.

This version brings stronger validation, which meant some Nexus tests had to correctly use absolute attachment URIs instead of the relative ones.