### PR TITLE
feat: follow events handlers partial recovery

### DIFF
--- a/nexus-watcher/src/events/handlers/follow.rs
+++ b/nexus-watcher/src/events/handlers/follow.rs
@@ -91,7 +91,7 @@ pub async fn sync_del(
     follower_id: PubkyId,
     followee_id: PubkyId,
 ) -> Result<(), EventProcessorError> {
-    // Check friendship while graph edge still exists
+    // Check friendship while Redis follow sets are still populated
     let were_friends = Friends::check(&follower_id, &followee_id).await?;
 
     // Guard counters/notifications: only run if still in Redis index (first attempt).

--- a/nexus-watcher/src/events/handlers/follow.rs
+++ b/nexus-watcher/src/events/handlers/follow.rs
@@ -19,8 +19,22 @@ pub async fn sync_put(
     // SAVE TO GRAPH
     // (follower_id)-[:FOLLOWS]->(followee_id)
     match Followers::put_to_graph(&follower_id, &followee_id).await? {
-        // Do not duplicate the follow relationship
-        OperationOutcome::Updated => return Ok(()),
+        OperationOutcome::Updated => {
+            // Retry / duplicate: graph edge already exists.
+            // Re-run idempotent index writes (SADD is a no-op for existing members)
+            // to recover from partial failures where graph wrote but indexes didn't.
+            // Skip counters and notifications (prefer 0 over N).
+            let followers = Followers(vec![follower_id.to_string()]);
+            let following = Following(vec![followee_id.to_string()]);
+            let indexing_results = nexus_common::traced_join!(
+                tracing::info_span!("index.write");
+                followers.put_to_index(&followee_id),
+                following.put_to_index(&follower_id)
+            );
+            indexing_results.0?;
+            indexing_results.1?;
+            return Ok(());
+        }
         OperationOutcome::MissingDependency => {
             if let Err(e) = Homeserver::maybe_ingest_for_user(followee_id.as_str()).await {
                 tracing::error!("Failed to ingest homeserver: {e}");
@@ -77,41 +91,41 @@ pub async fn sync_del(
     follower_id: PubkyId,
     followee_id: PubkyId,
 ) -> Result<(), EventProcessorError> {
-    match Followers::del_from_graph(&follower_id, &followee_id).await? {
-        // Both users exists but they do not have that relationship
-        OperationOutcome::Updated => Ok(()),
-        OperationOutcome::MissingDependency => Err(EventProcessorError::SkipIndexing),
-        OperationOutcome::CreatedOrDeleted => {
-            // Check if the users are friends. Is this a break? :(
-            let were_friends = Friends::check(&follower_id, &followee_id).await?;
+    // Check friendship while graph edge still exists
+    let were_friends = Friends::check(&follower_id, &followee_id).await?;
 
-            // REMOVE FROM INDEX
-            let followers = Followers(vec![follower_id.to_string()]);
-            let following = Following(vec![followee_id.to_string()]);
+    // Guard counters/notifications: only run if still in Redis index (first attempt).
+    // On retry (Redis already cleaned, graph edge still present), skip non-idempotent ops.
+    let still_indexed = Followers::check_in_index(&followee_id, &follower_id).await?;
 
-            let indexing_results = nexus_common::traced_join!(
-                tracing::info_span!("index.delete");
-                // Remove a follower to the followee index
-                followers.del_from_index(&followee_id),
-                // Remove from the Following:follower_id index a followee user
-                following.del_from_index(&follower_id),
-                update_follow_counts(
-                    &follower_id,
-                    &followee_id,
-                    JsonAction::Decrement(1),
-                    were_friends,
-                ),
-                // Notify the followee
-                Notification::lost_follow(&follower_id, &followee_id, were_friends)
-            );
-            indexing_results.0?;
-            indexing_results.1?;
-            indexing_results.2?;
-            indexing_results.3?;
+    let followers = Followers(vec![follower_id.to_string()]);
+    let following = Following(vec![followee_id.to_string()]);
 
-            Ok(())
-        }
+    // Redis cleanup first — SREM is idempotent
+    let indexing_results = nexus_common::traced_join!(
+        tracing::info_span!("index.delete");
+        followers.del_from_index(&followee_id),
+        following.del_from_index(&follower_id)
+    );
+    indexing_results.0?;
+    indexing_results.1?;
+
+    // Only after indexes are confirmed clean: non-idempotent ops
+    if still_indexed {
+        update_follow_counts(
+            &follower_id,
+            &followee_id,
+            JsonAction::Decrement(1),
+            were_friends,
+        )
+        .await?;
+        Notification::lost_follow(&follower_id, &followee_id, were_friends).await?;
     }
+
+    // Graph deletion LAST — on retry, we re-enter here with indexes already clean.
+    // MissingDependency means the resource is already gone — deletion is complete.
+    Followers::del_from_graph(&follower_id, &followee_id).await?;
+    Ok(())
 }
 
 async fn update_follow_counts(

--- a/nexus-watcher/tests/event_processor/follows/del_idempotent.rs
+++ b/nexus-watcher/tests/event_processor/follows/del_idempotent.rs
@@ -1,0 +1,305 @@
+use super::utils::find_follow_relationship;
+use crate::event_processor::users::utils::find_user_counts;
+use crate::event_processor::utils::watcher::WatcherTest;
+use anyhow::Result;
+use nexus_common::{
+    db::kv::JsonAction,
+    db::RedisOps,
+    models::{
+        follow::{Followers, Following, UserFollows},
+        user::UserCounts,
+    },
+};
+use nexus_watcher::events::handlers::follow;
+use pubky::Keypair;
+use pubky_app_specs::{PubkyAppUser, PubkyId};
+
+/// Test that calling sync_del twice (simulating a retry) does not produce
+/// negative counts or corrupt indexes.
+#[tokio_shared_rt::test(shared)]
+async fn test_follow_del_idempotent() -> Result<()> {
+    let mut test = WatcherTest::setup().await?;
+
+    // Create follower
+    let follower_kp = Keypair::random();
+    let follower_user = PubkyAppUser {
+        bio: Some("test_follow_del_idempotent".to_string()),
+        image: None,
+        links: None,
+        name: "Watcher:IdempotentDel:Follower".to_string(),
+        status: None,
+    };
+    let follower_id = test.create_user(&follower_kp, &follower_user).await?;
+
+    // Create followee
+    let followee_kp = Keypair::random();
+    let followee_user = PubkyAppUser {
+        bio: Some("test_follow_del_idempotent".to_string()),
+        image: None,
+        links: None,
+        name: "Watcher:IdempotentDel:Followee".to_string(),
+        status: None,
+    };
+    let followee_id = test.create_user(&followee_kp, &followee_user).await?;
+
+    // Create follow and then unfollow (normal flow)
+    let follow_url = test.create_follow(&follower_kp, &followee_id).await?;
+    test.del(&follower_kp, &follow_url).await?;
+
+    // Verify initial state after unfollow: counts = 0
+    let followee_counts = find_user_counts(&followee_id).await;
+    assert_eq!(
+        followee_counts.followers, 0,
+        "Followee should have 0 followers"
+    );
+    let follower_counts = find_user_counts(&follower_id).await;
+    assert_eq!(
+        follower_counts.following, 0,
+        "Follower should be following 0"
+    );
+
+    // Verify index membership cleared
+    let (_, is_follower) = Followers::check_set_member(&[&followee_id], &follower_id).await?;
+    assert!(
+        !is_follower,
+        "Follower should not be in followee's follower set"
+    );
+    let (_, is_following) = Following::check_set_member(&[&follower_id], &followee_id).await?;
+    assert!(
+        !is_following,
+        "Followee should not be in follower's following set"
+    );
+
+    // Verify graph relationship removed
+    let exists = find_follow_relationship(&follower_id, &followee_id).await?;
+    assert!(!exists, "Follow relationship should not exist in graph");
+
+    // Simulate retry: call sync_del directly with the same follower/followee
+    let follower_pubky = PubkyId::try_from(follower_id.as_str()).map_err(|e| anyhow::anyhow!(e))?;
+    let followee_pubky = PubkyId::try_from(followee_id.as_str()).map_err(|e| anyhow::anyhow!(e))?;
+    follow::sync_del(follower_pubky, followee_pubky).await?;
+
+    // Verify counts are still 0 (not negative)
+    let followee_counts = find_user_counts(&followee_id).await;
+    assert_eq!(
+        followee_counts.followers, 0,
+        "Followee should still have 0 followers after retry"
+    );
+    let follower_counts = find_user_counts(&follower_id).await;
+    assert_eq!(
+        follower_counts.following, 0,
+        "Follower should still be following 0 after retry"
+    );
+
+    // Verify index membership still cleared
+    let (_, is_follower) = Followers::check_set_member(&[&followee_id], &follower_id).await?;
+    assert!(
+        !is_follower,
+        "Follower should still not be in followee's follower set after retry"
+    );
+    let (_, is_following) = Following::check_set_member(&[&follower_id], &followee_id).await?;
+    assert!(
+        !is_following,
+        "Followee should still not be in follower's following set after retry"
+    );
+
+    // Cleanup
+    test.cleanup_user(&follower_kp).await?;
+    test.cleanup_user(&followee_kp).await?;
+
+    Ok(())
+}
+
+/// Test partial failure recovery: the original DEL attempt failed before SREM
+/// and counter decrement ran, so indexes and counters still reflect the PUT
+/// state (stale). On retry, sync_del should clean up indexes and decrement
+/// counters exactly once (from 1 to 0), not double-decrement.
+#[tokio_shared_rt::test(shared)]
+async fn test_follow_del_recovers_stale_indexes() -> Result<()> {
+    let mut test = WatcherTest::setup().await?;
+
+    // Create follower
+    let follower_kp = Keypair::random();
+    let follower_user = PubkyAppUser {
+        bio: Some("test_follow_del_recovers_stale_indexes".to_string()),
+        image: None,
+        links: None,
+        name: "Watcher:RecoverDel:Follower".to_string(),
+        status: None,
+    };
+    let follower_id = test.create_user(&follower_kp, &follower_user).await?;
+
+    // Create followee
+    let followee_kp = Keypair::random();
+    let followee_user = PubkyAppUser {
+        bio: Some("test_follow_del_recovers_stale_indexes".to_string()),
+        image: None,
+        links: None,
+        name: "Watcher:RecoverDel:Followee".to_string(),
+        status: None,
+    };
+    let followee_id = test.create_user(&followee_kp, &followee_user).await?;
+
+    // Create follow and then unfollow (normal flow — everything completes)
+    let follow_url = test.create_follow(&follower_kp, &followee_id).await?;
+    test.del(&follower_kp, &follow_url).await?;
+
+    // Verify clean state: counts = 0, indexes cleared
+    let followee_counts = find_user_counts(&followee_id).await;
+    assert_eq!(followee_counts.followers, 0);
+    let follower_counts = find_user_counts(&follower_id).await;
+    assert_eq!(follower_counts.following, 0);
+
+    // Simulate partial failure: restore indexes and counters to their PUT state
+    // as if the original DEL never ran SREM or counter decrement.
+    let followers = Followers(vec![follower_id.to_string()]);
+    let following = Following(vec![followee_id.to_string()]);
+    followers.put_to_index(&followee_id).await?;
+    following.put_to_index(&follower_id).await?;
+    UserCounts::update_index_field(&followee_id, "followers", JsonAction::Increment(1)).await?;
+    UserCounts::update_index_field(&follower_id, "following", JsonAction::Increment(1)).await?;
+
+    // Verify stale state: indexes present, counters = 1
+    let (_, is_follower) = Followers::check_set_member(&[&followee_id], &follower_id).await?;
+    assert!(is_follower, "Stale follower index should be present");
+    let (_, is_following) = Following::check_set_member(&[&follower_id], &followee_id).await?;
+    assert!(is_following, "Stale following index should be present");
+    let followee_counts = find_user_counts(&followee_id).await;
+    assert_eq!(
+        followee_counts.followers, 1,
+        "Followee should have 1 follower (stale)"
+    );
+    let follower_counts = find_user_counts(&follower_id).await;
+    assert_eq!(
+        follower_counts.following, 1,
+        "Follower should be following 1 (stale)"
+    );
+
+    // Simulate retry: sync_del sees stale indexes, decrements counters once, cleans up
+    let follower_pubky = PubkyId::try_from(follower_id.as_str()).map_err(|e| anyhow::anyhow!(e))?;
+    let followee_pubky = PubkyId::try_from(followee_id.as_str()).map_err(|e| anyhow::anyhow!(e))?;
+    follow::sync_del(follower_pubky, followee_pubky).await?;
+
+    // Verify both stale indexes are cleaned up
+    let (_, is_follower) = Followers::check_set_member(&[&followee_id], &follower_id).await?;
+    assert!(
+        !is_follower,
+        "Stale follower index should be cleaned up after retry"
+    );
+    let (_, is_following) = Following::check_set_member(&[&follower_id], &followee_id).await?;
+    assert!(
+        !is_following,
+        "Stale following index should be cleaned up after retry"
+    );
+
+    // Verify counts decremented from 1 to 0 (exactly once, not double-decremented)
+    let followee_counts = find_user_counts(&followee_id).await;
+    assert_eq!(
+        followee_counts.followers, 0,
+        "Follower count should be 0 after recovery (was 1)"
+    );
+    let follower_counts = find_user_counts(&follower_id).await;
+    assert_eq!(
+        follower_counts.following, 0,
+        "Following count should be 0 after recovery (was 1)"
+    );
+
+    // Cleanup
+    test.cleanup_user(&follower_kp).await?;
+    test.cleanup_user(&followee_kp).await?;
+
+    Ok(())
+}
+
+/// Test that retrying an unfollow between friends does not double-decrement
+/// the friends counter for either user.
+#[tokio_shared_rt::test(shared)]
+async fn test_follow_del_friends_idempotent() -> Result<()> {
+    let mut test = WatcherTest::setup().await?;
+
+    // Create user A
+    let a_kp = Keypair::random();
+    let a_user = PubkyAppUser {
+        bio: Some("test_follow_del_friends_idempotent".to_string()),
+        image: None,
+        links: None,
+        name: "Watcher:FriendsDel:A".to_string(),
+        status: None,
+    };
+    let a_id = test.create_user(&a_kp, &a_user).await?;
+
+    // Create user B
+    let b_kp = Keypair::random();
+    let b_user = PubkyAppUser {
+        bio: Some("test_follow_del_friends_idempotent".to_string()),
+        image: None,
+        links: None,
+        name: "Watcher:FriendsDel:B".to_string(),
+        status: None,
+    };
+    let b_id = test.create_user(&b_kp, &b_user).await?;
+
+    // Mutual follow: A→B and B→A (makes them friends)
+    let a_follows_b = test.create_follow(&a_kp, &b_id).await?;
+    test.create_follow(&b_kp, &a_id).await?;
+
+    // Verify friendship: both have friends = 1
+    let a_counts = find_user_counts(&a_id).await;
+    assert_eq!(a_counts.friends, 1, "A should have 1 friend");
+    let b_counts = find_user_counts(&b_id).await;
+    assert_eq!(b_counts.friends, 1, "B should have 1 friend");
+
+    // A unfollows B (breaks friendship)
+    test.del(&a_kp, &a_follows_b).await?;
+
+    // Verify friendship broken: both have friends = 0
+    let a_counts = find_user_counts(&a_id).await;
+    assert_eq!(
+        a_counts.friends, 0,
+        "A should have 0 friends after unfollow"
+    );
+    assert_eq!(a_counts.following, 0, "A should be following 0");
+    let b_counts = find_user_counts(&b_id).await;
+    assert_eq!(
+        b_counts.friends, 0,
+        "B should have 0 friends after unfollow"
+    );
+    assert_eq!(b_counts.followers, 0, "B should have 0 followers");
+
+    // Simulate retry: call sync_del again for A→B
+    let a_pubky = PubkyId::try_from(a_id.as_str()).map_err(|e| anyhow::anyhow!(e))?;
+    let b_pubky = PubkyId::try_from(b_id.as_str()).map_err(|e| anyhow::anyhow!(e))?;
+    follow::sync_del(a_pubky, b_pubky).await?;
+
+    // Verify counts unchanged (friends not double-decremented)
+    let a_counts = find_user_counts(&a_id).await;
+    assert_eq!(
+        a_counts.friends, 0,
+        "A should still have 0 friends after retry"
+    );
+    assert_eq!(
+        a_counts.following, 0,
+        "A following should still be 0 after retry"
+    );
+    let b_counts = find_user_counts(&b_id).await;
+    assert_eq!(
+        b_counts.friends, 0,
+        "B should still have 0 friends after retry"
+    );
+    assert_eq!(
+        b_counts.followers, 0,
+        "B followers should still be 0 after retry"
+    );
+
+    // B's follow toward A should be unaffected
+    let b_counts = find_user_counts(&b_id).await;
+    assert_eq!(b_counts.following, 1, "B should still be following 1 (A)");
+    let a_counts = find_user_counts(&a_id).await;
+    assert_eq!(a_counts.followers, 1, "A should still have 1 follower (B)");
+
+    // Cleanup
+    test.cleanup_user(&a_kp).await?;
+    test.cleanup_user(&b_kp).await?;
+
+    Ok(())
+}

--- a/nexus-watcher/tests/event_processor/follows/del_idempotent.rs
+++ b/nexus-watcher/tests/event_processor/follows/del_idempotent.rs
@@ -75,8 +75,8 @@ async fn test_follow_del_idempotent() -> Result<()> {
     assert!(!exists, "Follow relationship should not exist in graph");
 
     // Simulate retry: call sync_del directly with the same follower/followee
-    let follower_pubky = PubkyId::try_from(follower_id.as_str()).map_err(|e| anyhow::anyhow!(e))?;
-    let followee_pubky = PubkyId::try_from(followee_id.as_str()).map_err(|e| anyhow::anyhow!(e))?;
+    let follower_pubky = PubkyId::from(follower_kp.clone());
+    let followee_pubky = PubkyId::from(followee_kp.clone());
     follow::sync_del(follower_pubky, followee_pubky).await?;
 
     // Verify counts are still 0 (not negative)
@@ -176,8 +176,8 @@ async fn test_follow_del_recovers_stale_indexes() -> Result<()> {
     );
 
     // Simulate retry: sync_del sees stale indexes, decrements counters once, cleans up
-    let follower_pubky = PubkyId::try_from(follower_id.as_str()).map_err(|e| anyhow::anyhow!(e))?;
-    let followee_pubky = PubkyId::try_from(followee_id.as_str()).map_err(|e| anyhow::anyhow!(e))?;
+    let follower_pubky = PubkyId::from(follower_kp.clone());
+    let followee_pubky = PubkyId::from(followee_kp.clone());
     follow::sync_del(follower_pubky, followee_pubky).await?;
 
     // Verify both stale indexes are cleaned up
@@ -267,8 +267,8 @@ async fn test_follow_del_friends_idempotent() -> Result<()> {
     assert_eq!(b_counts.followers, 0, "B should have 0 followers");
 
     // Simulate retry: call sync_del again for A→B
-    let a_pubky = PubkyId::try_from(a_id.as_str()).map_err(|e| anyhow::anyhow!(e))?;
-    let b_pubky = PubkyId::try_from(b_id.as_str()).map_err(|e| anyhow::anyhow!(e))?;
+    let a_pubky = PubkyId::from(a_kp.public_key());
+    let b_pubky = PubkyId::from(b_kp.public_key());
     follow::sync_del(a_pubky, b_pubky).await?;
 
     // Verify counts unchanged (friends not double-decremented)

--- a/nexus-watcher/tests/event_processor/follows/mod.rs
+++ b/nexus-watcher/tests/event_processor/follows/mod.rs
@@ -1,10 +1,12 @@
 mod del;
 mod del_friends;
+mod del_idempotent;
 mod del_notification;
 mod del_sequential;
 mod fail_index;
 mod put;
 mod put_friends;
+mod put_idempotent;
 mod put_notification;
 mod put_sequential;
 mod retry_follow;

--- a/nexus-watcher/tests/event_processor/follows/put_idempotent.rs
+++ b/nexus-watcher/tests/event_processor/follows/put_idempotent.rs
@@ -71,8 +71,8 @@ async fn test_follow_put_idempotent() -> Result<()> {
     let notification_count_before = notifications_before.len();
 
     // Simulate retry: call sync_put directly with the same follower/followee
-    let follower_pubky = PubkyId::try_from(follower_id.as_str()).map_err(|e| anyhow::anyhow!(e))?;
-    let followee_pubky = PubkyId::try_from(followee_id.as_str()).map_err(|e| anyhow::anyhow!(e))?;
+    let follower_pubky = PubkyId::from(follower_kp.clone());
+    let followee_pubky = PubkyId::from(followee_kp.clone());
     follow::sync_put(follower_pubky, followee_pubky).await?;
 
     // Verify counts are unchanged (not doubled)
@@ -167,8 +167,8 @@ async fn test_follow_put_recovers_missing_indexes() -> Result<()> {
     let notifications_before = Notification::get_by_id(&followee_id, Pagination::default()).await?;
 
     // Simulate retry: sync_put hits Updated (graph edge exists) and runs recovery
-    let follower_pubky = PubkyId::try_from(follower_id.as_str()).map_err(|e| anyhow::anyhow!(e))?;
-    let followee_pubky = PubkyId::try_from(followee_id.as_str()).map_err(|e| anyhow::anyhow!(e))?;
+    let follower_pubky = PubkyId::from(follower_kp.clone());
+    let followee_pubky = PubkyId::from(followee_kp.clone());
     follow::sync_put(follower_pubky, followee_pubky).await?;
 
     // Verify both indexes are recovered

--- a/nexus-watcher/tests/event_processor/follows/put_idempotent.rs
+++ b/nexus-watcher/tests/event_processor/follows/put_idempotent.rs
@@ -1,0 +1,206 @@
+use super::utils::find_follow_relationship;
+use crate::event_processor::users::utils::find_user_counts;
+use crate::event_processor::utils::watcher::WatcherTest;
+use anyhow::Result;
+use nexus_common::{
+    db::RedisOps,
+    models::{
+        follow::{Followers, Following, UserFollows},
+        notification::Notification,
+    },
+    types::Pagination,
+};
+use nexus_watcher::events::handlers::follow;
+use pubky::Keypair;
+use pubky_app_specs::{PubkyAppUser, PubkyId};
+
+/// Test that calling sync_put twice (simulating a retry) does not double
+/// counters, duplicate index entries, or create extra notifications.
+#[tokio_shared_rt::test(shared)]
+async fn test_follow_put_idempotent() -> Result<()> {
+    let mut test = WatcherTest::setup().await?;
+
+    // Create follower
+    let follower_kp = Keypair::random();
+    let follower_user = PubkyAppUser {
+        bio: Some("test_follow_put_idempotent".to_string()),
+        image: None,
+        links: None,
+        name: "Watcher:IdempotentPut:Follower".to_string(),
+        status: None,
+    };
+    let follower_id = test.create_user(&follower_kp, &follower_user).await?;
+
+    // Create followee
+    let followee_kp = Keypair::random();
+    let followee_user = PubkyAppUser {
+        bio: Some("test_follow_put_idempotent".to_string()),
+        image: None,
+        links: None,
+        name: "Watcher:IdempotentPut:Followee".to_string(),
+        status: None,
+    };
+    let followee_id = test.create_user(&followee_kp, &followee_user).await?;
+
+    // First follow (normal flow through event processing)
+    test.create_follow(&follower_kp, &followee_id).await?;
+
+    // Verify initial state: counts = 1
+    let followee_counts = find_user_counts(&followee_id).await;
+    assert_eq!(
+        followee_counts.followers, 1,
+        "Followee should have 1 follower"
+    );
+    let follower_counts = find_user_counts(&follower_id).await;
+    assert_eq!(
+        follower_counts.following, 1,
+        "Follower should be following 1"
+    );
+
+    // Verify index membership
+    let (_, is_follower) = Followers::check_set_member(&[&followee_id], &follower_id).await?;
+    assert!(is_follower, "Follower should be in followee's follower set");
+    let (_, is_following) = Following::check_set_member(&[&follower_id], &followee_id).await?;
+    assert!(
+        is_following,
+        "Followee should be in follower's following set"
+    );
+
+    // Count notifications before retry
+    let notifications_before = Notification::get_by_id(&followee_id, Pagination::default()).await?;
+    let notification_count_before = notifications_before.len();
+
+    // Simulate retry: call sync_put directly with the same follower/followee
+    let follower_pubky = PubkyId::try_from(follower_id.as_str()).map_err(|e| anyhow::anyhow!(e))?;
+    let followee_pubky = PubkyId::try_from(followee_id.as_str()).map_err(|e| anyhow::anyhow!(e))?;
+    follow::sync_put(follower_pubky, followee_pubky).await?;
+
+    // Verify counts are unchanged (not doubled)
+    let followee_counts = find_user_counts(&followee_id).await;
+    assert_eq!(
+        followee_counts.followers, 1,
+        "Followee should still have 1 follower after retry"
+    );
+    let follower_counts = find_user_counts(&follower_id).await;
+    assert_eq!(
+        follower_counts.following, 1,
+        "Follower should still be following 1 after retry"
+    );
+
+    // Verify index membership is unchanged
+    let (_, is_follower) = Followers::check_set_member(&[&followee_id], &follower_id).await?;
+    assert!(
+        is_follower,
+        "Follower should still be in followee's follower set after retry"
+    );
+    let (_, is_following) = Following::check_set_member(&[&follower_id], &followee_id).await?;
+    assert!(
+        is_following,
+        "Followee should still be in follower's following set after retry"
+    );
+
+    // Verify no duplicate notifications
+    let notifications_after = Notification::get_by_id(&followee_id, Pagination::default()).await?;
+    assert_eq!(
+        notifications_after.len(),
+        notification_count_before,
+        "No new notifications should be created on retry"
+    );
+
+    // Verify graph relationship still exists
+    let exists = find_follow_relationship(&follower_id, &followee_id).await?;
+    assert!(exists, "Follow relationship should still exist in graph");
+
+    // Cleanup
+    test.cleanup_user(&follower_kp).await?;
+    test.cleanup_user(&followee_kp).await?;
+
+    Ok(())
+}
+
+/// Test partial failure recovery: graph edge was created on a previous attempt
+/// but index writes failed. On retry, sync_put should recover both indexes
+/// without duplicating counters or notifications.
+#[tokio_shared_rt::test(shared)]
+async fn test_follow_put_recovers_missing_indexes() -> Result<()> {
+    let mut test = WatcherTest::setup().await?;
+
+    // Create follower
+    let follower_kp = Keypair::random();
+    let follower_user = PubkyAppUser {
+        bio: Some("test_follow_put_recovers_missing_indexes".to_string()),
+        image: None,
+        links: None,
+        name: "Watcher:RecoverPut:Follower".to_string(),
+        status: None,
+    };
+    let follower_id = test.create_user(&follower_kp, &follower_user).await?;
+
+    // Create followee
+    let followee_kp = Keypair::random();
+    let followee_user = PubkyAppUser {
+        bio: Some("test_follow_put_recovers_missing_indexes".to_string()),
+        image: None,
+        links: None,
+        name: "Watcher:RecoverPut:Followee".to_string(),
+        status: None,
+    };
+    let followee_id = test.create_user(&followee_kp, &followee_user).await?;
+
+    // Normal follow (graph + indexes + counters all complete)
+    test.create_follow(&follower_kp, &followee_id).await?;
+
+    // Simulate partial failure: remove both index entries as if they were never written
+    let followers = Followers(vec![follower_id.to_string()]);
+    let following = Following(vec![followee_id.to_string()]);
+    followers.del_from_index(&followee_id).await?;
+    following.del_from_index(&follower_id).await?;
+
+    // Verify indexes are gone
+    let (_, is_follower) = Followers::check_set_member(&[&followee_id], &follower_id).await?;
+    assert!(!is_follower, "Follower index should be missing");
+    let (_, is_following) = Following::check_set_member(&[&follower_id], &followee_id).await?;
+    assert!(!is_following, "Following index should be missing");
+
+    // Record counters and notifications before recovery
+    let counts_before = find_user_counts(&followee_id).await;
+    let notifications_before = Notification::get_by_id(&followee_id, Pagination::default()).await?;
+
+    // Simulate retry: sync_put hits Updated (graph edge exists) and runs recovery
+    let follower_pubky = PubkyId::try_from(follower_id.as_str()).map_err(|e| anyhow::anyhow!(e))?;
+    let followee_pubky = PubkyId::try_from(followee_id.as_str()).map_err(|e| anyhow::anyhow!(e))?;
+    follow::sync_put(follower_pubky, followee_pubky).await?;
+
+    // Verify both indexes are recovered
+    let (_, is_follower) = Followers::check_set_member(&[&followee_id], &follower_id).await?;
+    assert!(
+        is_follower,
+        "Follower index should be recovered after retry"
+    );
+    let (_, is_following) = Following::check_set_member(&[&follower_id], &followee_id).await?;
+    assert!(
+        is_following,
+        "Following index should be recovered after retry"
+    );
+
+    // Verify counters were NOT incremented again
+    let counts_after = find_user_counts(&followee_id).await;
+    assert_eq!(
+        counts_before.followers, counts_after.followers,
+        "Follower count should not change on recovery"
+    );
+
+    // Verify no duplicate notifications
+    let notifications_after = Notification::get_by_id(&followee_id, Pagination::default()).await?;
+    assert_eq!(
+        notifications_before.len(),
+        notifications_after.len(),
+        "No new notifications should be created on recovery"
+    );
+
+    // Cleanup
+    test.cleanup_user(&follower_kp).await?;
+    test.cleanup_user(&followee_kp).await?;
+
+    Ok(())
+}

--- a/nexus-watcher/tests/event_processor/follows/retry_follow.rs
+++ b/nexus-watcher/tests/event_processor/follows/retry_follow.rs
@@ -59,28 +59,5 @@ async fn test_homeserver_follow_cannot_index() -> Result<()> {
 
     test.del(&follower_kp, &follow_path).await?;
 
-    let del_index_key = format!(
-        "{}:{}",
-        EventType::Del,
-        RetryEvent::generate_index_key(&follow_absolute_url).unwrap()
-    );
-
-    assert_eventually_exists(&del_index_key).await;
-
-    let timestamp = RetryEvent::check_uri(&del_index_key).await.unwrap();
-    assert!(timestamp.is_some());
-
-    let event_retry = RetryEvent::get_from_index(&del_index_key).await.unwrap();
-    assert!(event_retry.is_some());
-
-    let event_state = event_retry.unwrap();
-
-    assert_eq!(event_state.retry_count, 0);
-
-    match event_state.error_type {
-        EventProcessorError::SkipIndexing => (),
-        _ => panic!("The error type has to be SkipIndexing type"),
-    };
-
     Ok(())
 }

--- a/nexus-watcher/tests/event_processor/users/idempotent_del.rs
+++ b/nexus-watcher/tests/event_processor/users/idempotent_del.rs
@@ -41,7 +41,7 @@ async fn test_user_del_idempotent() -> Result<()> {
     );
 
     // Simulate retry: call del() directly — graph node is gone so expect SkipIndexing
-    let user_pubky = PubkyId::try_from(user_id.as_str()).map_err(|e| anyhow::anyhow!(e))?;
+    let user_pubky = PubkyId::from(user_kp.public_key());
     let result = user::del(user_pubky).await;
     assert!(
         matches!(result, Err(EventProcessorError::SkipIndexing)),
@@ -112,7 +112,7 @@ async fn test_user_del_graph_last_recovery() -> Result<()> {
     );
 
     // Retry: call del() directly — should recover and complete successfully
-    let user_pubky = PubkyId::try_from(user_id.as_str()).map_err(|e| anyhow::anyhow!(e))?;
+    let user_pubky = PubkyId::from(user_kp.public_key());
     user::del(user_pubky).await?;
 
     // Verify full cleanup after recovery


### PR DESCRIPTION
Prepares follow handlers for partial recovery.

  - DEL handler: graph-last ordering — Runs Redis SREM cleanup first, then deletes the FOLLOWS edge last. On retry after partial failure, the graph edge survives so the handler re-enters and re-runs the idempotent Redis cleanup.                    
  - DEL handler: guarded counters/notifications — Uses Followers::check_in_index to verify the follower is still in the Redis set before decrementing UserCounts or sending lost-follow notifications, preventing double-decrement on retry.            
  - DEL handler: friendship state captured early — Friends::check runs before any deletes so were_friends remains correct even if cleanup is interrupted mid-flight.                                                                                    
  - PUT handler: retry recovery — When put_to_graph returns Updated (edge already exists from a prior attempt), re-runs idempotent Followers/Following put_to_index writes to recover from partial failures where graph succeeded but Redis didn't.     
  Skips counters and notifications (prefer 0 over N).                                                                                                                                                                                                   
  - Idempotent no-op on replay — Follow DEL silently swallows the graph OperationOutcome, so replays of an already-deleted relationship return Ok(()).                                                                                                  
  - Adds del_idempotent.rs and put_idempotent.rs integration tests covering retry scenarios.