### PR TITLE
Simplify `EventHandler` by removing unused `moderation()`

### DIFF
--- a/nexus-watcher/src/events/mod.rs
+++ b/nexus-watcher/src/events/mod.rs
@@ -17,9 +17,6 @@ pub use moderation::Moderation;
 /// including mocked versions for testing.
 #[async_trait::async_trait]
 pub trait EventHandler: Send + Sync {
-    /// Returns the moderation instance used by this event handler.
-    fn moderation(&self) -> &Arc<Moderation>;
-
     /// Handle an event.
     ///
     /// Returns `Ok(())` on success, or `Err(EventProcessorError)` on failure.
@@ -39,10 +36,6 @@ impl DefaultEventHandler {
 
 #[async_trait::async_trait]
 impl EventHandler for DefaultEventHandler {
-    fn moderation(&self) -> &Arc<Moderation> {
-        &self.moderation
-    }
-
     async fn handle(&self, event: &Event) -> Result<(), EventProcessorError> {
         match event.event_type {
             EventType::Put => handle_put_event(event, self.moderation.clone()).await,

--- a/nexus-watcher/src/events/retry/processor.rs
+++ b/nexus-watcher/src/events/retry/processor.rs
@@ -35,10 +35,6 @@ impl TEventProcessor for RetryProcessor {
         &self.files_path
     }
 
-    fn moderation(&self) -> &Arc<Moderation> {
-        self.event_handler.moderation()
-    }
-
     fn event_handler(&self) -> &Arc<dyn EventHandler> {
         &self.event_handler
     }

--- a/nexus-watcher/src/service/indexer/homeserver.rs
+++ b/nexus-watcher/src/service/indexer/homeserver.rs
@@ -1,6 +1,6 @@
 use super::TEventProcessor;
 use crate::events::retry::RetryScheduler;
-use crate::events::{EventHandler, Moderation};
+use crate::events::EventHandler;
 use nexus_common::db::PubkyConnector;
 use nexus_common::models::event::EventProcessorError;
 use nexus_common::models::homeserver::Homeserver;
@@ -18,7 +18,6 @@ pub struct HsEventProcessor {
     /// See [WatcherConfig::events_limit]
     pub limit: u32,
     pub files_path: PathBuf,
-    pub moderation: Arc<Moderation>,
     pub event_handler: Arc<dyn EventHandler>,
     pub shutdown_rx: Receiver<bool>,
     /// Scheduler used to enqueue failed events onto the retry queue
@@ -29,10 +28,6 @@ pub struct HsEventProcessor {
 impl TEventProcessor for HsEventProcessor {
     fn files_path(&self) -> &PathBuf {
         &self.files_path
-    }
-
-    fn moderation(&self) -> &Arc<Moderation> {
-        &self.moderation
     }
 
     fn event_handler(&self) -> &Arc<dyn EventHandler> {

--- a/nexus-watcher/src/service/indexer/key_based.rs
+++ b/nexus-watcher/src/service/indexer/key_based.rs
@@ -6,7 +6,7 @@ use nexus_common::models::homeserver::Homeserver;
 
 use super::TEventProcessor;
 use crate::events::retry::RetryScheduler;
-use crate::events::{EventHandler, Moderation};
+use crate::events::EventHandler;
 use crate::service::user_hs_resolver;
 
 /// Event processor for non-default HSs, where the user-specific `/events-stream` endpoint is used
@@ -15,7 +15,6 @@ pub struct KeyBasedEventProcessor {
     pub homeserver: Homeserver,
 
     pub files_path: PathBuf,
-    pub moderation: Arc<Moderation>,
     pub event_handler: Arc<dyn EventHandler>,
     /// Scheduler used to enqueue failed events onto the retry queue
     pub retry_scheduler: Arc<RetryScheduler>,
@@ -25,10 +24,6 @@ pub struct KeyBasedEventProcessor {
 impl TEventProcessor for KeyBasedEventProcessor {
     fn files_path(&self) -> &PathBuf {
         &self.files_path
-    }
-
-    fn moderation(&self) -> &Arc<Moderation> {
-        &self.moderation
     }
 
     fn event_handler(&self) -> &Arc<dyn EventHandler> {

--- a/nexus-watcher/src/service/indexer/mod.rs
+++ b/nexus-watcher/src/service/indexer/mod.rs
@@ -12,7 +12,7 @@ use nexus_common::models::event::{Event, EventProcessorError};
 use tracing::{debug, error, warn};
 
 use crate::events::retry::RetryScheduler;
-use crate::events::{EventHandler, Moderation};
+use crate::events::EventHandler;
 use crate::service::PROCESSING_TIMEOUT_SECS;
 
 /// Possible error types of an event processor run
@@ -58,7 +58,6 @@ impl Display for RunError {
 #[async_trait::async_trait]
 pub trait TEventProcessor: Send + Sync + 'static {
     fn files_path(&self) -> &PathBuf;
-    fn moderation(&self) -> &Arc<Moderation>;
 
     /// Returns the event handler used to process events.
     ///

--- a/nexus-watcher/src/service/runner/homeserver.rs
+++ b/nexus-watcher/src/service/runner/homeserver.rs
@@ -14,7 +14,6 @@ pub struct HsEventProcessorRunner {
     /// See [WatcherConfig::events_limit]
     pub limit: u32,
     pub files_path: PathBuf,
-    pub moderation: Arc<Moderation>,
     pub event_handler: Arc<dyn EventHandler>,
     pub shutdown_rx: Receiver<bool>,
     /// See [WatcherConfig::homeserver]
@@ -26,12 +25,10 @@ pub struct HsEventProcessorRunner {
 impl HsEventProcessorRunner {
     /// Creates a new instance from the provided configuration
     pub fn from_config(config: &WatcherConfig, shutdown_rx: Receiver<bool>) -> Self {
-        let moderation = Moderation::from_config(config);
         Self {
             limit: config.events_limit,
             files_path: config.stack.files_path.clone(),
-            moderation: moderation.clone(),
-            event_handler: Arc::new(DefaultEventHandler::new(moderation)),
+            event_handler: Arc::new(DefaultEventHandler::new(Moderation::from_config(config))),
             shutdown_rx,
             default_homeserver: config.homeserver.clone(),
             retry_scheduler: Arc::new(RetryScheduler::from_config(config)),
@@ -60,7 +57,6 @@ impl TEventProcessorRunner for HsEventProcessorRunner {
             homeserver,
             limit: self.limit,
             files_path: self.files_path.clone(),
-            moderation: self.moderation.clone(),
             event_handler: self.event_handler.clone(),
             shutdown_rx: self.shutdown_rx.clone(),
             retry_scheduler: self.retry_scheduler.clone(),

--- a/nexus-watcher/src/service/runner/key_based.rs
+++ b/nexus-watcher/src/service/runner/key_based.rs
@@ -20,7 +20,6 @@ pub struct KeyBasedEventProcessorRunner {
     /// See [WatcherConfig::monitored_homeservers_limit]
     pub monitored_hs_limit: usize,
     pub files_path: PathBuf,
-    pub moderation: Arc<Moderation>,
     pub event_handler: Arc<dyn EventHandler>,
     pub shutdown_rx: Receiver<bool>,
     /// Default homeserver ID, excluded from the external targets list
@@ -34,13 +33,11 @@ pub struct KeyBasedEventProcessorRunner {
 impl KeyBasedEventProcessorRunner {
     /// Creates a new instance from the provided configuration
     pub fn from_config(config: &WatcherConfig, shutdown_rx: Receiver<bool>) -> Self {
-        let moderation = Moderation::from_config(config);
         Self {
             limit: config.events_limit,
             monitored_hs_limit: config.monitored_homeservers_limit,
             files_path: config.stack.files_path.clone(),
-            moderation: moderation.clone(),
-            event_handler: Arc::new(DefaultEventHandler::new(moderation)),
+            event_handler: Arc::new(DefaultEventHandler::new(Moderation::from_config(config))),
             shutdown_rx,
             default_homeserver: config.homeserver.clone(),
             backoff: Mutex::new(HomeserverBackoff::new(
@@ -83,7 +80,6 @@ impl TEventProcessorRunner for KeyBasedEventProcessorRunner {
         Ok(Arc::new(KeyBasedEventProcessor {
             homeserver,
             files_path: self.files_path.clone(),
-            moderation: self.moderation.clone(),
             event_handler: self.event_handler.clone(),
             retry_scheduler: self.retry_scheduler.clone(),
         }))

--- a/nexus-watcher/tests/event_processor/utils/watcher.rs
+++ b/nexus-watcher/tests/event_processor/utils/watcher.rs
@@ -13,7 +13,7 @@ use nexus_common::models::traits::Collection;
 use nexus_common::{StackConfig, StackManager};
 use nexus_watcher::events::retry::event::RetryEvent;
 use nexus_watcher::events::retry::{InitialBackoff, RedisRetryStore, RetryScheduler, RetryStore};
-use nexus_watcher::events::{DefaultEventHandler, EventHandler, Moderation};
+use nexus_watcher::events::{DefaultEventHandler, EventHandler};
 use nexus_watcher::service::HsEventProcessorRunner;
 use nexus_watcher::service::TEventProcessorRunner;
 use pubky::Keypair;
@@ -77,9 +77,8 @@ impl WatcherTest {
     /// # Returns
     /// Returns a fully configured `HsEventProcessorRunner` ready for use in tests.
     fn create_test_event_processor_runner(default_homeserver: PubkyId) -> HsEventProcessorRunner {
-        let moderation: Arc<Moderation> = default_moderation_tests();
         let event_handler: Arc<dyn EventHandler> =
-            Arc::new(DefaultEventHandler::new(moderation.clone()));
+            Arc::new(DefaultEventHandler::new(default_moderation_tests()));
 
         let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
 
@@ -95,7 +94,6 @@ impl WatcherTest {
         HsEventProcessorRunner {
             limit: 1000,
             files_path: get_files_dir_test_pathbuf(),
-            moderation,
             event_handler,
             shutdown_rx,
             default_homeserver,

--- a/nexus-watcher/tests/service/event_processor_prioritization.rs
+++ b/nexus-watcher/tests/service/event_processor_prioritization.rs
@@ -19,9 +19,8 @@ async fn test_event_processor_runner_default_homeserver_excluded() -> Result<(),
     // Initialize the test
     setup().await?;
 
-    let moderation = default_moderation_tests();
     let event_handler: Arc<dyn EventHandler> =
-        Arc::new(DefaultEventHandler::new(moderation.clone()));
+        Arc::new(DefaultEventHandler::new(default_moderation_tests()));
     let store: Arc<dyn RetryStore> = Arc::new(RedisRetryStore::new());
     let retry_scheduler = Arc::new(RetryScheduler::new(
         store,
@@ -34,7 +33,6 @@ async fn test_event_processor_runner_default_homeserver_excluded() -> Result<(),
         limit: 1000,
         monitored_hs_limit: HS_IDS.len(),
         files_path: PathBuf::from("/tmp/nexus-watcher-test"),
-        moderation: moderation.clone(),
         event_handler,
         shutdown_rx: tokio::sync::watch::channel(false).1,
         default_homeserver: PubkyId::try_from(HS_IDS[3]).unwrap(),

--- a/nexus-watcher/tests/service/retry_processor.rs
+++ b/nexus-watcher/tests/service/retry_processor.rs
@@ -37,12 +37,19 @@ fn create_test_config(
     }
 }
 
-/// Test helper to create a mock event handler that always returns `result`.
+/// Test helper to create a mock event handler scoped to a specific URI substring.
 ///
-/// Each test owns its own fresh [`InMemoryRetryStore`], so the handler only ever
-/// sees the events the test itself enqueued — no cross-test isolation needed.
-fn create_mock_handler(result: Result<(), EventProcessorError>) -> Arc<dyn EventHandler> {
-    Arc::new(MockEventHandler { result })
+/// `target_substring` is typically the unique post_id prefix used by the test. Events
+/// whose URI matches get `result`; any other events (leftover entries from parallel
+/// tests in the shared retry queue) get `Ok(())` and are drained normally.
+fn create_mock_handler(
+    result: Result<(), EventProcessorError>,
+    target_substring: &str,
+) -> Arc<dyn EventHandler> {
+    Arc::new(MockEventHandler {
+        result,
+        target_uri_substring: Some(target_substring.to_string()),
+    })
 }
 
 /// Test helper to create a test RetryEvent with a valid URI
@@ -118,7 +125,10 @@ async fn test_backoff_first_retry_uses_initial_value() -> Result<()> {
     let processor = build_processor(
         store.clone(),
         create_test_config(10, 50, 60, 3600, 60, 3600),
-        create_mock_handler(Err(EventProcessorError::Generic("retry error".to_string()))),
+        create_mock_handler(
+            Err(EventProcessorError::Generic("retry error".to_string())),
+            post_id,
+        ),
         shutdown_rx,
     );
 
@@ -174,7 +184,10 @@ async fn test_backoff_exponential_growth() -> Result<()> {
     let processor = build_processor(
         store.clone(),
         create_test_config(10, 50, 10, 3600, 60, 3600),
-        create_mock_handler(Err(EventProcessorError::Generic("retry error".to_string()))),
+        create_mock_handler(
+            Err(EventProcessorError::Generic("retry error".to_string())),
+            post_id,
+        ),
         shutdown_rx,
     );
 
@@ -233,10 +246,13 @@ async fn test_infrastructure_error_at_max_retries_does_not_dead_letter() -> Resu
     let processor = build_processor(
         store.clone(),
         create_test_config(10, 50, 60, 3600, 60, 3600),
-        create_mock_handler(Err(EventProcessorError::GraphQueryFailed(
-            true, // is_infrastructure = true
-            "Database connection failed".to_string(),
-        ))),
+        create_mock_handler(
+            Err(EventProcessorError::GraphQueryFailed(
+                true, // is_infrastructure = true
+                "Database connection failed".to_string(),
+            )),
+            post_id,
+        ),
         shutdown_rx,
     );
 
@@ -296,7 +312,10 @@ async fn test_backoff_capped_at_max() -> Result<()> {
     let processor = build_processor(
         store.clone(),
         create_test_config(10, 50, 60, 3600, 60, 3600),
-        create_mock_handler(Err(EventProcessorError::Generic("retry error".to_string()))),
+        create_mock_handler(
+            Err(EventProcessorError::Generic("retry error".to_string())),
+            post_id,
+        ),
         shutdown_rx,
     );
 
@@ -358,7 +377,7 @@ async fn test_retry_success_removes_from_queue() -> Result<()> {
     let processor = build_processor(
         store.clone(),
         create_test_config(10, 50, 60, 3600, 60, 3600),
-        create_mock_handler(Ok(())), // Success
+        create_mock_handler(Ok(()), post_id), // Success
         shutdown_rx,
     );
 
@@ -405,9 +424,12 @@ async fn test_retry_404_removes_from_queue() -> Result<()> {
     let processor = build_processor(
         store.clone(),
         create_test_config(10, 50, 60, 3600, 60, 3600),
-        create_mock_handler(Err(EventProcessorError::PubkyClientError(
-            nexus_common::db::PubkyClientError::NotFound404 { message: event_uri },
-        ))),
+        create_mock_handler(
+            Err(EventProcessorError::PubkyClientError(
+                nexus_common::db::PubkyClientError::NotFound404 { message: event_uri },
+            )),
+            post_id,
+        ),
         shutdown_rx,
     );
 
@@ -454,10 +476,13 @@ async fn test_transient_error_schedules_retry() -> Result<()> {
     let processor = build_processor(
         store.clone(),
         create_test_config(10, 50, 60, 3600, 60, 3600),
-        create_mock_handler(Err(EventProcessorError::GraphQueryFailed(
-            true, // is_infrastructure = true
-            "Database connection failed".to_string(),
-        ))),
+        create_mock_handler(
+            Err(EventProcessorError::GraphQueryFailed(
+                true, // is_infrastructure = true
+                "Database connection failed".to_string(),
+            )),
+            post_id,
+        ),
         shutdown_rx,
     );
 
@@ -520,9 +545,12 @@ async fn test_missing_dependency_schedules_retry() -> Result<()> {
     let processor = build_processor(
         store.clone(),
         create_test_config(10, 50, 60, 3600, 300, 18000), // 300s initial for deps
-        create_mock_handler(Err(EventProcessorError::MissingDependency {
-            dependency: vec!["some_dependency".to_string()],
-        })),
+        create_mock_handler(
+            Err(EventProcessorError::MissingDependency {
+                dependency: vec!["some_dependency".to_string()],
+            }),
+            post_id,
+        ),
         shutdown_rx,
     );
 
@@ -592,9 +620,12 @@ async fn test_dead_letter_after_max_transient_retries() -> Result<()> {
     let processor = build_processor(
         store.clone(),
         create_test_config(10, 50, 60, 3600, 60, 3600),
-        create_mock_handler(Err(EventProcessorError::Generic(
-            "transient application failure".to_string(),
-        ))),
+        create_mock_handler(
+            Err(EventProcessorError::Generic(
+                "transient application failure".to_string(),
+            )),
+            post_id,
+        ),
         shutdown_rx,
     );
 
@@ -645,9 +676,12 @@ async fn test_dead_letter_after_max_dependency_retries() -> Result<()> {
     let processor = build_processor(
         store.clone(),
         create_test_config(10, 50, 60, 3600, 60, 3600),
-        create_mock_handler(Err(EventProcessorError::MissingDependency {
-            dependency: vec!["some_dependency".to_string()],
-        })),
+        create_mock_handler(
+            Err(EventProcessorError::MissingDependency {
+                dependency: vec!["some_dependency".to_string()],
+            }),
+            post_id,
+        ),
         shutdown_rx,
     );
 
@@ -749,7 +783,7 @@ async fn test_shutdown_interrupts_batch() -> Result<()> {
     let processor = build_processor(
         store.clone(),
         create_test_config(10, 50, 60, 3600, 60, 3600),
-        create_mock_handler(Ok(())),
+        create_mock_handler(Ok(()), "shutdown"),
         shutdown_rx,
     );
 
@@ -812,10 +846,13 @@ async fn test_infrastructure_error_stops_batch() -> Result<()> {
     let processor = build_processor(
         store.clone(),
         create_test_config(10, 50, 60, 3600, 60, 3600),
-        create_mock_handler(Err(EventProcessorError::GraphQueryFailed(
-            true, // is_infrastructure = true
-            "Critical database failure".to_string(),
-        ))),
+        create_mock_handler(
+            Err(EventProcessorError::GraphQueryFailed(
+                true, // is_infrastructure = true
+                "Critical database failure".to_string(),
+            )),
+            "infrastop",
+        ),
         shutdown_rx,
     );
 
@@ -884,7 +921,7 @@ async fn test_empty_batch_returns_ok() -> Result<()> {
     let processor = build_processor(
         store,
         create_test_config(10, 50, 60, 3600, 60, 3600),
-        create_mock_handler(Ok(())),
+        create_mock_handler(Ok(()), "empty"),
         shutdown_rx,
     );
 
@@ -919,7 +956,7 @@ async fn test_del_event_retry_success() -> Result<()> {
     let processor = build_processor(
         store.clone(),
         create_test_config(10, 50, 60, 3600, 60, 3600),
-        create_mock_handler(Ok(())),
+        create_mock_handler(Ok(()), post_id),
         shutdown_rx,
     );
 
@@ -958,9 +995,12 @@ async fn test_non_retryable_error_removes_event() -> Result<()> {
     let processor = build_processor(
         store.clone(),
         create_test_config(10, 50, 60, 3600, 60, 3600),
-        create_mock_handler(Err(EventProcessorError::InvalidEventLine(
-            "malformed data".to_string(),
-        ))),
+        create_mock_handler(
+            Err(EventProcessorError::InvalidEventLine(
+                "malformed data".to_string(),
+            )),
+            post_id,
+        ),
         shutdown_rx,
     );
 
@@ -1005,9 +1045,12 @@ async fn test_future_events_not_picked_up() -> Result<()> {
     let processor = build_processor(
         store.clone(),
         create_test_config(10, 50, 60, 3600, 60, 3600),
-        create_mock_handler(Err(EventProcessorError::Generic(
-            "should not be called".to_string(),
-        ))),
+        create_mock_handler(
+            Err(EventProcessorError::Generic(
+                "should not be called".to_string(),
+            )),
+            post_id,
+        ),
         shutdown_rx,
     );
 

--- a/nexus-watcher/tests/service/retry_processor.rs
+++ b/nexus-watcher/tests/service/retry_processor.rs
@@ -9,9 +9,8 @@ use nexus_watcher::events::retry::{
     InMemoryRetryStore, RedisRetryStore, RetryEvent, RetryEventIndexKey, RetryProcessor, RetryStore,
 };
 use nexus_watcher::events::EventHandler;
-use nexus_watcher::events::Moderation;
 use nexus_watcher::service::TEventProcessor;
-use pubky_app_specs::{post_uri_builder, PubkyId};
+use pubky_app_specs::post_uri_builder;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::watch;
@@ -38,25 +37,12 @@ fn create_test_config(
     }
 }
 
-/// Test helper to create a mock event handler scoped to a specific URI substring.
+/// Test helper to create a mock event handler that always returns `result`.
 ///
-/// `target_substring` is typically the unique post_id prefix used by the test. Events
-/// whose URI matches get `result`; any other events (leftover entries from parallel
-/// tests in the shared retry queue) get `Ok(())` and are drained normally.
-fn create_mock_handler(
-    result: Result<(), EventProcessorError>,
-    target_substring: &str,
-) -> Arc<dyn EventHandler> {
-    // Use real Moderation with a moderator ID that won't match test users
-    let moderation = Arc::new(Moderation {
-        id: PubkyId::try_from(TEST_USER_ID).expect("Valid test moderation key"),
-        tags: vec![],
-    });
-    Arc::new(MockEventHandler {
-        result,
-        target_uri_substring: Some(target_substring.to_string()),
-        moderation,
-    })
+/// Each test owns its own fresh [`InMemoryRetryStore`], so the handler only ever
+/// sees the events the test itself enqueued — no cross-test isolation needed.
+fn create_mock_handler(result: Result<(), EventProcessorError>) -> Arc<dyn EventHandler> {
+    Arc::new(MockEventHandler { result })
 }
 
 /// Test helper to create a test RetryEvent with a valid URI
@@ -132,10 +118,7 @@ async fn test_backoff_first_retry_uses_initial_value() -> Result<()> {
     let processor = build_processor(
         store.clone(),
         create_test_config(10, 50, 60, 3600, 60, 3600),
-        create_mock_handler(
-            Err(EventProcessorError::Generic("retry error".to_string())),
-            post_id,
-        ),
+        create_mock_handler(Err(EventProcessorError::Generic("retry error".to_string()))),
         shutdown_rx,
     );
 
@@ -191,10 +174,7 @@ async fn test_backoff_exponential_growth() -> Result<()> {
     let processor = build_processor(
         store.clone(),
         create_test_config(10, 50, 10, 3600, 60, 3600),
-        create_mock_handler(
-            Err(EventProcessorError::Generic("retry error".to_string())),
-            post_id,
-        ),
+        create_mock_handler(Err(EventProcessorError::Generic("retry error".to_string()))),
         shutdown_rx,
     );
 
@@ -253,13 +233,10 @@ async fn test_infrastructure_error_at_max_retries_does_not_dead_letter() -> Resu
     let processor = build_processor(
         store.clone(),
         create_test_config(10, 50, 60, 3600, 60, 3600),
-        create_mock_handler(
-            Err(EventProcessorError::GraphQueryFailed(
-                true, // is_infrastructure = true
-                "Database connection failed".to_string(),
-            )),
-            post_id,
-        ),
+        create_mock_handler(Err(EventProcessorError::GraphQueryFailed(
+            true, // is_infrastructure = true
+            "Database connection failed".to_string(),
+        ))),
         shutdown_rx,
     );
 
@@ -319,10 +296,7 @@ async fn test_backoff_capped_at_max() -> Result<()> {
     let processor = build_processor(
         store.clone(),
         create_test_config(10, 50, 60, 3600, 60, 3600),
-        create_mock_handler(
-            Err(EventProcessorError::Generic("retry error".to_string())),
-            post_id,
-        ),
+        create_mock_handler(Err(EventProcessorError::Generic("retry error".to_string()))),
         shutdown_rx,
     );
 
@@ -384,7 +358,7 @@ async fn test_retry_success_removes_from_queue() -> Result<()> {
     let processor = build_processor(
         store.clone(),
         create_test_config(10, 50, 60, 3600, 60, 3600),
-        create_mock_handler(Ok(()), post_id), // Success
+        create_mock_handler(Ok(())), // Success
         shutdown_rx,
     );
 
@@ -431,12 +405,9 @@ async fn test_retry_404_removes_from_queue() -> Result<()> {
     let processor = build_processor(
         store.clone(),
         create_test_config(10, 50, 60, 3600, 60, 3600),
-        create_mock_handler(
-            Err(EventProcessorError::PubkyClientError(
-                nexus_common::db::PubkyClientError::NotFound404 { message: event_uri },
-            )),
-            post_id,
-        ),
+        create_mock_handler(Err(EventProcessorError::PubkyClientError(
+            nexus_common::db::PubkyClientError::NotFound404 { message: event_uri },
+        ))),
         shutdown_rx,
     );
 
@@ -483,13 +454,10 @@ async fn test_transient_error_schedules_retry() -> Result<()> {
     let processor = build_processor(
         store.clone(),
         create_test_config(10, 50, 60, 3600, 60, 3600),
-        create_mock_handler(
-            Err(EventProcessorError::GraphQueryFailed(
-                true, // is_infrastructure = true
-                "Database connection failed".to_string(),
-            )),
-            post_id,
-        ),
+        create_mock_handler(Err(EventProcessorError::GraphQueryFailed(
+            true, // is_infrastructure = true
+            "Database connection failed".to_string(),
+        ))),
         shutdown_rx,
     );
 
@@ -552,12 +520,9 @@ async fn test_missing_dependency_schedules_retry() -> Result<()> {
     let processor = build_processor(
         store.clone(),
         create_test_config(10, 50, 60, 3600, 300, 18000), // 300s initial for deps
-        create_mock_handler(
-            Err(EventProcessorError::MissingDependency {
-                dependency: vec!["some_dependency".to_string()],
-            }),
-            post_id,
-        ),
+        create_mock_handler(Err(EventProcessorError::MissingDependency {
+            dependency: vec!["some_dependency".to_string()],
+        })),
         shutdown_rx,
     );
 
@@ -627,12 +592,9 @@ async fn test_dead_letter_after_max_transient_retries() -> Result<()> {
     let processor = build_processor(
         store.clone(),
         create_test_config(10, 50, 60, 3600, 60, 3600),
-        create_mock_handler(
-            Err(EventProcessorError::Generic(
-                "transient application failure".to_string(),
-            )),
-            post_id,
-        ),
+        create_mock_handler(Err(EventProcessorError::Generic(
+            "transient application failure".to_string(),
+        ))),
         shutdown_rx,
     );
 
@@ -683,12 +645,9 @@ async fn test_dead_letter_after_max_dependency_retries() -> Result<()> {
     let processor = build_processor(
         store.clone(),
         create_test_config(10, 50, 60, 3600, 60, 3600),
-        create_mock_handler(
-            Err(EventProcessorError::MissingDependency {
-                dependency: vec!["some_dependency".to_string()],
-            }),
-            post_id,
-        ),
+        create_mock_handler(Err(EventProcessorError::MissingDependency {
+            dependency: vec!["some_dependency".to_string()],
+        })),
         shutdown_rx,
     );
 
@@ -790,7 +749,7 @@ async fn test_shutdown_interrupts_batch() -> Result<()> {
     let processor = build_processor(
         store.clone(),
         create_test_config(10, 50, 60, 3600, 60, 3600),
-        create_mock_handler(Ok(()), "shutdown"),
+        create_mock_handler(Ok(())),
         shutdown_rx,
     );
 
@@ -853,13 +812,10 @@ async fn test_infrastructure_error_stops_batch() -> Result<()> {
     let processor = build_processor(
         store.clone(),
         create_test_config(10, 50, 60, 3600, 60, 3600),
-        create_mock_handler(
-            Err(EventProcessorError::GraphQueryFailed(
-                true, // is_infrastructure = true
-                "Critical database failure".to_string(),
-            )),
-            "infrastop",
-        ),
+        create_mock_handler(Err(EventProcessorError::GraphQueryFailed(
+            true, // is_infrastructure = true
+            "Critical database failure".to_string(),
+        ))),
         shutdown_rx,
     );
 
@@ -928,7 +884,7 @@ async fn test_empty_batch_returns_ok() -> Result<()> {
     let processor = build_processor(
         store,
         create_test_config(10, 50, 60, 3600, 60, 3600),
-        create_mock_handler(Ok(()), "empty"),
+        create_mock_handler(Ok(())),
         shutdown_rx,
     );
 
@@ -963,7 +919,7 @@ async fn test_del_event_retry_success() -> Result<()> {
     let processor = build_processor(
         store.clone(),
         create_test_config(10, 50, 60, 3600, 60, 3600),
-        create_mock_handler(Ok(()), post_id),
+        create_mock_handler(Ok(())),
         shutdown_rx,
     );
 
@@ -1002,12 +958,9 @@ async fn test_non_retryable_error_removes_event() -> Result<()> {
     let processor = build_processor(
         store.clone(),
         create_test_config(10, 50, 60, 3600, 60, 3600),
-        create_mock_handler(
-            Err(EventProcessorError::InvalidEventLine(
-                "malformed data".to_string(),
-            )),
-            post_id,
-        ),
+        create_mock_handler(Err(EventProcessorError::InvalidEventLine(
+            "malformed data".to_string(),
+        ))),
         shutdown_rx,
     );
 
@@ -1052,12 +1005,9 @@ async fn test_future_events_not_picked_up() -> Result<()> {
     let processor = build_processor(
         store.clone(),
         create_test_config(10, 50, 60, 3600, 60, 3600),
-        create_mock_handler(
-            Err(EventProcessorError::Generic(
-                "should not be called".to_string(),
-            )),
-            post_id,
-        ),
+        create_mock_handler(Err(EventProcessorError::Generic(
+            "should not be called".to_string(),
+        ))),
         shutdown_rx,
     );
 

--- a/nexus-watcher/tests/service/utils/processor.rs
+++ b/nexus-watcher/tests/service/utils/processor.rs
@@ -10,7 +10,7 @@ use nexus_common::models::event::EventProcessorError;
 use nexus_common::models::homeserver::Homeserver;
 use nexus_common::models::user::UserDetails;
 use nexus_watcher::events::retry::RetryScheduler;
-use nexus_watcher::events::{EventHandler, Moderation};
+use nexus_watcher::events::EventHandler;
 use nexus_watcher::service::TEventProcessor;
 use pubky::Keypair;
 use pubky_app_specs::PubkyId;
@@ -26,7 +26,6 @@ pub struct MockEventProcessor {
     custom_timeout: Option<Duration>,
     shutdown_rx: Receiver<bool>,
     files_path: PathBuf,
-    moderation: Arc<Moderation>,
     event_handler: Arc<dyn EventHandler>,
 }
 
@@ -34,10 +33,6 @@ pub struct MockEventProcessor {
 impl TEventProcessor for MockEventProcessor {
     fn files_path(&self) -> &PathBuf {
         &self.files_path
-    }
-
-    fn moderation(&self) -> &Arc<Moderation> {
-        &self.moderation
     }
 
     fn event_handler(&self) -> &Arc<dyn EventHandler> {
@@ -75,14 +70,6 @@ impl TEventProcessor for MockEventProcessor {
             MockEventProcessorResult::Panic => panic!("Event processor panicked: unknown error"),
         }
     }
-}
-
-fn default_mock_moderation() -> Arc<Moderation> {
-    // Use a moderator ID that won't match any test user, so moderation is effectively disabled
-    Arc::new(Moderation {
-        id: PubkyId::try_from("8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo").unwrap(),
-        tags: vec![],
-    })
 }
 
 /// Create a random homeserver and add it to the event processor list.
@@ -126,7 +113,6 @@ pub async fn create_random_homeservers_and_persist(
         }
     }
 
-    let moderation = default_mock_moderation();
     let event_processor = MockEventProcessor {
         homeserver_id,
         sleep_duration,
@@ -134,12 +120,7 @@ pub async fn create_random_homeservers_and_persist(
         custom_timeout,
         shutdown_rx,
         files_path: PathBuf::from("/tmp/mock"),
-        moderation: moderation.clone(),
-        event_handler: Arc::new(MockEventHandler {
-            result: Ok(()),
-            target_uri_substring: None,
-            moderation,
-        }),
+        event_handler: Arc::new(MockEventHandler { result: Ok(()) }),
     };
     event_processor_list.push(event_processor);
 }
@@ -150,12 +131,7 @@ pub fn create_mock_event_processors(
     shutdown_rx: Receiver<bool>,
 ) -> Vec<MockEventProcessor> {
     use MockEventProcessorResult::*;
-    let moderation = default_mock_moderation();
-    let event_handler = Arc::new(MockEventHandler {
-        result: Ok(()),
-        target_uri_substring: None,
-        moderation: moderation.clone(),
-    });
+    let event_handler = Arc::new(MockEventHandler { result: Ok(()) });
     [
         (HS_IDS[0], None, Success),
         (HS_IDS[1], None, Error("Event processor error!".into())),
@@ -172,7 +148,6 @@ pub fn create_mock_event_processors(
             custom_timeout,
             shutdown_rx: shutdown_rx.clone(),
             files_path: PathBuf::from("/tmp/mock"),
-            moderation: moderation.clone(),
             event_handler: event_handler.clone(),
         },
     )

--- a/nexus-watcher/tests/service/utils/processor.rs
+++ b/nexus-watcher/tests/service/utils/processor.rs
@@ -120,7 +120,10 @@ pub async fn create_random_homeservers_and_persist(
         custom_timeout,
         shutdown_rx,
         files_path: PathBuf::from("/tmp/mock"),
-        event_handler: Arc::new(MockEventHandler { result: Ok(()) }),
+        event_handler: Arc::new(MockEventHandler {
+            result: Ok(()),
+            target_uri_substring: None,
+        }),
     };
     event_processor_list.push(event_processor);
 }
@@ -131,7 +134,10 @@ pub fn create_mock_event_processors(
     shutdown_rx: Receiver<bool>,
 ) -> Vec<MockEventProcessor> {
     use MockEventProcessorResult::*;
-    let event_handler = Arc::new(MockEventHandler { result: Ok(()) });
+    let event_handler = Arc::new(MockEventHandler {
+        result: Ok(()),
+        target_uri_substring: None,
+    });
     [
         (HS_IDS[0], None, Success),
         (HS_IDS[1], None, Error("Event processor error!".into())),

--- a/nexus-watcher/tests/utils/mod.rs
+++ b/nexus-watcher/tests/utils/mod.rs
@@ -4,14 +4,21 @@ use pubky_app_specs::PubkyId;
 use std::sync::Arc;
 
 /// Mock implementation of EventHandler for testing.
+///
+/// If `target_uri_substring` is set, `result` only applies to events whose URI contains
+/// the substring; all other events return `Ok(())`.
 pub struct MockEventHandler {
     pub result: Result<(), EventProcessorError>,
+    pub target_uri_substring: Option<String>,
 }
 
 #[async_trait::async_trait]
 impl EventHandler for MockEventHandler {
-    async fn handle(&self, _event: &Event) -> Result<(), EventProcessorError> {
-        self.result.clone()
+    async fn handle(&self, event: &Event) -> Result<(), EventProcessorError> {
+        match &self.target_uri_substring {
+            Some(s) if !event.uri.contains(s) => Ok(()),
+            _ => self.result.clone(),
+        }
     }
 }
 

--- a/nexus-watcher/tests/utils/mod.rs
+++ b/nexus-watcher/tests/utils/mod.rs
@@ -4,8 +4,6 @@ use pubky_app_specs::PubkyId;
 use std::sync::Arc;
 
 /// Mock implementation of EventHandler for testing.
-///
-/// `handle` returns `result` for every event.
 pub struct MockEventHandler {
     pub result: Result<(), EventProcessorError>,
 }

--- a/nexus-watcher/tests/utils/mod.rs
+++ b/nexus-watcher/tests/utils/mod.rs
@@ -5,25 +5,15 @@ use std::sync::Arc;
 
 /// Mock implementation of EventHandler for testing.
 ///
-/// If `target_uri_substring` is set, `result` only applies to events whose URI contains
-/// the substring; all other events return `Ok(())`.
+/// `handle` returns `result` for every event.
 pub struct MockEventHandler {
     pub result: Result<(), EventProcessorError>,
-    pub target_uri_substring: Option<String>,
-    pub moderation: std::sync::Arc<Moderation>,
 }
 
 #[async_trait::async_trait]
 impl EventHandler for MockEventHandler {
-    fn moderation(&self) -> &std::sync::Arc<Moderation> {
-        &self.moderation
-    }
-
-    async fn handle(&self, event: &Event) -> Result<(), EventProcessorError> {
-        match &self.target_uri_substring {
-            Some(s) if !event.uri.contains(s) => Ok(()),
-            _ => self.result.clone(),
-        }
+    async fn handle(&self, _event: &Event) -> Result<(), EventProcessorError> {
+        self.result.clone()
     }
 }
 


### PR DESCRIPTION
This PR simplifies `EventHandler` by removing the unused `moderation()` fn.