### PR TITLE
feat: add 'this week' filter

### DIFF
--- a/nexus-common/src/types/timeframe.rs
+++ b/nexus-common/src/types/timeframe.rs
@@ -6,6 +6,7 @@ use utoipa::ToSchema;
 #[serde(rename_all = "snake_case")]
 pub enum Timeframe {
     Today,
+    ThisWeek,
     ThisMonth,
     AllTime,
 }
@@ -14,6 +15,7 @@ impl Display for Timeframe {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Timeframe::Today => write!(f, "Today"),
+            Timeframe::ThisWeek => write!(f, "ThisWeek"),
             Timeframe::ThisMonth => write!(f, "ThisMonth"),
             Timeframe::AllTime => write!(f, "AllTime"),
         }
@@ -25,6 +27,7 @@ impl Timeframe {
         let now = chrono::Utc::now();
         let start = match self {
             Timeframe::Today => (now - chrono::Duration::hours(24)).timestamp_millis(),
+            Timeframe::ThisWeek => (now - chrono::Duration::days(7)).timestamp_millis(),
             Timeframe::ThisMonth => (now - chrono::Duration::days(30)).timestamp_millis(),
             Timeframe::AllTime => 0,
         };
@@ -34,6 +37,7 @@ impl Timeframe {
     pub fn to_cache_period(&self) -> i64 {
         match self {
             Timeframe::Today => 60 * 60,
+            Timeframe::ThisWeek => 60 * 60 * 6,
             Timeframe::ThisMonth => 60 * 60 * 24,
             Timeframe::AllTime => 60 * 60 * 24,
         }

--- a/nexus-webapi/tests/tags/hot.rs
+++ b/nexus-webapi/tests/tags/hot.rs
@@ -92,6 +92,23 @@ async fn test_global_hot_tags_with_today_timeframe() -> Result<()> {
 }
 
 #[tokio_shared_rt::test(shared)]
+async fn test_global_hot_tags_with_this_week_timeframe() -> Result<()> {
+    let body = get_request("/v0/tags/hot?timeframe=this_week").await?;
+
+    assert!(body.is_array());
+
+    let tags = body.as_array().expect("Stream tags should be an array");
+
+    analyse_hot_tags_structure(tags);
+
+    // "today" tagged items are within 7 days, so they should appear
+    let hot_tag = StreamTagMockup::new(String::from("today"), 3, 3, 3);
+    compare_unit_hot_tag(&tags[0], hot_tag);
+
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
 async fn test_global_hot_tags_with_this_month_timeframe() -> Result<()> {
     let body = get_request("/v0/tags/hot?timeframe=this_month").await?;
 


### PR DESCRIPTION
Northstar Item for the franky project.

Adds a 7-day timeframe option to the /v0/tags/hot endpoint, filling the gap between "today" (24h) and "this month" (30d). 
                                                                                                                            
Changes:                                                                                                                  
- Add ThisWeek variant to Timeframe enum                                                                                  
- 7-day window, 6-hour cache TTL