### PR TITLE
chore: remove superfluous error helpers

### DIFF
--- a/nexus-common/src/models/event/errors.rs
+++ b/nexus-common/src/models/event/errors.rs
@@ -105,18 +105,8 @@ impl EventProcessorError {
         Self::PubkyClientError(crate::db::PubkyClientError::ClientError(message))
     }
 
-    pub fn index_operation_failed(e: RedisError) -> Self {
-        let is_infrastructure_err = e.is_infrastructure_err();
-        Self::IndexOperationFailed(is_infrastructure_err, e.to_string())
-    }
-
     pub fn static_save_failed(source: impl std::fmt::Display) -> Self {
         Self::StaticSaveFailed(source.to_string())
-    }
-
-    pub fn graph_query_failed(e: GraphError) -> Self {
-        let is_infrastructure_err = e.is_infrastructure_err();
-        Self::GraphQueryFailed(is_infrastructure_err, e.to_string())
     }
 
     pub fn generic(source: impl std::fmt::Display) -> Self {

--- a/nexus-watcher/src/events/handlers/post.rs
+++ b/nexus-watcher/src/events/handlers/post.rs
@@ -156,8 +156,7 @@ pub async fn sync_put(
                         &POST_TOTAL_ENGAGEMENT_KEY_PARTS,
                         parent_post_key_parts,
                     )
-                    .await
-                    .map_err(EventProcessorError::index_operation_failed)?;
+                    .await?;
                 }
                 Ok::<(), EventProcessorError>(())
             },
@@ -207,8 +206,7 @@ pub async fn sync_put(
                         &POST_TOTAL_ENGAGEMENT_KEY_PARTS,
                         parent_post_key_parts,
                     )
-                    .await
-                    .map_err(EventProcessorError::index_operation_failed)?;
+                    .await?;
                 }
                 Ok::<(), EventProcessorError>(())
             },
@@ -317,9 +315,7 @@ async fn put_mentioned_relationships_for_prefix(
     for pubky_id in found_pubky_ids {
         // Create the MENTIONED relationship in the graph
         let query = queries::put::create_mention_relationship(author_id, post_id, &pubky_id);
-        exec_single_row(query)
-            .await
-            .map_err(EventProcessorError::graph_query_failed)?;
+        exec_single_row(query).await?;
 
         let maybe_mentioned_id = Notification::new_mention(author_id, &pubky_id, post_id).await?;
         if let Some(mentioned_user_id) = maybe_mentioned_id {
@@ -340,10 +336,7 @@ pub async fn del(author_id: PubkyId, post_id: String) -> Result<(), EventProcess
     // If there is none other relationship (OperationOutcome::CreatedOrDeleted), we delete from graph and redis.
     // But if there is any (OperationOutcome::Updated), then we simply update the post with keyword content [DELETED].
     // A deleted post is a post whose content is EXACTLY `"[DELETED]"`
-    match execute_graph_operation(query)
-        .await
-        .map_err(EventProcessorError::graph_query_failed)?
-    {
+    match execute_graph_operation(query).await? {
         OperationOutcome::CreatedOrDeleted => sync_del(author_id, post_id).await?,
         OperationOutcome::Updated => {
             let existing_relationships = PostRelationships::get_by_id(&author_id, &post_id).await?;
@@ -429,8 +422,7 @@ pub async fn sync_del(author_id: PubkyId, post_id: String) -> Result<(), EventPr
                             &POST_TOTAL_ENGAGEMENT_KEY_PARTS,
                             &parent_post_key_parts,
                         )
-                        .await
-                        .map_err(EventProcessorError::index_operation_failed)?;
+                        .await?;
                     }
                     Ok::<(), EventProcessorError>(())
                 },
@@ -476,8 +468,7 @@ pub async fn sync_del(author_id: PubkyId, post_id: String) -> Result<(), EventPr
                             &POST_TOTAL_ENGAGEMENT_KEY_PARTS,
                             parent_post_key_parts,
                         )
-                        .await
-                        .map_err(EventProcessorError::index_operation_failed)?;
+                        .await?;
                     }
                     Ok::<(), EventProcessorError>(())
                 },

--- a/nexus-watcher/src/events/handlers/tag.rs
+++ b/nexus-watcher/src/events/handlers/tag.rs
@@ -84,7 +84,8 @@ async fn put_sync_post(
             // Ensure that dependencies follow the same format as the RetryManager keys
             let dependency = vec![format!("{author_id}:posts:{post_id}")];
             if let Ok(referenced_post_uri) = ParsedUri::try_from(post_uri) {
-                if let Err(e) = PostDetails::maybe_ingest_author_of_post(&referenced_post_uri).await {
+                if let Err(e) = PostDetails::maybe_ingest_author_of_post(&referenced_post_uri).await
+                {
                     tracing::error!("Failed to ingest user: {e}");
                 }
             }
@@ -134,8 +135,7 @@ async fn put_sync_post(
                             post_id,
                             ScoreAction::Increment(1.0),
                         )
-                        .await
-                        .map_err(EventProcessorError::index_operation_failed)?;
+                        .await?;
                     }
                     Ok::<(), EventProcessorError>(())
                 },
@@ -345,8 +345,7 @@ async fn del_sync_post(
             if !post_relationships_is_reply(author_id, post_id).await? {
                 // Decrement in one post global engagement
                 PostStream::update_index_score(author_id, post_id, ScoreAction::Decrement(1.0))
-                    .await
-                    .map_err(EventProcessorError::index_operation_failed)?;
+                    .await?;
             }
             Ok::<(), EventProcessorError>(())
         },

--- a/nexus-watcher/src/events/handlers/user.rs
+++ b/nexus-watcher/src/events/handlers/user.rs
@@ -58,10 +58,7 @@ pub async fn del(user_id: PubkyId) -> Result<(), EventProcessorError> {
     // 3. But if there is any relationship (OperationOutcome::Updated), then we simply update the user with empty profile
     // and keyword username [DELETED].
     // A deleted user is a user whose profile is empty and has username `"[DELETED]"`
-    match execute_graph_operation(query)
-        .await
-        .map_err(EventProcessorError::graph_query_failed)?
-    {
+    match execute_graph_operation(query).await? {
         OperationOutcome::CreatedOrDeleted => {
             // UserSearch::delete reads UserDetails from the index to find the username,
             // so it must complete before UserDetails::delete runs.


### PR DESCRIPTION
This PR removes two unused error helpers:

- `EventProcessorError::index_operation_failed`
- `EventProcessorError::graph_query_failed`

as their logic is already handled by the existing `From<RedisError>` and `From<GraphError>` of `EventProcessorError`.