### PR TITLE
fix: add moderation of Universal Tags + integration test

### DIFF
--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -128,10 +128,15 @@ pub fn get_post_replies(author_id: &str, post_id: &str) -> Query {
 
 // Read the target details for a tag without deleting the TAGGED edge.
 // Used in tag del to read before graph-last deletion.
-pub fn get_tag_target(user_id: &str, tag_id: &str) -> Query {
-    Query::new(
-        "get_tag_target",
-        "MATCH (user:User {id: $user_id})-[tag:TAGGED {id: $tag_id}]->(target)
+pub fn get_tag_target(user_id: &str, tag_id: &str, app: Option<&str>) -> Query {
+    let app_filter = match app {
+        Some(_) => "WHERE tag.app = $app",
+        None => "WHERE tag.app IS NULL",
+    };
+
+    let cypher = format!(
+        "MATCH (user:User {{id: $user_id}})-[tag:TAGGED {{id: $tag_id}}]->(target)
+         {app_filter}
          OPTIONAL MATCH (target)<-[:AUTHORED]-(author:User)
          WITH CASE WHEN target:User THEN target.id ELSE null END AS user_id,
               CASE WHEN target:Post THEN target.id ELSE null END AS post_id,
@@ -139,10 +144,18 @@ pub fn get_tag_target(user_id: &str, tag_id: &str) -> Query {
               CASE WHEN target:Resource THEN target.id ELSE null END AS resource_id,
               tag.label AS label,
               tag.app AS app
-         RETURN user_id, post_id, author_id, resource_id, label, app",
-    )
-    .param("user_id", user_id)
-    .param("tag_id", tag_id)
+         RETURN user_id, post_id, author_id, resource_id, label, app"
+    );
+
+    let mut query = Query::new("get_tag_target", &cypher)
+        .param("user_id", user_id)
+        .param("tag_id", tag_id);
+
+    if let Some(app) = app {
+        query = query.param("app", app);
+    }
+
+    query
 }
 
 // Get all the tags/taggers that a post has received (used for edit/delete notifications)

--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -158,6 +158,34 @@ pub fn get_tag_target(user_id: &str, tag_id: &str, app: Option<&str>) -> Query {
     query
 }
 
+// Checks whether the same tagger still has this Resource tagged with the same label through a
+// different app namespace. Resource tagger sets are global, so deletion must not remove the user
+// from that set while another app-scoped TAGGED edge still represents the same tag.
+pub fn has_other_resource_tag_for_tagger(
+    user_id: &str,
+    resource_id: &str,
+    label: &str,
+    app: Option<&str>,
+) -> Query {
+    let app_filter = match app {
+        Some(app) => &format!("WHERE tag.app IS NULL OR tag.app <> '{app}'"),
+        None => "WHERE tag.app IS NOT NULL",
+    };
+
+    let cypher = format!(
+        "MATCH (user:User {{id: $user_id}})-[tag:TAGGED {{label: $label}}]->(resource:Resource {{id: $resource_id}})
+         {app_filter}
+         RETURN count(tag) > 0 AS exists"
+    );
+
+    let query = Query::new("has_other_resource_tag_for_tagger", &cypher)
+        .param("user_id", user_id)
+        .param("resource_id", resource_id)
+        .param("label", label);
+
+    query
+}
+
 // Get all the tags/taggers that a post has received (used for edit/delete notifications)
 pub fn get_post_tags(author_id: &str, post_id: &str) -> Query {
     Query::new(

--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -168,7 +168,7 @@ pub fn has_other_resource_tag_for_tagger(
     app: Option<&str>,
 ) -> Query {
     let app_filter = match app {
-        Some(app) => &format!("WHERE tag.app IS NULL OR tag.app <> '{app}'"),
+        Some(_) => "WHERE tag.app IS NULL OR tag.app <> $app",
         None => "WHERE tag.app IS NOT NULL",
     };
 
@@ -178,10 +178,14 @@ pub fn has_other_resource_tag_for_tagger(
          RETURN count(tag) > 0 AS exists"
     );
 
-    let query = Query::new("has_other_resource_tag_for_tagger", &cypher)
+    let mut query = Query::new("has_other_resource_tag_for_tagger", &cypher)
         .param("user_id", user_id)
         .param("resource_id", resource_id)
         .param("label", label);
+
+    if let Some(app) = app {
+        query = query.param("app", app);
+    }
 
     query
 }

--- a/nexus-common/src/db/graph/queries/put.rs
+++ b/nexus-common/src/db/graph/queries/put.rs
@@ -229,59 +229,97 @@ pub fn create_post_tag(
     tag_id: &str,
     label: &str,
     indexed_at: i64,
+    app: Option<&str>,
 ) -> Query {
-    Query::new(
-        "create_post_tag",
-        "MATCH (user:User {id: $user_id})
-        // We assume these nodes are already created. If not we would not be able to add a tag
-        MATCH (author:User {id: $author_id})-[:AUTHORED]->(post:Post {id: $post_id})
-        // Check if tag already existed
-        OPTIONAL MATCH (user)-[existing:TAGGED {label: $label}]->(post)
-        MERGE (user)-[t:TAGGED {label: $label}]->(post)
-        ON CREATE SET t.indexed_at = $indexed_at,
-                      t.id = $tag_id
-        // Returns true if the post tag relationship already existed
-        RETURN existing IS NOT NULL AS flag;",
-    )
-    .param("user_id", user_id)
-    .param("author_id", author_id)
-    .param("post_id", post_id)
-    .param("tag_id", tag_id)
-    .param("label", label)
-    .param("indexed_at", indexed_at)
+    let cypher = match app {
+        Some(_) => {
+            "MATCH (user:User {id: $user_id})
+            // We assume these nodes are already created. If not we would not be able to add a tag
+            MATCH (author:User {id: $author_id})-[:AUTHORED]->(post:Post {id: $post_id})
+            // Check if tag already existed in this app namespace
+            OPTIONAL MATCH (user)-[existing:TAGGED {label: $label, app: $app}]->(post)
+            MERGE (user)-[t:TAGGED {label: $label, app: $app}]->(post)
+            ON CREATE SET t.indexed_at = $indexed_at,
+                        t.id = $tag_id
+            // Returns true if the post tag relationship already existed
+            RETURN existing IS NOT NULL AS flag;"
+        }
+        None => {
+            "MATCH (user:User {id: $user_id})
+            // We assume these nodes are already created. If not we would not be able to add a tag
+            MATCH (author:User {id: $author_id})-[:AUTHORED]->(post:Post {id: $post_id})
+            // Check if tag already existed on the standard pubky.app path
+            OPTIONAL MATCH (user)-[existing:TAGGED {label: $label}]->(post)
+            WHERE existing.app IS NULL
+            FOREACH (_ IN CASE WHEN existing IS NULL THEN [1] ELSE [] END |
+                CREATE (user)-[:TAGGED {label: $label, indexed_at: $indexed_at, id: $tag_id}]->(post)
+            )
+            // Returns true if the post tag relationship already existed
+            RETURN existing IS NOT NULL AS flag;"
+        }
+    };
+
+    let mut query = Query::new("create_post_tag", cypher)
+        .param("user_id", user_id)
+        .param("author_id", author_id)
+        .param("post_id", post_id)
+        .param("tag_id", tag_id)
+        .param("label", label)
+        .param("indexed_at", indexed_at);
+
+    if let Some(app) = app {
+        query = query.param("app", app);
+    }
+
+    query
 }
 
-/// Creates a `TAGGED` relationship between two users. The relationship is uniquely identified by a `label`
-/// # Arguments
-/// * `tagger_user_id` - The unique identifier of the user creating the tag.
-/// * `tagged_user_id` - The unique identifier of the user being tagged.
-/// * `tag_id` - A unique identifier for the tagging relationship.
-/// * `label` - A string representing the label of the tag.
-/// * `indexed_at` - A timestamp indicating when the tagging relationship was created or last updated.
 pub fn create_user_tag(
     tagger_user_id: &str,
     tagged_user_id: &str,
     tag_id: &str,
     label: &str,
     indexed_at: i64,
+    app: Option<&str>,
 ) -> Query {
-    Query::new(
-        "create_user_tag",
-        "MATCH (tagged_used:User {id: $tagged_user_id})
-        MATCH (tagger:User {id: $tagger_user_id})
-        // Check if tag already existed
-        OPTIONAL MATCH (tagger)-[existing:TAGGED {label: $label}]->(tagged_used)
-        MERGE (tagger)-[t:TAGGED {label: $label}]->(tagged_used)
-        ON CREATE SET t.indexed_at = $indexed_at,
-                      t.id = $tag_id
-        // Returns true if the user tag relationship already existed
-        RETURN existing IS NOT NULL AS flag;",
-    )
-    .param("tagger_user_id", tagger_user_id)
-    .param("tagged_user_id", tagged_user_id)
-    .param("tag_id", tag_id)
-    .param("label", label)
-    .param("indexed_at", indexed_at)
+    let cypher = match app {
+        Some(_) => {
+            "MATCH (tagged_used:User {id: $tagged_user_id})
+            MATCH (tagger:User {id: $tagger_user_id})
+            // Check if tag already existed in this app namespace
+            OPTIONAL MATCH (tagger)-[existing:TAGGED {label: $label, app: $app}]->(tagged_used)
+            MERGE (tagger)-[t:TAGGED {label: $label, app: $app}]->(tagged_used)
+            ON CREATE SET t.indexed_at = $indexed_at,
+                        t.id = $tag_id
+            // Returns true if the user tag relationship already existed
+            RETURN existing IS NOT NULL AS flag;"
+        }
+        None => {
+            "MATCH (tagged_used:User {id: $tagged_user_id})
+            MATCH (tagger:User {id: $tagger_user_id})
+            // Check if tag already existed on the standard pubky.app path
+            OPTIONAL MATCH (tagger)-[existing:TAGGED {label: $label}]->(tagged_used)
+            WHERE existing.app IS NULL
+            FOREACH (_ IN CASE WHEN existing IS NULL THEN [1] ELSE [] END |
+                CREATE (tagger)-[:TAGGED {label: $label, indexed_at: $indexed_at, id: $tag_id}]->(tagged_used)
+            )
+            // Returns true if the user tag relationship already existed
+            RETURN existing IS NOT NULL AS flag;"
+        }
+    };
+
+    let mut query = Query::new("create_user_tag", cypher)
+        .param("tagger_user_id", tagger_user_id)
+        .param("tagged_user_id", tagged_user_id)
+        .param("tag_id", tag_id)
+        .param("label", label)
+        .param("indexed_at", indexed_at);
+
+    if let Some(app) = app {
+        query = query.param("app", app);
+    }
+
+    query
 }
 
 /// Creates a `TAGGED` relationship between a user and a generic Resource node.

--- a/nexus-common/src/models/tag/traits/collection.rs
+++ b/nexus-common/src/models/tag/traits/collection.rs
@@ -325,6 +325,28 @@ where
         label: &str,
         indexed_at: i64,
     ) -> GraphResult<OperationOutcome> {
+        Self::put_to_graph_with_app(
+            tagger_user_id,
+            tagged_user_id,
+            extra_param,
+            tag_id,
+            label,
+            indexed_at,
+            None,
+        )
+        .await
+    }
+
+    /// Inserts a tag relationship into the graph database, optionally scoped to an app namespace.
+    async fn put_to_graph_with_app(
+        tagger_user_id: &str,
+        tagged_user_id: &str,
+        extra_param: Option<&str>,
+        tag_id: &str,
+        label: &str,
+        indexed_at: i64,
+        app: Option<&str>,
+    ) -> GraphResult<OperationOutcome> {
         let query = match extra_param {
             Some(post_id) => queries::put::create_post_tag(
                 tagger_user_id,
@@ -333,6 +355,7 @@ where
                 tag_id,
                 label,
                 indexed_at,
+                app,
             ),
             None => queries::put::create_user_tag(
                 tagger_user_id,
@@ -340,6 +363,7 @@ where
                 tag_id,
                 label,
                 indexed_at,
+                app,
             ),
         };
         execute_graph_operation(query).await

--- a/nexus-watcher/src/events/handlers/tag.rs
+++ b/nexus-watcher/src/events/handlers/tag.rs
@@ -90,9 +90,18 @@ pub async fn sync_put(
     tagger_id: PubkyId,
     tag_id: String,
 ) -> Result<(), EventProcessorError> {
+    sync_put_with_app(tag, tagger_id, tag_id, None).await
+}
+
+async fn sync_put_with_app(
+    tag: PubkyAppTag,
+    tagger_id: PubkyId,
+    tag_id: String,
+    app: Option<&str>,
+) -> Result<(), EventProcessorError> {
     debug!("Indexing new tag: {} -> {}", tagger_id, tag_id);
 
-    // Parse the embeded URI to extract author_id and post_id using parse_tagged_post_uri
+    // Parse the embedded URI to extract author_id and post_id using parse_tagged_post_uri
     let parsed_uri = ParsedUri::try_from(tag.uri.as_str()).map_err(EventProcessorError::generic)?;
     let user_id = parsed_uri.user_id;
     let indexed_at = Utc::now().timestamp_millis();
@@ -102,12 +111,14 @@ pub async fn sync_put(
         Resource::Post(post_id) => {
             // Place the tag on post
             put_sync_post(
-                tagger_id, user_id, &post_id, &tag_id, &tag.label, &tag.uri, indexed_at,
+                tagger_id, user_id, &post_id, &tag_id, &tag.label, &tag.uri, indexed_at, app,
             )
             .await
         }
         // If no post_id in the tagged URI, we place tag to a user.
-        Resource::User => put_sync_user(tagger_id, user_id, &tag_id, &tag.label, indexed_at).await,
+        Resource::User => {
+            put_sync_user(tagger_id, user_id, &tag_id, &tag.label, indexed_at, app).await
+        }
         other => Err(EventProcessorError::generic(format!(
             "The tagged resource is not Post or User, instead is: {other:?}"
         ))),
@@ -131,8 +142,8 @@ pub async fn sync_put_resource(
     let category = classify_uri(&tag.uri);
     match category {
         UriCategory::InternalKnown => {
-            // The tagged URI is a known Post/User — delegate to existing flow
-            sync_put(tag, tagger_id, tag_id).await
+            // The tagged URI is a known Post/User, but the app path remains part of tag identity.
+            sync_put_with_app(tag, tagger_id, tag_id, Some(&app)).await
         }
         UriCategory::InternalUnknown | UriCategory::External => {
             let (normalized, scheme) =
@@ -255,6 +266,7 @@ async fn put_sync_resource(
 /// - `post_uri` - A `String` representing the homeserver URI of the tagged post.
 /// - `indexed_at` - A 64-bit integer representing the timestamp when the post was indexed.
 ///
+#[allow(clippy::too_many_arguments)]
 async fn put_sync_post(
     tagger_user_id: PubkyId,
     author_id: PubkyId,
@@ -263,14 +275,16 @@ async fn put_sync_post(
     tag_label: &str,
     post_uri: &str,
     indexed_at: i64,
+    app: Option<&str>,
 ) -> Result<(), EventProcessorError> {
-    match TagPost::put_to_graph(
+    match TagPost::put_to_graph_with_app(
         &tagger_user_id,
         &author_id,
         Some(post_id),
         tag_id,
         tag_label,
         indexed_at,
+        app,
     )
     .await?
     {
@@ -383,14 +397,16 @@ async fn put_sync_user(
     tag_id: &str,
     tag_label: &str,
     indexed_at: i64,
+    app: Option<&str>,
 ) -> Result<(), EventProcessorError> {
-    match TagUser::put_to_graph(
+    match TagUser::put_to_graph_with_app(
         &tagger_user_id,
         &tagged_user_id,
         None,
         tag_id,
         tag_label,
         indexed_at,
+        app,
     )
     .await?
     {
@@ -456,19 +472,7 @@ async fn put_sync_user(
 
 #[tracing::instrument(name = "tag.del", skip_all, fields(tag_path = ?tag_path))]
 pub async fn del(tag_path: TagPath) -> Result<(), EventProcessorError> {
-    if del_with_app_filter(&tag_path).await? {
-        return Ok(());
-    }
-
-    if let TagPath::Universal {
-        user_id, tag_id, ..
-    } = tag_path
-    {
-        // Universal-tag paths targeting known pubky.app resources are indexed by the standard tag
-        // flow, so their TAGGED edge has no app property.
-        del_with_app_filter(&TagPath::pubky_app(user_id, tag_id)).await?;
-    }
-
+    del_with_app_filter(&tag_path).await?;
     Ok(())
 }
 

--- a/nexus-watcher/src/events/handlers/tag.rs
+++ b/nexus-watcher/src/events/handlers/tag.rs
@@ -392,14 +392,20 @@ async fn put_sync_user(
     }
 }
 
-#[tracing::instrument(name = "tag.del", skip_all, fields(user_id = %user_id, tag_id = %tag_id))]
-pub async fn del(user_id: PubkyId, tag_id: String) -> Result<(), EventProcessorError> {
+/// Deletes a tag from the pubky.app path.
+///
+/// For deleting an Universal Tag, see [Self::del_universal_tag]
+#[tracing::instrument(name = "tag.del_pubky_tag", skip_all, fields(user_id = %user_id, tag_id = %tag_id))]
+pub async fn del_pubky_tag(user_id: PubkyId, tag_id: String) -> Result<(), EventProcessorError> {
     del_with_app_filter(user_id, tag_id, None).await?;
     Ok(())
 }
 
-#[tracing::instrument(name = "tag.del_by_app", skip_all, fields(user_id = %user_id, tag_id = %tag_id, app = %app))]
-pub async fn del_by_app(
+/// Deletes a tag from a 3rd party app path.
+///
+/// For deleting a tag in the pubky.app path, see [Self::del_pubky_tag]
+#[tracing::instrument(name = "tag.del_universal_tag", skip_all, fields(user_id = %user_id, tag_id = %tag_id, app = %app))]
+pub async fn del_universal_tag(
     user_id: PubkyId,
     tag_id: String,
     app: &str,

--- a/nexus-watcher/src/events/handlers/tag.rs
+++ b/nexus-watcher/src/events/handlers/tag.rs
@@ -3,7 +3,9 @@ use crate::events::EventProcessorError;
 
 use chrono::Utc;
 use nexus_common::db::kv::{RedisResult, ScoreAction};
-use nexus_common::db::{fetch_row_from_graph, queries, OperationOutcome, RedisOps};
+use nexus_common::db::{
+    fetch_key_from_graph, fetch_row_from_graph, queries, OperationOutcome, RedisOps,
+};
 use nexus_common::models::homeserver::Homeserver;
 use nexus_common::models::notification::Notification;
 use nexus_common::models::post::search::PostsByTagSearch;
@@ -21,6 +23,66 @@ use pubky_app_specs::{post_uri_builder, ParsedUri, PubkyAppTag, PubkyId, Resourc
 use tracing::debug;
 
 use super::utils::post_relationships_is_reply;
+
+/// Path identity for a tag deletion.
+///
+/// The app namespace is part of Universal Tag identity, so callers should pass this instead of
+/// separate user/tag/app values that can drift apart.
+#[derive(Clone, Debug)]
+pub enum TagPath {
+    PubkyApp {
+        user_id: PubkyId,
+        tag_id: String,
+    },
+    Universal {
+        user_id: PubkyId,
+        app: String,
+        tag_id: String,
+    },
+}
+
+impl TagPath {
+    pub fn pubky_app(user_id: PubkyId, tag_id: String) -> Self {
+        Self::PubkyApp { user_id, tag_id }
+    }
+
+    pub fn universal(user_id: PubkyId, app: String, tag_id: String) -> Self {
+        Self::Universal {
+            user_id,
+            app,
+            tag_id,
+        }
+    }
+
+    /// Parses a standard pubky.app tag URI into a delete path.
+    pub fn from_pubky_app_uri(uri: &str) -> Result<Option<Self>, EventProcessorError> {
+        let parsed_uri = ParsedUri::try_from(uri).map_err(EventProcessorError::generic)?;
+        let Resource::Tag(tag_id) = parsed_uri.resource else {
+            return Ok(None);
+        };
+
+        Ok(Some(Self::pubky_app(parsed_uri.user_id, tag_id)))
+    }
+
+    fn user_id(&self) -> &PubkyId {
+        match self {
+            Self::PubkyApp { user_id, .. } | Self::Universal { user_id, .. } => user_id,
+        }
+    }
+
+    fn tag_id(&self) -> &str {
+        match self {
+            Self::PubkyApp { tag_id, .. } | Self::Universal { tag_id, .. } => tag_id,
+        }
+    }
+
+    fn app(&self) -> Option<&str> {
+        match self {
+            Self::PubkyApp { .. } => None,
+            Self::Universal { app, .. } => Some(app),
+        }
+    }
+}
 
 #[tracing::instrument(name = "tag.put", skip_all, fields(user_id = %tagger_id, tag_id = %tag_id))]
 pub async fn sync_put(
@@ -392,43 +454,34 @@ async fn put_sync_user(
     }
 }
 
-/// Deletes a tag from the pubky.app path.
-///
-/// For deleting an Universal Tag, see [Self::del_universal_tag]
-#[tracing::instrument(name = "tag.del_pubky_tag", skip_all, fields(user_id = %user_id, tag_id = %tag_id))]
-pub async fn del_pubky_tag(user_id: PubkyId, tag_id: String) -> Result<(), EventProcessorError> {
-    del_with_app_filter(user_id, tag_id, None).await?;
-    Ok(())
-}
-
-/// Deletes a tag from a 3rd party app path.
-///
-/// For deleting a tag in the pubky.app path, see [Self::del_pubky_tag]
-#[tracing::instrument(name = "tag.del_universal_tag", skip_all, fields(user_id = %user_id, tag_id = %tag_id, app = %app))]
-pub async fn del_universal_tag(
-    user_id: PubkyId,
-    tag_id: String,
-    app: &str,
-) -> Result<(), EventProcessorError> {
-    if del_with_app_filter(user_id.clone(), tag_id.clone(), Some(app)).await? {
+#[tracing::instrument(name = "tag.del", skip_all, fields(tag_path = ?tag_path))]
+pub async fn del(tag_path: TagPath) -> Result<(), EventProcessorError> {
+    if del_with_app_filter(&tag_path).await? {
         return Ok(());
     }
 
-    // Internal-known resources from app-specific tag paths are stored by the standard tag flow.
-    del_with_app_filter(user_id, tag_id, None).await?;
+    if let TagPath::Universal {
+        user_id, tag_id, ..
+    } = tag_path
+    {
+        // Universal-tag paths targeting known pubky.app resources are indexed by the standard tag
+        // flow, so their TAGGED edge has no app property.
+        del_with_app_filter(&TagPath::pubky_app(user_id, tag_id)).await?;
+    }
+
     Ok(())
 }
 
-async fn del_with_app_filter(
-    user_id: PubkyId,
-    tag_id: String,
-    app_filter: Option<&str>,
-) -> Result<bool, EventProcessorError> {
-    debug!("Deleting tag: {} -> {}", user_id, tag_id);
+async fn del_with_app_filter(tag_path: &TagPath) -> Result<bool, EventProcessorError> {
+    let user_id = tag_path.user_id();
+    let tag_id = tag_path.tag_id();
+    let app_filter = tag_path.app();
+
+    debug!("Deleting tag: {user_id} -> {tag_id} (app: {app_filter})");
 
     // 1. Read target from graph WITHOUT deleting the edge
     let Some(row) =
-        fetch_row_from_graph(queries::get::get_tag_target(&user_id, &tag_id, app_filter)).await?
+        fetch_row_from_graph(queries::get::get_tag_target(user_id, tag_id, app_filter)).await?
     else {
         // Edge already gone (fully completed on a prior attempt) — idempotent no-op
         return Ok(false);
@@ -467,7 +520,26 @@ async fn del_with_app_filter(
             .await?;
         }
         (None, None, None, Some(res_id)) => {
-            del_sync_resource(user_id.clone(), &res_id, &label, app.as_deref()).await?;
+            let has_other_global_tag = fetch_key_from_graph(
+                queries::get::has_other_resource_tag_for_tagger(
+                    user_id,
+                    &res_id,
+                    &label,
+                    app.as_deref(),
+                ),
+                "exists",
+            )
+            .await?
+            .unwrap_or(false);
+
+            del_sync_resource(
+                user_id.clone(),
+                &res_id,
+                &label,
+                app.as_deref(),
+                has_other_global_tag,
+            )
+            .await?;
         }
         _ => {
             debug!("DEL-Tag: Unexpected combination of tag details");
@@ -475,7 +547,7 @@ async fn del_with_app_filter(
     }
 
     // 3. Graph deletion LAST — ensures data survives for retry if Redis ops fail
-    fetch_row_from_graph(queries::del::delete_tag(&user_id, &tag_id, app.as_deref())).await?;
+    fetch_row_from_graph(queries::del::delete_tag(user_id, tag_id, app.as_deref())).await?;
 
     Ok(true)
 }
@@ -652,14 +724,19 @@ async fn del_sync_resource(
     resource_id: &str,
     tag_label: &str,
     app: Option<&str>,
+    has_other_global_tag: bool,
 ) -> Result<(), EventProcessorError> {
     // Step 1: Decrement scores and remove tagger from sets
     let score_results = tokio::join!(
         TagResource::update_index_score(resource_id, None, tag_label, ScoreAction::Decrement(1.0)),
         async {
-            TagResource(vec![tagger_id.to_string()])
-                .del_from_index(resource_id, None, tag_label)
-                .await?;
+            // The tagger set is global across app namespaces. Keep the user while another
+            // app-scoped edge still represents this same user/resource/label tag.
+            if !has_other_global_tag {
+                TagResource(vec![tagger_id.to_string()])
+                    .del_from_index(resource_id, None, tag_label)
+                    .await?;
+            }
             Ok::<(), EventProcessorError>(())
         },
         ResourceStream::update_global_taggers_count(resource_id, ScoreAction::Decrement(1.0)),

--- a/nexus-watcher/src/events/handlers/tag.rs
+++ b/nexus-watcher/src/events/handlers/tag.rs
@@ -477,7 +477,7 @@ async fn del_with_app_filter(tag_path: &TagPath) -> Result<bool, EventProcessorE
     let tag_id = tag_path.tag_id();
     let app_filter = tag_path.app();
 
-    debug!("Deleting tag: {user_id} -> {tag_id} (app: {app_filter})");
+    debug!("Deleting tag: {user_id} -> {tag_id} (app: {app_filter:?})");
 
     // 1. Read target from graph WITHOUT deleting the edge
     let Some(row) =

--- a/nexus-watcher/src/events/handlers/tag.rs
+++ b/nexus-watcher/src/events/handlers/tag.rs
@@ -394,13 +394,38 @@ async fn put_sync_user(
 
 #[tracing::instrument(name = "tag.del", skip_all, fields(user_id = %user_id, tag_id = %tag_id))]
 pub async fn del(user_id: PubkyId, tag_id: String) -> Result<(), EventProcessorError> {
+    del_with_app_filter(user_id, tag_id, None).await?;
+    Ok(())
+}
+
+#[tracing::instrument(name = "tag.del_by_app", skip_all, fields(user_id = %user_id, tag_id = %tag_id, app = %app))]
+pub async fn del_by_app(
+    user_id: PubkyId,
+    tag_id: String,
+    app: &str,
+) -> Result<(), EventProcessorError> {
+    if del_with_app_filter(user_id.clone(), tag_id.clone(), Some(app)).await? {
+        return Ok(());
+    }
+
+    // Internal-known resources from app-specific tag paths are stored by the standard tag flow.
+    del_with_app_filter(user_id, tag_id, None).await?;
+    Ok(())
+}
+
+async fn del_with_app_filter(
+    user_id: PubkyId,
+    tag_id: String,
+    app_filter: Option<&str>,
+) -> Result<bool, EventProcessorError> {
     debug!("Deleting tag: {} -> {}", user_id, tag_id);
 
     // 1. Read target from graph WITHOUT deleting the edge
-    let Some(row) = fetch_row_from_graph(queries::get::get_tag_target(&user_id, &tag_id)).await?
+    let Some(row) =
+        fetch_row_from_graph(queries::get::get_tag_target(&user_id, &tag_id, app_filter)).await?
     else {
         // Edge already gone (fully completed on a prior attempt) — idempotent no-op
-        return Ok(());
+        return Ok(false);
     };
 
     let tagged_user_id: Option<String> = row.get("user_id").unwrap_or(None);
@@ -446,7 +471,7 @@ pub async fn del(user_id: PubkyId, tag_id: String) -> Result<(), EventProcessorE
     // 3. Graph deletion LAST — ensures data survives for retry if Redis ops fail
     fetch_row_from_graph(queries::del::delete_tag(&user_id, &tag_id, app.as_deref())).await?;
 
-    Ok(())
+    Ok(true)
 }
 
 async fn del_sync_user(

--- a/nexus-watcher/src/events/handlers/universal_tag.rs
+++ b/nexus-watcher/src/events/handlers/universal_tag.rs
@@ -70,7 +70,7 @@ async fn handle_put(info: AppTagInfo) -> Result<(), EventProcessorError> {
 }
 
 async fn handle_del(info: AppTagInfo) -> Result<(), EventProcessorError> {
-    tag::del_by_app(info.user_id, info.tag_id, &info.app).await
+    tag::del_universal_tag(info.user_id, info.tag_id, &info.app).await
 }
 
 /// Try to parse a URI as an app-specific tag path.

--- a/nexus-watcher/src/events/handlers/universal_tag.rs
+++ b/nexus-watcher/src/events/handlers/universal_tag.rs
@@ -70,7 +70,7 @@ async fn handle_put(info: AppTagInfo) -> Result<(), EventProcessorError> {
 }
 
 async fn handle_del(info: AppTagInfo) -> Result<(), EventProcessorError> {
-    tag::del_universal_tag(info.user_id, info.tag_id, &info.app).await
+    tag::del(tag::TagPath::universal(info.user_id, info.app, info.tag_id)).await
 }
 
 /// Try to parse a URI as an app-specific tag path.

--- a/nexus-watcher/src/events/handlers/universal_tag.rs
+++ b/nexus-watcher/src/events/handlers/universal_tag.rs
@@ -70,7 +70,7 @@ async fn handle_put(info: AppTagInfo) -> Result<(), EventProcessorError> {
 }
 
 async fn handle_del(info: AppTagInfo) -> Result<(), EventProcessorError> {
-    tag::del(info.user_id, info.tag_id).await
+    tag::del_by_app(info.user_id, info.tag_id, &info.app).await
 }
 
 /// Try to parse a URI as an app-specific tag path.

--- a/nexus-watcher/src/events/handlers/universal_tag.rs
+++ b/nexus-watcher/src/events/handlers/universal_tag.rs
@@ -80,7 +80,7 @@ async fn handle_del(info: AppTagInfo) -> Result<(), EventProcessorError> {
 /// - Not a pubky:// URI
 /// - Not a */tags/* path
 /// - App is "pubky.app" (handled by the standard event flow)
-fn try_parse_app_tag_path(uri: &str) -> Option<AppTagInfo> {
+pub fn try_parse_app_tag_path(uri: &str) -> Option<AppTagInfo> {
     // Case-insensitive scheme check per RFC 3986 (safe UTF-8 access)
     let rest = match uri.get(..8) {
         Some(prefix) if prefix.eq_ignore_ascii_case("pubky://") => &uri[8..],

--- a/nexus-watcher/src/events/mod.rs
+++ b/nexus-watcher/src/events/mod.rs
@@ -107,7 +107,16 @@ pub async fn handle_del_event(event: &Event) -> Result<(), EventProcessorError> 
         Resource::Bookmark(bookmark_id) => {
             handlers::bookmark::del(user_id, bookmark_id.clone()).await?
         }
-        Resource::Tag(tag_id) => handlers::tag::del_pubky_tag(user_id, tag_id.clone()).await?,
+        Resource::Tag(_) => {
+            let tag_path =
+                handlers::tag::TagPath::from_pubky_app_uri(&event.uri)?.ok_or_else(|| {
+                    EventProcessorError::InvalidEventLine(format!(
+                        "DEL tag event did not contain a tag URI: {}",
+                        event.uri
+                    ))
+                })?;
+            handlers::tag::del(tag_path).await?
+        }
         Resource::File(file_id) => {
             handlers::file::del(&user_id, file_id.clone(), event.files_path.clone()).await?
         }

--- a/nexus-watcher/src/events/mod.rs
+++ b/nexus-watcher/src/events/mod.rs
@@ -107,7 +107,7 @@ pub async fn handle_del_event(event: &Event) -> Result<(), EventProcessorError> 
         Resource::Bookmark(bookmark_id) => {
             handlers::bookmark::del(user_id, bookmark_id.clone()).await?
         }
-        Resource::Tag(tag_id) => handlers::tag::del(user_id, tag_id.clone()).await?,
+        Resource::Tag(tag_id) => handlers::tag::del_pubky_tag(user_id, tag_id.clone()).await?,
         Resource::File(file_id) => {
             handlers::file::del(&user_id, file_id.clone(), event.files_path.clone()).await?
         }

--- a/nexus-watcher/src/events/moderation.rs
+++ b/nexus-watcher/src/events/moderation.rs
@@ -31,7 +31,8 @@ impl Moderation {
                 "Moderation tag '{}' detected. Deleting universal tag {}:{}",
                 moderator_tag.label, info.user_id, info.tag_id
             );
-            return handlers::tag::del_universal_tag(info.user_id, info.tag_id, &info.app).await;
+            let tag_to_del = handlers::tag::TagPath::universal(info.user_id, info.app, info.tag_id);
+            return handlers::tag::del(tag_to_del).await;
         }
 
         // Parse the embedded URI to extract author_id and post_id using parse_tagged_post_uri
@@ -54,7 +55,14 @@ impl Moderation {
                     "Moderation tag '{}' detected. Deleting tag {}:{}",
                     moderator_tag.label, user_id, tag_id
                 );
-                handlers::tag::del_pubky_tag(user_id, tag_id).await
+                let tag_path = handlers::tag::TagPath::from_pubky_app_uri(&moderator_tag.uri)?
+                    .ok_or_else(|| {
+                        EventProcessorError::InvalidEventLine(format!(
+                            "Moderation tag did not point to a tag URI: {}",
+                            moderator_tag.uri
+                        ))
+                    })?;
+                handlers::tag::del(tag_path).await
             }
             Resource::User => {
                 // Delete the user profile and return the result

--- a/nexus-watcher/src/events/moderation.rs
+++ b/nexus-watcher/src/events/moderation.rs
@@ -31,7 +31,7 @@ impl Moderation {
                 "Moderation tag '{}' detected. Deleting universal tag {}:{}",
                 moderator_tag.label, info.user_id, info.tag_id
             );
-            return handlers::tag::del_by_app(info.user_id, info.tag_id, &info.app).await;
+            return handlers::tag::del_universal_tag(info.user_id, info.tag_id, &info.app).await;
         }
 
         // Parse the embedded URI to extract author_id and post_id using parse_tagged_post_uri
@@ -54,7 +54,7 @@ impl Moderation {
                     "Moderation tag '{}' detected. Deleting tag {}:{}",
                     moderator_tag.label, user_id, tag_id
                 );
-                handlers::tag::del(user_id, tag_id).await
+                handlers::tag::del_pubky_tag(user_id, tag_id).await
             }
             Resource::User => {
                 // Delete the user profile and return the result

--- a/nexus-watcher/src/events/moderation.rs
+++ b/nexus-watcher/src/events/moderation.rs
@@ -31,7 +31,7 @@ impl Moderation {
                 "Moderation tag '{}' detected. Deleting universal tag {}:{}",
                 moderator_tag.label, info.user_id, info.tag_id
             );
-            return handlers::tag::del(info.user_id, info.tag_id).await;
+            return handlers::tag::del_by_app(info.user_id, info.tag_id, &info.app).await;
         }
 
         // Parse the embedded URI to extract author_id and post_id using parse_tagged_post_uri

--- a/nexus-watcher/src/events/moderation.rs
+++ b/nexus-watcher/src/events/moderation.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use crate::events::handlers;
+use crate::events::handlers::universal_tag::try_parse_app_tag_path;
 use nexus_common::models::event::EventProcessorError;
 use pubky_app_specs::{ParsedUri, PubkyAppTag, PubkyId, Resource};
 use tracing::info;
@@ -22,6 +23,17 @@ impl Moderation {
         moderator_tag: PubkyAppTag,
         files_path: PathBuf,
     ) -> Result<(), EventProcessorError> {
+        // Check if the tagged URI is a universal tag (non-pubky.app tag path such as
+        // pubky://<user_id>/pub/<app>/tags/<tag_id>). These are rejected by ParsedUri::try_from
+        // because it only recognises pubky.app-prefixed paths, so we handle them first.
+        if let Some(info) = try_parse_app_tag_path(moderator_tag.uri.as_str()) {
+            info!(
+                "Moderation tag '{}' detected. Deleting universal tag {}:{}",
+                moderator_tag.label, info.user_id, info.tag_id
+            );
+            return handlers::tag::del(info.user_id, info.tag_id).await;
+        }
+
         // Parse the embeded URI to extract author_id and post_id using parse_tagged_post_uri
         let parsed_uri = ParsedUri::try_from(moderator_tag.uri.as_str())
             .map_err(EventProcessorError::generic)?;

--- a/nexus-watcher/src/events/moderation.rs
+++ b/nexus-watcher/src/events/moderation.rs
@@ -34,7 +34,7 @@ impl Moderation {
             return handlers::tag::del(info.user_id, info.tag_id).await;
         }
 
-        // Parse the embeded URI to extract author_id and post_id using parse_tagged_post_uri
+        // Parse the embedded URI to extract author_id and post_id using parse_tagged_post_uri
         let parsed_uri = ParsedUri::try_from(moderator_tag.uri.as_str())
             .map_err(EventProcessorError::generic)?;
         let user_id = parsed_uri.user_id;

--- a/nexus-watcher/tests/event_processor/tags/del_idempotent.rs
+++ b/nexus-watcher/tests/event_processor/tags/del_idempotent.rs
@@ -8,7 +8,7 @@ use nexus_common::models::post::PostCounts;
 use nexus_common::models::tag::post::TagPost;
 use nexus_common::models::tag::traits::{TagCollection, TaggersCollection};
 use nexus_common::models::user::UserCounts;
-use nexus_watcher::events::handlers;
+use nexus_watcher::events::handlers::{self, tag::TagPath};
 use pubky::Keypair;
 use pubky_app_specs::{PubkyAppPost, PubkyAppUser, PubkyId};
 
@@ -93,7 +93,7 @@ async fn test_tag_post_del_retry_no_double_decrement() -> Result<()> {
 
     // Retry: call del handler directly — should delete graph without double-decrement
     let tagger_pubky_id = PubkyId::from(tagger_kp.public_key());
-    handlers::tag::del_pubky_tag(tagger_pubky_id, tag_id.to_string()).await?;
+    handlers::tag::del(TagPath::pubky_app(tagger_pubky_id, tag_id.to_string())).await?;
 
     // Verify final state: graph edge deleted, counters still 0
     let post_tag = find_post_tag(&author_id, &post_id, label).await?;
@@ -160,14 +160,18 @@ async fn test_tag_post_del_replay_after_success_skips() -> Result<()> {
 
     // First delete via handler (should succeed)
     let tagger_pubky_id = PubkyId::from(tagger_kp.public_key());
-    handlers::tag::del_pubky_tag(tagger_pubky_id.clone(), tag_id.to_string()).await?;
+    handlers::tag::del(TagPath::pubky_app(
+        tagger_pubky_id.clone(),
+        tag_id.to_string(),
+    ))
+    .await?;
 
     // Verify fully deleted state
     let post_tag = find_post_tag(&author_id, &post_id, label).await?;
     assert!(post_tag.is_none());
 
     // Replay: call del again — should succeed as idempotent no-op
-    handlers::tag::del_pubky_tag(tagger_pubky_id, tag_id.to_string()).await?;
+    handlers::tag::del(TagPath::pubky_app(tagger_pubky_id, tag_id.to_string())).await?;
 
     // Cleanup
     test.cleanup_post(&author_kp, &post_path).await?;

--- a/nexus-watcher/tests/event_processor/tags/del_idempotent.rs
+++ b/nexus-watcher/tests/event_processor/tags/del_idempotent.rs
@@ -93,7 +93,7 @@ async fn test_tag_post_del_retry_no_double_decrement() -> Result<()> {
 
     // Retry: call del handler directly — should delete graph without double-decrement
     let tagger_pubky_id = PubkyId::from(tagger_kp.public_key());
-    handlers::tag::del(tagger_pubky_id, tag_id.to_string()).await?;
+    handlers::tag::del_pubky_tag(tagger_pubky_id, tag_id.to_string()).await?;
 
     // Verify final state: graph edge deleted, counters still 0
     let post_tag = find_post_tag(&author_id, &post_id, label).await?;
@@ -160,14 +160,14 @@ async fn test_tag_post_del_replay_after_success_skips() -> Result<()> {
 
     // First delete via handler (should succeed)
     let tagger_pubky_id = PubkyId::from(tagger_kp.public_key());
-    handlers::tag::del(tagger_pubky_id.clone(), tag_id.to_string()).await?;
+    handlers::tag::del_pubky_tag(tagger_pubky_id.clone(), tag_id.to_string()).await?;
 
     // Verify fully deleted state
     let post_tag = find_post_tag(&author_id, &post_id, label).await?;
     assert!(post_tag.is_none());
 
     // Replay: call del again — should succeed as idempotent no-op
-    handlers::tag::del(tagger_pubky_id, tag_id.to_string()).await?;
+    handlers::tag::del_pubky_tag(tagger_pubky_id, tag_id.to_string()).await?;
 
     // Cleanup
     test.cleanup_post(&author_kp, &post_path).await?;

--- a/nexus-watcher/tests/event_processor/tags/mod.rs
+++ b/nexus-watcher/tests/event_processor/tags/mod.rs
@@ -1,5 +1,6 @@
 mod del_idempotent;
 mod fail_index;
+mod moderated;
 mod multi_user;
 mod post_del;
 mod post_del_notification;

--- a/nexus-watcher/tests/event_processor/tags/moderated.rs
+++ b/nexus-watcher/tests/event_processor/tags/moderated.rs
@@ -1,0 +1,78 @@
+use super::resource_utils::{compute_resource_id, find_resource_tag};
+use crate::event_processor::utils::watcher::{HomeserverHashIdPath, WatcherTest};
+use anyhow::Result;
+use chrono::Utc;
+use pubky::{recovery_file, Keypair};
+use pubky::ResourcePath;
+use pubky_app_specs::traits::HashId;
+use pubky_app_specs::{PubkyAppTag, PubkyAppUser};
+use tokio::fs;
+
+/// Verify that a moderation tag whose `uri` field points to a Universal Tag URI
+/// (i.e. a tag stored at a non-pubky.app path such as `/pub/mapky/tags/<tag_id>`)
+/// causes that Universal Tag to be deleted.
+#[tokio_shared_rt::test(shared)]
+async fn test_moderated_universal_tag_lifecycle() -> Result<()> {
+    let mut test = WatcherTest::setup().await?;
+
+    // 1. Create the user who will publish the Universal Tag
+    let user_kp = Keypair::random();
+    let user = PubkyAppUser {
+        bio: Some("test_moderated_universal_tag".to_string()),
+        image: None,
+        links: None,
+        name: "Watcher:UniversalTagModerate:User".to_string(),
+        status: None,
+    };
+    let user_id = test.create_user(&user_kp, &user).await?;
+
+    // 2. User creates a Universal Tag at /pub/mapky/tags/<tag_id> pointing to an external URI
+    let target_uri = "https://example.com/moderation-target";
+    let label = "bitcoin";
+
+    let tag = PubkyAppTag {
+        uri: target_uri.to_string(),
+        label: label.to_string(),
+        created_at: Utc::now().timestamp_millis(),
+    };
+
+    let tag_id = tag.create_id();
+    let resource_id = compute_resource_id(target_uri);
+    let custom_path: ResourcePath = format!("/pub/mapky/tags/{tag_id}").parse()?;
+    test.put(&user_kp, &custom_path, &tag).await?;
+
+    // 3. Confirm the Universal Tag exists in the graph
+    let tag_result = find_resource_tag(&resource_id, label).await?;
+    assert!(
+        tag_result.is_some(),
+        "Universal Tag should exist in graph after PUT"
+    );
+
+    // 4. Load the moderator key and create the moderator account
+    let moderator_recovery_file =
+        fs::read("./tests/event_processor/utils/moderator_key.pkarr").await?;
+    let moderator_key =
+        recovery_file::decrypt_recovery_file(&moderator_recovery_file, "password").unwrap();
+
+    test.create_user(&moderator_key, &user).await?;
+
+    // 5. Moderator places a standard pubky.app tag whose `uri` is the Universal Tag's own URI.
+    //    The moderation system should recognise this as a Universal Tag and delete it.
+    let universal_tag_uri = format!("pubky://{user_id}/pub/mapky/tags/{tag_id}");
+    let moderation_tag = PubkyAppTag {
+        uri: universal_tag_uri,
+        label: "label_to_moderate".to_string(),
+        created_at: Utc::now().timestamp_millis(),
+    };
+    let moderation_tag_path = moderation_tag.hs_path();
+    test.put(&moderator_key, &moderation_tag_path, &moderation_tag).await?;
+
+    // 6. Confirm the Universal Tag has been deleted
+    let tag_after = find_resource_tag(&resource_id, label).await?;
+    assert!(
+        tag_after.is_none(),
+        "Universal Tag should be deleted after moderation"
+    );
+
+    Ok(())
+}

--- a/nexus-watcher/tests/event_processor/tags/moderated.rs
+++ b/nexus-watcher/tests/event_processor/tags/moderated.rs
@@ -1,4 +1,4 @@
-use super::resource_utils::{compute_resource_id, find_resource_tag};
+use super::resource_utils::{compute_resource_id, find_resource_tag_for_app};
 use crate::event_processor::utils::watcher::{HomeserverHashIdPath, WatcherTest};
 use anyhow::Result;
 use chrono::Utc;
@@ -26,7 +26,7 @@ async fn test_moderated_universal_tag_lifecycle() -> Result<()> {
     };
     let user_id = test.create_user(&user_kp, &user).await?;
 
-    // 2. User creates a Universal Tag at /pub/mapky/tags/<tag_id> pointing to an external URI
+    // 2. User creates Universal Tags with the same deterministic tag_id in two app namespaces.
     let target_uri = "https://example.com/moderation-target";
     let label = "bitcoin";
 
@@ -38,14 +38,21 @@ async fn test_moderated_universal_tag_lifecycle() -> Result<()> {
 
     let tag_id = tag.create_id();
     let resource_id = compute_resource_id(target_uri);
-    let custom_path: ResourcePath = format!("/pub/mapky/tags/{tag_id}").parse()?;
-    test.put(&user_kp, &custom_path, &tag).await?;
+    let mapky_path: ResourcePath = format!("/pub/mapky/tags/{tag_id}").parse()?;
+    let eventky_path: ResourcePath = format!("/pub/eventky/tags/{tag_id}").parse()?;
+    test.put(&user_kp, &mapky_path, &tag).await?;
+    test.put(&user_kp, &eventky_path, &tag).await?;
 
-    // 3. Confirm the Universal Tag exists in the graph
-    let tag_result = find_resource_tag(&resource_id, label).await?;
+    // 3. Confirm both Universal Tags exist in the graph
+    let tag_result = find_resource_tag_for_app(&resource_id, label, "mapky").await?;
     assert!(
         tag_result.is_some(),
-        "Universal Tag should exist in graph after PUT"
+        "mapky Universal Tag should exist in graph after PUT"
+    );
+    let tag_result = find_resource_tag_for_app(&resource_id, label, "eventky").await?;
+    assert!(
+        tag_result.is_some(),
+        "eventky Universal Tag should exist in graph after PUT"
     );
 
     // 4. Load the moderator key and create the moderator account
@@ -58,7 +65,7 @@ async fn test_moderated_universal_tag_lifecycle() -> Result<()> {
 
     // 5. Moderator places a standard pubky.app tag whose `uri` is the Universal Tag's own URI.
     //    The moderation system should recognise this as a Universal Tag and delete it.
-    let universal_tag_uri = format!("pubky://{user_id}/pub/mapky/tags/{tag_id}");
+    let universal_tag_uri = format!("pubky://{user_id}/pub/eventky/tags/{tag_id}");
     let moderation_tag = PubkyAppTag {
         uri: universal_tag_uri,
         label: "label_to_moderate".to_string(),
@@ -68,11 +75,16 @@ async fn test_moderated_universal_tag_lifecycle() -> Result<()> {
     test.put(&moderator_key, &moderation_tag_path, &moderation_tag)
         .await?;
 
-    // 6. Confirm the Universal Tag has been deleted
-    let tag_after = find_resource_tag(&resource_id, label).await?;
+    // 6. Confirm only the app-scoped Universal Tag has been deleted
+    let tag_after = find_resource_tag_for_app(&resource_id, label, "eventky").await?;
     assert!(
         tag_after.is_none(),
-        "Universal Tag should be deleted after moderation"
+        "eventky Universal Tag should be deleted after moderation"
+    );
+    let tag_after = find_resource_tag_for_app(&resource_id, label, "mapky").await?;
+    assert!(
+        tag_after.is_some(),
+        "mapky Universal Tag should remain after eventky moderation"
     );
 
     Ok(())

--- a/nexus-watcher/tests/event_processor/tags/moderated.rs
+++ b/nexus-watcher/tests/event_processor/tags/moderated.rs
@@ -2,8 +2,8 @@ use super::resource_utils::{compute_resource_id, find_resource_tag};
 use crate::event_processor::utils::watcher::{HomeserverHashIdPath, WatcherTest};
 use anyhow::Result;
 use chrono::Utc;
-use pubky::{recovery_file, Keypair};
 use pubky::ResourcePath;
+use pubky::{recovery_file, Keypair};
 use pubky_app_specs::traits::HashId;
 use pubky_app_specs::{PubkyAppTag, PubkyAppUser};
 use tokio::fs;
@@ -65,7 +65,8 @@ async fn test_moderated_universal_tag_lifecycle() -> Result<()> {
         created_at: Utc::now().timestamp_millis(),
     };
     let moderation_tag_path = moderation_tag.hs_path();
-    test.put(&moderator_key, &moderation_tag_path, &moderation_tag).await?;
+    test.put(&moderator_key, &moderation_tag_path, &moderation_tag)
+        .await?;
 
     // 6. Confirm the Universal Tag has been deleted
     let tag_after = find_resource_tag(&resource_id, label).await?;

--- a/nexus-watcher/tests/event_processor/tags/moderated.rs
+++ b/nexus-watcher/tests/event_processor/tags/moderated.rs
@@ -2,6 +2,8 @@ use super::resource_utils::{compute_resource_id, find_resource_tag_for_app};
 use crate::event_processor::utils::watcher::{HomeserverHashIdPath, WatcherTest};
 use anyhow::Result;
 use chrono::Utc;
+use nexus_common::models::resource::tag::TagResource;
+use nexus_common::models::tag::traits::TagCollection;
 use pubky::ResourcePath;
 use pubky::{recovery_file, Keypair};
 use pubky_app_specs::traits::HashId;
@@ -86,6 +88,15 @@ async fn test_moderated_universal_tag_lifecycle() -> Result<()> {
         tag_after.is_some(),
         "mapky Universal Tag should remain after eventky moderation"
     );
+
+    // The global Resource tagger set is shared across apps, so the remaining mapky tag should
+    // keep the user visible in cached tag details after eventky is removed.
+    let cache_tags = TagResource::get_from_index(&resource_id, None, None, None, None, None, false)
+        .await?
+        .expect("global Resource tag cache should remain while mapky tag exists");
+    assert_eq!(cache_tags.len(), 1);
+    assert_eq!(cache_tags[0].label, label);
+    assert_eq!(cache_tags[0].taggers, vec![user_id.to_string()]);
 
     Ok(())
 }

--- a/nexus-watcher/tests/event_processor/tags/resource_utils.rs
+++ b/nexus-watcher/tests/event_processor/tags/resource_utils.rs
@@ -24,6 +24,17 @@ pub async fn find_resource_tag(
     Ok(result)
 }
 
+/// Find a Resource tag in the graph database for a specific app namespace.
+pub async fn find_resource_tag_for_app(
+    resource_id: &str,
+    label: &str,
+    app: &str,
+) -> Result<Option<ResourceTagResult>> {
+    let query = resource_tag_for_app_query(resource_id, label, app);
+    let result = fetch_key_from_graph(query, "details").await.unwrap();
+    Ok(result)
+}
+
 /// Check if a Resource node exists in the graph
 pub async fn resource_exists_in_graph(resource_id: &str) -> Result<bool> {
     let query = Query::new(
@@ -85,4 +96,23 @@ fn resource_tag_query(resource_id: &str, label: &str) -> Query {
     )
     .param("resource_id", resource_id)
     .param("label", label)
+}
+
+fn resource_tag_for_app_query(resource_id: &str, label: &str, app: &str) -> Query {
+    Query::new(
+        "resource_tag_for_app_query",
+        "
+        MATCH (tagger:User)-[t:TAGGED {label: $label, app: $app}]->(r:Resource {id: $resource_id})
+        RETURN {
+            label: t.label,
+            app: t.app,
+            tagger: tagger.id,
+            uri: r.uri,
+            scheme: r.scheme
+        } AS details
+        ",
+    )
+    .param("resource_id", resource_id)
+    .param("label", label)
+    .param("app", app)
 }


### PR DESCRIPTION
This PR fixes moderation of Universal Tags.

---

`apply_moderation` silently failed when the moderation tag's `uri` pointed to a Universal Tag (e.g. `pubky://<user_id>/pub/mapky/tags/<tag_id>`). `ParsedUri::try_from` rejects any URI where the app segment isn't `pubky.app`, so moderating Universal Tags was broken with no test coverage catching it.

## Changes

- **`universal_tag.rs`** — make `try_parse_app_tag_path` `pub` so moderation can reuse it.
- **`moderation.rs`** — in `apply_moderation`, check for a Universal Tag URI *before* calling `ParsedUri::try_from`. When matched, delegate directly to `handlers::tag::del`:

  ```rust
  if let Some(info) = try_parse_app_tag_path(moderator_tag.uri.as_str()) {
      info!("Moderation tag '{}' detected. Deleting universal tag {}:{}", ...);
      return handlers::tag::del(info.user_id, info.tag_id).await;
  }
  // existing ParsedUri::try_from path follows
  ```

- **`tags/moderated.rs`** *(new)* — integration test `test_moderated_universal_tag_lifecycle`: creates a Universal Tag at `/pub/mapky/tags/<tag_id>`, verifies it exists, moderator tags its own URI with the moderation label, asserts the Universal Tag is deleted.
