### PR TITLE
feat: bookmarks events handler partial recovery

### DIFF
--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -90,6 +90,18 @@ pub fn get_post_bookmarks(author_id: &str, post_id: &str) -> Query {
     .param("post_id", post_id)
 }
 
+// Read the target (post_id, author_id) for a bookmark without deleting the edge.
+// Used in sync_del to read before graph-last deletion.
+pub fn get_bookmark_target(user_id: &str, bookmark_id: &str) -> Query {
+    Query::new(
+        "get_bookmark_target",
+        "MATCH (u:User {id: $user_id})-[b:BOOKMARKED {id: $bookmark_id}]->(post:Post)<-[:AUTHORED]-(author:User)
+         RETURN post.id AS post_id, author.id AS author_id",
+    )
+    .param("user_id", user_id)
+    .param("bookmark_id", bookmark_id)
+}
+
 // Get all the reposts that a post has received (used for edit/delete notifications)
 pub fn get_post_reposts(author_id: &str, post_id: &str) -> Query {
     Query::new(

--- a/nexus-common/src/models/post/bookmark.rs
+++ b/nexus-common/src/models/post/bookmark.rs
@@ -110,6 +110,24 @@ impl Bookmark {
         Ok(())
     }
 
+    /// Reads (post_id, author_id) for a bookmark from the graph without deleting the edge.
+    pub async fn get_target_from_graph(
+        user_id: &str,
+        bookmark_id: &str,
+    ) -> GraphResult<Option<(String, String)>> {
+        let query = queries::get::get_bookmark_target(user_id, bookmark_id);
+        let rows = fetch_all_rows_from_graph(query).await?;
+
+        for row in rows {
+            let post_id: Option<String> = row.get("post_id").unwrap_or(None);
+            let author_id: Option<String> = row.get("author_id").unwrap_or(None);
+            if let (Some(post_id), Some(author_id)) = (post_id, author_id) {
+                return Ok(Some((post_id, author_id)));
+            }
+        }
+        Ok(None)
+    }
+
     pub async fn del_from_graph(
         user_id: &str,
         bookmark_id: &str,

--- a/nexus-watcher/src/events/handlers/bookmark.rs
+++ b/nexus-watcher/src/events/handlers/bookmark.rs
@@ -60,9 +60,11 @@ pub async fn del(user_id: PubkyId, bookmark_id: String) -> Result<(), EventProce
 
 pub async fn sync_del(user_id: PubkyId, bookmark_id: String) -> Result<(), EventProcessorError> {
     // 1. Read target from graph WITHOUT deleting the edge
-    let (post_id, author_id) = Bookmark::get_target_from_graph(&user_id, &bookmark_id)
-        .await?
-        .ok_or(EventProcessorError::SkipIndexing)?;
+    let Some((post_id, author_id)) =
+        Bookmark::get_target_from_graph(&user_id, &bookmark_id).await?
+    else {
+        return Ok(());
+    };
 
     // 2. Guard counter decrement: only decrement if bookmark still exists in Redis index
     let existed_in_index = Bookmark::get_from_index(&author_id, &post_id, &user_id)

--- a/nexus-watcher/src/events/handlers/bookmark.rs
+++ b/nexus-watcher/src/events/handlers/bookmark.rs
@@ -59,16 +59,27 @@ pub async fn del(user_id: PubkyId, bookmark_id: String) -> Result<(), EventProce
 }
 
 pub async fn sync_del(user_id: PubkyId, bookmark_id: String) -> Result<(), EventProcessorError> {
-    let deleted_bookmark_info = Bookmark::del_from_graph(&user_id, &bookmark_id).await?;
-    // Ensure the bookmark exists in the graph before proceeding
-    let (post_id, author_id) = match deleted_bookmark_info {
+    // 1. Read target from graph WITHOUT deleting the edge
+    let (post_id, author_id) = match Bookmark::get_target_from_graph(&user_id, &bookmark_id).await?
+    {
         Some(info) => info,
         None => return Err(EventProcessorError::SkipIndexing),
     };
 
+    // 2. Guard counter decrement: only decrement if bookmark still exists in Redis index
+    let existed_in_index = Bookmark::get_from_index(&author_id, &post_id, &user_id)
+        .await?
+        .is_some();
+
+    // 3. Redis cleanup (idempotent)
     Bookmark::del_from_index(&user_id, &post_id, &author_id).await?;
-    // Update user counts
-    UserCounts::decrement(&user_id, "bookmarks", None).await?;
+
+    if existed_in_index {
+        UserCounts::decrement(&user_id, "bookmarks", None).await?;
+    }
+
+    // 4. Graph deletion LAST — ensures data survives for retry if Redis ops fail
+    Bookmark::del_from_graph(&user_id, &bookmark_id).await?;
 
     Ok(())
 }

--- a/nexus-watcher/src/events/handlers/bookmark.rs
+++ b/nexus-watcher/src/events/handlers/bookmark.rs
@@ -60,11 +60,9 @@ pub async fn del(user_id: PubkyId, bookmark_id: String) -> Result<(), EventProce
 
 pub async fn sync_del(user_id: PubkyId, bookmark_id: String) -> Result<(), EventProcessorError> {
     // 1. Read target from graph WITHOUT deleting the edge
-    let (post_id, author_id) = match Bookmark::get_target_from_graph(&user_id, &bookmark_id).await?
-    {
-        Some(info) => info,
-        None => return Err(EventProcessorError::SkipIndexing),
-    };
+    let (post_id, author_id) = Bookmark::get_target_from_graph(&user_id, &bookmark_id)
+        .await?
+        .ok_or(EventProcessorError::SkipIndexing)?;
 
     // 2. Guard counter decrement: only decrement if bookmark still exists in Redis index
     let existed_in_index = Bookmark::get_from_index(&author_id, &post_id, &user_id)

--- a/nexus-watcher/tests/event_processor/bookmarks/del_idempotent.rs
+++ b/nexus-watcher/tests/event_processor/bookmarks/del_idempotent.rs
@@ -1,0 +1,151 @@
+use super::utils::find_post_bookmark;
+use crate::event_processor::utils::watcher::WatcherTest;
+use crate::event_processor::{
+    users::utils::find_user_counts, utils::watcher::HomeserverHashIdPath,
+};
+use anyhow::Result;
+use nexus_common::models::event::EventProcessorError;
+use nexus_common::models::post::Bookmark;
+use nexus_common::models::user::UserCounts;
+use nexus_watcher::events::handlers;
+use pubky::Keypair;
+use pubky_app_specs::{
+    post_uri_builder, traits::HashId, PubkyAppBookmark, PubkyAppPost, PubkyAppUser, PubkyId,
+};
+
+/// Simulate a retry of sync_del after a partial failure where Redis cleanup
+/// succeeded but graph deletion failed. On retry, the counter must NOT be
+/// decremented again (guarded by the Redis index check).
+#[tokio_shared_rt::test(shared)]
+async fn test_bookmark_del_retry_no_double_decrement() -> Result<()> {
+    let mut test = WatcherTest::setup().await?;
+
+    // Create user + post + bookmark through the normal watcher flow
+    let user_kp = Keypair::random();
+    let user = PubkyAppUser {
+        bio: Some("test_bookmark_del_retry_no_double_decrement".to_string()),
+        image: None,
+        links: None,
+        name: "Watcher:Bookmark:DelRetry:User".to_string(),
+        status: None,
+    };
+    let user_id = test.create_user(&user_kp, &user).await?;
+
+    let post = PubkyAppPost {
+        content: "Watcher:Bookmark:DelRetry:Post".to_string(),
+        kind: PubkyAppPost::default().kind,
+        parent: None,
+        embed: None,
+        attachments: None,
+    };
+    let (post_id, post_path) = test.create_post(&user_kp, &post).await?;
+
+    let bookmark = PubkyAppBookmark {
+        uri: post_uri_builder(user_id.clone(), post_id.clone()),
+        created_at: chrono::Utc::now().timestamp_millis(),
+    };
+    let bookmark_id = bookmark.create_id();
+    let bookmark_path = bookmark.hs_path();
+
+    test.put(&user_kp, &bookmark_path, bookmark).await?;
+
+    // Verify initial state: bookmark exists in graph + Redis, count = 1
+    assert!(find_post_bookmark(&user_id, &post_id, &user_id)
+        .await
+        .is_ok());
+    assert!(Bookmark::get_from_index(&user_id, &post_id, &user_id)
+        .await?
+        .is_some());
+    assert_eq!(find_user_counts(&user_id).await.bookmarks, 1);
+
+    // Simulate partial completion of a previous sync_del attempt:
+    // Redis cleanup succeeded (index removed + counter decremented) but graph delete failed.
+    Bookmark::del_from_index(&user_id, &post_id, &user_id).await?;
+    UserCounts::decrement(&user_id, "bookmarks", None).await?;
+
+    // Verify simulated state: graph still has edge, Redis is clean, counter = 0
+    assert!(find_post_bookmark(&user_id, &post_id, &user_id)
+        .await
+        .is_ok());
+    assert!(Bookmark::get_from_index(&user_id, &post_id, &user_id)
+        .await?
+        .is_none());
+    assert_eq!(find_user_counts(&user_id).await.bookmarks, 0);
+
+    // Retry: call sync_del directly — should complete graph cleanup without double-decrement
+    let user_pubky_id = PubkyId::try_from(user_id.as_str()).map_err(anyhow::Error::msg)?;
+    handlers::bookmark::sync_del(user_pubky_id, bookmark_id).await?;
+
+    // Verify final state: graph edge deleted, counter still 0 (not decremented again)
+    assert!(find_post_bookmark(&user_id, &post_id, &user_id)
+        .await
+        .is_err());
+    assert_eq!(find_user_counts(&user_id).await.bookmarks, 0);
+
+    // Cleanup
+    test.cleanup_post(&user_kp, &post_path).await?;
+    test.cleanup_user(&user_kp).await?;
+
+    Ok(())
+}
+
+/// After a fully successful delete, a replay of sync_del should return Ok
+#[tokio_shared_rt::test(shared)]
+async fn test_bookmark_del_replay_after_success_skips() -> Result<()> {
+    let mut test = WatcherTest::setup().await?;
+
+    let user_kp = Keypair::random();
+    let user = PubkyAppUser {
+        bio: Some("test_bookmark_del_replay_after_success_skips".to_string()),
+        image: None,
+        links: None,
+        name: "Watcher:Bookmark:DelReplay:User".to_string(),
+        status: None,
+    };
+    let user_id = test.create_user(&user_kp, &user).await?;
+
+    let post = PubkyAppPost {
+        content: "Watcher:Bookmark:DelReplay:Post".to_string(),
+        kind: PubkyAppPost::default().kind,
+        parent: None,
+        embed: None,
+        attachments: None,
+    };
+    let (post_id, post_path) = test.create_post(&user_kp, &post).await?;
+
+    let bookmark = PubkyAppBookmark {
+        uri: post_uri_builder(user_id.clone(), post_id.clone()),
+        created_at: chrono::Utc::now().timestamp_millis(),
+    };
+    let bookmark_id = bookmark.create_id();
+    let bookmark_path = bookmark.hs_path();
+
+    test.put(&user_kp, &bookmark_path, bookmark).await?;
+
+    // Delete through normal event flow
+    test.del(&user_kp, &bookmark_path).await?;
+
+    // Verify fully deleted state
+    assert!(find_post_bookmark(&user_id, &post_id, &user_id)
+        .await
+        .is_err());
+    assert_eq!(find_user_counts(&user_id).await.bookmarks, 0);
+
+    // Replay: call sync_del again — should get SkipIndexing (graph edge gone)
+    let user_pubky_id = PubkyId::try_from(user_id.as_str()).map_err(anyhow::Error::msg)?;
+    let result = handlers::bookmark::sync_del(user_pubky_id, bookmark_id).await;
+
+    assert!(
+        matches!(result, Err(EventProcessorError::SkipIndexing)),
+        "Replay after full delete should return SkipIndexing, got: {result:?}"
+    );
+
+    // Counter must remain 0
+    assert_eq!(find_user_counts(&user_id).await.bookmarks, 0);
+
+    // Cleanup
+    test.cleanup_post(&user_kp, &post_path).await?;
+    test.cleanup_user(&user_kp).await?;
+
+    Ok(())
+}

--- a/nexus-watcher/tests/event_processor/bookmarks/del_idempotent.rs
+++ b/nexus-watcher/tests/event_processor/bookmarks/del_idempotent.rs
@@ -20,16 +20,27 @@ use pubky_app_specs::{
 async fn test_bookmark_del_retry_no_double_decrement() -> Result<()> {
     let mut test = WatcherTest::setup().await?;
 
-    // Create user + post + bookmark through the normal watcher flow
-    let user_kp = Keypair::random();
-    let user = PubkyAppUser {
+    // Create post author
+    let author_kp = Keypair::random();
+    let author = PubkyAppUser {
         bio: Some("test_bookmark_del_retry_no_double_decrement".to_string()),
         image: None,
         links: None,
-        name: "Watcher:Bookmark:DelRetry:User".to_string(),
+        name: "Watcher:Bookmark:DelRetry:Author".to_string(),
         status: None,
     };
-    let user_id = test.create_user(&user_kp, &user).await?;
+    let author_id = test.create_user(&author_kp, &author).await?;
+
+    // Create bookmark owner (different user)
+    let bookmarker_kp = Keypair::random();
+    let bookmarker = PubkyAppUser {
+        bio: Some("test_bookmark_del_retry_no_double_decrement".to_string()),
+        image: None,
+        links: None,
+        name: "Watcher:Bookmark:DelRetry:Bookmarker".to_string(),
+        status: None,
+    };
+    let bookmarker_id = test.create_user(&bookmarker_kp, &bookmarker).await?;
 
     let post = PubkyAppPost {
         content: "Watcher:Bookmark:DelRetry:Post".to_string(),
@@ -38,53 +49,60 @@ async fn test_bookmark_del_retry_no_double_decrement() -> Result<()> {
         embed: None,
         attachments: None,
     };
-    let (post_id, post_path) = test.create_post(&user_kp, &post).await?;
+    let (post_id, post_path) = test.create_post(&author_kp, &post).await?;
 
     let bookmark = PubkyAppBookmark {
-        uri: post_uri_builder(user_id.clone(), post_id.clone()),
+        uri: post_uri_builder(author_id.clone(), post_id.clone()),
         created_at: chrono::Utc::now().timestamp_millis(),
     };
     let bookmark_id = bookmark.create_id();
     let bookmark_path = bookmark.hs_path();
 
-    test.put(&user_kp, &bookmark_path, bookmark).await?;
+    test.put(&bookmarker_kp, &bookmark_path, bookmark).await?;
 
     // Verify initial state: bookmark exists in graph + Redis, count = 1
-    assert!(find_post_bookmark(&user_id, &post_id, &user_id)
+    assert!(find_post_bookmark(&author_id, &post_id, &bookmarker_id)
         .await
         .is_ok());
-    assert!(Bookmark::get_from_index(&user_id, &post_id, &user_id)
-        .await?
-        .is_some());
-    assert_eq!(find_user_counts(&user_id).await.bookmarks, 1);
+    assert!(
+        Bookmark::get_from_index(&author_id, &post_id, &bookmarker_id)
+            .await?
+            .is_some()
+    );
+    assert_eq!(find_user_counts(&bookmarker_id).await.bookmarks, 1);
 
     // Simulate partial completion of a previous sync_del attempt:
     // Redis cleanup succeeded (index removed + counter decremented) but graph delete failed.
-    Bookmark::del_from_index(&user_id, &post_id, &user_id).await?;
-    UserCounts::decrement(&user_id, "bookmarks", None).await?;
+    // NOTE: del_from_index takes (bookmarker_id, post_id, author_id) — different param order than get_from_index!
+    Bookmark::del_from_index(&bookmarker_id, &post_id, &author_id).await?;
+    UserCounts::decrement(&bookmarker_id, "bookmarks", None).await?;
 
     // Verify simulated state: graph still has edge, Redis is clean, counter = 0
-    assert!(find_post_bookmark(&user_id, &post_id, &user_id)
+    assert!(find_post_bookmark(&author_id, &post_id, &bookmarker_id)
         .await
         .is_ok());
-    assert!(Bookmark::get_from_index(&user_id, &post_id, &user_id)
-        .await?
-        .is_none());
-    assert_eq!(find_user_counts(&user_id).await.bookmarks, 0);
+    assert!(
+        Bookmark::get_from_index(&author_id, &post_id, &bookmarker_id)
+            .await?
+            .is_none()
+    );
+    assert_eq!(find_user_counts(&bookmarker_id).await.bookmarks, 0);
 
     // Retry: call sync_del directly — should complete graph cleanup without double-decrement
-    let user_pubky_id = PubkyId::try_from(user_id.as_str()).map_err(anyhow::Error::msg)?;
-    handlers::bookmark::sync_del(user_pubky_id, bookmark_id).await?;
+    let bookmarker_pubky_id =
+        PubkyId::try_from(bookmarker_id.as_str()).map_err(anyhow::Error::msg)?;
+    handlers::bookmark::sync_del(bookmarker_pubky_id, bookmark_id).await?;
 
     // Verify final state: graph edge deleted, counter still 0 (not decremented again)
-    assert!(find_post_bookmark(&user_id, &post_id, &user_id)
+    assert!(find_post_bookmark(&author_id, &post_id, &bookmarker_id)
         .await
         .is_err());
-    assert_eq!(find_user_counts(&user_id).await.bookmarks, 0);
+    assert_eq!(find_user_counts(&bookmarker_id).await.bookmarks, 0);
 
     // Cleanup
-    test.cleanup_post(&user_kp, &post_path).await?;
-    test.cleanup_user(&user_kp).await?;
+    test.cleanup_post(&author_kp, &post_path).await?;
+    test.cleanup_user(&bookmarker_kp).await?;
+    test.cleanup_user(&author_kp).await?;
 
     Ok(())
 }
@@ -94,15 +112,27 @@ async fn test_bookmark_del_retry_no_double_decrement() -> Result<()> {
 async fn test_bookmark_del_replay_after_success_skips() -> Result<()> {
     let mut test = WatcherTest::setup().await?;
 
-    let user_kp = Keypair::random();
-    let user = PubkyAppUser {
+    // Create post author
+    let author_kp = Keypair::random();
+    let author = PubkyAppUser {
         bio: Some("test_bookmark_del_replay_after_success_skips".to_string()),
         image: None,
         links: None,
-        name: "Watcher:Bookmark:DelReplay:User".to_string(),
+        name: "Watcher:Bookmark:DelReplay:Author".to_string(),
         status: None,
     };
-    let user_id = test.create_user(&user_kp, &user).await?;
+    let author_id = test.create_user(&author_kp, &author).await?;
+
+    // Create bookmark owner (different user)
+    let bookmarker_kp = Keypair::random();
+    let bookmarker = PubkyAppUser {
+        bio: Some("test_bookmark_del_replay_after_success_skips".to_string()),
+        image: None,
+        links: None,
+        name: "Watcher:Bookmark:DelReplay:Bookmarker".to_string(),
+        status: None,
+    };
+    let bookmarker_id = test.create_user(&bookmarker_kp, &bookmarker).await?;
 
     let post = PubkyAppPost {
         content: "Watcher:Bookmark:DelReplay:Post".to_string(),
@@ -111,29 +141,30 @@ async fn test_bookmark_del_replay_after_success_skips() -> Result<()> {
         embed: None,
         attachments: None,
     };
-    let (post_id, post_path) = test.create_post(&user_kp, &post).await?;
+    let (post_id, post_path) = test.create_post(&author_kp, &post).await?;
 
     let bookmark = PubkyAppBookmark {
-        uri: post_uri_builder(user_id.clone(), post_id.clone()),
+        uri: post_uri_builder(author_id.clone(), post_id.clone()),
         created_at: chrono::Utc::now().timestamp_millis(),
     };
     let bookmark_id = bookmark.create_id();
     let bookmark_path = bookmark.hs_path();
 
-    test.put(&user_kp, &bookmark_path, bookmark).await?;
+    test.put(&bookmarker_kp, &bookmark_path, bookmark).await?;
 
     // Delete through normal event flow
-    test.del(&user_kp, &bookmark_path).await?;
+    test.del(&bookmarker_kp, &bookmark_path).await?;
 
     // Verify fully deleted state
-    assert!(find_post_bookmark(&user_id, &post_id, &user_id)
+    assert!(find_post_bookmark(&author_id, &post_id, &bookmarker_id)
         .await
         .is_err());
-    assert_eq!(find_user_counts(&user_id).await.bookmarks, 0);
+    assert_eq!(find_user_counts(&bookmarker_id).await.bookmarks, 0);
 
     // Replay: call sync_del again — should get SkipIndexing (graph edge gone)
-    let user_pubky_id = PubkyId::try_from(user_id.as_str()).map_err(anyhow::Error::msg)?;
-    let result = handlers::bookmark::sync_del(user_pubky_id, bookmark_id).await;
+    let bookmarker_pubky_id =
+        PubkyId::try_from(bookmarker_id.as_str()).map_err(anyhow::Error::msg)?;
+    let result = handlers::bookmark::sync_del(bookmarker_pubky_id, bookmark_id).await;
 
     assert!(
         matches!(result, Err(EventProcessorError::SkipIndexing)),
@@ -141,11 +172,12 @@ async fn test_bookmark_del_replay_after_success_skips() -> Result<()> {
     );
 
     // Counter must remain 0
-    assert_eq!(find_user_counts(&user_id).await.bookmarks, 0);
+    assert_eq!(find_user_counts(&bookmarker_id).await.bookmarks, 0);
 
     // Cleanup
-    test.cleanup_post(&user_kp, &post_path).await?;
-    test.cleanup_user(&user_kp).await?;
+    test.cleanup_post(&author_kp, &post_path).await?;
+    test.cleanup_user(&bookmarker_kp).await?;
+    test.cleanup_user(&author_kp).await?;
 
     Ok(())
 }

--- a/nexus-watcher/tests/event_processor/bookmarks/del_idempotent.rs
+++ b/nexus-watcher/tests/event_processor/bookmarks/del_idempotent.rs
@@ -73,7 +73,6 @@ async fn test_bookmark_del_retry_no_double_decrement() -> Result<()> {
 
     // Simulate partial completion of a previous sync_del attempt:
     // Redis cleanup succeeded (index removed + counter decremented) but graph delete failed.
-    // NOTE: del_from_index takes (bookmarker_id, post_id, author_id) — different param order than get_from_index!
     Bookmark::del_from_index(&bookmarker_id, &post_id, &author_id).await?;
     UserCounts::decrement(&bookmarker_id, "bookmarks", None).await?;
 

--- a/nexus-watcher/tests/event_processor/bookmarks/del_idempotent.rs
+++ b/nexus-watcher/tests/event_processor/bookmarks/del_idempotent.rs
@@ -4,7 +4,6 @@ use crate::event_processor::{
     users::utils::find_user_counts, utils::watcher::HomeserverHashIdPath,
 };
 use anyhow::Result;
-use nexus_common::models::event::EventProcessorError;
 use nexus_common::models::post::Bookmark;
 use nexus_common::models::user::UserCounts;
 use nexus_watcher::events::handlers;
@@ -160,14 +159,14 @@ async fn test_bookmark_del_replay_after_success_skips() -> Result<()> {
         .is_err());
     assert_eq!(find_user_counts(&bookmarker_id).await.bookmarks, 0);
 
-    // Replay: call sync_del again — should get SkipIndexing (graph edge gone)
+    // Replay: call sync_del again — should succeed silently (graph edge already gone)
     let bookmarker_pubky_id =
         PubkyId::try_from(bookmarker_id.as_str()).map_err(anyhow::Error::msg)?;
     let result = handlers::bookmark::sync_del(bookmarker_pubky_id, bookmark_id).await;
 
     assert!(
-        matches!(result, Err(EventProcessorError::SkipIndexing)),
-        "Replay after full delete should return SkipIndexing, got: {result:?}"
+        result.is_ok(),
+        "Replay after full delete should return Ok, got: {result:?}"
     );
 
     // Counter must remain 0

--- a/nexus-watcher/tests/event_processor/bookmarks/mod.rs
+++ b/nexus-watcher/tests/event_processor/bookmarks/mod.rs
@@ -1,4 +1,5 @@
 mod del;
+mod del_idempotent;
 mod fail_index;
 mod raw;
 mod retry_bookmark;

--- a/nexus-watcher/tests/event_processor/bookmarks/retry_bookmark.rs
+++ b/nexus-watcher/tests/event_processor/bookmarks/retry_bookmark.rs
@@ -8,6 +8,7 @@ use pubky::Keypair;
 use pubky_app_specs::{
     bookmark_uri_builder, post_uri_builder, traits::HashId, PubkyAppBookmark, PubkyAppUser,
 };
+use tokio::time;
 
 /// The user profile is stored in the homeserver. Missing the post to connect the bookmark
 #[tokio_shared_rt::test(shared)]
@@ -69,7 +70,7 @@ async fn test_homeserver_bookmark_cannot_index() -> Result<()> {
         _ => panic!("The error type has to be MissingDependency type"),
     };
 
-    // DEL bookmark
+    // DEL bookmark — bookmark was never indexed, so DEL returns Ok (no-op)
     test.del(&user_kp, &bookmark_path).await?;
 
     let del_index_key = format!(
@@ -78,21 +79,13 @@ async fn test_homeserver_bookmark_cannot_index() -> Result<()> {
         RetryEvent::generate_index_key(&bookmark_absolute_url).unwrap()
     );
 
-    assert_eventually_exists(&del_index_key).await;
-
-    let timestamp = RetryEvent::check_uri(&del_index_key).await.unwrap();
-    assert!(timestamp.is_some());
-
+    // DEL should succeed silently — no retry event created
+    time::sleep(std::time::Duration::from_millis(500)).await;
     let event_retry = RetryEvent::get_from_index(&del_index_key).await.unwrap();
-    assert!(event_retry.is_some());
-
-    let event_state = event_retry.unwrap();
-    assert_eq!(event_state.retry_count, 0);
-
-    match event_state.error_type {
-        EventProcessorError::SkipIndexing => (),
-        _ => panic!("The error type has to be SkipIndexing type"),
-    };
+    assert!(
+        event_retry.is_none(),
+        "DEL of non-existent bookmark should not create a retry event"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Prepares bookmark handlers for partial recovery.

  - Reorders sync_del to read the bookmark target from the graph before deleting the edge, ensuring data survives for retries if Redis ops fail (graph-last pattern)                                                                                    
  - Guards counter decrement behind a Redis index existence check, preventing double-decrement on retry
  - Adds get_bookmark_target graph query and Bookmark::get_target_from_graph to read without side effects           