### PR TITLE
Simplify `RetryEvent::check_uri`

### DIFF
--- a/nexus-watcher/src/events/retry/event.rs
+++ b/nexus-watcher/src/events/retry/event.rs
@@ -68,21 +68,20 @@ impl RetryEvent {
         Ok(())
     }
 
-    /// Checks if a specific event exists in the Redis sorted set
+    /// Checks if a specific event exists in the Redis sorted set.
+    ///
+    /// Only used by integration tests (`nexus-watcher/tests/`); kept `pub` because
+    /// those tests compile against this crate as an external consumer.
     /// # Arguments
     /// * `index_key` - A `&str` representing the index key to check
-    pub async fn check_uri(index_key: &str) -> Result<Option<isize>, EventProcessorError> {
+    pub async fn check_uri(index_key: &str) -> RedisResult<bool> {
         Self::check_sorted_set_member(
             Some(RETRY_MANAGER_PREFIX),
             &RETRY_MANAGER_EVENTS_INDEX,
             &[index_key],
         )
         .await
-        .map_err(|e| {
-            EventProcessorError::internal_error(format!(
-                "Could not check uri for event: {index_key}, reason {e}"
-            ))
-        })
+        .map(|rank| rank.is_some())
     }
 
     /// Retrieves an event from the JSON index in Redis based on its index

--- a/nexus-watcher/tests/event_processor/bookmarks/retry_bookmark.rs
+++ b/nexus-watcher/tests/event_processor/bookmarks/retry_bookmark.rs
@@ -46,8 +46,7 @@ async fn test_homeserver_bookmark_cannot_index() -> Result<()> {
 
     assert_eventually_exists(&index_key).await;
 
-    let timestamp = RetryEvent::check_uri(&index_key).await.unwrap();
-    assert!(timestamp.is_some());
+    assert!(RetryEvent::check_uri(&index_key).await.unwrap());
 
     let event_retry = RetryEvent::get_from_index(&index_key).await.unwrap();
     assert!(event_retry.is_some());

--- a/nexus-watcher/tests/event_processor/follows/retry_follow.rs
+++ b/nexus-watcher/tests/event_processor/follows/retry_follow.rs
@@ -31,8 +31,7 @@ async fn test_homeserver_follow_cannot_index() -> Result<()> {
     let index_key: RetryEventIndexKey = follow_absolute_url.clone();
     assert_eventually_exists(&index_key).await;
 
-    let timestamp = RetryEvent::check_uri(&index_key).await.unwrap();
-    assert!(timestamp.is_some());
+    assert!(RetryEvent::check_uri(&index_key).await.unwrap());
 
     let event_retry = RetryEvent::get_from_index(&index_key).await.unwrap();
     assert!(event_retry.is_some());

--- a/nexus-watcher/tests/event_processor/posts/retry_all.rs
+++ b/nexus-watcher/tests/event_processor/posts/retry_all.rs
@@ -48,8 +48,7 @@ async fn test_homeserver_post_with_reply_repost_cannot_index() -> Result<()> {
 
     assert_eventually_exists(&index_key).await;
 
-    let timestamp = RetryEvent::check_uri(&index_key).await.unwrap();
-    assert!(timestamp.is_some());
+    assert!(RetryEvent::check_uri(&index_key).await.unwrap());
 
     let event_retry = RetryEvent::get_from_index(&index_key).await.unwrap();
     assert!(event_retry.is_some());

--- a/nexus-watcher/tests/event_processor/posts/retry_post.rs
+++ b/nexus-watcher/tests/event_processor/posts/retry_post.rs
@@ -32,8 +32,7 @@ async fn test_homeserver_post_cannot_index() -> Result<()> {
 
     assert_eventually_exists(&index_key).await;
 
-    let timestamp = RetryEvent::check_uri(&index_key).await.unwrap();
-    assert!(timestamp.is_some());
+    assert!(RetryEvent::check_uri(&index_key).await.unwrap());
 
     let event_retry = RetryEvent::get_from_index(&index_key).await.unwrap();
     assert!(event_retry.is_some());

--- a/nexus-watcher/tests/event_processor/posts/retry_reply.rs
+++ b/nexus-watcher/tests/event_processor/posts/retry_reply.rs
@@ -42,8 +42,7 @@ async fn test_homeserver_post_reply_cannot_index() -> Result<()> {
 
     assert_eventually_exists(&index_key).await;
 
-    let timestamp = RetryEvent::check_uri(&index_key).await.unwrap();
-    assert!(timestamp.is_some());
+    assert!(RetryEvent::check_uri(&index_key).await.unwrap());
 
     let event_retry = RetryEvent::get_from_index(&index_key).await.unwrap();
     assert!(event_retry.is_some());

--- a/nexus-watcher/tests/event_processor/posts/retry_repost.rs
+++ b/nexus-watcher/tests/event_processor/posts/retry_repost.rs
@@ -47,8 +47,7 @@ async fn test_homeserver_post_repost_cannot_index() -> Result<()> {
 
     assert_eventually_exists(&index_key).await;
 
-    let timestamp = RetryEvent::check_uri(&index_key).await.unwrap();
-    assert!(timestamp.is_some());
+    assert!(RetryEvent::check_uri(&index_key).await.unwrap());
 
     let event_retry = RetryEvent::get_from_index(&index_key).await.unwrap();
     assert!(event_retry.is_some());

--- a/nexus-watcher/tests/event_processor/tags/retry_post_tag.rs
+++ b/nexus-watcher/tests/event_processor/tags/retry_post_tag.rs
@@ -56,8 +56,7 @@ async fn test_homeserver_post_tag_event_to_queue() -> Result<()> {
 
     assert_eventually_exists(&index_key).await;
 
-    let timestamp = RetryEvent::check_uri(&index_key).await.unwrap();
-    assert!(timestamp.is_some());
+    assert!(RetryEvent::check_uri(&index_key).await.unwrap());
 
     let event_retry = RetryEvent::get_from_index(&index_key).await.unwrap();
     assert!(event_retry.is_some());

--- a/nexus-watcher/tests/event_processor/tags/retry_user_tag.rs
+++ b/nexus-watcher/tests/event_processor/tags/retry_user_tag.rs
@@ -49,8 +49,7 @@ async fn test_homeserver_user_tag_event_to_queue() -> Result<()> {
 
     assert_eventually_exists(&index_key).await;
 
-    let timestamp = RetryEvent::check_uri(&index_key).await.unwrap();
-    assert!(timestamp.is_some());
+    assert!(RetryEvent::check_uri(&index_key).await.unwrap());
 
     let event_retry = RetryEvent::get_from_index(&index_key).await.unwrap();
     assert!(event_retry.is_some());

--- a/nexus-watcher/tests/event_processor/utils/watcher.rs
+++ b/nexus-watcher/tests/event_processor/utils/watcher.rs
@@ -383,11 +383,8 @@ pub async fn assert_eventually_exists(event_index: &str) {
             SLEEP_MS * attempt as u64
         );
         match RetryEvent::check_uri(event_index).await {
-            Ok(timeframe) => {
-                if timeframe.is_some() {
-                    return;
-                }
-            }
+            Ok(true) => return,
+            Ok(false) => {}
             Err(e) => panic!("Error while getting index: {e:?}"),
         };
         // Nap time


### PR DESCRIPTION
This PR simplifies  `RetryEvent::check_uri`, which is only used in tests.

The return value `Option` was only checked whether it was `Some`. It was therefore changed from `Result<Option<..>>` to `Result<bool>`.