### PR TITLE
fix: infra errors from `reschedule` mask the original error

### DIFF
--- a/nexus-common/src/config/watcher.rs
+++ b/nexus-common/src/config/watcher.rs
@@ -1,3 +1,5 @@
+use crate::models::event::EventProcessorError;
+
 use super::file::ConfigLoader;
 use super::{default_stack, DaemonConfig, StackConfig};
 use async_trait::async_trait;
@@ -78,6 +80,21 @@ impl Default for EventRetryConfig {
             initial_missing_dep_backoff_secs: DEFAULT_INITIAL_MISSING_DEP_BACKOFF_SECS,
             max_missing_dep_backoff_secs: DEFAULT_MAX_MISSING_DEP_BACKOFF_SECS,
         }
+    }
+}
+
+impl EventRetryConfig {
+    /// Returns (initial_backoff, max_backoff) values, in seconds, for the given error
+    pub fn get_backoff_params(&self, error: &EventProcessorError) -> (u64, u64) {
+        let initial = match error.is_missing_dependency() {
+            true => self.initial_missing_dep_backoff_secs,
+            false => self.initial_backoff_secs,
+        };
+        let max = match error.is_missing_dependency() {
+            true => self.max_missing_dep_backoff_secs,
+            false => self.max_backoff_secs,
+        };
+        (initial, max)
     }
 }
 

--- a/nexus-watcher/src/events/retry/processor.rs
+++ b/nexus-watcher/src/events/retry/processor.rs
@@ -120,10 +120,17 @@ impl RetryProcessor {
             }
         };
 
-        // Call event_handler directly to get the actual error (bypassing handle_event/handle_error)
         let ev_uri = &retry_event.event_uri;
         let ev_retry_count = retry_event.retry_count;
-        match self.event_handler().handle(&event).await {
+
+        // Call event_handler directly to get the actual error (bypassing handle_event/handle_error)
+        let event_handle_res = self.event_handler().handle(&event).await.inspect_err(|e| {
+            // In case of error, log it before the error is itself is classified and handled
+            // Error handling could itself throw an error. We log it here to pre-empt this possibility.
+            warn!("Retry event handling failed: {e}");
+        });
+
+        match event_handle_res {
             Ok(()) => {
                 // Success - event was processed, remove from retry queue
                 debug!("Retry successful for event: {ev_uri}");

--- a/nexus-watcher/src/events/retry/processor.rs
+++ b/nexus-watcher/src/events/retry/processor.rs
@@ -138,12 +138,10 @@ impl RetryProcessor {
             }
             Err(e) if e.is_404() => {
                 // Content gone - remove from retry queue
-                warn!("Content no longer exists (404) for retry: {ev_uri}");
                 self.store.remove(index_key).await?;
             }
             Err(e) if !e.is_retryable() => {
                 // Non-retryable error (ParseFailed, etc.) - dead-letter immediately
-                warn!("Event {ev_uri} failed with non-retryable error, dead-lettering: {e}");
                 self.store.remove(index_key).await?;
             }
             Err(e) if e.is_infrastructure() => {

--- a/nexus-watcher/src/events/retry/processor.rs
+++ b/nexus-watcher/src/events/retry/processor.rs
@@ -142,6 +142,7 @@ impl RetryProcessor {
             }
             Err(e) if !e.is_retryable() => {
                 // Non-retryable error (ParseFailed, etc.) - dead-letter immediately
+                warn!("Event {ev_uri} failed with non-retryable error, dead-lettering: {e}");
                 self.store.remove(index_key).await?;
             }
             Err(e) if e.is_infrastructure() => {

--- a/nexus-watcher/src/events/retry/processor.rs
+++ b/nexus-watcher/src/events/retry/processor.rs
@@ -181,16 +181,8 @@ impl RetryProcessor {
             false => retry_event.retry_count,
         };
 
-        let initial = match error.is_missing_dependency() {
-            true => self.config.initial_missing_dep_backoff_secs,
-            false => self.config.initial_backoff_secs,
-        };
-        let max = match error.is_missing_dependency() {
-            true => self.config.max_missing_dep_backoff_secs,
-            false => self.config.max_backoff_secs,
-        };
-
         // Calculate backoff based on error type
+        let (initial, max) = self.config.get_backoff_params(error);
         // Use retry_count (not new_retry_count) so first retry uses 2^0 * initial = initial
         let backoff_secs = self.calculate_backoff(retry_event.retry_count, initial, max);
 

--- a/nexus-watcher/src/events/retry/processor.rs
+++ b/nexus-watcher/src/events/retry/processor.rs
@@ -125,7 +125,7 @@ impl RetryProcessor {
 
         // Call event_handler directly to get the actual error (bypassing handle_event/handle_error)
         let event_handle_res = self.event_handler().handle(&event).await.inspect_err(|e| {
-            // In case of error, log it before the error is itself is classified and handled
+            // In case of error, log it before the error itself is classified and handled
             // Error handling could itself throw an error. We log it here to pre-empt this possibility.
             warn!("Retry event handling failed: {e}");
         });

--- a/nexus-watcher/src/events/retry/processor.rs
+++ b/nexus-watcher/src/events/retry/processor.rs
@@ -225,9 +225,10 @@ impl RetryProcessor {
     }
 
     fn get_max_retries_for_err(&self, e: &EventProcessorError) -> u32 {
-        match e.is_missing_dependency() {
-            true => self.config.max_dependency_retries,
-            false => self.config.max_retries,
+        if e.is_missing_dependency() {
+            self.config.max_dependency_retries
+        } else {
+            self.config.max_retries
         }
     }
 }

--- a/nexus-watcher/src/events/retry/processor.rs
+++ b/nexus-watcher/src/events/retry/processor.rs
@@ -146,20 +146,11 @@ impl RetryProcessor {
                 self.reschedule(&retry_event, index_key, &e, false).await?;
                 return Err(e);
             }
+            Err(e) if ev_retry_count >= self.get_max_retries_for_err(&e) => {
+                warn!("Event {ev_uri} exceeded max retries ({ev_retry_count}), dead-lettering");
+                self.store.remove(index_key).await?;
+            }
             Err(e) => {
-                // Check if we've exceeded max retries based on current error type
-                let max_retries = if e.is_missing_dependency() {
-                    self.config.max_dependency_retries
-                } else {
-                    self.config.max_retries
-                };
-
-                if ev_retry_count >= max_retries {
-                    warn!("Event {ev_uri} exceeded max retries ({ev_retry_count}), dead-lettering");
-                    self.store.remove(index_key).await?;
-                    return Ok(());
-                }
-
                 // Schedule retry with backoff (increments retry_count)
                 self.reschedule(&retry_event, index_key, &e, true).await?;
             }
@@ -224,5 +215,12 @@ impl RetryProcessor {
             .and_then(|p| initial.checked_mul(p))
             .unwrap_or(max);
         min(exponential, max)
+    }
+
+    fn get_max_retries_for_err(&self, e: &EventProcessorError) -> u32 {
+        match e.is_missing_dependency() {
+            true => self.config.max_dependency_retries,
+            false => self.config.max_retries,
+        }
     }
 }

--- a/nexus-watcher/src/events/retry/processor.rs
+++ b/nexus-watcher/src/events/retry/processor.rs
@@ -121,26 +121,22 @@ impl RetryProcessor {
         };
 
         // Call event_handler directly to get the actual error (bypassing handle_event/handle_error)
+        let ev_uri = &retry_event.event_uri;
+        let ev_retry_count = retry_event.retry_count;
         match self.event_handler().handle(&event).await {
             Ok(()) => {
                 // Success - event was processed, remove from retry queue
-                debug!("Retry successful for event: {}", retry_event.event_uri);
+                debug!("Retry successful for event: {ev_uri}");
                 self.store.remove(index_key).await?;
             }
             Err(e) if e.is_404() => {
                 // Content gone - remove from retry queue
-                warn!(
-                    "Content no longer exists (404) for retry: {}",
-                    retry_event.event_uri
-                );
+                warn!("Content no longer exists (404) for retry: {ev_uri}");
                 self.store.remove(index_key).await?;
             }
             Err(e) if !e.is_retryable() => {
                 // Non-retryable error (ParseFailed, etc.) - dead-letter immediately
-                warn!(
-                    "Event {} failed with non-retryable error, dead-lettering: {}",
-                    retry_event.event_uri, e
-                );
+                warn!("Event {ev_uri} failed with non-retryable error, dead-lettering: {e}");
                 self.store.remove(index_key).await?;
             }
             Err(e) if e.is_infrastructure() => {
@@ -158,11 +154,8 @@ impl RetryProcessor {
                     self.config.max_retries
                 };
 
-                if retry_event.retry_count >= max_retries {
-                    warn!(
-                        "Event {} exceeded max retries ({}) - dead-lettering",
-                        retry_event.event_uri, retry_event.retry_count
-                    );
+                if ev_retry_count >= max_retries {
+                    warn!("Event {ev_uri} exceeded max retries ({ev_retry_count}), dead-lettering");
                     self.store.remove(index_key).await?;
                     return Ok(());
                 }


### PR DESCRIPTION
The handling of infrastructure errors requires

```rust
self.reschedule(&retry_event, index_key, &e, false).await?;
```

which itself can fail due to the same infrastructure error that caused it. This can mask the error being handled, which is supposed to be re-thrown on the line below.

This PR pre-emptively logs errors before they are being classified and handled.