### PR TITLE
Remove `files_path` from `Event` struct

### DIFF
--- a/nexus-common/src/config/stack.rs
+++ b/nexus-common/src/config/stack.rs
@@ -1,4 +1,4 @@
-use crate::{db::DatabaseConfig, get_files_dir_pathbuf};
+use crate::{db::DatabaseConfig, get_files_dir_pathbuf, get_files_dir_test_pathbuf};
 use serde::{Deserialize, Deserializer, Serialize};
 use std::{fmt::Debug, path::PathBuf};
 
@@ -52,6 +52,15 @@ impl Default for StackConfig {
             files_path: get_files_dir_pathbuf(),
             otlp: OtlpConfig::default(),
             db: DatabaseConfig::default(),
+        }
+    }
+}
+
+impl StackConfig {
+    pub fn test_default() -> Self {
+        Self {
+            files_path: get_files_dir_test_pathbuf(),
+            ..Default::default()
         }
     }
 }

--- a/nexus-common/src/models/event/mod.rs
+++ b/nexus-common/src/models/event/mod.rs
@@ -3,7 +3,7 @@ mod errors;
 use crate::db::{kv::RedisResult, RedisOps};
 use pubky_app_specs::{ParsedUri, Resource};
 use serde::{Deserialize, Serialize};
-use std::{fmt, path::PathBuf};
+use std::fmt;
 use tracing::{debug, error};
 
 pub use errors::EventProcessorError;
@@ -56,7 +56,6 @@ pub struct Event {
     pub uri: String,
     pub event_type: EventType,
     pub parsed_uri: ParsedUri,
-    pub files_path: PathBuf,
     event_line: String,
 }
 
@@ -71,11 +70,7 @@ impl AsRef<[String]> for Event {
 impl Event {
     /// Parse event based on event line returned by homeservers' /events endpoint.
     /// - line - event line string
-    /// - files_path - path to the directory where files are stored on nexus
-    pub fn parse_event(
-        line: &str,
-        files_path: PathBuf,
-    ) -> Result<ParseResult, EventProcessorError> {
+    pub fn parse_event(line: &str) -> Result<ParseResult, EventProcessorError> {
         debug!("New event: {}", line);
         let parts: Vec<&str> = line.split(' ').collect();
         if parts.len() != 2 {
@@ -122,7 +117,6 @@ impl Event {
             uri,
             event_type,
             parsed_uri,
-            files_path,
             event_line,
         }))
     }

--- a/nexus-common/src/models/homeserver.rs
+++ b/nexus-common/src/models/homeserver.rs
@@ -179,7 +179,7 @@ mod tests {
 
     #[tokio_shared_rt::test(shared)]
     async fn test_put_to_get_from_graph() -> Result<(), DynError> {
-        StackManager::setup(&StackConfig::default()).await?;
+        StackManager::setup(&StackConfig::test_default()).await?;
 
         let keys = Keypair::random();
         let id = PubkyId::try_from(&keys.public_key().to_z32())?;
@@ -202,7 +202,7 @@ mod tests {
 
     #[tokio_shared_rt::test(shared)]
     async fn test_put_to_get_from_index() -> Result<(), DynError> {
-        StackManager::setup(&StackConfig::default()).await?;
+        StackManager::setup(&StackConfig::test_default()).await?;
 
         let keys = Keypair::random();
         let id = PubkyId::try_from(&keys.public_key().to_z32())?;

--- a/nexus-watcher/src/events/context.rs
+++ b/nexus-watcher/src/events/context.rs
@@ -1,0 +1,26 @@
+use std::path::PathBuf;
+
+use nexus_common::WatcherConfig;
+
+use super::Moderation;
+
+pub struct EventContext {
+    pub moderation: Moderation,
+
+    /// Nexus-local directory path where certain events may store data on Nexus.
+    ///
+    /// Moderation may trigger the deletion of such data for specific events.
+    pub files_path: PathBuf,
+}
+
+impl EventContext {
+    pub(crate) fn from_config(config: &WatcherConfig) -> Self {
+        EventContext {
+            moderation: Moderation {
+                id: config.moderation_id.clone(),
+                tags: config.moderated_tags.clone(),
+            },
+            files_path: config.stack.files_path.clone(),
+        }
+    }
+}

--- a/nexus-watcher/src/events/handlers/file.rs
+++ b/nexus-watcher/src/events/handlers/file.rs
@@ -19,7 +19,7 @@ pub async fn sync_put(
     uri: String,
     user_id: PubkyId,
     file_id: String,
-    files_path: &PathBuf,
+    files_path: PathBuf,
 ) -> Result<(), EventProcessorError> {
     debug!("Indexing new file resource at {}/{}", user_id, file_id);
 
@@ -50,7 +50,7 @@ async fn ingest(
     user_id: &PubkyId,
     file_id: &str,
     pubkyapp_file: &PubkyAppFile,
-    files_path: &PathBuf,
+    files_path: PathBuf,
 ) -> Result<FileMeta, EventProcessorError> {
     let pubky = PubkyConnector::get()?;
     let response = pubky.public_storage().get(&pubkyapp_file.src).await?;
@@ -88,7 +88,7 @@ async fn ingest(
 pub async fn del(
     user_id: &PubkyId,
     file_id: String,
-    files_path: &PathBuf,
+    files_path: PathBuf,
 ) -> Result<(), EventProcessorError> {
     debug!("Deleting File resource at {}/{}", user_id, file_id);
     let result = FileDetails::get_by_ids(&[&[user_id, &file_id]]).await?;

--- a/nexus-watcher/src/events/handlers/file.rs
+++ b/nexus-watcher/src/events/handlers/file.rs
@@ -88,7 +88,7 @@ async fn ingest(
 pub async fn del(
     user_id: &PubkyId,
     file_id: String,
-    files_path: PathBuf,
+    files_path: &Path,
 ) -> Result<(), EventProcessorError> {
     debug!("Deleting File resource at {}/{}", user_id, file_id);
     let result = FileDetails::get_by_ids(&[&[user_id, &file_id]]).await?;

--- a/nexus-watcher/src/events/handlers/file.rs
+++ b/nexus-watcher/src/events/handlers/file.rs
@@ -9,7 +9,7 @@ use nexus_common::models::{
     traits::Collection,
 };
 use pubky_app_specs::{PubkyAppFile, PubkyAppObject, PubkyId};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use tokio::fs::remove_dir_all;
 use tracing::debug;
 
@@ -19,7 +19,7 @@ pub async fn sync_put(
     uri: String,
     user_id: PubkyId,
     file_id: String,
-    files_path: PathBuf,
+    files_path: &Path,
 ) -> Result<(), EventProcessorError> {
     debug!("Indexing new file resource at {}/{}", user_id, file_id);
 
@@ -50,7 +50,7 @@ async fn ingest(
     user_id: &PubkyId,
     file_id: &str,
     pubkyapp_file: &PubkyAppFile,
-    files_path: PathBuf,
+    files_path: &Path,
 ) -> Result<FileMeta, EventProcessorError> {
     let pubky = PubkyConnector::get()?;
     let response = pubky.public_storage().get(&pubkyapp_file.src).await?;

--- a/nexus-watcher/src/events/handlers/file.rs
+++ b/nexus-watcher/src/events/handlers/file.rs
@@ -19,7 +19,7 @@ pub async fn sync_put(
     uri: String,
     user_id: PubkyId,
     file_id: String,
-    files_path: PathBuf,
+    files_path: &PathBuf,
 ) -> Result<(), EventProcessorError> {
     debug!("Indexing new file resource at {}/{}", user_id, file_id);
 
@@ -50,7 +50,7 @@ async fn ingest(
     user_id: &PubkyId,
     file_id: &str,
     pubkyapp_file: &PubkyAppFile,
-    files_path: PathBuf,
+    files_path: &PathBuf,
 ) -> Result<FileMeta, EventProcessorError> {
     let pubky = PubkyConnector::get()?;
     let response = pubky.public_storage().get(&pubkyapp_file.src).await?;
@@ -88,7 +88,7 @@ async fn ingest(
 pub async fn del(
     user_id: &PubkyId,
     file_id: String,
-    files_path: PathBuf,
+    files_path: &PathBuf,
 ) -> Result<(), EventProcessorError> {
     debug!("Deleting File resource at {}/{}", user_id, file_id);
     let result = FileDetails::get_by_ids(&[&[user_id, &file_id]]).await?;

--- a/nexus-watcher/src/events/mod.rs
+++ b/nexus-watcher/src/events/mod.rs
@@ -1,7 +1,7 @@
 use nexus_common::db::PubkyConnector;
 use nexus_common::models::event::{Event, EventProcessorError, EventType};
 use pubky_app_specs::{PubkyAppObject, Resource};
-use std::path::PathBuf;
+use std::path::Path;
 use std::sync::Arc;
 use tracing::debug;
 
@@ -14,7 +14,7 @@ pub use moderation::Moderation;
 pub async fn handle(event: &Event, moderation: Arc<Moderation>) -> Result<(), EventProcessorError> {
     match event.event_type {
         EventType::Put => handle_put_event(event, moderation).await,
-        EventType::Del => handle_del_event(event, moderation.files_path.clone()).await,
+        EventType::Del => handle_del_event(event, &moderation.files_path).await,
     }?;
 
     event.store_event().await?;
@@ -88,10 +88,7 @@ pub async fn handle_put_event(
 }
 
 /// Handles a DEL event by dispatching to the appropriate handler.
-pub async fn handle_del_event(
-    event: &Event,
-    files_path: PathBuf,
-) -> Result<(), EventProcessorError> {
+pub async fn handle_del_event(event: &Event, files_path: &Path) -> Result<(), EventProcessorError> {
     debug!("Handling DEL event for URI: {}", event.uri);
 
     let user_id = event.parsed_uri.user_id.clone();

--- a/nexus-watcher/src/events/mod.rs
+++ b/nexus-watcher/src/events/mod.rs
@@ -1,6 +1,7 @@
 use nexus_common::db::PubkyConnector;
 use nexus_common::models::event::{Event, EventProcessorError, EventType};
 use pubky_app_specs::{PubkyAppObject, Resource};
+use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::debug;
 
@@ -13,7 +14,7 @@ pub use moderation::Moderation;
 pub async fn handle(event: &Event, moderation: Arc<Moderation>) -> Result<(), EventProcessorError> {
     match event.event_type {
         EventType::Put => handle_put_event(event, moderation).await,
-        EventType::Del => handle_del_event(event).await,
+        EventType::Del => handle_del_event(event, &moderation.files_path).await,
     }?;
 
     event.store_event().await?;
@@ -72,20 +73,14 @@ pub async fn handle_put_event(
         }
         (PubkyAppObject::Tag(tag), Resource::Tag(tag_id)) => {
             if moderation.should_delete(&tag, user_id.clone()).await {
-                Moderation::apply_moderation(tag, event.files_path.clone()).await?
+                moderation.apply_moderation(tag).await?
             } else {
                 handlers::tag::sync_put(tag, user_id, tag_id).await?
             }
         }
         (PubkyAppObject::File(file), Resource::File(file_id)) => {
-            handlers::file::sync_put(
-                file,
-                event.uri.clone(),
-                user_id,
-                file_id,
-                event.files_path.clone(),
-            )
-            .await?
+            let files_path = &moderation.files_path;
+            handlers::file::sync_put(file, event.uri.clone(), user_id, file_id, files_path).await?
         }
         other => debug!("Event type not handled, Resource: {other:?}"),
     }
@@ -93,7 +88,10 @@ pub async fn handle_put_event(
 }
 
 /// Handles a DEL event by dispatching to the appropriate handler.
-pub async fn handle_del_event(event: &Event) -> Result<(), EventProcessorError> {
+pub async fn handle_del_event(
+    event: &Event,
+    files_path: &PathBuf,
+) -> Result<(), EventProcessorError> {
     debug!("Handling DEL event for URI: {}", event.uri);
 
     let user_id = event.parsed_uri.user_id.clone();
@@ -109,7 +107,7 @@ pub async fn handle_del_event(event: &Event) -> Result<(), EventProcessorError> 
         }
         Resource::Tag(tag_id) => handlers::tag::del(user_id, tag_id.clone()).await?,
         Resource::File(file_id) => {
-            handlers::file::del(&user_id, file_id.clone(), event.files_path.clone()).await?
+            handlers::file::del(&user_id, file_id.clone(), files_path).await?
         }
         other => debug!("DEL event type not handled for resource: {other:?}"),
     }

--- a/nexus-watcher/src/events/mod.rs
+++ b/nexus-watcher/src/events/mod.rs
@@ -79,7 +79,7 @@ pub async fn handle_put_event(
             }
         }
         (PubkyAppObject::File(file), Resource::File(file_id)) => {
-            let files_path = moderation.files_path.clone();
+            let files_path = &moderation.files_path;
             handlers::file::sync_put(file, event.uri.clone(), user_id, file_id, files_path).await?
         }
         other => debug!("Event type not handled, Resource: {other:?}"),

--- a/nexus-watcher/src/events/mod.rs
+++ b/nexus-watcher/src/events/mod.rs
@@ -14,7 +14,7 @@ pub use moderation::Moderation;
 pub async fn handle(event: &Event, moderation: Arc<Moderation>) -> Result<(), EventProcessorError> {
     match event.event_type {
         EventType::Put => handle_put_event(event, moderation).await,
-        EventType::Del => handle_del_event(event, &moderation.files_path).await,
+        EventType::Del => handle_del_event(event, moderation.files_path.clone()).await,
     }?;
 
     event.store_event().await?;
@@ -79,7 +79,7 @@ pub async fn handle_put_event(
             }
         }
         (PubkyAppObject::File(file), Resource::File(file_id)) => {
-            let files_path = &moderation.files_path;
+            let files_path = moderation.files_path.clone();
             handlers::file::sync_put(file, event.uri.clone(), user_id, file_id, files_path).await?
         }
         other => debug!("Event type not handled, Resource: {other:?}"),
@@ -90,7 +90,7 @@ pub async fn handle_put_event(
 /// Handles a DEL event by dispatching to the appropriate handler.
 pub async fn handle_del_event(
     event: &Event,
-    files_path: &PathBuf,
+    files_path: PathBuf,
 ) -> Result<(), EventProcessorError> {
     debug!("Handling DEL event for URI: {}", event.uri);
 

--- a/nexus-watcher/src/events/mod.rs
+++ b/nexus-watcher/src/events/mod.rs
@@ -73,7 +73,7 @@ pub async fn handle_put_event(
             handlers::bookmark::sync_put(user_id, bookmark, bookmark_id).await?
         }
         (PubkyAppObject::Tag(tag), Resource::Tag(tag_id)) => {
-            if ctx.moderation.should_delete(&tag, user_id.clone()).await {
+            if ctx.moderation.should_delete(&tag, &user_id) {
                 ctx.moderation
                     .apply_moderation(tag, &ctx.files_path)
                     .await?

--- a/nexus-watcher/src/events/mod.rs
+++ b/nexus-watcher/src/events/mod.rs
@@ -1,20 +1,21 @@
 use nexus_common::db::PubkyConnector;
 use nexus_common::models::event::{Event, EventProcessorError, EventType};
 use pubky_app_specs::{PubkyAppObject, Resource};
-use std::path::Path;
 use std::sync::Arc;
 use tracing::debug;
 
+mod context;
 pub mod handlers;
 mod moderation;
 pub mod retry;
 
+pub use context::EventContext;
 pub use moderation::Moderation;
 
-pub async fn handle(event: &Event, moderation: Arc<Moderation>) -> Result<(), EventProcessorError> {
+pub async fn handle(event: &Event, ctx: Arc<EventContext>) -> Result<(), EventProcessorError> {
     match event.event_type {
-        EventType::Put => handle_put_event(event, moderation).await,
-        EventType::Del => handle_del_event(event, &moderation.files_path).await,
+        EventType::Put => handle_put_event(event, ctx).await,
+        EventType::Del => handle_del_event(event, ctx).await,
     }?;
 
     event.store_event().await?;
@@ -23,7 +24,7 @@ pub async fn handle(event: &Event, moderation: Arc<Moderation>) -> Result<(), Ev
 
 pub async fn handle_put_event(
     event: &Event,
-    moderation: Arc<Moderation>,
+    ctx: Arc<EventContext>,
 ) -> Result<(), EventProcessorError> {
     debug!("Handling PUT event for URI: {}", event.uri);
 
@@ -72,14 +73,16 @@ pub async fn handle_put_event(
             handlers::bookmark::sync_put(user_id, bookmark, bookmark_id).await?
         }
         (PubkyAppObject::Tag(tag), Resource::Tag(tag_id)) => {
-            if moderation.should_delete(&tag, user_id.clone()).await {
-                moderation.apply_moderation(tag).await?
+            if ctx.moderation.should_delete(&tag, user_id.clone()).await {
+                ctx.moderation
+                    .apply_moderation(tag, &ctx.files_path)
+                    .await?
             } else {
                 handlers::tag::sync_put(tag, user_id, tag_id).await?
             }
         }
         (PubkyAppObject::File(file), Resource::File(file_id)) => {
-            let files_path = &moderation.files_path;
+            let files_path = &ctx.files_path;
             handlers::file::sync_put(file, event.uri.clone(), user_id, file_id, files_path).await?
         }
         other => debug!("Event type not handled, Resource: {other:?}"),
@@ -88,7 +91,10 @@ pub async fn handle_put_event(
 }
 
 /// Handles a DEL event by dispatching to the appropriate handler.
-pub async fn handle_del_event(event: &Event, files_path: &Path) -> Result<(), EventProcessorError> {
+pub async fn handle_del_event(
+    event: &Event,
+    ctx: Arc<EventContext>,
+) -> Result<(), EventProcessorError> {
     debug!("Handling DEL event for URI: {}", event.uri);
 
     let user_id = event.parsed_uri.user_id.clone();
@@ -104,7 +110,7 @@ pub async fn handle_del_event(event: &Event, files_path: &Path) -> Result<(), Ev
         }
         Resource::Tag(tag_id) => handlers::tag::del(user_id, tag_id.clone()).await?,
         Resource::File(file_id) => {
-            handlers::file::del(&user_id, file_id.clone(), files_path).await?
+            handlers::file::del(&user_id, file_id.clone(), &ctx.files_path).await?
         }
         other => debug!("DEL event type not handled for resource: {other:?}"),
     }

--- a/nexus-watcher/src/events/moderation.rs
+++ b/nexus-watcher/src/events/moderation.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::Path;
 
 use crate::events::handlers;
 use nexus_common::models::event::EventProcessorError;
@@ -11,11 +11,6 @@ pub struct Moderation {
 
     /// Tags to be moderated (tagged content is deleted)
     pub tags: Vec<String>,
-
-    /// Nexus-local directory path where certain events may store data on Nexus.
-    ///
-    /// Moderation may trigger the deletion of such data for specific events.
-    pub files_path: PathBuf,
 }
 
 impl Moderation {
@@ -27,6 +22,7 @@ impl Moderation {
     pub async fn apply_moderation(
         &self,
         moderator_tag: PubkyAppTag,
+        files_path: &Path,
     ) -> Result<(), EventProcessorError> {
         // Parse the embeded URI to extract author_id and post_id using parse_tagged_post_uri
         let parsed_uri = ParsedUri::try_from(moderator_tag.uri.as_str())
@@ -64,7 +60,7 @@ impl Moderation {
                     "Moderation tag '{}' detected. Deleting file {}:{}",
                     moderator_tag.label, user_id, file_id
                 );
-                handlers::file::del(&user_id, file_id, &self.files_path).await
+                handlers::file::del(&user_id, file_id, files_path).await
             }
             _ => Ok(()),
         }

--- a/nexus-watcher/src/events/moderation.rs
+++ b/nexus-watcher/src/events/moderation.rs
@@ -64,7 +64,7 @@ impl Moderation {
                     "Moderation tag '{}' detected. Deleting file {}:{}",
                     moderator_tag.label, user_id, file_id
                 );
-                handlers::file::del(&user_id, file_id, self.files_path.clone()).await
+                handlers::file::del(&user_id, file_id, &self.files_path).await
             }
             _ => Ok(()),
         }

--- a/nexus-watcher/src/events/moderation.rs
+++ b/nexus-watcher/src/events/moderation.rs
@@ -8,9 +8,13 @@ use tracing::info;
 pub struct Moderation {
     /// Moderator trusted user id
     pub id: PubkyId,
+
     /// Tags to be moderated (tagged content is deleted)
     pub tags: Vec<String>,
 
+    /// Nexus-local directory path where certain events may store data on Nexus.
+    ///
+    /// Moderation may trigger the deletion of such data for specific events.
     pub files_path: PathBuf,
 }
 

--- a/nexus-watcher/src/events/moderation.rs
+++ b/nexus-watcher/src/events/moderation.rs
@@ -10,6 +10,8 @@ pub struct Moderation {
     pub id: PubkyId,
     /// Tags to be moderated (tagged content is deleted)
     pub tags: Vec<String>,
+
+    pub files_path: PathBuf,
 }
 
 impl Moderation {
@@ -19,8 +21,8 @@ impl Moderation {
 
     #[tracing::instrument(name = "moderation.apply", skip_all)]
     pub async fn apply_moderation(
+        &self,
         moderator_tag: PubkyAppTag,
-        files_path: PathBuf,
     ) -> Result<(), EventProcessorError> {
         // Parse the embeded URI to extract author_id and post_id using parse_tagged_post_uri
         let parsed_uri = ParsedUri::try_from(moderator_tag.uri.as_str())
@@ -58,7 +60,7 @@ impl Moderation {
                     "Moderation tag '{}' detected. Deleting file {}:{}",
                     moderator_tag.label, user_id, file_id
                 );
-                handlers::file::del(&user_id, file_id, files_path).await
+                handlers::file::del(&user_id, file_id, &self.files_path).await
             }
             _ => Ok(()),
         }

--- a/nexus-watcher/src/events/moderation.rs
+++ b/nexus-watcher/src/events/moderation.rs
@@ -14,8 +14,8 @@ pub struct Moderation {
 }
 
 impl Moderation {
-    pub async fn should_delete(&self, tag: &PubkyAppTag, tagger_id: PubkyId) -> bool {
-        tagger_id == self.id && self.tags.contains(&tag.label)
+    pub fn should_delete(&self, tag: &PubkyAppTag, tagger_id: &PubkyId) -> bool {
+        tagger_id == &self.id && self.tags.contains(&tag.label)
     }
 
     #[tracing::instrument(name = "moderation.apply", skip_all)]

--- a/nexus-watcher/src/events/moderation.rs
+++ b/nexus-watcher/src/events/moderation.rs
@@ -60,7 +60,7 @@ impl Moderation {
                     "Moderation tag '{}' detected. Deleting file {}:{}",
                     moderator_tag.label, user_id, file_id
                 );
-                handlers::file::del(&user_id, file_id, &self.files_path).await
+                handlers::file::del(&user_id, file_id, self.files_path.clone()).await
             }
             _ => Ok(()),
         }

--- a/nexus-watcher/src/service/processor.rs
+++ b/nexus-watcher/src/service/processor.rs
@@ -115,7 +115,7 @@ impl EventProcessor {
                     Err(e) => warn!("{e}"),
                 }
             } else {
-                match Event::parse_event(line, self.files_path.clone()) {
+                match Event::parse_event(line) {
                     Err(e) => error!("{e}"),
                     Ok(ParseResult::Skipped) => {}
                     Ok(ParseResult::UnrecognizedUri {

--- a/nexus-watcher/src/service/processor.rs
+++ b/nexus-watcher/src/service/processor.rs
@@ -1,6 +1,6 @@
 use crate::events::handle;
 use crate::events::retry::event::RetryEvent;
-use crate::events::Moderation;
+use crate::events::EventContext;
 use crate::service::traits::TEventProcessor;
 use nexus_common::db::PubkyConnector;
 use nexus_common::models::event::{Event, EventProcessorError, EventType, ParseResult};
@@ -18,7 +18,7 @@ pub struct EventProcessor {
     /// See [WatcherConfig::events_limit]
     pub limit: u32,
     pub tracer_name: String,
-    pub moderation: Arc<Moderation>,
+    pub context: Arc<EventContext>,
     pub shutdown_rx: Receiver<bool>,
 }
 
@@ -198,7 +198,7 @@ impl EventProcessor {
     )]
     async fn handle_event(&self, event: &Event) -> Result<(), EventProcessorError> {
         let span = tracing::Span::current();
-        if let Err(e) = handle(event, self.moderation.clone()).await {
+        if let Err(e) = handle(event, self.context.clone()).await {
             span.record("otel.status_code", "ERROR");
             span.record("otel.status_message", tracing::field::display(&e));
 

--- a/nexus-watcher/src/service/processor.rs
+++ b/nexus-watcher/src/service/processor.rs
@@ -1,16 +1,14 @@
-use nexus_common::models::event::{Event, EventProcessorError, EventType, ParseResult};
-
 use crate::events::handle;
 use crate::events::retry::event::RetryEvent;
 use crate::events::Moderation;
 use crate::service::traits::TEventProcessor;
 use nexus_common::db::PubkyConnector;
+use nexus_common::models::event::{Event, EventProcessorError, EventType, ParseResult};
 use nexus_common::models::homeserver::Homeserver;
 use opentelemetry::trace::{FutureExt, Span, TraceContextExt, Tracer};
 use opentelemetry::{global, Context, KeyValue};
 use pubky::Method;
 use pubky_app_specs::PubkyId;
-use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::watch::Receiver;
 use tracing::{debug, error, info, warn};
@@ -19,7 +17,6 @@ pub struct EventProcessor {
     pub homeserver: Homeserver,
     /// See [WatcherConfig::events_limit]
     pub limit: u32,
-    pub files_path: PathBuf,
     pub tracer_name: String,
     pub moderation: Arc<Moderation>,
     pub shutdown_rx: Receiver<bool>,

--- a/nexus-watcher/src/service/processor_runner.rs
+++ b/nexus-watcher/src/service/processor_runner.rs
@@ -33,6 +33,7 @@ impl EventProcessorRunner {
             moderation: Arc::new(Moderation {
                 id: config.moderation_id.clone(),
                 tags: config.moderated_tags.clone(),
+                files_path: config.stack.files_path.clone(),
             }),
             shutdown_rx,
             default_homeserver: config.homeserver.clone(),

--- a/nexus-watcher/src/service/processor_runner.rs
+++ b/nexus-watcher/src/service/processor_runner.rs
@@ -5,7 +5,6 @@ use nexus_common::models::homeserver::Homeserver;
 use nexus_common::types::DynError;
 use nexus_common::WatcherConfig;
 use pubky_app_specs::PubkyId;
-use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::watch::Receiver;
 
@@ -14,7 +13,6 @@ pub struct EventProcessorRunner {
     pub limit: u32,
     /// See [WatcherConfig::monitored_homeservers_limit]
     pub monitored_homeservers_limit: usize,
-    pub files_path: PathBuf,
     pub tracer_name: String,
     pub moderation: Arc<Moderation>,
     pub shutdown_rx: Receiver<bool>,
@@ -28,7 +26,6 @@ impl EventProcessorRunner {
         Self {
             limit: config.events_limit,
             monitored_homeservers_limit: config.monitored_homeservers_limit,
-            files_path: config.stack.files_path.clone(),
             tracer_name: config.stack.otlp.name.clone(),
             moderation: Arc::new(Moderation {
                 id: config.moderation_id.clone(),
@@ -81,7 +78,6 @@ impl TEventProcessorRunner for EventProcessorRunner {
         Ok(Arc::new(EventProcessor {
             homeserver,
             limit: self.limit,
-            files_path: self.files_path.clone(),
             tracer_name: self.tracer_name.clone(),
             moderation: self.moderation.clone(),
             shutdown_rx: self.shutdown_rx.clone(),

--- a/nexus-watcher/src/service/processor_runner.rs
+++ b/nexus-watcher/src/service/processor_runner.rs
@@ -1,4 +1,4 @@
-use crate::events::Moderation;
+use crate::events::EventContext;
 use crate::service::processor::EventProcessor;
 use crate::service::traits::{TEventProcessor, TEventProcessorRunner};
 use nexus_common::models::homeserver::Homeserver;
@@ -14,7 +14,7 @@ pub struct EventProcessorRunner {
     /// See [WatcherConfig::monitored_homeservers_limit]
     pub monitored_homeservers_limit: usize,
     pub tracer_name: String,
-    pub moderation: Arc<Moderation>,
+    pub context: Arc<EventContext>,
     pub shutdown_rx: Receiver<bool>,
     /// See [WatcherConfig::homeserver]
     pub default_homeserver: PubkyId,
@@ -27,11 +27,7 @@ impl EventProcessorRunner {
             limit: config.events_limit,
             monitored_homeservers_limit: config.monitored_homeservers_limit,
             tracer_name: config.stack.otlp.name.clone(),
-            moderation: Arc::new(Moderation {
-                id: config.moderation_id.clone(),
-                tags: config.moderated_tags.clone(),
-                files_path: config.stack.files_path.clone(),
-            }),
+            context: Arc::new(EventContext::from_config(config)),
             shutdown_rx,
             default_homeserver: config.homeserver.clone(),
         }
@@ -79,7 +75,7 @@ impl TEventProcessorRunner for EventProcessorRunner {
             homeserver,
             limit: self.limit,
             tracer_name: self.tracer_name.clone(),
-            moderation: self.moderation.clone(),
+            context: self.context.clone(),
             shutdown_rx: self.shutdown_rx.clone(),
         }))
     }

--- a/nexus-watcher/tests/event_processor/bookmarks/fail_index.rs
+++ b/nexus-watcher/tests/event_processor/bookmarks/fail_index.rs
@@ -63,8 +63,8 @@ async fn test_homeserver_bookmark_without_user() -> Result<()> {
     // Simulate the event processor to handle the event.
     // If the event processor were activated, the test would not catch the missing dependency
     // error, and it would pass successfully
-    let moderation_ref = test.event_processor_runner.moderation.clone();
-    let sync_fail = retrieve_and_handle_event_line(&bookmark_event, moderation_ref)
+    let context_ref = test.event_processor_runner.context.clone();
+    let sync_fail = retrieve_and_handle_event_line(&bookmark_event, context_ref)
         .await
         .map_err(|e| error!("SYNC ERROR: {:?}", e))
         .is_err();

--- a/nexus-watcher/tests/event_processor/files/delete.rs
+++ b/nexus-watcher/tests/event_processor/files/delete.rs
@@ -122,7 +122,7 @@ async fn test_delete_pubkyapp_file_is_idempotent() -> Result<()> {
 
     // Simulate a replay: call the DEL handler again directly (e.g. crash between FS delete and store_event)
     let user_pubky_id = PubkyId::try_from(user_id.as_str()).map_err(anyhow::Error::msg)?;
-    let result = handlers::file::del(&user_pubky_id, file_id, &get_files_dir_test_pathbuf()).await;
+    let result = handlers::file::del(&user_pubky_id, file_id, get_files_dir_test_pathbuf()).await;
 
     assert!(
         result.is_ok(),

--- a/nexus-watcher/tests/event_processor/files/delete.rs
+++ b/nexus-watcher/tests/event_processor/files/delete.rs
@@ -122,7 +122,7 @@ async fn test_delete_pubkyapp_file_is_idempotent() -> Result<()> {
 
     // Simulate a replay: call the DEL handler again directly (e.g. crash between FS delete and store_event)
     let user_pubky_id = PubkyId::try_from(user_id.as_str()).map_err(anyhow::Error::msg)?;
-    let result = handlers::file::del(&user_pubky_id, file_id, get_files_dir_test_pathbuf()).await;
+    let result = handlers::file::del(&user_pubky_id, file_id, &get_files_dir_test_pathbuf()).await;
 
     assert!(
         result.is_ok(),

--- a/nexus-watcher/tests/event_processor/follows/fail_index.rs
+++ b/nexus-watcher/tests/event_processor/follows/fail_index.rs
@@ -43,8 +43,8 @@ async fn test_homeserver_follow_cannot_complete() -> Result<()> {
     // Simulate the event processor to handle the event.
     // If the event processor were activated, the test would not catch the missing dependency
     // error, and it would pass successfully
-    let moderation_ref = test.event_processor_runner.moderation.clone();
-    let sync_fail = retrieve_and_handle_event_line(&follow_event, moderation_ref)
+    let context_ref = test.event_processor_runner.context.clone();
+    let sync_fail = retrieve_and_handle_event_line(&follow_event, context_ref)
         .await
         .map_err(|e| error!("SYNC ERROR: {:?}", e))
         .is_err();
@@ -63,8 +63,8 @@ async fn test_homeserver_follow_cannot_complete() -> Result<()> {
     // Simulate the event processor to handle the event.
     // If the event processor were activated, the test would not catch the missing dependency
     // error, and it would pass successfully
-    let moderation_ref = test.event_processor_runner.moderation.clone();
-    let sync_fail = retrieve_and_handle_event_line(&opposite_follow_event, moderation_ref)
+    let context_ref = test.event_processor_runner.context.clone();
+    let sync_fail = retrieve_and_handle_event_line(&opposite_follow_event, context_ref)
         .await
         .map_err(|e| error!("SYNC ERROR: {:?}", e))
         .is_err();

--- a/nexus-watcher/tests/event_processor/posts/fail_reply.rs
+++ b/nexus-watcher/tests/event_processor/posts/fail_reply.rs
@@ -52,8 +52,8 @@ async fn test_homeserver_post_reply_without_post_parent() -> Result<()> {
     // Simulate the event processor to handle the event.
     // If the event processor were activated, the test would not catch the missing dependency
     // error, and it would pass successfully
-    let moderation_ref = test.event_processor_runner.moderation.clone();
-    let sync_fail = retrieve_and_handle_event_line(&post_event, moderation_ref)
+    let context_ref = test.event_processor_runner.context.clone();
+    let sync_fail = retrieve_and_handle_event_line(&post_event, context_ref)
         .await
         .map_err(|e| error!("SYNC ERROR: {:?}", e))
         .is_err();

--- a/nexus-watcher/tests/event_processor/posts/fail_repost.rs
+++ b/nexus-watcher/tests/event_processor/posts/fail_repost.rs
@@ -66,8 +66,8 @@ async fn test_homeserver_post_repost_without_post_parent() -> Result<()> {
     // Simulate the event processor to handle the event.
     // If the event processor were activated, the test would not catch the missing dependency
     // error, and it would pass successfully
-    let moderation_ref = test.event_processor_runner.moderation.clone();
-    let sync_fail = retrieve_and_handle_event_line(&post_homeserver_uri, moderation_ref)
+    let context_ref = test.event_processor_runner.context.clone();
+    let sync_fail = retrieve_and_handle_event_line(&post_homeserver_uri, context_ref)
         .await
         .map_err(|e| error!("SYNC ERROR: {:?}", e))
         .is_err();

--- a/nexus-watcher/tests/event_processor/tags/fail_index.rs
+++ b/nexus-watcher/tests/event_processor/tags/fail_index.rs
@@ -62,8 +62,8 @@ async fn test_homeserver_tag_cannot_add_while_index() -> Result<()> {
     // Simulate the event processor to handle the event.
     // If the event processor were activated, the test would not catch the missing dependency
     // error, and it would pass successfully
-    let moderation_ref = test.event_processor_runner.moderation.clone();
-    let sync_fail = retrieve_and_handle_event_line(&tag_event, moderation_ref)
+    let context_ref = test.event_processor_runner.context.clone();
+    let sync_fail = retrieve_and_handle_event_line(&tag_event, context_ref)
         .await
         .map_err(|e| error!("SYNC ERROR: {:?}", e))
         .is_err();
@@ -112,8 +112,8 @@ async fn test_homeserver_tag_cannot_add_while_index() -> Result<()> {
     // Simulate the event processor to handle the event.
     // If the event processor were activated, the test would not catch the missing dependency
     // error, and it would pass successfully
-    let moderation_ref = test.event_processor_runner.moderation.clone();
-    let sync_fail = retrieve_and_handle_event_line(&tag_event, moderation_ref)
+    let context_ref = test.event_processor_runner.context.clone();
+    let sync_fail = retrieve_and_handle_event_line(&tag_event, context_ref)
         .await
         .map_err(|e| error!("SYNC ERROR: {:?}", e))
         .is_err();

--- a/nexus-watcher/tests/event_processor/utils/mod.rs
+++ b/nexus-watcher/tests/event_processor/utils/mod.rs
@@ -1,3 +1,4 @@
+use nexus_common::get_files_dir_test_pathbuf;
 use nexus_watcher::events::Moderation;
 use pubky_app_specs::PubkyId;
 
@@ -8,5 +9,9 @@ pub fn default_moderation_tests() -> Moderation {
     let id = PubkyId::try_from("uo7jgkykft4885n8cruizwy6khw71mnu5pq3ay9i8pw1ymcn85ko")
         .expect("Hardcoded test moderation key should be valid");
     let tags = Vec::from(["label_to_moderate".to_string()]);
-    Moderation { id, tags }
+    Moderation {
+        id,
+        tags,
+        files_path: get_files_dir_test_pathbuf(),
+    }
 }

--- a/nexus-watcher/tests/event_processor/utils/mod.rs
+++ b/nexus-watcher/tests/event_processor/utils/mod.rs
@@ -1,5 +1,5 @@
 use nexus_common::get_files_dir_test_pathbuf;
-use nexus_watcher::events::Moderation;
+use nexus_watcher::events::{EventContext, Moderation};
 use pubky_app_specs::PubkyId;
 
 pub mod watcher;
@@ -9,9 +9,12 @@ pub fn default_moderation_tests() -> Moderation {
     let id = PubkyId::try_from("uo7jgkykft4885n8cruizwy6khw71mnu5pq3ay9i8pw1ymcn85ko")
         .expect("Hardcoded test moderation key should be valid");
     let tags = Vec::from(["label_to_moderate".to_string()]);
-    Moderation {
-        id,
-        tags,
+    Moderation { id, tags }
+}
+
+pub fn default_event_context_tests() -> EventContext {
+    EventContext {
+        moderation: default_moderation_tests(),
         files_path: get_files_dir_test_pathbuf(),
     }
 }

--- a/nexus-watcher/tests/event_processor/utils/watcher.rs
+++ b/nexus-watcher/tests/event_processor/utils/watcher.rs
@@ -8,7 +8,7 @@ use nexus_common::models::homeserver::Homeserver;
 use nexus_common::models::traits::Collection;
 use nexus_common::{StackConfig, StackManager};
 use nexus_watcher::events::retry::event::RetryEvent;
-use nexus_watcher::events::{handle, Moderation};
+use nexus_watcher::events::{handle, EventContext};
 use nexus_watcher::service::EventProcessorRunner;
 use nexus_watcher::service::TEventProcessorRunner;
 use pubky::Keypair;
@@ -26,7 +26,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tracing::debug;
 
-use crate::event_processor::utils::default_moderation_tests;
+use crate::event_processor::utils::default_event_context_tests;
 
 static COUNTER: AtomicU64 = AtomicU64::new(0);
 
@@ -74,7 +74,7 @@ impl WatcherTest {
     /// # Returns
     /// Returns a fully configured `EventProcessorRunner` ready for use in tests.
     fn create_test_event_processor_runner(default_homeserver: PubkyId) -> EventProcessorRunner {
-        let moderation = Arc::new(default_moderation_tests());
+        let context = Arc::new(default_event_context_tests());
 
         let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
 
@@ -82,7 +82,7 @@ impl WatcherTest {
             limit: 1000,
             monitored_homeservers_limit: 100,
             tracer_name: "test".to_string(),
-            moderation,
+            context,
             shutdown_rx,
             default_homeserver,
         }
@@ -342,10 +342,10 @@ impl WatcherTest {
 /// Throws an error if event parsing fails
 pub async fn retrieve_and_handle_event_line(
     event_line: &str,
-    moderation: Arc<Moderation>,
+    context: Arc<EventContext>,
 ) -> Result<(), EventProcessorError> {
     match Event::parse_event(event_line)? {
-        ParseResult::Parsed(event) => handle(&event, moderation).await,
+        ParseResult::Parsed(event) => handle(&event, context).await,
         ParseResult::Skipped => Ok(()),
 
         // Propagate UnrecognizedUri as error, because this test helper is only meant for standard event handling

--- a/nexus-watcher/tests/event_processor/utils/watcher.rs
+++ b/nexus-watcher/tests/event_processor/utils/watcher.rs
@@ -2,7 +2,6 @@ use anyhow::{anyhow, Error, Result};
 use base32::{encode, Alphabet};
 use chrono::Utc;
 use nexus_common::db::PubkyConnector;
-use nexus_common::get_files_dir_test_pathbuf;
 use nexus_common::models::event::{Event, EventProcessorError, ParseResult};
 use nexus_common::models::file::FileDetails;
 use nexus_common::models::homeserver::Homeserver;
@@ -82,7 +81,6 @@ impl WatcherTest {
         EventProcessorRunner {
             limit: 1000,
             monitored_homeservers_limit: 100,
-            files_path: get_files_dir_test_pathbuf(),
             tracer_name: "test".to_string(),
             moderation,
             shutdown_rx,

--- a/nexus-watcher/tests/event_processor/utils/watcher.rs
+++ b/nexus-watcher/tests/event_processor/utils/watcher.rs
@@ -2,7 +2,6 @@ use anyhow::{anyhow, Error, Result};
 use base32::{encode, Alphabet};
 use chrono::Utc;
 use nexus_common::db::PubkyConnector;
-use nexus_common::get_files_dir_pathbuf;
 use nexus_common::get_files_dir_test_pathbuf;
 use nexus_common::models::event::{Event, EventProcessorError, ParseResult};
 use nexus_common::models::file::FileDetails;
@@ -105,7 +104,7 @@ impl WatcherTest {
     /// Returns an instance of `Self` containing the configuration, homeserver,
     /// event processor, and other test setup details, including the shutdown receiver.
     pub async fn setup() -> Result<Self> {
-        if let Err(e) = StackManager::setup(&StackConfig::default()).await {
+        if let Err(e) = StackManager::setup(&StackConfig::test_default()).await {
             return Err(Error::msg(format!("could not initialise the stack, {e:?}")));
         }
 
@@ -347,7 +346,7 @@ pub async fn retrieve_and_handle_event_line(
     event_line: &str,
     moderation: Arc<Moderation>,
 ) -> Result<(), EventProcessorError> {
-    match Event::parse_event(event_line, get_files_dir_pathbuf())? {
+    match Event::parse_event(event_line)? {
         ParseResult::Parsed(event) => handle(&event, moderation).await,
         ParseResult::Skipped => Ok(()),
 

--- a/nexus-watcher/tests/service/event_processor_prioritization.rs
+++ b/nexus-watcher/tests/service/event_processor_prioritization.rs
@@ -1,4 +1,4 @@
-use crate::event_processor::utils::default_moderation_tests;
+use crate::event_processor::utils::default_event_context_tests;
 use crate::service::utils::HS_IDS;
 use crate::service::utils::{create_mock_event_processors, setup, MockEventProcessorRunner};
 use anyhow::Result;
@@ -20,7 +20,7 @@ async fn test_event_processor_runner_default_homeserver_prioritization() -> Resu
         limit: 1000,
         monitored_homeservers_limit: HS_IDS.len(),
         tracer_name: "test".to_string(),
-        moderation: Arc::new(default_moderation_tests()),
+        context: Arc::new(default_event_context_tests()),
     };
 
     // Persist the homeservers

--- a/nexus-watcher/tests/service/event_processor_prioritization.rs
+++ b/nexus-watcher/tests/service/event_processor_prioritization.rs
@@ -7,7 +7,6 @@ use nexus_common::types::DynError;
 use nexus_watcher::service::EventProcessorRunner;
 use nexus_watcher::service::TEventProcessorRunner;
 use pubky_app_specs::PubkyId;
-use std::path::PathBuf;
 use std::sync::Arc;
 
 #[tokio_shared_rt::test(shared)]
@@ -20,7 +19,6 @@ async fn test_event_processor_runner_default_homeserver_prioritization() -> Resu
         shutdown_rx: tokio::sync::watch::channel(false).1,
         limit: 1000,
         monitored_homeservers_limit: HS_IDS.len(),
-        files_path: PathBuf::from("/tmp/nexus-watcher-test"),
         tracer_name: "test".to_string(),
         moderation: Arc::new(default_moderation_tests()),
     };

--- a/nexus-watcher/tests/service/utils/setup.rs
+++ b/nexus-watcher/tests/service/utils/setup.rs
@@ -13,7 +13,7 @@ pub const HS_IDS: [&str; 5] = [
 
 pub async fn setup() -> Result<Vec<MockEventProcessor>> {
     // Initialize the test stack
-    if let Err(e) = StackManager::setup(&StackConfig::default()).await {
+    if let Err(e) = StackManager::setup(&StackConfig::test_default()).await {
         return Err(Error::msg(format!("could not initialise the stack, {e:?}")));
     }
 

--- a/nexus-webapi/src/mock.rs
+++ b/nexus-webapi/src/mock.rs
@@ -18,7 +18,7 @@ pub struct MockDb {}
 
 impl MockDb {
     async fn init_stack() {
-        StackManager::setup(&StackConfig::default())
+        StackManager::setup(&StackConfig::test_default())
             .await
             .expect("Failed to initialize stack");
     }


### PR DESCRIPTION
This PR removes the `Event.files_path` field, which conceptually doesn't belong to an `Event`.