### PR TITLE
fix: remove stale `HOSTED_BY` edge if no HS is found for user

### DIFF
--- a/nexus-common/src/db/graph/queries/del.rs
+++ b/nexus-common/src/db/graph/queries/del.rs
@@ -82,6 +82,16 @@ pub fn delete_tag(user_id: &str, tag_id: &str) -> Query {
     .param("tag_id", tag_id)
 }
 
+/// Removes the `HOSTED_BY` relationship from a user, if one exists.
+pub fn remove_user_homeserver(user_id: &str) -> Query {
+    Query::new(
+        "remove_user_homeserver",
+        "MATCH (u:User {id: $user_id})-[r:HOSTED_BY]->(:Homeserver)
+         DELETE r;",
+    )
+    .param("user_id", user_id.to_string())
+}
+
 /// Deletes a file node and all its relationships
 /// # Arguments
 /// * `owner_id` - The unique identifier of the user who owns the file

--- a/nexus-watcher/src/service/user_hs_resolver.rs
+++ b/nexus-watcher/src/service/user_hs_resolver.rs
@@ -49,7 +49,12 @@ async fn resolve_user(user_id: &str) -> Result<(), DynError> {
 
     let user_pk = user_id.parse::<PublicKey>()?;
     let Some(hs_pk) = pubky.get_homeserver_of(&user_pk).await else {
-        return Err(format!("User {user_id} has no published homeserver").into());
+        // No PKDNS record: remove stale HOSTED_BY edge
+        let query = queries::del::remove_user_homeserver(user_id);
+        exec_single_row(query).await?;
+
+        debug!("User {user_id} has no published homeserver, removed HOSTED_BY");
+        return Ok(());
     };
 
     let hs_id = PubkyId::try_from(&hs_pk.into_inner().to_z32())?;
@@ -237,6 +242,49 @@ mod tests {
         cleanup_test_user(user_a).await?;
         cleanup_test_user(user_b).await?;
         cleanup_test_user(user_c).await?;
+
+        Ok(())
+    }
+
+    #[tokio_shared_rt::test(shared)]
+    async fn test_remove_user_homeserver() -> Result<(), DynError> {
+        setup().await?;
+
+        let user_id = "remove_hosted_by_test_user";
+        let hs_id = "remove_hosted_by_test_hs";
+
+        create_test_user(user_id).await?;
+
+        // Assign a homeserver
+        exec_single_row(queries::put::set_user_homeserver(user_id, hs_id)).await?;
+        let users = get_user_ids_by_homeserver(hs_id).await?;
+        assert!(
+            users.contains(&user_id.to_string()),
+            "user should be hosted"
+        );
+
+        // Remove the HOSTED_BY edge
+        exec_single_row(queries::del::remove_user_homeserver(user_id)).await?;
+
+        // User is no longer listed on that homeserver
+        let users = get_user_ids_by_homeserver(hs_id).await?;
+        assert!(
+            !users.contains(&user_id.to_string()),
+            "user should no longer be hosted after removal"
+        );
+
+        // User now needs resolution again (no HOSTED_BY edge)
+        let needing = get_users_needing_resolution(3_600_000).await?;
+        assert!(
+            needing.contains(&user_id.to_string()),
+            "user without HOSTED_BY should need resolution"
+        );
+
+        // Removing again is a no-op (no error)
+        exec_single_row(queries::del::remove_user_homeserver(user_id)).await?;
+
+        // Cleanup
+        cleanup_test_user(user_id).await?;
 
         Ok(())
     }


### PR DESCRIPTION
This PR removes the `HOSTED_BY` edge, if the HS resolver task founds the user has no published HS mapping.