### PR TITLE
feat: post events handlers partial recovery

### DIFF
--- a/nexus-common/src/models/event/errors.rs
+++ b/nexus-common/src/models/event/errors.rs
@@ -101,10 +101,6 @@ impl EventProcessorError {
         Self::PubkyClientError(crate::db::PubkyClientError::ClientError(message))
     }
 
-    pub fn index_operation_failed(source: impl std::fmt::Display) -> Self {
-        Self::IndexOperationFailed(source.to_string())
-    }
-
     pub fn static_save_failed(source: impl std::fmt::Display) -> Self {
         Self::StaticSaveFailed(source.to_string())
     }

--- a/nexus-common/src/models/post/details.rs
+++ b/nexus-common/src/models/post/details.rs
@@ -1,8 +1,7 @@
 use super::{PostRelationships, PostStream};
 use crate::db::kv::RedisResult;
 use crate::db::{
-    exec_single_row, execute_graph_operation, fetch_row_from_graph, queries, GraphResult,
-    OperationOutcome, RedisOps,
+    execute_graph_operation, fetch_row_from_graph, queries, GraphResult, OperationOutcome, RedisOps,
 };
 use crate::models::error::ModelResult;
 use chrono::Utc;
@@ -137,22 +136,24 @@ impl PostDetails {
         execute_graph_operation(query).await
     }
 
-    pub async fn delete(
+    /// Removes the post details JSON entry and its sorted-set memberships from Redis.
+    /// Idempotent: every operation is a JSON.DEL or ZREM, safe to retry.
+    /// Does NOT touch the graph — callers must run `delete_post` separately to
+    /// preserve the graph-last invariant.
+    pub async fn delete_from_index(
         author_id: &str,
         post_id: &str,
-        parent_post_key_wrapper: Option<[String; 2]>,
-    ) -> ModelResult<()> {
-        // Delete user_details on Redis
+        parent_post_key_wrapper: Option<(String, String)>,
+    ) -> RedisResult<()> {
+        // Delete post details on Redis
         Self::remove_from_index_multiple_json(&[&[author_id, post_id]]).await?;
-        // Delete post graph node
-        exec_single_row(queries::del::delete_post(author_id, post_id)).await?;
         // The replies are not indexed in the global feeds
         match parent_post_key_wrapper {
             None => {
                 PostStream::remove_from_timeline_sorted_set(author_id, post_id).await?;
                 PostStream::remove_from_per_user_sorted_set(author_id, post_id).await?;
             }
-            Some([parent_author_id, parent_post_id]) => {
+            Some((parent_author_id, parent_post_id)) => {
                 PostStream::remove_from_post_reply_sorted_set(
                     &[&parent_author_id, &parent_post_id],
                     author_id,

--- a/nexus-watcher/src/events/handlers/post.rs
+++ b/nexus-watcher/src/events/handlers/post.rs
@@ -272,8 +272,7 @@ async fn recover_post_index_state(
     // edge recovery (needs the content) and to re-populate the PostDetails
     // index below (avoids a second round-trip through `PostDetails::reindex`).
     let (post_details, reply) = PostDetails::get_from_graph(author_id, post_id)
-        .await
-        .map_err(EventProcessorError::graph_query_failed)?
+        .await?
         .ok_or_else(|| {
             EventProcessorError::generic(
                 "Post recovery: graph reported existing post but get_from_graph returned None",
@@ -292,7 +291,6 @@ async fn recover_post_index_state(
         PostCounts::reindex(author_id, post_id)
     );
 
-    // Collect results and return any errors
     details_result?;
     relationships_result?;
     counts_result?;
@@ -407,9 +405,7 @@ async fn merge_mention_edges(
     for prefix in ["pk:", "pubky"] {
         for pubky_id in find_mentioned_ids(content, prefix) {
             let query = queries::put::create_mention_relationship(author_id, post_id, &pubky_id);
-            exec_single_row(query)
-                .await
-                .map_err(EventProcessorError::graph_query_failed)?;
+            exec_single_row(query).await?
         }
     }
     Ok(())
@@ -476,9 +472,7 @@ pub async fn sync_del(author_id: PubkyId, post_id: String) -> Result<(), EventPr
     //    The graph is guaranteed to still have the post because the graph delete
     //    runs LAST.
     if post_relationships_opt.is_none() {
-        post_relationships_opt = PostRelationships::get_from_graph(&author_id, &post_id)
-            .await
-            .map_err(EventProcessorError::graph_query_failed)?;
+        post_relationships_opt = PostRelationships::get_from_graph(&author_id, &post_id).await?;
     }
 
     // If the post is a reply, cannot delete from the main feeds

--- a/nexus-watcher/src/events/handlers/post.rs
+++ b/nexus-watcher/src/events/handlers/post.rs
@@ -454,9 +454,9 @@ pub async fn sync_del(author_id: PubkyId, post_id: String) -> Result<(), EventPr
     //    parent (replied/reposted) URIs needed for parent cleanup.
     //    NOTE: deliberately NOT using `get_by_id`, which would re-populate the
     //    index from the graph and defeat the gate.
-    let mut post_relationships_opt =
+    let post_relationships_from_index =
         PostRelationships::get_from_index(&author_id, &post_id).await?;
-    let post_in_index = post_relationships_opt.is_some();
+    let post_in_index = post_relationships_from_index.is_some();
 
     // 2. Atomically commit the cleanup decision: remove the gate as the very
     //    first mutation. Subsequent retries will observe `post_in_index = false`
@@ -469,9 +469,10 @@ pub async fn sync_del(author_id: PubkyId, post_id: String) -> Result<(), EventPr
     //    so that idempotent index cleanup can still target the right sorted sets.
     //    The graph is guaranteed to still have the post because the graph delete
     //    runs LAST.
-    if post_relationships_opt.is_none() {
-        post_relationships_opt = PostRelationships::get_from_graph(&author_id, &post_id).await?;
-    }
+    let post_relationships_opt = match post_relationships_from_index {
+        some @ Some(_) => some,
+        None => PostRelationships::get_from_graph(&author_id, &post_id).await?,
+    };
 
     // If the post is a reply, cannot delete from the main feeds
     // In the main feed, we just include the root posts and reposts

--- a/nexus-watcher/src/events/handlers/post.rs
+++ b/nexus-watcher/src/events/handlers/post.rs
@@ -384,6 +384,7 @@ async fn put_mentioned_relationships_for_prefix(
 
 fn find_mentioned_ids(content: &str, prefix: &str) -> Vec<PubkyId> {
     let user_id_len = 52;
+    let mut seen = std::collections::HashSet::new();
     content
         .match_indices(prefix)
         .filter_map(|(start_idx, _)| {
@@ -392,6 +393,7 @@ fn find_mentioned_ids(content: &str, prefix: &str) -> Vec<PubkyId> {
                 .get(user_id_start..user_id_start + user_id_len)
                 .and_then(|candidate| PubkyId::try_from(candidate).ok())
         })
+        .filter(|id| seen.insert(id.to_string()))
         .collect()
 }
 

--- a/nexus-watcher/src/events/handlers/post.rs
+++ b/nexus-watcher/src/events/handlers/post.rs
@@ -165,8 +165,7 @@ pub async fn sync_put(
                         &POST_TOTAL_ENGAGEMENT_KEY_PARTS,
                         parent_post_key_parts,
                     )
-                    .await
-                    .map_err(EventProcessorError::index_operation_failed)?;
+                    .await?;
                 }
                 Ok::<(), EventProcessorError>(())
             },
@@ -216,8 +215,7 @@ pub async fn sync_put(
                         &POST_TOTAL_ENGAGEMENT_KEY_PARTS,
                         parent_post_key_parts,
                     )
-                    .await
-                    .map_err(EventProcessorError::index_operation_failed)?;
+                    .await?;
                 }
                 Ok::<(), EventProcessorError>(())
             },
@@ -546,8 +544,7 @@ pub async fn sync_del(author_id: PubkyId, post_id: String) -> Result<(), EventPr
                             &POST_TOTAL_ENGAGEMENT_KEY_PARTS,
                             &parent_post_key_parts,
                         )
-                        .await
-                        .map_err(EventProcessorError::index_operation_failed)?;
+                        .await?;
                     }
                     Ok::<(), EventProcessorError>(())
                 },
@@ -607,8 +604,7 @@ pub async fn sync_del(author_id: PubkyId, post_id: String) -> Result<(), EventPr
                             &POST_TOTAL_ENGAGEMENT_KEY_PARTS,
                             parent_post_key_parts,
                         )
-                        .await
-                        .map_err(EventProcessorError::index_operation_failed)?;
+                        .await?;
                     }
                     Ok::<(), EventProcessorError>(())
                 },

--- a/nexus-watcher/src/events/handlers/post.rs
+++ b/nexus-watcher/src/events/handlers/post.rs
@@ -13,7 +13,7 @@ use nexus_common::models::user::UserCounts;
 use pubky_app_specs::{
     post_uri_builder, ParsedUri, PubkyAppPost, PubkyAppPostKind, PubkyId, Resource,
 };
-use tracing::debug;
+use tracing::{debug, Instrument};
 
 use super::utils::post_relationships_is_reply;
 
@@ -64,12 +64,20 @@ pub async fn sync_put(
 
     if existed {
         // If the post existed, let's confirm this is an edit. Is the content different?
-        let existing_details = PostDetails::get_from_index(&author_id, &post_id)
-            .await?
-            .ok_or("An existing post in graph, could not be retrieved from index")
-            .map_err(EventProcessorError::generic)?;
-        if existing_details.content != post_details.content {
-            sync_edit(post, author_id, post_id, post_details).await?;
+        match PostDetails::get_from_index(&author_id, &post_id).await? {
+            Some(existing_details) => {
+                if existing_details.content != post_details.content {
+                    sync_edit(post, author_id, post_id, post_details).await?;
+                }
+            }
+            None => {
+                // Partial-failure recovery: graph already had the post but Redis is
+                // missing PostDetails. A previous sync_put attempt wrote the graph node
+                // but failed before completing the index writes. Re-run idempotent
+                // index writes only — counters/scores/notifications are intentionally
+                // skipped (prefer drift over duplicates).
+                recover_post_index_state(&author_id, &post_id).await?;
+            }
         }
         return Ok(());
     }
@@ -239,6 +247,58 @@ pub async fn sync_put(
     Ok(())
 }
 
+/// Re-runs idempotent post index writes when a previous `sync_put` attempt
+/// successfully wrote the graph node but failed before persisting the Redis
+/// index entries. MENTIONED edges are also re-merged because the original
+/// mention loop may have crashed mid-way; reindex reads from the graph, so
+/// any gap would otherwise be unrecoverable.
+///
+/// Counters are recomputed from graph truth via the canonical `reindex`
+/// functions — graph `post_counts` computes counts live from edges, so any
+/// concurrent tag/bookmark/reply handler that also went through graph is
+/// already reflected.
+///
+/// Notifications are intentionally NOT re-run (0 > N duplicates on retry).
+async fn recover_post_index_state(
+    author_id: &PubkyId,
+    post_id: &str,
+) -> Result<(), EventProcessorError> {
+    debug!(
+        "Recovering post index state from graph: {}/{}",
+        author_id, post_id
+    );
+
+    // Fetch post details from the graph once — used both to drive mention
+    // edge recovery (needs the content) and to re-populate the PostDetails
+    // index below (avoids a second round-trip through `PostDetails::reindex`).
+    let (post_details, reply) = PostDetails::get_from_graph(author_id, post_id)
+        .await
+        .map_err(EventProcessorError::graph_query_failed)?
+        .ok_or_else(|| {
+            EventProcessorError::generic(
+                "Post recovery: graph reported existing post but get_from_graph returned None",
+            )
+        })?;
+
+    // Re-merge any MENTIONED graph edges that the original mention loop
+    // didn't finish. Skips notifications (0 > N on retry).
+    merge_mention_edges(author_id, post_id, &post_details.content).await?;
+
+    // Reindex all Redis state from graph truth.
+    let (details_result, relationships_result, counts_result) = nexus_common::traced_join!(
+        tracing::info_span!("index.write", phase = "post_recovery");
+        post_details.put_to_index(author_id, reply, false),
+        PostRelationships::reindex(author_id, post_id),
+        PostCounts::reindex(author_id, post_id)
+    );
+
+    // Collect results and return any errors
+    details_result?;
+    relationships_result?;
+    counts_result?;
+    Ok(())
+}
+
 async fn sync_edit(
     post: PubkyAppPost,
     author_id: PubkyId,
@@ -306,16 +366,7 @@ async fn put_mentioned_relationships_for_prefix(
     relationships: &mut PostRelationships,
     prefix: &str,
 ) -> Result<(), EventProcessorError> {
-    let user_id_len = 52;
-
-    let found_pubky_ids = content.match_indices(prefix).filter_map(|(start_idx, _)| {
-        let user_id_start = start_idx + prefix.len();
-        content
-            .get(user_id_start..user_id_start + user_id_len)
-            .and_then(|candidate| PubkyId::try_from(candidate).ok())
-    });
-
-    for pubky_id in found_pubky_ids {
+    for pubky_id in find_mentioned_ids(content, prefix) {
         // Create the MENTIONED relationship in the graph
         let query = queries::put::create_mention_relationship(author_id, post_id, &pubky_id);
         exec_single_row(query)
@@ -328,6 +379,37 @@ async fn put_mentioned_relationships_for_prefix(
         }
     }
 
+    Ok(())
+}
+
+fn find_mentioned_ids(content: &str, prefix: &str) -> Vec<PubkyId> {
+    let user_id_len = 52;
+    content
+        .match_indices(prefix)
+        .filter_map(|(start_idx, _)| {
+            let user_id_start = start_idx + prefix.len();
+            content
+                .get(user_id_start..user_id_start + user_id_len)
+                .and_then(|candidate| PubkyId::try_from(candidate).ok())
+        })
+        .collect()
+}
+
+/// Idempotent MERGE of every MENTIONED edge for the post. No notifications,
+/// no Redis — safe to re-run from recovery.
+async fn merge_mention_edges(
+    author_id: &PubkyId,
+    post_id: &str,
+    content: &str,
+) -> Result<(), EventProcessorError> {
+    for prefix in ["pk:", "pubky"] {
+        for pubky_id in find_mentioned_ids(content, prefix) {
+            let query = queries::put::create_mention_relationship(author_id, post_id, &pubky_id);
+            exec_single_row(query)
+                .await
+                .map_err(EventProcessorError::graph_query_failed)?;
+        }
+    }
     Ok(())
 }
 
@@ -372,20 +454,51 @@ pub async fn del(author_id: PubkyId, post_id: String) -> Result<(), EventProcess
 pub async fn sync_del(author_id: PubkyId, post_id: String) -> Result<(), EventProcessorError> {
     let deleted_uri = post_uri_builder(author_id.to_string(), post_id.clone());
 
-    let post_relationships = PostRelationships::get_by_id(&author_id, &post_id).await?;
-    // If the post is reply, cannot delete from the main feeds
+    // 1. Read PostRelationships from index — captures both the gate and the
+    //    parent (replied/reposted) URIs needed for parent cleanup.
+    //    NOTE: deliberately NOT using `get_by_id`, which would re-populate the
+    //    index from the graph and defeat the gate.
+    let mut post_relationships_opt =
+        PostRelationships::get_from_index(&author_id, &post_id).await?;
+    let post_in_index = post_relationships_opt.is_some();
+
+    // 2. Atomically commit the cleanup decision: remove the gate as the very
+    //    first mutation. Subsequent retries will observe `post_in_index = false`
+    //    and skip non-idempotent ops (counters, scores, notifications).
+    if post_in_index {
+        PostRelationships::delete(&author_id, &post_id).await?;
+    }
+
+    // 3. On retry (gate already gone), fall back to the graph for parent info
+    //    so that idempotent index cleanup can still target the right sorted sets.
+    //    The graph is guaranteed to still have the post because the graph delete
+    //    runs LAST.
+    if post_relationships_opt.is_none() {
+        post_relationships_opt = PostRelationships::get_from_graph(&author_id, &post_id)
+            .await
+            .map_err(EventProcessorError::graph_query_failed)?;
+    }
+
+    // If the post is a reply, cannot delete from the main feeds
     // In the main feed, we just include the root posts and reposts
     // It could be a situation that relationship would not exist and we will treat the post as a not reply
     let is_reply =
-        matches!(&post_relationships, Some(relationship) if relationship.replied.is_some());
+        matches!(&post_relationships_opt, Some(relationship) if relationship.replied.is_some());
 
     // DELETE TO INDEX - PHASE 1, decrease post counts
     let indexing_results = nexus_common::traced_join!(
         tracing::info_span!("index.delete", phase = "post_counts");
+        // Idempotent: JSON DEL + ZREM from engagement sorted set.
         PostCounts::delete(&author_id, &post_id, !is_reply),
-        UserCounts::decrement(&author_id, "posts", None),
+        // Guarded: skip on retry to avoid double-decrement.
         async {
-            if is_reply {
+            if post_in_index {
+                UserCounts::decrement(&author_id, "posts", None).await?;
+            }
+            Ok::<(), EventProcessorError>(())
+        },
+        async {
+            if post_in_index && is_reply {
                 UserCounts::decrement(&author_id, "replies", None).await?;
             };
             Ok::<(), EventProcessorError>(())
@@ -397,9 +510,9 @@ pub async fn sync_del(author_id: PubkyId, post_id: String) -> Result<(), EventPr
     indexing_results.2?;
 
     // Use that index wrapper to delete a post reply
-    let mut reply_parent_post_key_wrapper: Option<[String; 2]> = None;
+    let mut reply_parent_post_key_wrapper: Option<(String, String)> = None;
 
-    if let Some(relationships) = post_relationships {
+    if let Some(relationships) = post_relationships_opt {
         // PHASE 2: Process POST REPLIES indexes
         // Decrement counts for parent post if replied
         if let Some(replied_uri) = relationships.replied {
@@ -418,14 +531,21 @@ pub async fn sync_del(author_id: PubkyId, post_id: String) -> Result<(), EventPr
 
             let parent_post_key_parts: [&str; 2] = [&parent_user_id, &parent_post_id];
             reply_parent_post_key_wrapper =
-                Some([parent_user_id.to_string(), parent_post_id.clone()]);
+                Some((parent_user_id.to_string(), parent_post_id.clone()));
 
             let indexing_results = nexus_common::traced_join!(
                 tracing::info_span!("index.delete", phase = "reply_parent");
-                PostCounts::decrement_index_field(&parent_post_key_parts, "replies", None),
+                async {
+                    if post_in_index {
+                        PostCounts::decrement_index_field(&parent_post_key_parts, "replies", None).await?;
+                    }
+                    Ok::<(), EventProcessorError>(())
+                },
                 async {
                     // Post replies cannot be included in the total engagement index after the reply is deleted
-                    if !post_relationships_is_reply(&parent_user_id, &parent_post_id).await? {
+                    if post_in_index
+                        && !post_relationships_is_reply(&parent_user_id, &parent_post_id).await?
+                    {
                         PostStream::decrement_score_index_sorted_set(
                             &POST_TOTAL_ENGAGEMENT_KEY_PARTS,
                             &parent_post_key_parts,
@@ -435,15 +555,22 @@ pub async fn sync_del(author_id: PubkyId, post_id: String) -> Result<(), EventPr
                     }
                     Ok::<(), EventProcessorError>(())
                 },
-                // Notification: "A reply to your post was deleted"
-                Notification::post_children_changed(
-                    &author_id,
-                    &replied_uri_str,
-                    &parent_user_id,
-                    &deleted_uri,
-                    PostChangedSource::Reply,
-                    &PostChangedType::Deleted,
-                )
+                // Notification: "A reply to your post was deleted" — guarded to
+                // prevent duplicate notifications on retry.
+                async {
+                    if post_in_index {
+                        Notification::post_children_changed(
+                            &author_id,
+                            &replied_uri_str,
+                            &parent_user_id,
+                            &deleted_uri,
+                            PostChangedSource::Reply,
+                            &PostChangedType::Deleted,
+                        )
+                        .await?;
+                    }
+                    Ok::<(), EventProcessorError>(())
+                }
             );
 
             indexing_results.0?;
@@ -469,10 +596,17 @@ pub async fn sync_del(author_id: PubkyId, post_id: String) -> Result<(), EventPr
 
             let indexing_results = nexus_common::traced_join!(
                 tracing::info_span!("index.delete", phase = "repost_parent");
-                PostCounts::decrement_index_field(parent_post_key_parts, "reposts", None),
+                async {
+                    if post_in_index {
+                        PostCounts::decrement_index_field(parent_post_key_parts, "reposts", None).await?;
+                    }
+                    Ok::<(), EventProcessorError>(())
+                },
                 async {
                     // Post replies cannot be included in the total engagement index after the repost is deleted
-                    if !post_relationships_is_reply(&reposted_uri.user_id, &parent_post_id).await? {
+                    if post_in_index
+                        && !post_relationships_is_reply(&reposted_uri.user_id, &parent_post_id).await?
+                    {
                         PostStream::decrement_score_index_sorted_set(
                             &POST_TOTAL_ENGAGEMENT_KEY_PARTS,
                             parent_post_key_parts,
@@ -482,15 +616,21 @@ pub async fn sync_del(author_id: PubkyId, post_id: String) -> Result<(), EventPr
                     }
                     Ok::<(), EventProcessorError>(())
                 },
-                // Notification: "A repost of your post was deleted"
-                Notification::post_children_changed(
-                    &author_id,
-                    &reposted_uri_str,
-                    &reposted_uri.user_id,
-                    &deleted_uri,
-                    PostChangedSource::Repost,
-                    &PostChangedType::Deleted,
-                )
+                // Notification: "A repost of your post was deleted" — guarded.
+                async {
+                    if post_in_index {
+                        Notification::post_children_changed(
+                            &author_id,
+                            &reposted_uri_str,
+                            &reposted_uri.user_id,
+                            &deleted_uri,
+                            PostChangedSource::Repost,
+                            &PostChangedType::Deleted,
+                        )
+                        .await?;
+                    }
+                    Ok::<(), EventProcessorError>(())
+                }
             );
 
             indexing_results.0?;
@@ -498,14 +638,18 @@ pub async fn sync_del(author_id: PubkyId, post_id: String) -> Result<(), EventPr
             indexing_results.2?;
         }
     }
-    let indexing_results = nexus_common::traced_join!(
-        tracing::info_span!("index.delete", phase = "post_details");
-        PostDetails::delete(&author_id, &post_id, reply_parent_post_key_wrapper),
-        PostRelationships::delete(&author_id, &post_id)
-    );
 
-    indexing_results.0?;
-    indexing_results.1?;
+    // PHASE 4: Final Redis cleanup of PostDetails (idempotent JSON DEL + ZREM).
+    PostDetails::delete_from_index(&author_id, &post_id, reply_parent_post_key_wrapper)
+        .instrument(tracing::info_span!("index.delete", phase = "post_details"))
+        .await?;
+
+    // PHASE 5: Graph deletion LAST — survives until all Redis cleanup completes,
+    // so a partial failure leaves the graph node available for retry to re-enter
+    // `post::del` -> `CreatedOrDeleted` -> `sync_del`.
+    exec_single_row(queries::del::delete_post(&author_id, &post_id))
+        .instrument(tracing::info_span!("graph.delete", phase = "post_graph"))
+        .await?;
 
     Ok(())
 }

--- a/nexus-watcher/src/events/handlers/tag.rs
+++ b/nexus-watcher/src/events/handlers/tag.rs
@@ -133,8 +133,7 @@ async fn put_sync_post(
                             post_id,
                             ScoreAction::Increment(1.0),
                         )
-                        .await
-                        .map_err(EventProcessorError::index_operation_failed)?;
+                        .await?;
                     }
                     Ok::<(), EventProcessorError>(())
                 },
@@ -344,8 +343,7 @@ async fn del_sync_post(
             if !post_relationships_is_reply(author_id, post_id).await? {
                 // Decrement in one post global engagement
                 PostStream::update_index_score(author_id, post_id, ScoreAction::Decrement(1.0))
-                    .await
-                    .map_err(EventProcessorError::index_operation_failed)?;
+                    .await?;
             }
             Ok::<(), EventProcessorError>(())
         },

--- a/nexus-watcher/tests/event_processor/mentions/mod.rs
+++ b/nexus-watcher/tests/event_processor/mentions/mod.rs
@@ -1,3 +1,3 @@
 mod notification;
 mod raw;
-mod utils;
+pub mod utils;

--- a/nexus-watcher/tests/event_processor/posts/idempotent/del.rs
+++ b/nexus-watcher/tests/event_processor/posts/idempotent/del.rs
@@ -1,0 +1,293 @@
+use crate::event_processor::posts::utils::{
+    assert_notification_count, check_member_total_engagement_user_posts, find_post_counts,
+    find_post_details, pubky_id, short_post, short_reply, short_repost, test_user,
+};
+use crate::event_processor::users::utils::find_user_counts;
+use crate::event_processor::utils::watcher::WatcherTest;
+use anyhow::Result;
+use nexus_common::models::event::EventProcessorError;
+use nexus_watcher::events::handlers;
+use pubky::Keypair;
+use pubky_app_specs::post_uri_builder;
+
+use super::{simulate_partial_del_cleanup_child, simulate_partial_del_cleanup_root, ChildKind};
+
+/// sync_del graph-last recovery: simulate a previous attempt that completed
+/// every Redis cleanup step but failed before deleting the graph node. On
+/// retry, the handler must idempotently re-run cleanup, leave UserCounts at 0
+/// (no double-decrement), and finally delete the graph node.
+#[tokio_shared_rt::test(shared)]
+async fn test_post_del_recovers_after_partial_redis_cleanup() -> Result<()> {
+    let mut test = WatcherTest::setup().await?;
+
+    let user_kp = Keypair::random();
+    let user_id = test
+        .create_user(
+            &user_kp,
+            &test_user(
+                "Watcher:Post:DelRecovery:User",
+                "test_post_del_recovers_after_partial_redis_cleanup",
+            ),
+        )
+        .await?;
+
+    let post = short_post("Watcher:Post:DelRecovery:Post");
+    let (post_id, _post_path) = test.create_post(&user_kp, &post).await?;
+
+    // Sanity: fully indexed.
+    assert!(find_post_details(&user_id, &post_id).await.is_ok());
+    assert_eq!(find_user_counts(&user_id).await.posts, 1);
+
+    // Simulate the partial-failure state of the new graph-last sync_del:
+    //   - Gate (PostRelationships) atomically removed
+    //   - UserCounts decremented (gate was true on the failed attempt)
+    //   - PostCounts + PostDetails Redis entries removed
+    //   - Graph node still present (graph delete is the LAST step)
+    simulate_partial_del_cleanup_root(&user_id, &post_id).await?;
+
+    // Sanity: graph still has the post (graph delete is the final step).
+    assert!(find_post_details(&user_id, &post_id).await.is_ok());
+
+    // Retry through the public entry point: post::del re-checks
+    // post_is_safe_to_delete and dispatches into sync_del again.
+    handlers::post::del(pubky_id(&user_id)?, post_id.clone()).await?;
+
+    // Final state: graph node gone (retry ran its sole remaining step — the
+    // graph delete), count NOT double-decremented (still 0, not -1 — retry
+    // saw `post_in_index = false` and skipped `UserCounts::decrement`).
+    assert!(find_post_details(&user_id, &post_id).await.is_err());
+    assert_eq!(find_user_counts(&user_id).await.posts, 0);
+
+    test.cleanup_user(&user_kp).await?;
+    Ok(())
+}
+
+/// Replay sync_del on a fully deleted post: post::del should report
+/// MissingDependency (mapped to SkipIndexing) without corrupting state.
+#[tokio_shared_rt::test(shared)]
+async fn test_post_del_replay_after_full_success_skips() -> Result<()> {
+    let mut test = WatcherTest::setup().await?;
+
+    let user_kp = Keypair::random();
+    let user_id = test
+        .create_user(
+            &user_kp,
+            &test_user(
+                "Watcher:Post:DelReplay:User",
+                "test_post_del_replay_after_full_success_skips",
+            ),
+        )
+        .await?;
+
+    let post = short_post("Watcher:Post:DelReplay:Post");
+    let (post_id, post_path) = test.create_post(&user_kp, &post).await?;
+
+    // Delete through the normal event flow.
+    test.cleanup_post(&user_kp, &post_path).await?;
+
+    assert!(find_post_details(&user_id, &post_id).await.is_err());
+    assert_eq!(find_user_counts(&user_id).await.posts, 0);
+
+    // Replay: graph is gone, post_is_safe_to_delete returns no rows ->
+    // MissingDependency -> SkipIndexing.
+    let result = handlers::post::del(pubky_id(&user_id)?, post_id.clone()).await;
+    assert!(
+        matches!(result, Err(EventProcessorError::SkipIndexing)),
+        "Replay after full delete should return SkipIndexing, got: {result:?}"
+    );
+
+    // State must remain clean.
+    assert_eq!(find_user_counts(&user_id).await.posts, 0);
+
+    test.cleanup_user(&user_kp).await?;
+    Ok(())
+}
+
+/// sync_del recovery for a reply post: simulate the same partial-cleanup
+/// scenario for a post that has a parent (reply). The parent's reply count,
+/// parent's engagement sorted-set score, and parent author's notification
+/// count MUST NOT be double-mutated on retry.
+#[tokio_shared_rt::test(shared)]
+async fn test_post_del_reply_recovers_without_double_decrement() -> Result<()> {
+    let mut test = WatcherTest::setup().await?;
+
+    // Parent author (Alice).
+    let alice_kp = Keypair::random();
+    let alice_id = test
+        .create_user(
+            &alice_kp,
+            &test_user(
+                "Watcher:Post:DelReplyRecovery:Alice",
+                "test_post_del_reply_recovers_without_double_decrement",
+            ),
+        )
+        .await?;
+
+    // Reply author (Bob).
+    let bob_kp = Keypair::random();
+    let bob_id = test
+        .create_user(
+            &bob_kp,
+            &test_user(
+                "Watcher:Post:DelReplyRecovery:Bob",
+                "test_post_del_reply_recovers_without_double_decrement",
+            ),
+        )
+        .await?;
+
+    // Alice's parent post.
+    let parent_post = short_post("Watcher:Post:DelReplyRecovery:Parent");
+    let (parent_id, _parent_path) = test.create_post(&alice_kp, &parent_post).await?;
+    let parent_absolute_uri = post_uri_builder(alice_id.clone(), parent_id.clone());
+
+    // Bob's reply to Alice's parent.
+    let reply_post = short_reply(
+        "Watcher:Post:DelReplyRecovery:Reply",
+        parent_absolute_uri.clone(),
+    );
+    let (reply_id, _reply_path) = test.create_post(&bob_kp, &reply_post).await?;
+
+    // Sanity: parent has 1 reply, parent's engagement score is 1, Alice has
+    // 1 notification (from Bob's reply creation).
+    let parent_key: &[&str] = &[alice_id.as_str(), parent_id.as_str()];
+    assert_eq!(find_post_counts(&alice_id, &parent_id).await.replies, 1);
+    assert_eq!(find_user_counts(&bob_id).await.replies, 1);
+    assert_eq!(
+        check_member_total_engagement_user_posts(parent_key).await?,
+        Some(1),
+        "parent engagement = 1 after reply creation"
+    );
+    assert_notification_count(&alice_id, 1, "1 notif after reply creation").await;
+
+    // Simulate a fully-completed Redis cleanup of sync_del where only the
+    // graph delete failed at the very end.
+    simulate_partial_del_cleanup_child(&bob_id, &reply_id, &alice_id, &parent_id, ChildKind::Reply)
+        .await?;
+
+    // Retry through the public entry point.
+    handlers::post::del(pubky_id(&bob_id)?, reply_id.clone()).await?;
+
+    // Reply graph node gone; parent reply count NOT decremented again.
+    assert!(find_post_details(&bob_id, &reply_id).await.is_err());
+    assert_eq!(
+        find_post_counts(&alice_id, &parent_id).await.replies,
+        0,
+        "parent reply count not double-decremented on retry"
+    );
+    assert_eq!(
+        find_user_counts(&bob_id).await.replies,
+        0,
+        "Bob's reply count not double-decremented on retry"
+    );
+    // Parent engagement score must not go negative — retry saw
+    // `post_in_index = false` and skipped `decrement_score_index_sorted_set`.
+    assert_eq!(
+        check_member_total_engagement_user_posts(parent_key).await?,
+        Some(0),
+        "parent engagement not double-decremented on retry"
+    );
+    // Alice's notification count must not have grown — retry saw
+    // `post_in_index = false` and skipped the `post_children_changed` fire.
+    assert_notification_count(&alice_id, 1, "no duplicate reply-del notif on retry").await;
+
+    test.cleanup_user(&alice_kp).await?;
+    test.cleanup_user(&bob_kp).await?;
+    Ok(())
+}
+
+/// sync_del recovery for a repost post: simulate a partial cleanup of a
+/// repost where every Redis mutation completed but the graph delete failed.
+/// The parent post's `reposts` count MUST NOT be double-decremented on retry,
+/// and the parent author's notification set MUST NOT receive a duplicate
+/// repost-deletion notification.
+#[tokio_shared_rt::test(shared)]
+async fn test_post_del_repost_recovers_without_double_decrement() -> Result<()> {
+    let mut test = WatcherTest::setup().await?;
+
+    // Parent author (Alice).
+    let alice_kp = Keypair::random();
+    let alice_id = test
+        .create_user(
+            &alice_kp,
+            &test_user(
+                "Watcher:Post:DelRepostRecovery:Alice",
+                "test_post_del_repost_recovers_without_double_decrement",
+            ),
+        )
+        .await?;
+
+    // Reposter (Bob).
+    let bob_kp = Keypair::random();
+    let bob_id = test
+        .create_user(
+            &bob_kp,
+            &test_user(
+                "Watcher:Post:DelRepostRecovery:Bob",
+                "test_post_del_repost_recovers_without_double_decrement",
+            ),
+        )
+        .await?;
+
+    // Alice's parent post.
+    let parent_post = short_post("Watcher:Post:DelRepostRecovery:Parent");
+    let (parent_id, _parent_path) = test.create_post(&alice_kp, &parent_post).await?;
+    let parent_absolute_uri = post_uri_builder(alice_id.clone(), parent_id.clone());
+
+    // Bob's repost of Alice's parent.
+    let repost = short_repost(
+        "Watcher:Post:DelRepostRecovery:Repost",
+        parent_absolute_uri.clone(),
+    );
+    let (repost_id, _repost_path) = test.create_post(&bob_kp, &repost).await?;
+
+    // Sanity: parent has 1 repost, engagement score 1, Alice has 1 notification.
+    let parent_key: &[&str] = &[alice_id.as_str(), parent_id.as_str()];
+    assert_eq!(find_post_counts(&alice_id, &parent_id).await.reposts, 1);
+    assert_eq!(
+        check_member_total_engagement_user_posts(parent_key).await?,
+        Some(1),
+        "parent engagement = 1 after repost creation"
+    );
+    assert_notification_count(&alice_id, 1, "1 notif after repost creation").await;
+
+    // Simulate a fully-completed Redis cleanup of sync_del where only the
+    // graph delete failed at the very end.
+    simulate_partial_del_cleanup_child(
+        &bob_id,
+        &repost_id,
+        &alice_id,
+        &parent_id,
+        ChildKind::Repost,
+    )
+    .await?;
+
+    // Retry through the public entry point.
+    handlers::post::del(pubky_id(&bob_id)?, repost_id.clone()).await?;
+
+    // Repost graph node gone; parent repost count NOT decremented again.
+    assert!(find_post_details(&bob_id, &repost_id).await.is_err());
+    assert_eq!(
+        find_post_counts(&alice_id, &parent_id).await.reposts,
+        0,
+        "parent repost count not double-decremented on retry"
+    );
+    assert_eq!(
+        find_user_counts(&bob_id).await.posts,
+        0,
+        "Bob's post count not double-decremented on retry"
+    );
+    // Parent engagement score must not go negative — retry saw
+    // `post_in_index = false` and skipped `decrement_score_index_sorted_set`.
+    assert_eq!(
+        check_member_total_engagement_user_posts(parent_key).await?,
+        Some(0),
+        "parent engagement not double-decremented on retry"
+    );
+    // Alice's notification count must not have grown — retry saw
+    // `post_in_index = false` and skipped the `post_children_changed` fire.
+    assert_notification_count(&alice_id, 1, "no duplicate repost-del notif on retry").await;
+
+    test.cleanup_user(&alice_kp).await?;
+    test.cleanup_user(&bob_kp).await?;
+    Ok(())
+}

--- a/nexus-watcher/tests/event_processor/posts/idempotent/mod.rs
+++ b/nexus-watcher/tests/event_processor/posts/idempotent/mod.rs
@@ -1,0 +1,199 @@
+//! Shared helpers for post idempotency recovery tests.
+//!
+//! The sibling submodules (`put`, `del`) use these simulators to drive the
+//! handlers through partial-failure windows and then assert the recovered
+//! state is correct.
+
+use crate::event_processor::posts::utils::{
+    check_member_global_timeline_user_post, check_member_total_engagement_user_posts,
+    check_member_user_post_timeline, pubky_id,
+};
+use anyhow::Result;
+use nexus_common::db::graph::Query;
+use nexus_common::db::{exec_single_row, RedisOps};
+use nexus_common::models::post::{PostCounts, PostDetails, PostRelationships, PostStream};
+use nexus_common::models::user::UserCounts;
+
+mod del;
+mod put;
+
+// ---------------------------------------------------------------------------
+// Idempotency-test partial-failure simulators
+// ---------------------------------------------------------------------------
+
+/// Simulate the partial-failure window of a `sync_put` for a ROOT post:
+/// the graph still holds the post but every Redis index/sorted-set entry
+/// has been wiped. Caller must NOT also wipe `UserCounts` — the failed
+/// attempt is assumed to have already incremented it.
+pub(super) async fn simulate_partial_put_failure_root(user_id: &str, post_id: &str) -> Result<()> {
+    let post_key: &[&str] = &[user_id, post_id];
+    PostDetails::remove_from_index_multiple_json(&[post_key]).await?;
+    PostRelationships::remove_from_index_multiple_json(&[post_key]).await?;
+    PostCounts::remove_from_index_multiple_json(&[post_key]).await?;
+    PostStream::remove_from_timeline_sorted_set(user_id, post_id).await?;
+    PostStream::remove_from_per_user_sorted_set(user_id, post_id).await?;
+    PostStream::delete_from_engagement_sorted_set(user_id, post_id).await?;
+    Ok(())
+}
+
+/// Simulate the partial-failure window of a `sync_put` for a REPLY post:
+/// in addition to the root wipes, also clear the parent's post-reply
+/// sorted set and the author's replies-per-user sorted set (the writes
+/// `PostDetails::put_to_index` performs in the `Some(parent)` branch).
+///
+/// `parent_post_key` is `[parent_author_id, parent_post_id]`.
+pub(super) async fn simulate_partial_put_failure_reply(
+    author_id: &str,
+    post_id: &str,
+    parent_post_key: &[&str; 2],
+) -> Result<()> {
+    let post_key: &[&str] = &[author_id, post_id];
+    PostDetails::remove_from_index_multiple_json(&[post_key]).await?;
+    PostRelationships::remove_from_index_multiple_json(&[post_key]).await?;
+    PostCounts::remove_from_index_multiple_json(&[post_key]).await?;
+    PostStream::remove_from_post_reply_sorted_set(parent_post_key, author_id, post_id).await?;
+    PostStream::remove_from_replies_per_user_sorted_set(author_id, post_id).await?;
+    Ok(())
+}
+
+/// Simulate the partial-failure window of a graph-last `sync_del` for a
+/// ROOT post: every Redis cleanup step succeeded but the graph delete
+/// failed. The gate (`PostRelationships`) is removed atomically, the
+/// author's `posts` count was decremented, and the JSON indexes are gone
+/// — only the graph node remains.
+pub(super) async fn simulate_partial_del_cleanup_root(user_id: &str, post_id: &str) -> Result<()> {
+    let post_key: &[&str] = &[user_id, post_id];
+    PostRelationships::remove_from_index_multiple_json(&[post_key]).await?;
+    UserCounts::decrement(&pubky_id(user_id)?, "posts", None).await?;
+    PostDetails::delete_from_index(user_id, post_id, None).await?;
+    PostCounts::delete(user_id, post_id, true).await?;
+    Ok(())
+}
+
+/// Whether a child post in a del-cleanup simulation is a reply or a repost.
+/// The two cases share most cleanup steps but differ in: parent-count field,
+/// `remove_from_feeds` flag for `PostCounts::delete`, the parent tuple passed
+/// to `PostDetails::delete_from_index`, and whether to also decrement the
+/// author's `replies` counter.
+pub(super) enum ChildKind {
+    Reply,
+    Repost,
+}
+
+/// Simulate the partial-failure window of a graph-last `sync_del` for a
+/// CHILD post (reply or repost): every Redis cleanup step completed but the
+/// graph delete failed. Covers the scenario-specific writes (parent
+/// reply/repost count decrement, parent engagement decrement, and — for
+/// replies — the author's `replies` counter decrement).
+pub(super) async fn simulate_partial_del_cleanup_child(
+    author_id: &str,
+    post_id: &str,
+    parent_author_id: &str,
+    parent_post_id: &str,
+    kind: ChildKind,
+) -> Result<()> {
+    let child_key: &[&str] = &[author_id, post_id];
+    let parent_key: &[&str] = &[parent_author_id, parent_post_id];
+    let author_pubky = pubky_id(author_id)?;
+
+    // Gate removed atomically.
+    PostRelationships::remove_from_index_multiple_json(&[child_key]).await?;
+    // Author's post count decremented.
+    UserCounts::decrement(&author_pubky, "posts", None).await?;
+
+    let (parent_field, remove_from_feeds, delete_parent_tuple) = match kind {
+        ChildKind::Reply => {
+            // Replies also decrement the author's `replies` counter.
+            UserCounts::decrement(&author_pubky, "replies", None).await?;
+            (
+                "replies",
+                false,
+                Some((parent_author_id.to_string(), parent_post_id.to_string())),
+            )
+        }
+        ChildKind::Repost => ("reposts", true, None),
+    };
+
+    // Parent's reply/repost count decremented.
+    PostCounts::decrement_index_field(parent_key, parent_field, None).await?;
+    // Parent engagement score decremented (parent is a root post).
+    PostStream::decrement_score_index_sorted_set(
+        &nexus_common::models::post::POST_TOTAL_ENGAGEMENT_KEY_PARTS,
+        parent_key,
+    )
+    .await?;
+    // PostCounts / PostDetails removed for the child.
+    PostCounts::delete(author_id, post_id, remove_from_feeds).await?;
+    PostDetails::delete_from_index(author_id, post_id, delete_parent_tuple).await?;
+    Ok(())
+}
+
+/// Delete the `MENTIONED` graph edge for a given (author, post, mentioned)
+/// triple, simulating a mid-mention-loop crash where the `MERGE` never
+/// committed.
+pub(super) async fn delete_mention_edge(
+    author_id: &str,
+    post_id: &str,
+    mentioned_id: &str,
+) -> Result<()> {
+    let q = Query::new(
+        "test_delete_mention_edge",
+        "MATCH (u:User {id: $author_id})-[:AUTHORED]->(p:Post {id: $post_id})
+         MATCH (p)-[m:MENTIONED]->(:User {id: $mentioned_id})
+         DELETE m",
+    )
+    .param("author_id", author_id)
+    .param("post_id", post_id)
+    .param("mentioned_id", mentioned_id);
+    exec_single_row(q).await?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Recovery-state assertions
+// ---------------------------------------------------------------------------
+
+/// Assert that all three post JSON indexes (`PostDetails`, `PostRelationships`,
+/// `PostCounts`) and all three root-post sorted-set memberships (global
+/// timeline, per-user timeline, total engagement) are present — i.e. the
+/// full root-post indexed state has been rebuilt.
+pub(super) async fn assert_root_post_fully_indexed(user_id: &str, post_id: &str) -> Result<()> {
+    let post_key: &[&str] = &[user_id, post_id];
+    assert!(
+        PostDetails::get_from_index(user_id, post_id)
+            .await?
+            .is_some(),
+        "PostDetails missing for {user_id}:{post_id}"
+    );
+    assert!(
+        PostRelationships::get_from_index(user_id, post_id)
+            .await?
+            .is_some(),
+        "PostRelationships missing for {user_id}:{post_id}"
+    );
+    assert!(
+        PostCounts::get_from_index(user_id, post_id)
+            .await?
+            .is_some(),
+        "PostCounts missing for {user_id}:{post_id}"
+    );
+    assert!(
+        check_member_global_timeline_user_post(user_id, post_id)
+            .await?
+            .is_some(),
+        "global timeline membership missing for {user_id}:{post_id}"
+    );
+    assert!(
+        check_member_user_post_timeline(user_id, post_id)
+            .await?
+            .is_some(),
+        "per-user timeline membership missing for {user_id}:{post_id}"
+    );
+    assert!(
+        check_member_total_engagement_user_posts(post_key)
+            .await?
+            .is_some(),
+        "total-engagement membership missing for {user_id}:{post_id}"
+    );
+    Ok(())
+}

--- a/nexus-watcher/tests/event_processor/posts/idempotent/put.rs
+++ b/nexus-watcher/tests/event_processor/posts/idempotent/put.rs
@@ -1,0 +1,449 @@
+use crate::event_processor::mentions::utils::find_post_mentions;
+use crate::event_processor::posts::utils::{
+    assert_notification_count, check_member_post_replies, check_member_total_engagement_user_posts,
+    find_post_counts, pubky_id, short_post, short_reply, short_repost, test_user,
+};
+use crate::event_processor::users::utils::find_user_counts;
+use crate::event_processor::utils::watcher::WatcherTest;
+use anyhow::Result;
+use nexus_common::db::RedisOps;
+use nexus_common::models::post::{PostCounts, PostDetails, PostRelationships};
+use nexus_watcher::events::handlers;
+use pubky::Keypair;
+use pubky_app_specs::post_uri_builder;
+
+use super::{
+    assert_root_post_fully_indexed, delete_mention_edge, simulate_partial_put_failure_reply,
+    simulate_partial_put_failure_root,
+};
+
+/// sync_put recovery: simulate a previous attempt that wrote the post to the
+/// graph but failed before persisting Redis state. On retry, the handler must
+/// re-run idempotent index writes WITHOUT double-incrementing user counts.
+#[tokio_shared_rt::test(shared)]
+async fn test_post_put_recovers_after_partial_redis_write() -> Result<()> {
+    let mut test = WatcherTest::setup().await?;
+
+    let user_kp = Keypair::random();
+    let user_id = test
+        .create_user(
+            &user_kp,
+            &test_user(
+                "Watcher:Post:PutRecovery:User",
+                "test_post_put_recovers_after_partial_redis_write",
+            ),
+        )
+        .await?;
+
+    let post = short_post("Watcher:Post:PutRecovery:Post");
+    let (post_id, _post_path) = test.create_post(&user_kp, &post).await?;
+
+    // Sanity: post is fully indexed and user count is 1.
+    assert_root_post_fully_indexed(&user_id, &post_id).await?;
+    assert_eq!(find_user_counts(&user_id).await.posts, 1);
+
+    // Simulate the partial-failure window: graph still has the post but Redis
+    // is missing PostDetails / PostRelationships / PostCounts AND all sorted-set
+    // memberships. UserCounts has already been incremented by the prior
+    // (failed) attempt.
+    simulate_partial_put_failure_root(&user_id, &post_id).await?;
+
+    // Retry: invoke sync_put directly. Graph reports `Updated`, the handler
+    // takes the recovery path and rebuilds the Redis state from the graph.
+    handlers::post::sync_put(post.clone(), pubky_id(&user_id)?, post_id.clone()).await?;
+
+    // PostDetails / PostRelationships / PostCounts and the three root-post
+    // sorted-set memberships must all be back.
+    assert_root_post_fully_indexed(&user_id, &post_id).await?;
+
+    let recovered_details = PostDetails::get_from_index(&user_id, &post_id)
+        .await?
+        .expect("PostDetails should be re-indexed during recovery");
+    assert_eq!(recovered_details.content, post.content);
+
+    // UserCounts MUST NOT have been double-incremented by the recovery.
+    assert_eq!(find_user_counts(&user_id).await.posts, 1);
+
+    test.cleanup_user(&user_kp).await?;
+    Ok(())
+}
+
+/// Replay sync_put after a full-success first attempt: calling sync_put again
+/// with identical content must be a no-op. User counts must not be
+/// double-incremented. For replies/reposts, parent sorted-set scores and
+/// parent counts must also stay stable.
+#[tokio_shared_rt::test(shared)]
+async fn test_post_put_replay_after_full_success_is_noop() -> Result<()> {
+    let mut test = WatcherTest::setup().await?;
+
+    let user_kp = Keypair::random();
+    let user_id = test
+        .create_user(
+            &user_kp,
+            &test_user(
+                "Watcher:Post:PutReplay:User",
+                "test_post_put_replay_after_full_success_is_noop",
+            ),
+        )
+        .await?;
+
+    let post = short_post("Watcher:Post:PutReplay:Post");
+    let (post_id, _post_path) = test.create_post(&user_kp, &post).await?;
+
+    // Snapshot the state after the first (full-success) sync_put.
+    let details_before = PostDetails::get_from_index(&user_id, &post_id)
+        .await?
+        .expect("details after first put");
+    let counts_before = PostCounts::get_from_index(&user_id, &post_id)
+        .await?
+        .expect("counts after first put");
+    assert_eq!(find_user_counts(&user_id).await.posts, 1);
+
+    // Replay sync_put with identical content. Handler must hit the
+    // `existed == Some(matching)` branch and early-return.
+    handlers::post::sync_put(post.clone(), pubky_id(&user_id)?, post_id.clone()).await?;
+
+    // User counts must not have been double-incremented.
+    assert_eq!(
+        find_user_counts(&user_id).await.posts,
+        1,
+        "UserCounts.posts must not be double-incremented on replay"
+    );
+
+    // PostDetails must be unchanged (same indexed_at in particular — no
+    // re-stamp that would drift sorted-set scores).
+    let details_after = PostDetails::get_from_index(&user_id, &post_id)
+        .await?
+        .expect("details after replay");
+    assert_eq!(details_before.content, details_after.content);
+    assert_eq!(
+        details_before.indexed_at, details_after.indexed_at,
+        "indexed_at must not drift on replay"
+    );
+
+    // PostCounts must be unchanged.
+    let counts_after = PostCounts::get_from_index(&user_id, &post_id)
+        .await?
+        .expect("counts after replay");
+    assert_eq!(counts_before.replies, counts_after.replies);
+    assert_eq!(counts_before.reposts, counts_after.reposts);
+    assert_eq!(counts_before.tags, counts_after.tags);
+
+    test.cleanup_user(&user_kp).await?;
+    Ok(())
+}
+
+/// sync_put recovery of MENTIONED graph edges: simulate a partial mention
+/// loop where the MENTIONED edge was never committed to the graph AND the
+/// PostDetails Redis entry is missing. On retry, `recover_post_index_state`
+/// must re-MERGE the MENTIONED edge via `merge_mention_edges` WITHOUT
+/// re-sending the mention notification (0 > N).
+#[tokio_shared_rt::test(shared)]
+async fn test_post_put_recovers_mention_edge() -> Result<()> {
+    let mut test = WatcherTest::setup().await?;
+
+    // Author (Alice).
+    let alice_kp = Keypair::random();
+    let alice_id = test
+        .create_user(
+            &alice_kp,
+            &test_user(
+                "Watcher:Post:PutRecoverMention:Alice",
+                "test_post_put_recovers_mention_edge",
+            ),
+        )
+        .await?;
+
+    // Mentioned user (Bob).
+    let bob_kp = Keypair::random();
+    let bob_id = test
+        .create_user(
+            &bob_kp,
+            &test_user(
+                "Watcher:Post:PutRecoverMention:Bob",
+                "test_post_put_recovers_mention_edge",
+            ),
+        )
+        .await?;
+
+    // Alice posts mentioning Bob.
+    let post = short_post(format!("Hello pubky{bob_id} — a mention"));
+    let (post_id, _post_path) = test.create_post(&alice_kp, &post).await?;
+
+    // Sanity: MENTIONED edge exists in graph, Bob has 1 mention notification.
+    let mentioned_before = find_post_mentions(&alice_id, &post_id).await?;
+    assert!(
+        mentioned_before.contains(&bob_id),
+        "Bob MENTIONED by Alice's post after first sync_put"
+    );
+    assert_notification_count(&bob_id, 1, "1 mention notif after first sync_put").await;
+
+    // Simulate a mid-mention-loop crash state:
+    //   - DELETE the MENTIONED edge from graph (as if the MERGE never ran).
+    //   - Wipe PostDetails from Redis (forces recovery branch on retry).
+    delete_mention_edge(&alice_id, &post_id, &bob_id).await?;
+    let post_key: &[&str] = &[alice_id.as_str(), post_id.as_str()];
+    PostDetails::remove_from_index_multiple_json(&[post_key]).await?;
+
+    // Retry: graph reports Updated, handler enters recovery path, which
+    // calls merge_mention_edges and then reindexes Redis state.
+    handlers::post::sync_put(post.clone(), pubky_id(&alice_id)?, post_id.clone()).await?;
+
+    // MENTIONED edge must be back.
+    let mentioned_after = find_post_mentions(&alice_id, &post_id).await?;
+    assert!(
+        mentioned_after.contains(&bob_id),
+        "recovery must re-MERGE MENTIONED edge via merge_mention_edges"
+    );
+
+    // PostDetails must be re-indexed.
+    assert!(PostDetails::get_from_index(&alice_id, &post_id)
+        .await?
+        .is_some());
+
+    // Bob must NOT have received a duplicate mention notification —
+    // merge_mention_edges is notification-free (0 > N on retry).
+    assert_notification_count(&bob_id, 1, "no duplicate mention notif on recovery").await;
+
+    test.cleanup_user(&alice_kp).await?;
+    test.cleanup_user(&bob_kp).await?;
+    Ok(())
+}
+
+/// sync_put recovery for a reply post: a reply takes a different branch in
+/// `PostDetails::put_to_index` (the `Some(parent)` branch that writes to the
+/// post-reply and replies-per-user sorted sets). This test exercises that
+/// branch by wiping the reply's Redis state including its entry in the
+/// parent's post-reply sorted set, then verifying recovery rebuilds it.
+#[tokio_shared_rt::test(shared)]
+async fn test_post_put_recovers_reply_preserves_parent_sorted_sets() -> Result<()> {
+    let mut test = WatcherTest::setup().await?;
+
+    // Parent author (Alice).
+    let alice_kp = Keypair::random();
+    let alice_id = test
+        .create_user(
+            &alice_kp,
+            &test_user(
+                "Watcher:Post:PutRecoverReply:Alice",
+                "test_post_put_recovers_reply_preserves_parent_sorted_sets",
+            ),
+        )
+        .await?;
+
+    // Reply author (Bob).
+    let bob_kp = Keypair::random();
+    let bob_id = test
+        .create_user(
+            &bob_kp,
+            &test_user(
+                "Watcher:Post:PutRecoverReply:Bob",
+                "test_post_put_recovers_reply_preserves_parent_sorted_sets",
+            ),
+        )
+        .await?;
+
+    // Alice's parent post.
+    let parent_post = short_post("Watcher:Post:PutRecoverReply:Parent");
+    let (parent_id, _parent_path) = test.create_post(&alice_kp, &parent_post).await?;
+    let parent_absolute_uri = post_uri_builder(alice_id.clone(), parent_id.clone());
+
+    // Bob's reply.
+    let reply_post = short_reply(
+        "Watcher:Post:PutRecoverReply:Reply",
+        parent_absolute_uri.clone(),
+    );
+    let (reply_id, _reply_path) = test.create_post(&bob_kp, &reply_post).await?;
+
+    // Sanity: reply fully indexed, parent's post-reply sorted set has the
+    // reply member, Alice has 1 notification from Bob's reply.
+    let parent_post_key: &[&str; 2] = &[alice_id.as_str(), parent_id.as_str()];
+    let reply_member_key: &[&str] = &[bob_id.as_str(), reply_id.as_str()];
+    assert!(
+        check_member_post_replies(&alice_id, &parent_id, reply_member_key)
+            .await?
+            .is_some(),
+        "reply in parent's post-reply sorted set after creation"
+    );
+    assert!(PostDetails::get_from_index(&bob_id, &reply_id)
+        .await?
+        .is_some());
+    assert_notification_count(&alice_id, 1, "1 notif after reply creation").await;
+    assert_eq!(find_post_counts(&alice_id, &parent_id).await.replies, 1);
+
+    // Simulate a partial-failure window on the reply sync_put: PostDetails/
+    // Relationships/Counts wiped from Redis, plus the reply removed from
+    // the parent's post-reply sorted set and Bob's replies-per-user sorted
+    // set (the writes that PostDetails::put_to_index does in the
+    // Some(parent) branch).
+    simulate_partial_put_failure_reply(&bob_id, &reply_id, parent_post_key).await?;
+
+    // Retry: graph reports Updated, handler enters recovery path. Recovery
+    // calls PostDetails::reindex which re-runs put_to_index — including the
+    // Some(parent) branch that re-adds the reply to the parent's post-reply
+    // sorted set.
+    handlers::post::sync_put(reply_post.clone(), pubky_id(&bob_id)?, reply_id.clone()).await?;
+
+    // Reply's Redis state must be rebuilt.
+    assert!(PostDetails::get_from_index(&bob_id, &reply_id)
+        .await?
+        .is_some());
+    assert!(PostRelationships::get_from_index(&bob_id, &reply_id)
+        .await?
+        .is_some());
+    assert!(PostCounts::get_from_index(&bob_id, &reply_id)
+        .await?
+        .is_some());
+
+    // Parent's post-reply sorted set must contain Bob's reply again.
+    assert!(
+        check_member_post_replies(&alice_id, &parent_id, reply_member_key)
+            .await?
+            .is_some(),
+        "recovery must re-add reply to parent's post-reply sorted set"
+    );
+
+    // Parent's `replies` count must not have been incremented again
+    // (reindex from graph reads the live edge count, which is still 1).
+    assert_eq!(
+        find_post_counts(&alice_id, &parent_id).await.replies,
+        1,
+        "parent reply count not double-counted on recovery"
+    );
+
+    // Bob's user counts must not have been double-incremented.
+    assert_eq!(
+        find_user_counts(&bob_id).await.posts,
+        1,
+        "Bob's post count not double-incremented"
+    );
+    assert_eq!(
+        find_user_counts(&bob_id).await.replies,
+        1,
+        "Bob's reply count not double-incremented"
+    );
+
+    // Alice's notification count must be unchanged — recovery does not
+    // re-fire `new_post_reply`.
+    assert_notification_count(&alice_id, 1, "no duplicate reply notif on recovery").await;
+
+    test.cleanup_user(&alice_kp).await?;
+    test.cleanup_user(&bob_kp).await?;
+    Ok(())
+}
+
+/// sync_put recovery for a repost: a repost is a root post from the
+/// reposter's perspective (is_reply = false) but carries a REPOSTED edge in
+/// the graph that PostRelationships::reindex must recover. This test wipes
+/// the reposter's Redis state (but leaves the parent's repost count and
+/// engagement score untouched) and verifies recovery rebuilds the repost's
+/// indexes without double-counting the parent or re-notifying the parent
+/// author.
+#[tokio_shared_rt::test(shared)]
+async fn test_post_put_recovers_repost_preserves_parent_state() -> Result<()> {
+    let mut test = WatcherTest::setup().await?;
+
+    // Parent author (Alice).
+    let alice_kp = Keypair::random();
+    let alice_id = test
+        .create_user(
+            &alice_kp,
+            &test_user(
+                "Watcher:Post:PutRecoverRepost:Alice",
+                "test_post_put_recovers_repost_preserves_parent_state",
+            ),
+        )
+        .await?;
+
+    // Reposter (Bob).
+    let bob_kp = Keypair::random();
+    let bob_id = test
+        .create_user(
+            &bob_kp,
+            &test_user(
+                "Watcher:Post:PutRecoverRepost:Bob",
+                "test_post_put_recovers_repost_preserves_parent_state",
+            ),
+        )
+        .await?;
+
+    // Alice's parent post.
+    let parent_post = short_post("Watcher:Post:PutRecoverRepost:Parent");
+    let (parent_id, _parent_path) = test.create_post(&alice_kp, &parent_post).await?;
+    let parent_absolute_uri = post_uri_builder(alice_id.clone(), parent_id.clone());
+
+    // Bob's repost of Alice's parent.
+    let repost = short_repost(
+        "Watcher:Post:PutRecoverRepost:Repost",
+        parent_absolute_uri.clone(),
+    );
+    let (repost_id, _repost_path) = test.create_post(&bob_kp, &repost).await?;
+
+    // Sanity: Bob's repost is fully indexed as a root post, parent state and
+    // Alice's notification are set.
+    let parent_key: &[&str] = &[alice_id.as_str(), parent_id.as_str()];
+    assert_root_post_fully_indexed(&bob_id, &repost_id).await?;
+    assert_eq!(find_user_counts(&bob_id).await.posts, 1);
+    assert_eq!(find_post_counts(&alice_id, &parent_id).await.reposts, 1);
+    assert_eq!(
+        check_member_total_engagement_user_posts(parent_key).await?,
+        Some(1),
+        "parent engagement = 1 before simulation"
+    );
+    assert_notification_count(&alice_id, 1, "1 notif after repost creation").await;
+
+    // Simulate a partial-failure window on the repost's sync_put: wipe
+    // everything the reposter's side wrote (PostDetails, PostRelationships,
+    // PostCounts, and the three root-post sorted-set memberships). Leave
+    // Alice's parent state and Bob's UserCounts alone — the failed attempt
+    // is assumed to have already incremented UserCounts.posts and updated
+    // Alice's parent.
+    simulate_partial_put_failure_root(&bob_id, &repost_id).await?;
+
+    // Retry: graph reports Updated, handler enters recovery path. Recovery
+    // rebuilds PostDetails/PostRelationships/PostCounts from graph truth —
+    // PostRelationships::reindex must read the REPOSTED edge back into the
+    // `reposted` field, and PostCounts::reindex must put the repost back in
+    // the engagement sorted set (is_reply = false from graph).
+    handlers::post::sync_put(repost.clone(), pubky_id(&bob_id)?, repost_id.clone()).await?;
+
+    // Bob's repost must be fully indexed again as a root post.
+    assert_root_post_fully_indexed(&bob_id, &repost_id).await?;
+
+    // PostRelationships.reposted must be recovered from graph.
+    let recovered_rel = PostRelationships::get_from_index(&bob_id, &repost_id)
+        .await?
+        .expect("PostRelationships must be re-indexed during recovery");
+    assert!(
+        recovered_rel.reposted.is_some(),
+        "recovery must re-populate PostRelationships.reposted from graph"
+    );
+
+    // Bob's user counts must not have been double-incremented.
+    assert_eq!(
+        find_user_counts(&bob_id).await.posts,
+        1,
+        "Bob's post count not double-incremented"
+    );
+
+    // Alice's parent state must be unchanged — recovery only touches the
+    // repost's own indexes, not the parent's counters or engagement score.
+    assert_eq!(
+        find_post_counts(&alice_id, &parent_id).await.reposts,
+        1,
+        "parent repost count not double-counted on recovery"
+    );
+    assert_eq!(
+        check_member_total_engagement_user_posts(parent_key).await?,
+        Some(1),
+        "parent engagement unchanged after recovery"
+    );
+
+    // Alice's notification count must be unchanged — recovery does not
+    // re-fire `new_repost`.
+    assert_notification_count(&alice_id, 1, "no duplicate repost notif on recovery").await;
+
+    test.cleanup_user(&alice_kp).await?;
+    test.cleanup_user(&bob_kp).await?;
+    Ok(())
+}

--- a/nexus-watcher/tests/event_processor/posts/mod.rs
+++ b/nexus-watcher/tests/event_processor/posts/mod.rs
@@ -17,6 +17,7 @@ mod engagement;
 mod fail_reply;
 mod fail_repost;
 mod fail_user;
+mod idempotent;
 mod influencer;
 mod moderated;
 mod raw;

--- a/nexus-watcher/tests/event_processor/posts/utils.rs
+++ b/nexus-watcher/tests/event_processor/posts/utils.rs
@@ -1,5 +1,7 @@
 use anyhow::Result;
 use nexus_common::db::graph::Query;
+use nexus_common::models::notification::Notification;
+use nexus_common::types::Pagination;
 use nexus_common::{
     db::{fetch_key_from_graph, RedisOps},
     models::post::{
@@ -8,7 +10,9 @@ use nexus_common::{
         POST_TOTAL_ENGAGEMENT_KEY_PARTS,
     },
 };
-use pubky_app_specs::post_uri_builder;
+use pubky_app_specs::{
+    post_uri_builder, PubkyAppPost, PubkyAppPostEmbed, PubkyAppPostKind, PubkyAppUser, PubkyId,
+};
 
 pub async fn find_post_counts(user_id: &str, post_id: &str) -> PostCounts {
     PostCounts::get_from_index(user_id, post_id)
@@ -142,6 +146,65 @@ pub fn post_repost_relationships(author_id: &str, post_id: &str) -> Query {
     )
     .param("author_id", author_id)
     .param("post_id", post_id)
+}
+
+// ---------------------------------------------------------------------------
+// Test fixture builders
+// ---------------------------------------------------------------------------
+
+/// Build a `Short` root post with the given content.
+pub fn short_post(content: impl Into<String>) -> PubkyAppPost {
+    PubkyAppPost {
+        content: content.into(),
+        kind: PubkyAppPostKind::Short,
+        parent: None,
+        embed: None,
+        attachments: None,
+    }
+}
+
+/// Build a `Short` reply post with the given content and parent URI.
+pub fn short_reply(content: impl Into<String>, parent_uri: String) -> PubkyAppPost {
+    PubkyAppPost {
+        parent: Some(parent_uri),
+        ..short_post(content)
+    }
+}
+
+/// Build a `Short` repost (post with an embed pointing at the parent URI).
+pub fn short_repost(content: impl Into<String>, parent_uri: String) -> PubkyAppPost {
+    PubkyAppPost {
+        embed: Some(PubkyAppPostEmbed {
+            kind: PubkyAppPostKind::Short,
+            uri: parent_uri,
+        }),
+        ..short_post(content)
+    }
+}
+
+/// Build a `PubkyAppUser` for tests with the given display name and bio.
+pub fn test_user(name: impl Into<String>, bio: impl Into<String>) -> PubkyAppUser {
+    PubkyAppUser {
+        bio: Some(bio.into()),
+        image: None,
+        links: None,
+        name: name.into(),
+        status: None,
+    }
+}
+
+/// Convert a user-id string into a `PubkyId`, surfacing the parse error
+/// through `anyhow`.
+pub fn pubky_id(id: &str) -> Result<PubkyId> {
+    PubkyId::try_from(id).map_err(anyhow::Error::msg)
+}
+
+/// Assert that `user_id` currently has exactly `expected` notifications.
+pub async fn assert_notification_count(user_id: &str, expected: usize, ctx: &str) {
+    let notifs = Notification::get_by_id(user_id, Pagination::default())
+        .await
+        .unwrap();
+    assert_eq!(notifs.len(), expected, "{ctx}");
 }
 
 // Retrieve a post by id


### PR DESCRIPTION
Prepares POST handlers for partial recovery.

  - PUT (sync_put): When a previous attempt wrote the graph node but failed before persisting Redis index entries, the retry now detects the missing PostDetails in Redis and runs recover_post_index_state to rebuild index state from graph truth     
  (details, relationships, counts, mention edges). Notifications are intentionally skipped on recovery (0 > N duplicates).
  - DEL (sync_del): Reordered to graph-last: PostRelationships is deleted first as a gate, so retries observe post_in_index = false and skip non-idempotent ops (counter decrements, notifications, score adjustments). On retry, parent URIs are       
  fetched from the still-present graph node. The graph node is deleted only after all Redis cleanup succeeds.                                                                                                                                           
  - Refactors: Extracted find_mentioned_ids and merge_mention_edges helpers for reuse in recovery. Renamed PostDetails::delete to delete_from_index and removed its graph deletion side-effect to support the graph-last invariant. Changed
  parent_post_key_wrapper from [String; 2] to (String, String).