### PR TITLE
Simplify tag-path parsing, re-use `try_parse_app_tag_path`

### DIFF
--- a/nexus-common/src/universal_tag/app_tag_info.rs
+++ b/nexus-common/src/universal_tag/app_tag_info.rs
@@ -32,6 +32,11 @@ pub fn try_parse_app_tag_path(uri: &str) -> Option<AppTagInfo> {
         return None;
     }
 
+    // Strip query string (?...) or fragment (#...) from tag_id
+    let tag_id = tag_id
+        .find(|c| c == '?' || c == '#')
+        .map_or(tag_id, |pos| &tag_id[..pos]);
+
     // Validate: app must be a single path segment, tag_id must not contain slashes
     if app.is_empty() || app.contains('/') || tag_id.is_empty() || tag_id.contains('/') {
         return None;
@@ -158,6 +163,41 @@ mod tests {
     fn test_try_parse_app_tag_path_empty_tag_returns_none() {
         assert!(try_parse_app_tag_path(
             "pubky://8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo/pub/mapky/tags/"
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn test_try_parse_app_tag_path_query_string_stripped() {
+        let info = try_parse_app_tag_path(
+            "pubky://8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo/pub/mapky/tags/ABC123?foo=bar",
+        );
+        assert!(info.is_some(), "Should accept URI with query string");
+        assert_eq!(
+            info.unwrap().tag_id,
+            "ABC123",
+            "tag_id must not include query string"
+        );
+    }
+
+    #[test]
+    fn test_try_parse_app_tag_path_fragment_stripped() {
+        let info = try_parse_app_tag_path(
+            "pubky://8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo/pub/mapky/tags/ABC123#section",
+        );
+        assert!(info.is_some(), "Should accept URI with fragment");
+        assert_eq!(
+            info.unwrap().tag_id,
+            "ABC123",
+            "tag_id must not include fragment"
+        );
+    }
+
+    #[test]
+    fn test_try_parse_app_tag_path_empty_tag_after_query_returns_none() {
+        // tag_id becomes empty after stripping the query string
+        assert!(try_parse_app_tag_path(
+            "pubky://8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo/pub/mapky/tags/?foo=bar"
         )
         .is_none());
     }

--- a/nexus-common/src/universal_tag/homeserver_parsed_uri.rs
+++ b/nexus-common/src/universal_tag/homeserver_parsed_uri.rs
@@ -1,6 +1,8 @@
-use pubky_app_specs::{ParsedUri, PubkyId, Resource, PROTOCOL, PUBLIC_PATH};
+use pubky_app_specs::{ParsedUri, PubkyId, Resource};
 use serde::{Deserialize, Serialize};
 use std::convert::{From, TryFrom};
+
+use super::app_tag_info::try_parse_app_tag_path;
 
 /// Parsed URI representation that can handle both:
 /// 1. Standard pubky-app-specs URIs (pubky://<user_id>/pub/pubky.app/...)
@@ -87,69 +89,17 @@ impl TryFrom<&str> for HomeserverParsedUri {
 
         // If ParsedUri::try_from failed, the URI might be from a different app.
         // Try parsing as a universal tag URI: pubky://<user_id>/pub/<app>/tags/<tag_id>
-        // We need to manually parse the URI for non-pubky.app apps.
-        let parsed_url = url::Url::parse(uri).map_err(|e| format!("Invalid URL: {}", e))?;
-
-        // Validate the scheme.
-        if parsed_url.scheme() != PROTOCOL.trim_end_matches("://") {
-            return Err(format!(
-                "Invalid URI, must start with '{}': {}",
-                PROTOCOL, uri
-            ));
-        }
-
-        // Extract the user_id from the host.
-        let user_id_str = parsed_url
-            .host_str()
-            .ok_or_else(|| format!("Missing user ID in URI: {}", uri))?;
-        let user_id =
-            PubkyId::try_from(user_id_str).map_err(|e| format!("Invalid user ID: {e}"))?;
-
-        // Get the path segments.
-        let segments: Vec<&str> = parsed_url
-            .path_segments()
-            .ok_or_else(|| format!("Cannot parse path segments from URI: {}", uri))?
-            .collect();
-
-        if segments.len() < 3 {
-            return Err(format!("Not enough path segments in URI: {}", uri));
-        }
-
-        if segments[0] != PUBLIC_PATH.trim_matches('/') {
-            return Err(format!(
-                "Expected public path '{}' but got '{}' in URI: {}",
-                PUBLIC_PATH, segments[0], uri
-            ));
-        }
-
-        let app_path = segments[1];
-
-        // Skip pubky.app paths since those are handled by ParsedUri::try_from above.
-        if app_path == "pubky.app" {
-            return Err(format!(
-                "URI is not a recognized pubky-app-specs path or universal tag path: {}",
-                uri
-            ));
-        }
-
-        // Check for /tags/<tag_id> pattern: pubky://<user_id>/pub/<app>/tags/<tag_id>
-        let path_after_app = &segments[2..];
-        if path_after_app.len() == 2 && path_after_app[0] == "tags" && !path_after_app[1].is_empty()
-        {
-            let tag_id = path_after_app[1].to_string();
-
+        if let Some(info) = try_parse_app_tag_path(uri) {
             return Ok(HomeserverParsedUri::UniversalTag {
-                user_id,
-                app: app_path.to_string(),
-                resource: Resource::Tag(tag_id.clone()),
-                tag_id,
+                user_id: info.user_id,
+                app: info.app,
+                resource: Resource::Tag(info.tag_id.clone()),
+                tag_id: info.tag_id,
             });
         }
 
-        // Not a recognized universal tag path
         Err(format!(
-            "URI is not a recognized pubky-app-specs path or universal tag path: {}",
-            uri
+            "URI is not a recognized pubky-app-specs path or universal tag path: {uri}"
         ))
     }
 }

--- a/nexus-common/src/universal_tag/homeserver_parsed_uri.rs
+++ b/nexus-common/src/universal_tag/homeserver_parsed_uri.rs
@@ -190,4 +190,26 @@ mod tests {
         let result = HomeserverParsedUri::try_from(uri.as_str());
         assert!(result.is_ok());
     }
+
+    #[test]
+    fn test_universal_tag_uri_with_query_string() {
+        let user_id = "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo";
+        let uri = format!("pubky://{user_id}/pub/mapky/tags/ABC123?foo=bar");
+        let parsed = HomeserverParsedUri::try_from(uri.as_str())
+            .expect("Should accept universal tag URI with query string");
+        assert!(matches!(parsed, HomeserverParsedUri::UniversalTag { .. }));
+        assert_eq!(parsed.resource(), &Resource::Tag("ABC123".to_string()));
+        assert_eq!(parsed.tag_id(), Some("ABC123"));
+    }
+
+    #[test]
+    fn test_universal_tag_uri_with_fragment() {
+        let user_id = "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo";
+        let uri = format!("pubky://{user_id}/pub/mapky/tags/ABC123#section");
+        let parsed = HomeserverParsedUri::try_from(uri.as_str())
+            .expect("Should accept universal tag URI with fragment");
+        assert!(matches!(parsed, HomeserverParsedUri::UniversalTag { .. }));
+        assert_eq!(parsed.resource(), &Resource::Tag("ABC123".to_string()));
+        assert_eq!(parsed.tag_id(), Some("ABC123"));
+    }
 }


### PR DESCRIPTION
This PR removes duplicate tag parsing logic by re-using `try_parse_app_tag_path`.