### PR TITLE
Flatten `PubkyClientError` variants

### DIFF
--- a/nexus-common/src/db/connectors/mod.rs
+++ b/nexus-common/src/db/connectors/mod.rs
@@ -3,5 +3,5 @@ mod pubky;
 mod redis;
 
 pub use neo4j::{get_neo4j_graph, Neo4jConnector, NEO4J_CONNECTOR};
-pub use pubky::{PubkyClientError, PubkyClientErrorKind, PubkyConnector};
+pub use pubky::{PubkyClientError, PubkyConnector};
 pub use redis::{get_redis_conn, RedisConnector, REDIS_CONNECTOR};

--- a/nexus-common/src/db/connectors/pubky.rs
+++ b/nexus-common/src/db/connectors/pubky.rs
@@ -112,9 +112,7 @@ impl PubkyConnector {
                         .build(),
                     None => PubkyHttpClient::new(),
                 }
-                .map_err(|e| PubkyClientError::BuildFailed {
-                    message: e.to_string(),
-                })?;
+                .map_err(|e| PubkyClientError::from(pubky::Error::from(e)))?;
                 Ok(Arc::new(Pubky::with_client(client)))
             })
             .await

--- a/nexus-common/src/db/connectors/pubky.rs
+++ b/nexus-common/src/db/connectors/pubky.rs
@@ -83,7 +83,10 @@ impl PubkyClientError {
     pub fn is_retryable(&self) -> bool {
         matches!(
             self,
-            Self::ServerError5xx { .. } | Self::RequestFailed { .. } | Self::PkarrFailed { .. }
+            Self::NotInitialized
+                | Self::ServerError5xx { .. }
+                | Self::RequestFailed { .. }
+                | Self::PkarrFailed { .. }
         )
     }
 }

--- a/nexus-common/src/db/connectors/pubky.rs
+++ b/nexus-common/src/db/connectors/pubky.rs
@@ -8,7 +8,10 @@ use tracing::debug;
 static PUBKY_SINGLETON: OnceCell<Arc<Pubky>> = OnceCell::const_new();
 
 #[derive(Debug, Error, Clone, Serialize, Deserialize)]
-pub enum PubkyClientErrorKind {
+pub enum PubkyClientError {
+    #[error("PubkyClient not initialized")]
+    NotInitialized,
+
     #[error("404: {message}")]
     NotFound404 { message: String },
 
@@ -31,7 +34,7 @@ pub enum PubkyClientErrorKind {
     ParseFailed { message: String },
 }
 
-impl From<pubky::Error> for PubkyClientErrorKind {
+impl From<pubky::Error> for PubkyClientError {
     fn from(err: pubky::Error) -> Self {
         match err {
             pubky::Error::Request(req_err) => match req_err {
@@ -70,7 +73,7 @@ impl From<pubky::Error> for PubkyClientErrorKind {
     }
 }
 
-impl PubkyClientErrorKind {
+impl PubkyClientError {
     /// Returns true if this error is a 404 (content not found)
     pub fn is_404(&self) -> bool {
         matches!(self, Self::NotFound404 { .. })
@@ -83,15 +86,6 @@ impl PubkyClientErrorKind {
             Self::ServerError5xx { .. } | Self::RequestFailed { .. } | Self::PkarrFailed { .. }
         )
     }
-}
-
-#[derive(Debug, Error, Clone, Serialize, Deserialize)]
-pub enum PubkyClientError {
-    #[error("PubkyClient not initialized")]
-    NotInitialized,
-
-    #[error("Client error: {0}")]
-    ClientError(#[from] PubkyClientErrorKind),
 }
 
 pub struct PubkyConnector;
@@ -118,10 +112,8 @@ impl PubkyConnector {
                         .build(),
                     None => PubkyHttpClient::new(),
                 }
-                .map_err(|e| {
-                    PubkyClientError::ClientError(PubkyClientErrorKind::BuildFailed {
-                        message: e.to_string(),
-                    })
+                .map_err(|e| PubkyClientError::BuildFailed {
+                    message: e.to_string(),
                 })?;
                 Ok(Arc::new(Pubky::with_client(client)))
             })

--- a/nexus-common/src/db/mod.rs
+++ b/nexus-common/src/db/mod.rs
@@ -6,8 +6,8 @@ pub mod reindex;
 
 pub use config::*;
 pub use connectors::{
-    get_neo4j_graph, get_redis_conn, Neo4jConnector, PubkyClientError, PubkyClientErrorKind,
-    PubkyConnector, RedisConnector, NEO4J_CONNECTOR, REDIS_CONNECTOR,
+    get_neo4j_graph, get_redis_conn, Neo4jConnector, PubkyClientError, PubkyConnector,
+    RedisConnector, NEO4J_CONNECTOR, REDIS_CONNECTOR,
 };
 pub use graph::error::{GraphError, GraphResult};
 pub use graph::exec::*;

--- a/nexus-common/src/models/event/errors.rs
+++ b/nexus-common/src/models/event/errors.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::db::{kv::RedisError, GraphError, PubkyClientError, PubkyClientErrorKind};
+use crate::db::{kv::RedisError, GraphError, PubkyClientError};
 use crate::models::error::ModelError;
 
 #[derive(Error, Debug, Clone, Serialize, Deserialize)]
@@ -70,7 +70,7 @@ impl From<ModelError> for EventProcessorError {
 
 impl From<pubky::Error> for EventProcessorError {
     fn from(e: pubky::Error) -> Self {
-        EventProcessorError::PubkyClientError(PubkyClientError::from(PubkyClientErrorKind::from(e)))
+        EventProcessorError::PubkyClientError(PubkyClientError::from(e))
     }
 }
 
@@ -102,15 +102,11 @@ impl EventProcessorError {
     }
 
     pub fn client_error(message: String) -> Self {
-        Self::PubkyClientError(PubkyClientError::ClientError(
-            PubkyClientErrorKind::RequestFailed { message },
-        ))
+        Self::PubkyClientError(PubkyClientError::RequestFailed { message })
     }
 
     pub fn client_error_404(message: String) -> Self {
-        Self::PubkyClientError(PubkyClientError::ClientError(
-            PubkyClientErrorKind::NotFound404 { message },
-        ))
+        Self::PubkyClientError(PubkyClientError::NotFound404 { message })
     }
 
     pub fn static_save_failed(source: impl Display) -> Self {
@@ -143,7 +139,7 @@ impl EventProcessorError {
     /// dead-lettered immediately.
     pub fn is_retryable(&self) -> bool {
         match self {
-            Self::PubkyClientError(PubkyClientError::ClientError(kind)) => kind.is_retryable(),
+            Self::PubkyClientError(err) => err.is_retryable(),
             Self::InvalidEventLine(_) => false,
             Self::SkipIndexing => false,
             _ => true,
@@ -157,10 +153,6 @@ impl EventProcessorError {
 
     /// Returns whether this error indicates a 404 (content definitively gone)
     pub fn is_404(&self) -> bool {
-        matches!(
-            self,
-            Self::PubkyClientError(PubkyClientError::ClientError(kind))
-                if kind.is_404()
-        )
+        matches!(self, Self::PubkyClientError(err) if err.is_404())
     }
 }

--- a/nexus-watcher/tests/service/retry_processor.rs
+++ b/nexus-watcher/tests/service/retry_processor.rs
@@ -433,9 +433,7 @@ async fn test_retry_404_removes_from_queue() -> Result<()> {
         create_test_config(10, 50, 60, 3600, 60, 3600),
         create_mock_handler(
             Err(EventProcessorError::PubkyClientError(
-                nexus_common::db::PubkyClientError::ClientError(
-                    nexus_common::db::PubkyClientErrorKind::NotFound404 { message: event_uri },
-                ),
+                nexus_common::db::PubkyClientError::NotFound404 { message: event_uri },
             )),
             post_id,
         ),


### PR DESCRIPTION
This PR removes the newly-introduced `PubkyClientErrorKind` by merging it into `PubkyClientError` and making it the single public error surface for Pubky client failures. It replaces the transient `PubkyClientError::ClientError(...)` wrapper with direct error variants.