### PR TITLE
Batch `RetryEvent::remove_from_index` call

### DIFF
--- a/nexus-watcher/src/events/retry/event.rs
+++ b/nexus-watcher/src/events/retry/event.rs
@@ -113,6 +113,20 @@ impl RetryEvent {
         Ok(())
     }
 
+    /// Removes multiple sorted-set index entries without touching JSON state.
+    ///
+    /// Used for tombstone cleanup in the retry store: the JSON state is already
+    /// missing, so a single batched ZREM reconciles the index.
+    #[tracing::instrument(name = "retry.index.remove_stale", skip_all)]
+    pub async fn remove_stale_index_entries(index_keys: &[&str]) -> RedisResult<()> {
+        Self::remove_from_index_sorted_set(
+            Some(RETRY_MANAGER_PREFIX),
+            &RETRY_MANAGER_EVENTS_INDEX,
+            index_keys,
+        )
+        .await
+    }
+
     /// Fetches events from the retry queue that are ready to be retried (next_retry_at <= now)
     /// Returns Vec<(index_key, score)> pairs for events ready for retry
     /// # Arguments

--- a/nexus-watcher/src/events/retry/store.rs
+++ b/nexus-watcher/src/events/retry/store.rs
@@ -94,19 +94,23 @@ impl RetryStore for RedisRetryStore {
         };
 
         let mut events = Vec::with_capacity(key_score_pairs.len());
+        let mut stale: Vec<RetryEventIndexKey> = Vec::new();
         for (index_key, _score) in key_score_pairs {
             match RetryEvent::get_from_index(&index_key).await? {
-                Some(event) => events.push((index_key.clone(), event)),
+                Some(event) => events.push((index_key, event)),
                 None => {
                     // Sorted-set entry with no JSON state — tombstone, clean up and skip.
-                    debug!(
-                        "Stale retry entry detected for key {}, cleaning up",
-                        index_key
-                    );
-                    RetryEvent::remove_from_index(&index_key).await?;
+                    debug!("Stale retry entry detected for key {index_key}, cleaning up");
+                    stale.push(index_key);
                 }
             }
         }
+
+        if !stale.is_empty() {
+            let refs: Vec<&str> = stale.iter().map(String::as_str).collect();
+            RetryEvent::remove_stale_index_entries(&refs).await?;
+        }
+
         Ok(events)
     }
 }


### PR DESCRIPTION
This PR batches the tombstone cleanup calls in `RedisRetryStore::fetch_ready`.

After step 1, there is a `Vec<&str>` of stale keys. One

```
remove_from_index_sorted_set(Some(RETRY_MANAGER_PREFIX), &RETRY_MANAGER_EVENTS_INDEX, &stale)
```

call replaces `M` ZREM calls.

Also: a tombstone by definition already has no JSON state, so the JSON.DEL from `remove_from_index` was a wasted RTT.