### PR TITLE
chore: add key_based_events_limit param in config file

### DIFF
--- a/examples/watcher/watcher-config.toml
+++ b/examples/watcher/watcher-config.toml
@@ -1,6 +1,7 @@
 testnet = false
 homeserver = "8um71us3fyw6h8wbcxb5ar3rwusy1a6u49956ikzojg3gcwd1dty"
 events_limit = 50
+key_based_events_limit = 50
 watcher_sleep = 5000
 hs_resolver_sleep = 10000
 # Initial backoff duration (in seconds) after the first failure of a homeserver

--- a/nexus-common/default.config.toml
+++ b/nexus-common/default.config.toml
@@ -14,8 +14,10 @@ testnet = false
 testnet_host = "localhost"
 # Synonym homeserver pubky
 homeserver = "8um71us3fyw6h8wbcxb5ar3rwusy1a6u49956ikzojg3gcwd1dty"
-# Maximum number of events to fetch per run from each homeserver
+# Maximum number of events to fetch per run from the default homeserver (max: 1000)
 events_limit = 50
+# Maximum events per user per run for key-based (non-default) homeservers (max: 100)
+key_based_events_limit = 50
 # Maximum number of monitored homeservers. If set to 1, only the default homeserver is monitored.
 monitored_homeservers_limit = 50
 watcher_sleep = 5000

--- a/nexus-common/src/config/daemon.rs
+++ b/nexus-common/src/config/daemon.rs
@@ -82,6 +82,7 @@ mod tests {
             PubkyId::try_from("8um71us3fyw6h8wbcxb5ar3rwusy1a6u49956ikzojg3gcwd1dty").unwrap()
         );
         assert_eq!(c.watcher.events_limit, 50);
+        assert_eq!(c.watcher.key_based_events_limit, 50);
         assert_eq!(c.watcher.watcher_sleep, 5_000);
         assert_eq!(c.watcher.hs_resolver_sleep, 10_000);
         assert_eq!(

--- a/nexus-common/src/config/mod.rs
+++ b/nexus-common/src/config/mod.rs
@@ -40,6 +40,7 @@ pub use stack::{default_stack, OtlpConfig, StackConfig};
 pub use watcher::WatcherConfig;
 pub use watcher::{
     DEFAULT_HS_RESOLVER_TTL, DEFAULT_INITIAL_BACKOFF_SECS, DEFAULT_MAX_BACKOFF_SECS,
+    MAX_EVENTS_LIMIT, MAX_KEY_BASED_EVENTS_LIMIT,
 };
 
 use crate::file::validate_and_expand_path;

--- a/nexus-common/src/config/watcher.rs
+++ b/nexus-common/src/config/watcher.rs
@@ -10,7 +10,13 @@ pub const DEFAULT_TESTNET_HOST: &str = "localhost";
 // Testnet homeserver key
 pub const HOMESERVER_PUBKY: &str = "8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo";
 /// Default for [WatcherConfig::events_limit]
-pub const DEFAULT_EVENTS_LIMIT: u32 = 1_000;
+pub const DEFAULT_EVENTS_LIMIT: u16 = 1_000;
+/// Default for [WatcherConfig::key_based_events_limit]
+pub const DEFAULT_KEY_BASED_EVENTS_LIMIT: u16 = 50;
+/// Upper bound for [WatcherConfig::events_limit]
+pub const MAX_EVENTS_LIMIT: u16 = 1_000;
+/// Upper bound for [WatcherConfig::key_based_events_limit]
+pub const MAX_KEY_BASED_EVENTS_LIMIT: u16 = 100;
 /// Default for [WatcherConfig::monitored_homeservers_limit]
 pub const DEFAULT_MONITORED_HOMESERVERS_LIMIT: usize = 50;
 /// Default for [WatcherConfig::watcher_sleep]
@@ -44,8 +50,13 @@ pub struct WatcherConfig {
     /// Default homeserver. Other homeservers may be ingested in addition, but this one is prioritized.
     pub homeserver: PubkyId,
 
-    /// Maximum number of events to fetch per run from each homeserver
-    pub events_limit: u32,
+    /// Maximum number of events to fetch per run from the default homeserver.
+    /// Clamped to [MAX_EVENTS_LIMIT] at load time.
+    pub events_limit: u16,
+
+    /// Maximum events per user per run for key-based (non-default) homeservers.
+    /// Clamped to [MAX_KEY_BASED_EVENTS_LIMIT] at load time.
+    pub key_based_events_limit: u16,
 
     /// Maximum number of monitored homeservers
     pub monitored_homeservers_limit: usize,
@@ -91,6 +102,7 @@ impl Default for WatcherConfig {
             testnet_host: DEFAULT_TESTNET_HOST.to_string(),
             homeserver,
             events_limit: DEFAULT_EVENTS_LIMIT,
+            key_based_events_limit: DEFAULT_KEY_BASED_EVENTS_LIMIT,
             monitored_homeservers_limit: DEFAULT_MONITORED_HOMESERVERS_LIMIT,
             watcher_sleep: DEFAULT_WATCHER_SLEEP,
             hs_resolver_sleep: DEFAULT_HS_RESOLVER_SLEEP,

--- a/nexus-watcher/src/service/indexer/homeserver.rs
+++ b/nexus-watcher/src/service/indexer/homeserver.rs
@@ -16,7 +16,7 @@ pub struct HsEventProcessor {
     pub homeserver: Homeserver,
 
     /// See [WatcherConfig::events_limit]
-    pub limit: u32,
+    pub limit: u16,
     pub files_path: PathBuf,
     pub moderation: Arc<Moderation>,
     pub shutdown_rx: Receiver<bool>,

--- a/nexus-watcher/src/service/runner/homeserver.rs
+++ b/nexus-watcher/src/service/runner/homeserver.rs
@@ -3,15 +3,16 @@ use crate::events::Moderation;
 use crate::service::indexer::{HsEventProcessor, TEventProcessor};
 use nexus_common::models::homeserver::Homeserver;
 use nexus_common::types::DynError;
-use nexus_common::WatcherConfig;
+use nexus_common::{WatcherConfig, MAX_EVENTS_LIMIT};
 use pubky_app_specs::PubkyId;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::watch::Receiver;
+use tracing::warn;
 
 pub struct HsEventProcessorRunner {
     /// See [WatcherConfig::events_limit]
-    pub limit: u32,
+    pub limit: u16,
     pub files_path: PathBuf,
     pub moderation: Arc<Moderation>,
     pub shutdown_rx: Receiver<bool>,
@@ -22,8 +23,16 @@ pub struct HsEventProcessorRunner {
 impl HsEventProcessorRunner {
     /// Creates a new instance from the provided configuration
     pub fn from_config(config: &WatcherConfig, shutdown_rx: Receiver<bool>) -> Self {
+        let limit = config.events_limit.min(MAX_EVENTS_LIMIT);
+        if config.events_limit > MAX_EVENTS_LIMIT {
+            warn!(
+                "events_limit ({}) exceeds max ({}), clamped",
+                config.events_limit, MAX_EVENTS_LIMIT
+            );
+        }
+
         Self {
-            limit: config.events_limit,
+            limit,
             files_path: config.stack.files_path.clone(),
             moderation: Arc::new(Moderation {
                 id: config.moderation_id.clone(),

--- a/nexus-watcher/src/service/runner/key_based.rs
+++ b/nexus-watcher/src/service/runner/key_based.rs
@@ -6,6 +6,7 @@ use crate::service::stats::{ProcessedStats, ProcessorRunStatus, RunAllProcessors
 use nexus_common::models::homeserver::Homeserver;
 use nexus_common::types::DynError;
 use nexus_common::WatcherConfig;
+use nexus_common::MAX_KEY_BASED_EVENTS_LIMIT;
 use pubky_app_specs::PubkyId;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -14,8 +15,8 @@ use tracing::{debug, info, warn};
 
 /// Runner for [KeyBasedEventProcessor]
 pub struct KeyBasedEventProcessorRunner {
-    /// See [WatcherConfig::events_limit]
-    pub limit: u32,
+    /// See [WatcherConfig::key_based_events_limit]
+    pub limit: u16,
     /// See [WatcherConfig::monitored_homeservers_limit]
     pub monitored_hs_limit: usize,
     pub files_path: PathBuf,
@@ -30,8 +31,18 @@ pub struct KeyBasedEventProcessorRunner {
 impl KeyBasedEventProcessorRunner {
     /// Creates a new instance from the provided configuration
     pub fn from_config(config: &WatcherConfig, shutdown_rx: Receiver<bool>) -> Self {
+        let limit = config
+            .key_based_events_limit
+            .min(MAX_KEY_BASED_EVENTS_LIMIT);
+        if config.key_based_events_limit > MAX_KEY_BASED_EVENTS_LIMIT {
+            warn!(
+                "key_based_events_limit ({}) exceeds max ({}), clamped",
+                config.key_based_events_limit, MAX_KEY_BASED_EVENTS_LIMIT
+            );
+        }
+
         Self {
-            limit: config.events_limit,
+            limit,
             monitored_hs_limit: config.monitored_homeservers_limit,
             files_path: config.stack.files_path.clone(),
             moderation: Arc::new(Moderation {
@@ -78,7 +89,7 @@ impl TEventProcessorRunner for KeyBasedEventProcessorRunner {
 
         Ok(Arc::new(KeyBasedEventProcessor {
             homeserver,
-            limit: self.limit.try_into().unwrap_or(u16::MAX),
+            limit: self.limit,
             files_path: self.files_path.clone(),
             moderation: self.moderation.clone(),
             shutdown_rx: self.shutdown_rx.clone(),


### PR DESCRIPTION
## Pre-submission Checklist

> For tests to work you need a working neo4j and redis instance with the example dataset in `docker/db-graph`

- [ ] **Testing**: Implement and pass new tests for the new features/fixes, `cargo nextest run`.
- [ ] **Performance**: Ensure new code has relevant performance benchmarks, `cargo bench -p nexus-webapi`

## Summary
Separates the event stream limit for key-based (non-default) homeservers from the default homeserver's events_limit, since they have fundamentally different semantics: one is a bulk `batch` size, the other is a `per-user` SSE stream cap.

## Changes
- Added `key_based_events_limit (u16)` as a required field in WatcherConfig, with _MAX_KEY_BASED_EVENTS_LIMIT = 100_.
- Changed `events_limit` from u32 to u16, with _MAX_EVENTS_LIMIT = 1,000_.
- Both limits are warn-and-clamped at startup if the configured value exceeds the maximum.
- Removed the u32 -> u16 conversion hack (try_into().unwrap_or(u16::MAX)) in the key-based runner.