### PR TITLE
chore: simplify Moderation init

### DIFF
--- a/nexus-watcher/src/events/moderation.rs
+++ b/nexus-watcher/src/events/moderation.rs
@@ -1,7 +1,9 @@
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use crate::events::handlers;
 use nexus_common::models::event::EventProcessorError;
+use nexus_common::WatcherConfig;
 use pubky_app_specs::{ParsedUri, PubkyAppTag, PubkyId, Resource};
 use tracing::info;
 
@@ -13,6 +15,13 @@ pub struct Moderation {
 }
 
 impl Moderation {
+    pub fn from_config(config: &WatcherConfig) -> Arc<Self> {
+        Arc::new(Self {
+            id: config.moderation_id.clone(),
+            tags: config.moderated_tags.clone(),
+        })
+    }
+
     pub async fn should_delete(&self, tag: &PubkyAppTag, tagger_id: PubkyId) -> bool {
         tagger_id == self.id && self.tags.contains(&tag.label)
     }

--- a/nexus-watcher/src/service/runner/homeserver.rs
+++ b/nexus-watcher/src/service/runner/homeserver.rs
@@ -25,10 +25,7 @@ impl HsEventProcessorRunner {
         Self {
             limit: config.events_limit,
             files_path: config.stack.files_path.clone(),
-            moderation: Arc::new(Moderation {
-                id: config.moderation_id.clone(),
-                tags: config.moderated_tags.clone(),
-            }),
+            moderation: Moderation::from_config(config),
             shutdown_rx,
             default_homeserver: config.homeserver.clone(),
         }

--- a/nexus-watcher/src/service/runner/key_based.rs
+++ b/nexus-watcher/src/service/runner/key_based.rs
@@ -34,10 +34,7 @@ impl KeyBasedEventProcessorRunner {
             limit: config.events_limit,
             monitored_hs_limit: config.monitored_homeservers_limit,
             files_path: config.stack.files_path.clone(),
-            moderation: Arc::new(Moderation {
-                id: config.moderation_id.clone(),
-                tags: config.moderated_tags.clone(),
-            }),
+            moderation: Moderation::from_config(config),
             shutdown_rx,
             default_homeserver: config.homeserver.clone(),
             backoff: Mutex::new(HomeserverBackoff::new(


### PR DESCRIPTION
This PR adds a `Moderation::from_config` util, which can be re-used across the different event processors.