### PR TITLE
doc: add rustdocs to `Event` struct

### DIFF
--- a/nexus-common/src/models/event/mod.rs
+++ b/nexus-common/src/models/event/mod.rs
@@ -53,10 +53,19 @@ impl fmt::Display for EventType {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Event {
+    /// Pubky resource URI from the homeserver event line.
     pub uri: String,
+
+    /// Operation represented by the event, used to dispatch to PUT or DEL handlers.
     pub event_type: EventType,
+
+    /// Parsed representation of [`Self::uri`].
     pub parsed_uri: ParsedUri,
+
+    /// Local files directory on Nexus used for file-backed events.
     pub files_path: PathBuf,
+
+    /// Original event line as received from the homeserver.
     event_line: String,
 }
 


### PR DESCRIPTION
This PR documents the fields of `Event`.