### PR TITLE
Remove superfluous error mapping util

### DIFF
--- a/nexus-common/src/models/event/errors.rs
+++ b/nexus-common/src/models/event/errors.rs
@@ -101,10 +101,6 @@ impl EventProcessorError {
         Self::PubkyClientError(crate::db::PubkyClientError::ClientError(message))
     }
 
-    pub fn index_operation_failed(source: impl std::fmt::Display) -> Self {
-        Self::IndexOperationFailed(source.to_string())
-    }
-
     pub fn static_save_failed(source: impl std::fmt::Display) -> Self {
         Self::StaticSaveFailed(source.to_string())
     }

--- a/nexus-watcher/src/events/handlers/post.rs
+++ b/nexus-watcher/src/events/handlers/post.rs
@@ -165,8 +165,7 @@ pub async fn sync_put(
                         &POST_TOTAL_ENGAGEMENT_KEY_PARTS,
                         parent_post_key_parts,
                     )
-                    .await
-                    .map_err(EventProcessorError::index_operation_failed)?;
+                    .await?;
                 }
                 Ok::<(), EventProcessorError>(())
             },
@@ -216,8 +215,7 @@ pub async fn sync_put(
                         &POST_TOTAL_ENGAGEMENT_KEY_PARTS,
                         parent_post_key_parts,
                     )
-                    .await
-                    .map_err(EventProcessorError::index_operation_failed)?;
+                    .await?;
                 }
                 Ok::<(), EventProcessorError>(())
             },
@@ -546,8 +544,7 @@ pub async fn sync_del(author_id: PubkyId, post_id: String) -> Result<(), EventPr
                             &POST_TOTAL_ENGAGEMENT_KEY_PARTS,
                             &parent_post_key_parts,
                         )
-                        .await
-                        .map_err(EventProcessorError::index_operation_failed)?;
+                        .await?;
                     }
                     Ok::<(), EventProcessorError>(())
                 },
@@ -607,8 +604,7 @@ pub async fn sync_del(author_id: PubkyId, post_id: String) -> Result<(), EventPr
                             &POST_TOTAL_ENGAGEMENT_KEY_PARTS,
                             parent_post_key_parts,
                         )
-                        .await
-                        .map_err(EventProcessorError::index_operation_failed)?;
+                        .await?;
                     }
                     Ok::<(), EventProcessorError>(())
                 },

--- a/nexus-watcher/src/events/handlers/tag.rs
+++ b/nexus-watcher/src/events/handlers/tag.rs
@@ -133,8 +133,7 @@ async fn put_sync_post(
                             post_id,
                             ScoreAction::Increment(1.0),
                         )
-                        .await
-                        .map_err(EventProcessorError::index_operation_failed)?;
+                        .await?;
                     }
                     Ok::<(), EventProcessorError>(())
                 },
@@ -344,8 +343,7 @@ async fn del_sync_post(
             if !post_relationships_is_reply(author_id, post_id).await? {
                 // Decrement in one post global engagement
                 PostStream::update_index_score(author_id, post_id, ScoreAction::Decrement(1.0))
-                    .await
-                    .map_err(EventProcessorError::index_operation_failed)?;
+                    .await?;
             }
             Ok::<(), EventProcessorError>(())
         },


### PR DESCRIPTION
This PR removes an error utility method that is not needed, because there is already a `impl From<RedisError> for EventProcessorError` mapping.