### PR TITLE
Batch `RetryEvent::get_from_index`

### DIFF
--- a/nexus-watcher/src/events/retry/event.rs
+++ b/nexus-watcher/src/events/retry/event.rs
@@ -93,6 +93,19 @@ impl RetryEvent {
         Self::try_from_index_json(index, None).await
     }
 
+    /// Batched variant of [`Self::get_from_index`] backed by a single `JSON.MGET`.
+    ///
+    /// Results are returned positionally: element `i` corresponds to `index_keys[i]`,
+    /// with `None` for keys whose JSON state is missing (tombstones).
+    pub async fn get_multiple_from_index(index_keys: &[&str]) -> RedisResult<Vec<Option<Self>>> {
+        let key_parts: Vec<[&str; 2]> = index_keys
+            .iter()
+            .map(|k| [RETRY_MANAGER_STATE_INDEX[0], *k])
+            .collect();
+        let key_parts_refs: Vec<&[&str]> = key_parts.iter().map(|p| p.as_slice()).collect();
+        Self::try_from_index_multiple_json(&key_parts_refs).await
+    }
+
     /// Removes an event from the retry queue (both sorted set and JSON state)
     /// # Arguments
     /// * `index_key` - A `&RetryEventIndexKey` representing the index key to remove

--- a/nexus-watcher/src/events/retry/store.rs
+++ b/nexus-watcher/src/events/retry/store.rs
@@ -93,10 +93,14 @@ impl RetryStore for RedisRetryStore {
             None => return Ok(Vec::new()),
         };
 
+        // Batch-fetch JSON state for every candidate in a single JSON.MGET.
+        let keys: Vec<&str> = key_score_pairs.iter().map(|(k, _)| k.as_str()).collect();
+        let maybe_events = RetryEvent::get_multiple_from_index(&keys).await?;
+
         let mut events = Vec::with_capacity(key_score_pairs.len());
         let mut stale: Vec<RetryEventIndexKey> = Vec::new();
-        for (index_key, _score) in key_score_pairs {
-            match RetryEvent::get_from_index(&index_key).await? {
+        for ((index_key, _score), maybe_event) in key_score_pairs.into_iter().zip(maybe_events) {
+            match maybe_event {
                 Some(event) => events.push((index_key, event)),
                 None => {
                     // Sorted-set entry with no JSON state — tombstone, clean up and skip.


### PR DESCRIPTION
This PR batches the JSON fetches (`RetryEvent::get_from_index`) inside `RedisRetryStore::fetch_ready`.

`RedisOps` already exposes `try_from_index_multiple_json / mget`, which collapses the `N` `JSON.GETs` into one `JSON.MGET`. With `RETRY_BATCH_SIZE = 100`, that's 100 round trips → 1.