### PR TITLE
fix: handle attachment-only post edits

### DIFF
--- a/nexus-common/src/models/post/details.rs
+++ b/nexus-common/src/models/post/details.rs
@@ -10,7 +10,8 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 /// Represents post data with content, bio, image, links, and status.
-#[derive(Serialize, Deserialize, ToSchema, Default, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, ToSchema, Default, Debug, PartialEq)]
+#[cfg_attr(test, derive(Clone))]
 // NOTE: Might not be necessary the default values for serde because before PUT a PostDetails node
 // we do sanity check
 pub struct PostDetails {

--- a/nexus-common/src/models/post/details.rs
+++ b/nexus-common/src/models/post/details.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 /// Represents post data with content, bio, image, links, and status.
-#[derive(Serialize, Deserialize, ToSchema, Default, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, ToSchema, Default, Debug, PartialEq, Clone)]
 // NOTE: Might not be necessary the default values for serde because before PUT a PostDetails node
 // we do sanity check
 pub struct PostDetails {
@@ -169,5 +169,57 @@ impl PostDetails {
     /// Determines whether or not a given [PostDetails] is different than (e.g. may be an edit of) this post.
     pub fn is_different_than(&self, other: &PostDetails) -> bool {
         self.content != other.content || self.attachments != other.attachments
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pubky_app_specs::PubkyAppPostKind;
+
+    #[tokio_shared_rt::test(shared)]
+    async fn test_is_different_than() {
+        // Create a base PostDetails
+        let base_post = PostDetails {
+            content: "Original content".into(),
+            id: "post1".into(),
+            indexed_at: 123456789,
+            author: "author1".into(),
+            kind: PubkyAppPostKind::Short,
+            uri: "uri1".into(),
+            attachments: Some(vec!["image1.jpg".into(), "image2.jpg".into()]),
+        };
+
+        // Test with same content and attachments
+        let same_post = base_post.clone();
+        assert!(!base_post.is_different_than(&same_post));
+
+        // Test with same attachments but different order
+        let different_order_attachments_post = PostDetails {
+            attachments: Some(vec!["image2.jpg".into(), "image1.jpg".into()]),
+            ..base_post.clone()
+        };
+        assert!(base_post.is_different_than(&different_order_attachments_post));
+
+        // Test with different content
+        let different_content_post = PostDetails {
+            content: "Updated content".to_string(),
+            ..base_post.clone()
+        };
+        assert!(base_post.is_different_than(&different_content_post));
+
+        // Test with different attachments
+        let different_attachments_post = PostDetails {
+            attachments: Some(vec!["image3.jpg".to_string()]),
+            ..base_post.clone()
+        };
+        assert!(base_post.is_different_than(&different_attachments_post));
+
+        // Test with no attachments
+        let no_attachments_post = PostDetails {
+            attachments: None,
+            ..base_post.clone()
+        };
+        assert!(base_post.is_different_than(&no_attachments_post));
     }
 }

--- a/nexus-common/src/models/post/details.rs
+++ b/nexus-common/src/models/post/details.rs
@@ -165,4 +165,9 @@ impl PostDetails {
         }
         Ok(())
     }
+
+    /// Determines whether or not a given [PostDetails] is different than (e.g. may be an edit of) this post.
+    pub fn is_different_than(&self, other: &PostDetails) -> bool {
+        self.content != other.content || self.attachments != other.attachments
+    }
 }

--- a/nexus-watcher/src/events/handlers/post.rs
+++ b/nexus-watcher/src/events/handlers/post.rs
@@ -66,7 +66,7 @@ pub async fn sync_put(
         // If the post existed, let's confirm this is an edit. Is the content different?
         match PostDetails::get_from_index(&author_id, &post_id).await? {
             Some(existing_details) => {
-                if existing_details.content != post_details.content {
+                if post_details_changed(&existing_details, &post_details) {
                     sync_edit(post, author_id, post_id, post_details).await?;
                 }
             }
@@ -243,6 +243,11 @@ pub async fn sync_put(
     indexing_results.1?;
 
     Ok(())
+}
+
+fn post_details_changed(existing_details: &PostDetails, post_details: &PostDetails) -> bool {
+    existing_details.content != post_details.content
+        || existing_details.attachments != post_details.attachments
 }
 
 /// Re-runs idempotent post index writes when a previous `sync_put` attempt

--- a/nexus-watcher/src/events/handlers/post.rs
+++ b/nexus-watcher/src/events/handlers/post.rs
@@ -66,7 +66,7 @@ pub async fn sync_put(
         // If the post existed, let's confirm this is an edit. Is the content different?
         match PostDetails::get_from_index(&author_id, &post_id).await? {
             Some(existing_details) => {
-                if post_details_changed(&existing_details, &post_details) {
+                if existing_details.is_different_than(&post_details) {
                     sync_edit(post, author_id, post_id, post_details).await?;
                 }
             }
@@ -243,11 +243,6 @@ pub async fn sync_put(
     indexing_results.1?;
 
     Ok(())
-}
-
-fn post_details_changed(existing_details: &PostDetails, post_details: &PostDetails) -> bool {
-    existing_details.content != post_details.content
-        || existing_details.attachments != post_details.attachments
 }
 
 /// Re-runs idempotent post index writes when a previous `sync_put` attempt

--- a/nexus-watcher/tests/event_processor/posts/attachments.rs
+++ b/nexus-watcher/tests/event_processor/posts/attachments.rs
@@ -67,3 +67,121 @@ async fn test_homeserver_post_attachments() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio_shared_rt::test(shared)]
+async fn test_homeserver_post_attachment_only_edits() -> Result<()> {
+    let mut test = WatcherTest::setup().await?;
+
+    let user_kp = Keypair::random();
+    let user = PubkyAppUser {
+        bio: Some("test_homeserver_post_attachment_only_edits".to_string()),
+        image: None,
+        links: None,
+        name: "Watcher:PostAttachmentOnlyEdits:User".to_string(),
+        status: None,
+    };
+
+    let user_id = test.create_user(&user_kp, &user).await?;
+
+    let blob_a = PubkyAppBlob::new("First attachment".as_bytes().to_vec());
+    let first_blob_id = blob_a.create_id();
+    let blob_a_relative_url = PubkyAppBlob::create_path(&first_blob_id);
+    let blob_a_absolute_url = blob_uri_builder(user_id.clone(), first_blob_id);
+
+    test.create_file_from_body(&user_kp, blob_a_relative_url.as_str(), blob_a.0.clone())
+        .await?;
+
+    let file_a = PubkyAppFile {
+        name: "attachment-1".to_string(),
+        content_type: "text/plain".to_string(),
+        src: blob_a_absolute_url.clone(),
+        size: blob_a.0.len(),
+        created_at: Utc::now().timestamp_millis(),
+    };
+    let (first_file_id, first_file_path) = test.create_file(&user_kp, &file_a).await?;
+    let attachment_a = file_uri_builder(user_id.clone(), first_file_id.clone());
+
+    let blob_b = PubkyAppBlob::new("Second attachment".as_bytes().to_vec());
+    let blob_b_id = blob_b.create_id();
+    let blob_b_relative_url = PubkyAppBlob::create_path(&blob_b_id);
+    let blob_b_absolute_url = blob_uri_builder(user_id.clone(), blob_b_id);
+
+    test.create_file_from_body(&user_kp, blob_b_relative_url.as_str(), blob_b.0.clone())
+        .await?;
+
+    let file_b = PubkyAppFile {
+        name: "attachment-2".to_string(),
+        content_type: "text/plain".to_string(),
+        src: blob_b_absolute_url.clone(),
+        size: blob_b.0.len(),
+        created_at: Utc::now().timestamp_millis(),
+    };
+    let (file_b_id, file_b_path) = test.create_file(&user_kp, &file_b).await?;
+    let attachment_b = file_uri_builder(user_id.clone(), file_b_id.clone());
+
+    let blob_c = PubkyAppBlob::new("Third attachment".as_bytes().to_vec());
+    let blob_c_id = blob_c.create_id();
+    let blob_c_relative_url = PubkyAppBlob::create_path(&blob_c_id);
+    let blob_c_absolute_url = blob_uri_builder(user_id.clone(), blob_c_id);
+
+    test.create_file_from_body(&user_kp, blob_c_relative_url.as_str(), blob_c.0.clone())
+        .await?;
+
+    let third_file = PubkyAppFile {
+        name: "attachment-3".to_string(),
+        content_type: "text/plain".to_string(),
+        src: blob_c_absolute_url.clone(),
+        size: blob_c.0.len(),
+        created_at: Utc::now().timestamp_millis(),
+    };
+    let (file_c_id, file_c_path) = test.create_file(&user_kp, &third_file).await?;
+    let attachment_c = file_uri_builder(user_id.clone(), file_c_id.clone());
+
+    let mut post = PubkyAppPost {
+        content: "Watcher:PostAttachmentOnlyEdits:Post".to_string(),
+        kind: PubkyAppPostKind::Short,
+        parent: None,
+        embed: None,
+        attachments: Some(vec![attachment_a.clone(), attachment_b.clone()]),
+    };
+
+    let (post_id, post_path) = test.create_post(&user_kp, &post).await?;
+
+    // Check initial post state
+    let post_details = find_post_details(&user_id, &post_id).await?;
+    assert_eq!(
+        post_details.attachments,
+        Some(vec![attachment_a.clone(), attachment_b.clone()])
+    );
+
+    post.attachments = Some(vec![attachment_b.clone(), attachment_c.clone()]);
+    test.put(&user_kp, &post_path, &post).await?;
+
+    // Check post after attachments were changed
+    let post_details = find_post_details(&user_id, &post_id).await?;
+    assert_eq!(post_details.content, post.content);
+    assert_eq!(
+        post_details.attachments,
+        Some(vec![attachment_b.clone(), attachment_c.clone()])
+    );
+
+    post.attachments = Some(vec![attachment_c.clone()]);
+    test.put(&user_kp, &post_path, &post).await?;
+
+    // Check post after attachments were removed
+    let post_details = find_post_details(&user_id, &post_id).await?;
+    assert_eq!(post_details.content, post.content);
+    assert_eq!(
+        post_details.attachments,
+        Some(vec![attachment_c]),
+        "Expected the removed attachment to no longer appear in post lookup"
+    );
+
+    test.cleanup_post(&user_kp, &post_path).await?;
+    test.cleanup_file(&user_kp, &first_file_path).await?;
+    test.cleanup_file(&user_kp, &file_b_path).await?;
+    test.cleanup_file(&user_kp, &file_c_path).await?;
+    test.cleanup_user(&user_kp).await?;
+
+    Ok(())
+}


### PR DESCRIPTION
This PR fixes the way a post edit was detected. Now the logic checks the post attachments, as well.

Fixes #818