### PR TITLE
simplify error handling

### DIFF
--- a/nexus-common/src/models/event/errors.rs
+++ b/nexus-common/src/models/event/errors.rs
@@ -134,9 +134,14 @@ impl EventProcessorError {
         }
     }
 
-    /// Returns whether this error is transient and worth retrying.
-    /// Non-retryable errors (ParseFailed, AuthenticationFailed, BuildFailed) should be
-    /// dead-lettered immediately.
+    /// Returns whether this error is transient and worth queuing for retry.
+    ///
+    /// Default is **retryable**: when in doubt we enqueue rather than drop, since
+    /// `max_retries` bounds the waste on a misclassified deterministic error,
+    /// while silently dropping a misclassified transient error loses data outright.
+    /// Only variants we know to be deterministic at conversion time
+    /// (`InvalidEventLine`, `SkipIndexing`, and the dead-letter `PubkyClientError`
+    /// kinds — `ParseFailed` / `AuthenticationFailed` / `BuildFailed` / 404) opt out.
     pub fn is_retryable(&self) -> bool {
         match self {
             Self::PubkyClientError(err) => err.is_retryable(),

--- a/nexus-watcher/src/service/indexer/mod.rs
+++ b/nexus-watcher/src/service/indexer/mod.rs
@@ -144,50 +144,33 @@ pub trait TEventProcessor: Send + Sync + 'static {
     /// Called in the event processing loop.
     ///
     /// Returns:
-    /// - `Ok(())` - Continue processing the batch (for MissingDependency, InvalidEventLine, SkipIndexing, 404)
+    /// - `Ok(())` - Continue processing the batch (non-retryable errors are dropped, retryable
+    ///   ones are queued for retry)
     /// - `Err(e)` - Stop processing and return error (for infrastructure errors)
     async fn handle_error(
         &self,
         event: &Event,
         error: EventProcessorError,
     ) -> Result<(), EventProcessorError> {
-        match &error {
-            EventProcessorError::MissingDependency { dependency: _ } => {
-                if let Some(s) = self.retry_scheduler() {
-                    s.queue_missing_dep(event).await
-                } else {
-                    Ok(())
-                }
-            }
-            EventProcessorError::SkipIndexing => {
-                // Skip indexing - no retry entry needed
-                debug!("Skipping event indexing: {}", event.uri);
-                Ok(())
-            }
-            EventProcessorError::InvalidEventLine(_) => {
-                warn!("Invalid event line, skipping: {error}");
-                Ok(())
-            }
-            EventProcessorError::PubkyClientError(_) if error.is_404() => {
-                debug!("Content not found (404), skipping event: {}", event.uri);
-                Ok(())
-            }
-            EventProcessorError::PubkyClientError(_) => {
-                warn!("Client error, queuing event for retry: {error}");
-                if let Some(s) = self.retry_scheduler() {
-                    s.queue_transient(event).await
-                } else {
-                    Ok(())
-                }
-            }
-            _ if error.is_infrastructure() => {
-                warn!("Infrastructure error, stopping batch: {error}");
-                Err(error)
-            }
-            _ => {
-                warn!("Unhandled error, continuing batch: {error}");
-                Ok(())
-            }
+        if error.is_infrastructure() {
+            warn!("Infrastructure error, stopping batch: {error}");
+            return Err(error);
+        }
+
+        if !error.is_retryable() {
+            debug!("Non-retryable error, skipping event {}: {error}", event.uri);
+            return Ok(());
+        }
+
+        let Some(scheduler) = self.retry_scheduler() else {
+            return Ok(());
+        };
+
+        if error.is_missing_dependency() {
+            scheduler.queue_missing_dep(event).await
+        } else {
+            warn!("Retryable error, queuing event for retry: {error}");
+            scheduler.queue_transient(event).await
         }
     }
 


### PR DESCRIPTION
 Simplify `TEventProcessor::handle_error` to use `EventProcessorError::is_infrastructure` + `is_retryable` + `is_missing_dependency` instead of an exhaustive match. 