### PR TITLE
chore: add `TEventProcessor::instance_name()`

### DIFF
--- a/nexus-watcher/src/service/indexer/homeserver.rs
+++ b/nexus-watcher/src/service/indexer/homeserver.rs
@@ -12,7 +12,6 @@ use tracing::{debug, error, info, warn};
 /// Event processor for the default homeserver
 pub struct HsEventProcessor {
     /// The default HS endpoint this processor fetches events from
-    /// TODO Used in X1 (see mod.rs)
     pub homeserver: Homeserver,
 
     /// See [WatcherConfig::events_limit]
@@ -30,6 +29,10 @@ impl TEventProcessor for HsEventProcessor {
 
     fn moderation(&self) -> &Arc<Moderation> {
         &self.moderation
+    }
+
+    fn instance_name(&self) -> String {
+        format!("HsEventProcessor with HS ID: {}", self.homeserver.id)
     }
 
     async fn run_internal(self: Arc<Self>) -> Result<(), EventProcessorError> {

--- a/nexus-watcher/src/service/indexer/key_based.rs
+++ b/nexus-watcher/src/service/indexer/key_based.rs
@@ -11,7 +11,6 @@ use crate::service::user_hs_resolver;
 /// Event processor for non-default HSs, where the user-specific `/events-stream` endpoint is used
 pub struct KeyBasedEventProcessor {
     /// The HS endpoint this processor fetches events from
-    /// TODO Used in X1 (see mod.rs)
     pub homeserver: Homeserver,
 
     pub files_path: PathBuf,
@@ -26,6 +25,10 @@ impl TEventProcessor for KeyBasedEventProcessor {
 
     fn moderation(&self) -> &Arc<Moderation> {
         &self.moderation
+    }
+
+    fn instance_name(&self) -> String {
+        format!("KeyBasedEventProcessor with HS ID: {}", self.homeserver.id)
     }
 
     async fn run_internal(self: Arc<Self>) -> Result<(), EventProcessorError> {

--- a/nexus-watcher/src/service/indexer/mod.rs
+++ b/nexus-watcher/src/service/indexer/mod.rs
@@ -56,20 +56,23 @@ pub trait TEventProcessor: Send + Sync + 'static {
     fn files_path(&self) -> &PathBuf;
     fn moderation(&self) -> &Arc<Moderation>;
 
+    /// Returns the instance name of the event processor, used in the monitoring and tracing spans.
+    ///
+    /// For instances mapped to a specific HS, this should include the HS ID.
+    fn instance_name(&self) -> String;
+
     async fn run(self: Arc<Self>) -> Result<(), RunError> {
         let timeout = self
             .custom_timeout()
             .unwrap_or(Duration::from_secs(PROCESSING_TIMEOUT_SECS));
 
-        // Extract the class name of this instance
-        let instance_type_name = std::any::type_name::<Self>();
-        // TODO X1: Ensure we are using correct instance name (incl. which HS ID is used in case of HS Runner, etc)
-        let span = tracing::info_span!("event_processor.run", service = %instance_type_name);
+        let instance_name = self.instance_name();
+        let span = tracing::info_span!("event_processor.run", service = %instance_name);
         let handle = tokio::spawn(self.run_internal().instrument(span));
 
         let join_result = tokio::time::timeout(timeout, handle)
             .await
-            .inspect_err(|_| error!("Event processor timed out for {instance_type_name}")) // TODO See X1
+            .inspect_err(|_| error!("Event processor timed out for {instance_name}"))
             .map_err(|_| RunError::TimedOut)?;
 
         // The JoinError can be:
@@ -80,14 +83,11 @@ pub trait TEventProcessor: Send + Sync + 'static {
         // In our model, we don't trigger such interruptions. Instead we use the shutdown signal
         // to gracefully stop the event processing loop. Therefore we consider all JoinErrors as panics.
         let run_internal_result = join_result
-            .inspect_err(|je| {
-                error!("JoinError while running event processor for {instance_type_name}: {je:?}")
-                // TODO See X1
-            })
+            .inspect_err(|je| error!("JoinError by event processor for {instance_name}: {je:?}"))
             .map_err(|_| RunError::Panicked)?;
 
         run_internal_result
-            .inspect_err(|e| error!("Event processor failed for {instance_type_name}: {e:?}")) // TODO See X1
+            .inspect_err(|e| error!("Event processor failed for {instance_name}: {e:?}"))
             .map_err(RunError::Internal)
     }
 
@@ -150,7 +150,7 @@ pub trait TEventProcessor: Send + Sync + 'static {
             event.r#type = %event.event_type,
             event.user_id = %event.parsed_uri.user_id,
             event.resource_id = event.parsed_uri.resource.id().unwrap_or_default(),
-            // homeserver = %self.homeserver.id, // TODO Related to X1
+            instance = %self.instance_name(),
             otel.status_code = tracing::field::Empty,
             otel.status_message = tracing::field::Empty,
         )

--- a/nexus-watcher/tests/service/utils/processor.rs
+++ b/nexus-watcher/tests/service/utils/processor.rs
@@ -41,6 +41,10 @@ impl TEventProcessor for MockEventProcessor {
         self.custom_timeout
     }
 
+    fn instance_name(&self) -> String {
+        format!("MockEventProcessor for HS ID: {}", self.homeserver_id)
+    }
+
     async fn run_internal(self: Arc<Self>) -> Result<(), EventProcessorError> {
         // Simulate a long-running task if needed, but be responsive to shutdown
         // This simulates the processing of event lines, which can take a while but can be interrupted by the shutdown signal


### PR DESCRIPTION
This PR addresses TODOs pointing to the need to define a way to get a `TEventProcessor` instance's name.