### PR TITLE
Simplify `RetryEvent::fetch_ready`: return empty vec instead of None

### DIFF
--- a/nexus-watcher/src/events/retry/event.rs
+++ b/nexus-watcher/src/events/retry/event.rs
@@ -141,17 +141,16 @@ impl RetryEvent {
     }
 
     /// Fetches events from the retry queue that are ready to be retried (next_retry_at <= now)
-    /// Returns Vec<(index_key, score)> pairs for events ready for retry
     /// # Arguments
     /// * `now` - Current time in milliseconds since epoch
     /// * `limit` - Maximum number of events to fetch per batch
     /// # Returns
-    /// A vector of (index_key, score) pairs, or None if no events found
+    /// A vector of (index_key, score) pairs; empty when no events are ready.
     #[tracing::instrument(name = "retry.index.fetch_ready", skip_all)]
     pub async fn fetch_ready(
         now: i64,
         limit: Option<usize>,
-    ) -> Result<Option<Vec<(RetryEventIndexKey, f64)>>, EventProcessorError> {
+    ) -> Result<Vec<(RetryEventIndexKey, f64)>, EventProcessorError> {
         Self::try_from_index_sorted_set(
             &RETRY_MANAGER_EVENTS_INDEX,
             Some(now as f64), // max_score (start → max in get_range)
@@ -162,6 +161,7 @@ impl RetryEvent {
             Some(RETRY_MANAGER_PREFIX),
         )
         .await
+        .map(Option::unwrap_or_default)
         .map_err(|e| EventProcessorError::generic(format!("Failed to fetch retry events: {}", e)))
     }
 }

--- a/nexus-watcher/src/events/retry/store.rs
+++ b/nexus-watcher/src/events/retry/store.rs
@@ -88,10 +88,7 @@ impl RetryStore for RedisRetryStore {
         now: i64,
         limit: Option<usize>,
     ) -> Result<Vec<(RetryEventIndexKey, RetryEvent)>, EventProcessorError> {
-        let key_score_pairs = match RetryEvent::fetch_ready(now, limit).await? {
-            Some(pairs) => pairs,
-            None => return Ok(Vec::new()),
-        };
+        let key_score_pairs = RetryEvent::fetch_ready(now, limit).await?;
 
         // Batch-fetch JSON state for every candidate in a single JSON.MGET.
         let keys: Vec<&str> = key_score_pairs.iter().map(|(k, _)| k.as_str()).collect();

--- a/nexus-watcher/tests/service/retry_processor.rs
+++ b/nexus-watcher/tests/service/retry_processor.rs
@@ -733,10 +733,7 @@ async fn test_stale_sorted_set_entry_cleaned_up() -> Result<()> {
     // Sanity: the stale entry is visible in the raw sorted set.
     let raw_before = RetryEvent::fetch_ready(now, None).await?;
     assert!(
-        raw_before
-            .as_ref()
-            .map(|r| r.iter().any(|(key, _)| key == &resource_key))
-            .unwrap_or(false),
+        raw_before.iter().any(|(key, _)| key == &resource_key),
         "Stale entry should be present in sorted set before cleanup"
     );
 
@@ -746,19 +743,14 @@ async fn test_stale_sorted_set_entry_cleaned_up() -> Result<()> {
     let ready = store.fetch_ready(now, None).await?;
     assert!(
         !ready.iter().any(|(key, _)| key == &resource_key),
-        "Stale entry {} should be filtered out by RedisRetryStore::fetch_ready",
-        resource_key
+        "Stale entry {resource_key} should be filtered out by RedisRetryStore::fetch_ready"
     );
 
     // And it should actually be removed from the sorted set (not just filtered).
     let raw_after = RetryEvent::fetch_ready(now, None).await?;
     assert!(
-        raw_after
-            .as_ref()
-            .map(|r| !r.iter().any(|(key, _)| key == &resource_key))
-            .unwrap_or(true),
-        "Stale entry {} should be removed from sorted set after cleanup",
-        resource_key
+        !raw_after.iter().any(|(key, _)| key == &resource_key),
+        "Stale entry {resource_key} should be removed from sorted set after cleanup"
     );
 
     Ok(())


### PR DESCRIPTION
This PR collapses `Option<Vec<..>>` into a `Vec<..>` in the return type of `RetryEvent::fetch_ready`.

This makes it simpler for callers to deal with empty results.