### PR TITLE
Extract common `TEventProcessorRunner::run`

### DIFF
--- a/nexus-watcher/src/service/runner/homeserver.rs
+++ b/nexus-watcher/src/service/runner/homeserver.rs
@@ -1,17 +1,15 @@
 use super::TEventProcessorRunner;
 use crate::events::Moderation;
 use crate::service::indexer::{HsEventProcessor, TEventProcessor};
-use crate::service::runner::status_from_run_result;
-use crate::service::stats::{ProcessedStats, ProcessorRunStatus, RunAllProcessorsStats};
+use crate::service::stats::{ProcessedStats, RunAllProcessorsStats};
 use nexus_common::models::homeserver::Homeserver;
 use nexus_common::types::DynError;
 use nexus_common::WatcherConfig;
 use pubky_app_specs::PubkyId;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Instant;
 use tokio::sync::watch::Receiver;
-use tracing::{debug, error};
+use tracing::debug;
 
 pub struct HsEventProcessorRunner {
     /// See [WatcherConfig::events_limit]
@@ -68,32 +66,7 @@ impl TEventProcessorRunner for HsEventProcessorRunner {
     }
 
     async fn pre_run(&self) -> Result<Vec<String>, DynError> {
-        debug!("Skipping pre_run for default homeserver runner");
-        Ok(vec![])
-    }
-
-    async fn run(&self) -> Result<ProcessedStats, DynError> {
-        let hs_id = self.default_homeserver.to_string();
-        let mut run_stats = RunAllProcessorsStats::default();
-
-        let t0 = Instant::now();
-        let status = match self.build(hs_id.clone()).await {
-            Ok(event_processor) => status_from_run_result(event_processor.run().await),
-            Err(e) => {
-                error!(
-                    hs_id = %hs_id,
-                    error = %e,
-                    "Failed to build event processor for default homeserver"
-                );
-                ProcessorRunStatus::FailedToBuild
-            }
-        };
-        let duration = t0.elapsed();
-
-        run_stats.add_run_result(hs_id, duration, status);
-
-        let processed_stats = self.post_run(run_stats).await;
-        Ok(processed_stats)
+        Ok(vec![self.default_homeserver.to_string()])
     }
 
     async fn post_run(&self, stats: RunAllProcessorsStats) -> ProcessedStats {

--- a/nexus-watcher/src/service/runner/key_based.rs
+++ b/nexus-watcher/src/service/runner/key_based.rs
@@ -2,7 +2,6 @@ use super::TEventProcessorRunner;
 use crate::events::Moderation;
 use crate::service::backoff::HomeserverBackoff;
 use crate::service::indexer::{KeyBasedEventProcessor, TEventProcessor};
-use crate::service::runner::status_from_run_result;
 use crate::service::stats::{ProcessedStats, ProcessorRunStatus, RunAllProcessorsStats};
 use nexus_common::models::homeserver::Homeserver;
 use nexus_common::types::DynError;
@@ -10,9 +9,8 @@ use nexus_common::WatcherConfig;
 use pubky_app_specs::PubkyId;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Instant;
 use tokio::sync::{watch::Receiver, Mutex};
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
 pub struct KeyBasedEventProcessorRunner {
     /// See [WatcherConfig::events_limit]
@@ -91,53 +89,23 @@ impl TEventProcessorRunner for KeyBasedEventProcessorRunner {
         Ok(hs_ids[..max_index].to_vec())
     }
 
-    async fn run(&self) -> Result<ProcessedStats, DynError> {
-        let hs_ids = self.pre_run().await?;
-        let mut run_stats = RunAllProcessorsStats::default();
-
-        for hs_id in hs_ids {
-            if *self.shutdown_rx().borrow() {
-                info!(hs_id = %hs_id, "Shutdown detected; exiting run loop");
-                break;
-            }
-
-            {
-                let backoff = self.backoff.lock().await;
-                if backoff.should_skip(&hs_id) {
-                    debug!(hs_id = %hs_id, "Skipping homeserver in backoff");
-                    run_stats.add_run_result(
-                        hs_id,
-                        std::time::Duration::ZERO,
-                        ProcessorRunStatus::Skipped,
-                    );
-                    continue;
-                }
-            }
-
-            let t0 = Instant::now();
-            let status = match self.build(hs_id.clone()).await {
-                Ok(event_processor) => status_from_run_result(event_processor.run().await),
-                Err(e) => {
-                    error!(hs_id = %hs_id, error = %e, "Failed to build event processor");
-                    ProcessorRunStatus::FailedToBuild
-                }
-            };
-            let duration = t0.elapsed();
-
-            {
-                let mut backoff = self.backoff.lock().await;
-                if status == ProcessorRunStatus::Ok {
-                    backoff.record_success(&hs_id);
-                } else {
-                    backoff.record_failure(&hs_id);
-                }
-            }
-
-            run_stats.add_run_result(hs_id, duration, status);
+    async fn backoff_should_skip(&self, hs_id: &str) -> Option<ProcessorRunStatus> {
+        let backoff = self.backoff.lock().await;
+        if backoff.should_skip(hs_id) {
+            debug!(hs_id = %hs_id, "Skipping homeserver in backoff");
+            Some(ProcessorRunStatus::Skipped)
+        } else {
+            None
         }
+    }
 
-        let processed_stats = self.post_run(run_stats).await;
-        Ok(processed_stats)
+    async fn backoff_on_result(&self, hs_id: &str, status: &ProcessorRunStatus) {
+        let mut backoff = self.backoff.lock().await;
+        if *status == ProcessorRunStatus::Ok {
+            backoff.record_success(hs_id);
+        } else {
+            backoff.record_failure(hs_id);
+        }
     }
 
     async fn post_run(&self, stats: RunAllProcessorsStats) -> ProcessedStats {

--- a/nexus-watcher/src/service/runner/mod.rs
+++ b/nexus-watcher/src/service/runner/mod.rs
@@ -5,9 +5,11 @@ pub use homeserver::HsEventProcessorRunner;
 pub use key_based::KeyBasedEventProcessorRunner;
 
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use nexus_common::types::DynError;
 use tokio::sync::watch::Receiver;
+use tracing::{error, info};
 
 use crate::service::{
     indexer::{RunError, TEventProcessor},
@@ -51,14 +53,58 @@ pub trait TEventProcessorRunner: Send + Sync {
     /// Determines the list of target IDs to process in this run cycle.
     async fn pre_run(&self) -> Result<Vec<String>, DynError>;
 
-    /// Main run loop: builds and runs event processors for the relevant targets.
-    ///
-    /// # Returns
-    /// Statistics about the event processor run results, summarized as [`ProcessedStats`]
-    async fn run(&self) -> Result<ProcessedStats, DynError>;
-
     /// Post-processing of the run results.
     ///
     /// Receives the raw stats from the run and returns processed stats.
     async fn post_run(&self, stats: RunAllProcessorsStats) -> ProcessedStats;
+
+    /// Main run loop: builds and runs event processors for the relevant targets.
+    ///
+    /// # Returns
+    /// Statistics about the event processor run results, summarized as [`ProcessedStats`]
+    async fn run(&self) -> Result<ProcessedStats, DynError> {
+        let hs_ids = self.pre_run().await?;
+        let mut run_stats = RunAllProcessorsStats::default();
+
+        for hs_id in hs_ids {
+            if *self.shutdown_rx().borrow() {
+                info!(hs_id = %hs_id, "Shutdown detected; exiting run loop");
+                break;
+            }
+
+            if let Some(skip_status) = self.backoff_should_skip(&hs_id).await {
+                run_stats.add_run_result(hs_id, Duration::ZERO, skip_status);
+                continue;
+            }
+
+            let t0 = Instant::now();
+            let status = match self.build(hs_id.clone()).await {
+                Ok(event_processor) => status_from_run_result(event_processor.run().await),
+                Err(e) => {
+                    error!(hs_id = %hs_id, error = %e, "Failed to build event processor");
+                    ProcessorRunStatus::FailedToBuild
+                }
+            };
+            let duration = t0.elapsed();
+
+            self.backoff_on_result(&hs_id, &status).await;
+            run_stats.add_run_result(hs_id, duration, status);
+        }
+
+        let processed_stats = self.post_run(run_stats).await;
+        Ok(processed_stats)
+    }
+
+    /// Called before processing a homeserver, to check if backoff mechanism indicates it
+    /// should be skipped. Return `Some(status)` to skip it.
+    ///
+    /// No-op default implementation. Runners that use backoff should overwrite as needed.
+    async fn backoff_should_skip(&self, _hs_id: &str) -> Option<ProcessorRunStatus> {
+        None
+    }
+
+    /// Called after a homeserver is processed (build + run), to update its backoff status.
+    ///
+    /// No-op default implementation. Runners that use backoff should overwrite as needed.
+    async fn backoff_on_result(&self, _hs_id: &str, _status: &ProcessorRunStatus) {}
 }

--- a/nexus-watcher/tests/service/utils/processor_runner.rs
+++ b/nexus-watcher/tests/service/utils/processor_runner.rs
@@ -1,14 +1,10 @@
-use std::time::Instant;
-
 use crate::service::utils::processor::MockEventProcessor;
 use nexus_common::models::homeserver::Homeserver;
 use nexus_common::types::DynError;
-use nexus_watcher::service::runner::status_from_run_result;
-use nexus_watcher::service::stats::{ProcessedStats, ProcessorRunStatus, RunAllProcessorsStats};
+use nexus_watcher::service::stats::{ProcessedStats, RunAllProcessorsStats};
 use nexus_watcher::service::{TEventProcessor, TEventProcessorRunner};
 use std::sync::Arc;
 use tokio::sync::watch::Receiver;
-use tracing::{debug, info};
 
 /// Store processors as concrete MockEventProcessor instances.
 /// This allows access to the fields for testing purposes.
@@ -83,33 +79,6 @@ impl TEventProcessorRunner for MockEventProcessorRunner {
         let hs_ids = self.hs_by_priority().await?;
         let max_index = std::cmp::min(self.monitored_hs_limit, hs_ids.len());
         Ok(hs_ids[..max_index].to_vec())
-    }
-
-    async fn run(&self) -> Result<ProcessedStats, DynError> {
-        let hs_ids = self.pre_run().await?;
-        let mut run_stats = RunAllProcessorsStats::default();
-
-        for hs_id in hs_ids {
-            if *self.shutdown_rx().borrow() {
-                info!("Shutdown detected in homeserver {hs_id}, exiting run loop");
-                break;
-            }
-
-            let t0 = Instant::now();
-            let status = match self.build(hs_id.clone()).await {
-                Ok(event_processor) => status_from_run_result(event_processor.run().await),
-                Err(e) => {
-                    debug!("Failed to build event processor for homeserver: {hs_id}: {e}");
-                    ProcessorRunStatus::FailedToBuild
-                }
-            };
-            let duration = t0.elapsed();
-
-            run_stats.add_run_result(hs_id, duration, status);
-        }
-
-        let processed_stats = self.post_run(run_stats).await;
-        Ok(processed_stats)
     }
 
     async fn post_run(&self, stats: RunAllProcessorsStats) -> ProcessedStats {


### PR DESCRIPTION
All event processor runner implementations had an almost identical `run()` implementation.

This PR extracts it to the `TEventProcessorRunner` interface level.

Two backoff methods, which were only used for the `KeyBasedEventProcessorRunner` have no-op default implementations at the trait level, then the real implementation in `KeyBasedEventProcessorRunner`.

This PR is proposed on top of #783

---

Summary of the changes:

- `runner/mod.rs` — The trait now has a default run() implementation with two hooks:
  - `backoff_should_skip(hs_id)` → return Some(status) to skip, default None
  - `backoff_on_result(hs_id, status)` → post-processing hook, default no-op

 - `runner/homeserver.rs` — `pre_run()` now returns `vec![default_hs]` instead of empty vec. `run()` removed entirely.

 - `runner/key_based.rs` — `run()` removed. Backoff logic split into `backoff_should_skip()` and `backoff_on_result()`. 

 - `tests/.../processor_runner.rs` — `run()` removed.