### PR TITLE
fix: scope tag deletion to app namespace to prevent cross-app interference

### DIFF
--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -128,10 +128,21 @@ pub fn get_post_replies(author_id: &str, post_id: &str) -> Query {
 
 // Read the target details for a tag without deleting the TAGGED edge.
 // Used in tag del to read before graph-last deletion.
-pub fn get_tag_target(user_id: &str, tag_id: &str) -> Query {
-    Query::new(
-        "get_tag_target",
-        "MATCH (user:User {id: $user_id})-[tag:TAGGED {id: $tag_id}]->(target)
+//
+// `app` is used to scope the lookup to a specific app namespace.  When `app`
+// is `Some`, only the TAGGED relationship whose `app` property equals that
+// value is matched.  When `app` is `None`, only relationships whose `app`
+// property is absent (`IS NULL`) are matched — i.e. standard pubky.app tags.
+// This prevents ambiguous results when the same user has TAGGED relationships
+// with the same `tag_id` across different app namespaces.
+pub fn get_tag_target(user_id: &str, tag_id: &str, app: Option<&str>) -> Query {
+    let app_filter = match app {
+        Some(_) => "\n    WHERE tag.app = $app",
+        None => "\n    WHERE tag.app IS NULL",
+    };
+
+    let cypher = format!(
+        "MATCH (user:User {{id: $user_id}})-[tag:TAGGED {{id: $tag_id}}]->(target){app_filter}
          OPTIONAL MATCH (target)<-[:AUTHORED]-(author:User)
          WITH CASE WHEN target:User THEN target.id ELSE null END AS user_id,
               CASE WHEN target:Post THEN target.id ELSE null END AS post_id,
@@ -139,10 +150,18 @@ pub fn get_tag_target(user_id: &str, tag_id: &str) -> Query {
               CASE WHEN target:Resource THEN target.id ELSE null END AS resource_id,
               tag.label AS label,
               tag.app AS app
-         RETURN user_id, post_id, author_id, resource_id, label, app",
-    )
-    .param("user_id", user_id)
-    .param("tag_id", tag_id)
+         RETURN user_id, post_id, author_id, resource_id, label, app"
+    );
+
+    let mut query = Query::new("get_tag_target", &cypher)
+        .param("user_id", user_id)
+        .param("tag_id", tag_id);
+
+    if let Some(a) = app {
+        query = query.param("app", a);
+    }
+
+    query
 }
 
 // Get all the tags/taggers that a post has received (used for edit/delete notifications)

--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -175,8 +175,8 @@ pub fn has_other_resource_tag_by_label(
     app: Option<&str>,
 ) -> Query {
     let exclude_current_tag = match app {
-        Some(_) => "\n         WHERE NOT (tag.id = $tag_id AND tag.app = $app)",
-        None => "\n         WHERE NOT (tag.id = $tag_id AND tag.app IS NULL)",
+        Some(_) => "\n         WHERE tag.id <> $tag_id OR tag.app IS NULL OR tag.app <> $app",
+        None => "\n         WHERE tag.id <> $tag_id OR tag.app IS NOT NULL",
     };
 
     let cypher = format!(
@@ -187,6 +187,74 @@ pub fn has_other_resource_tag_by_label(
     let mut query = Query::new("has_other_resource_tag_by_label", &cypher)
         .param("user_id", user_id)
         .param("resource_id", resource_id)
+        .param("label", label)
+        .param("tag_id", tag_id);
+
+    if let Some(a) = app {
+        query = query.param("app", a);
+    }
+
+    query
+}
+
+/// Returns whether the tagger still has another TAGGED relationship with the
+/// same label on the same User after excluding the relationship currently being
+/// deleted.
+pub fn has_other_user_tag_by_label(
+    tagger_id: &str,
+    tagged_user_id: &str,
+    label: &str,
+    tag_id: &str,
+    app: Option<&str>,
+) -> Query {
+    let exclude_current_tag = match app {
+        Some(_) => "\n         WHERE tag.id <> $tag_id OR tag.app IS NULL OR tag.app <> $app",
+        None => "\n         WHERE tag.id <> $tag_id OR tag.app IS NOT NULL",
+    };
+
+    let cypher = format!(
+        "MATCH (:User {{id: $tagger_id}})-[tag:TAGGED {{label: $label}}]->(:User {{id: $tagged_user_id}}){exclude_current_tag}
+         RETURN COUNT(tag) > 0 AS has_other_tag"
+    );
+
+    let mut query = Query::new("has_other_user_tag_by_label", &cypher)
+        .param("tagger_id", tagger_id)
+        .param("tagged_user_id", tagged_user_id)
+        .param("label", label)
+        .param("tag_id", tag_id);
+
+    if let Some(a) = app {
+        query = query.param("app", a);
+    }
+
+    query
+}
+
+/// Returns whether the tagger still has another TAGGED relationship with the
+/// same label on the same Post after excluding the relationship currently being
+/// deleted.
+pub fn has_other_post_tag_by_label(
+    tagger_id: &str,
+    author_id: &str,
+    post_id: &str,
+    label: &str,
+    tag_id: &str,
+    app: Option<&str>,
+) -> Query {
+    let exclude_current_tag = match app {
+        Some(_) => "\n         WHERE tag.id <> $tag_id OR tag.app IS NULL OR tag.app <> $app",
+        None => "\n         WHERE tag.id <> $tag_id OR tag.app IS NOT NULL",
+    };
+
+    let cypher = format!(
+        "MATCH (:User {{id: $tagger_id}})-[tag:TAGGED {{label: $label}}]->(:Post {{id: $post_id}})<-[:AUTHORED]-(:User {{id: $author_id}}){exclude_current_tag}
+         RETURN COUNT(tag) > 0 AS has_other_tag"
+    );
+
+    let mut query = Query::new("has_other_post_tag_by_label", &cypher)
+        .param("tagger_id", tagger_id)
+        .param("author_id", author_id)
+        .param("post_id", post_id)
         .param("label", label)
         .param("tag_id", tag_id);
 

--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -126,15 +126,15 @@ pub fn get_post_replies(author_id: &str, post_id: &str) -> Query {
     .param("post_id", post_id)
 }
 
-// Read the target details for a tag without deleting the TAGGED edge.
-// Used in tag del to read before graph-last deletion.
-//
-// `app` is used to scope the lookup to a specific app namespace.  When `app`
-// is `Some`, only the TAGGED relationship whose `app` property equals that
-// value is matched.  When `app` is `None`, only relationships whose `app`
-// property is absent (`IS NULL`) are matched — i.e. standard pubky.app tags.
-// This prevents ambiguous results when the same user has TAGGED relationships
-// with the same `tag_id` across different app namespaces.
+/// Read the target details for a tag without deleting the TAGGED edge.
+/// Used in tag del to read before graph-last deletion.
+///
+/// `app` is used to scope the lookup to a specific app namespace.  When `app`
+/// is `Some`, only the TAGGED relationship whose `app` property equals that
+/// value is matched.  When `app` is `None`, only relationships whose `app`
+/// property is absent (`IS NULL`) are matched — i.e. standard pubky.app tags.
+/// This prevents ambiguous results when the same user has TAGGED relationships
+/// with the same `tag_id` across different app namespaces.
 pub fn get_tag_target(user_id: &str, tag_id: &str, app: Option<&str>) -> Query {
     let app_filter = match app {
         Some(_) => "\n    WHERE tag.app = $app",
@@ -447,7 +447,7 @@ pub fn get_viewer_trusted_network_tags(user_id: &str, viewer_id: &str, depth: u8
         }}
         MATCH (tagger)-[tag:TAGGED]->(tagged)
         WITH tag.label AS label, collect(tagger.id) AS taggerIds
-        RETURN 
+        RETURN
             taggerIds IS NOT NULL AS exists,
             collect({{
                 label: label,
@@ -507,9 +507,9 @@ pub fn user_counts(user_id: &str) -> Query {
 
 pub fn get_user_followers(user_id: &str, skip: Option<usize>, limit: Option<usize>) -> Query {
     let mut query_string = String::from(
-        "MATCH (u:User {id: $user_id}) 
+        "MATCH (u:User {id: $user_id})
          OPTIONAL MATCH (u)<-[:FOLLOWS]-(follower:User)
-         RETURN COUNT(u) > 0 AS user_exists, 
+         RETURN COUNT(u) > 0 AS user_exists,
                 COLLECT(follower.id) AS follower_ids",
     );
     if let Some(skip_value) = skip {
@@ -523,9 +523,9 @@ pub fn get_user_followers(user_id: &str, skip: Option<usize>, limit: Option<usiz
 
 pub fn get_user_following(user_id: &str, skip: Option<usize>, limit: Option<usize>) -> Query {
     let mut query_string = String::from(
-        "MATCH (u:User {id: $user_id}) 
+        "MATCH (u:User {id: $user_id})
          OPTIONAL MATCH (u)-[:FOLLOWS]->(following:User)
-         RETURN COUNT(u) > 0 AS user_exists, 
+         RETURN COUNT(u) > 0 AS user_exists,
                 COLLECT(following.id) AS following_ids",
     );
     if let Some(skip_value) = skip {
@@ -884,13 +884,13 @@ pub fn post_stream(
             cypher.push_str(
                 "
                 // Count tags
-                OPTIONAL MATCH (p)<-[tag:TAGGED]-(:User)  
+                OPTIONAL MATCH (p)<-[tag:TAGGED]-(:User)
                 // Count replies
                 OPTIONAL MATCH (p)<-[reply:REPLIED]-(:Post)
                 // Count reposts
                 OPTIONAL MATCH (p)<-[repost:REPOSTED]-(:Post)
 
-                WITH p, author, 
+                WITH p, author,
                     COUNT(DISTINCT tag) AS tags_count,
                     COUNT(DISTINCT reply) AS replies_count,
                     COUNT(DISTINCT repost) AS reposts_count,

--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -164,6 +164,39 @@ pub fn get_tag_target(user_id: &str, tag_id: &str, app: Option<&str>) -> Query {
     query
 }
 
+/// Returns whether the tagger still has another TAGGED relationship with the
+/// same label on the same Resource after excluding the relationship currently
+/// being deleted.
+pub fn has_other_resource_tag_by_label(
+    user_id: &str,
+    resource_id: &str,
+    label: &str,
+    tag_id: &str,
+    app: Option<&str>,
+) -> Query {
+    let exclude_current_tag = match app {
+        Some(_) => "\n         WHERE NOT (tag.id = $tag_id AND tag.app = $app)",
+        None => "\n         WHERE NOT (tag.id = $tag_id AND tag.app IS NULL)",
+    };
+
+    let cypher = format!(
+        "MATCH (:User {{id: $user_id}})-[tag:TAGGED {{label: $label}}]->(:Resource {{id: $resource_id}}){exclude_current_tag}
+         RETURN COUNT(tag) > 0 AS has_other_tag"
+    );
+
+    let mut query = Query::new("has_other_resource_tag_by_label", &cypher)
+        .param("user_id", user_id)
+        .param("resource_id", resource_id)
+        .param("label", label)
+        .param("tag_id", tag_id);
+
+    if let Some(a) = app {
+        query = query.param("app", a);
+    }
+
+    query
+}
+
 // Get all the tags/taggers that a post has received (used for edit/delete notifications)
 pub fn get_post_tags(author_id: &str, post_id: &str) -> Query {
     Query::new(

--- a/nexus-common/src/db/graph/queries/put.rs
+++ b/nexus-common/src/db/graph/queries/put.rs
@@ -221,6 +221,10 @@ pub fn create_post_bookmark(
 /// * `tag_id` - A unique identifier for the tagging relationship.
 /// * `label` - A string representing the label of the tag.
 /// * `indexed_at` - A timestamp representing when the tagging relationship was created or last updated.
+/// * `app` - The app namespace the tag was created from (e.g., "mapky"). When `Some`, the
+///   `app` property is included in the matched/merged TAGGED relationship so that tag deletion
+///   scoped to the same app can locate the edge. When `None`, no `app` property is set, which
+///   matches the behavior for standard pubky.app tags.
 ///
 pub fn create_post_tag(
     user_id: &str,
@@ -229,26 +233,42 @@ pub fn create_post_tag(
     tag_id: &str,
     label: &str,
     indexed_at: i64,
+    app: Option<&str>,
 ) -> Query {
-    Query::new(
-        "create_post_tag",
-        "MATCH (user:User {id: $user_id})
+    // `app` is part of the MERGE pattern so the edge identity is scoped to the
+    // app namespace — preventing one app's TAGGED edge from being matched
+    // (and thus re-used or deleted) by another app with the same tag_id.
+    let rel_props = match app {
+        Some(_) => "{label: $label, app: $app}",
+        None => "{label: $label}",
+    };
+
+    let cypher = format!(
+        "MATCH (user:User {{id: $user_id}})
         // We assume these nodes are already created. If not we would not be able to add a tag
-        MATCH (author:User {id: $author_id})-[:AUTHORED]->(post:Post {id: $post_id})
+        MATCH (author:User {{id: $author_id}})-[:AUTHORED]->(post:Post {{id: $post_id}})
         // Check if tag already existed
-        OPTIONAL MATCH (user)-[existing:TAGGED {label: $label}]->(post)
-        MERGE (user)-[t:TAGGED {label: $label}]->(post)
+        OPTIONAL MATCH (user)-[existing:TAGGED {rel_props}]->(post)
+        MERGE (user)-[t:TAGGED {rel_props}]->(post)
         ON CREATE SET t.indexed_at = $indexed_at,
                       t.id = $tag_id
         // Returns true if the post tag relationship already existed
-        RETURN existing IS NOT NULL AS flag;",
-    )
-    .param("user_id", user_id)
-    .param("author_id", author_id)
-    .param("post_id", post_id)
-    .param("tag_id", tag_id)
-    .param("label", label)
-    .param("indexed_at", indexed_at)
+        RETURN existing IS NOT NULL AS flag;"
+    );
+
+    let mut query = Query::new("create_post_tag", &cypher)
+        .param("user_id", user_id)
+        .param("author_id", author_id)
+        .param("post_id", post_id)
+        .param("tag_id", tag_id)
+        .param("label", label)
+        .param("indexed_at", indexed_at);
+
+    if let Some(a) = app {
+        query = query.param("app", a);
+    }
+
+    query
 }
 
 /// Creates a `TAGGED` relationship between two users. The relationship is uniquely identified by a `label`
@@ -258,30 +278,50 @@ pub fn create_post_tag(
 /// * `tag_id` - A unique identifier for the tagging relationship.
 /// * `label` - A string representing the label of the tag.
 /// * `indexed_at` - A timestamp indicating when the tagging relationship was created or last updated.
+/// * `app` - The app namespace the tag was created from (e.g., "mapky"). When `Some`, the
+///   `app` property is included in the matched/merged TAGGED relationship so that tag deletion
+///   scoped to the same app can locate the edge. When `None`, no `app` property is set, which
+///   matches the behavior for standard pubky.app tags.
 pub fn create_user_tag(
     tagger_user_id: &str,
     tagged_user_id: &str,
     tag_id: &str,
     label: &str,
     indexed_at: i64,
+    app: Option<&str>,
 ) -> Query {
-    Query::new(
-        "create_user_tag",
-        "MATCH (tagged_used:User {id: $tagged_user_id})
-        MATCH (tagger:User {id: $tagger_user_id})
+    // `app` is part of the MERGE pattern so the edge identity is scoped to the
+    // app namespace — preventing one app's TAGGED edge from being matched
+    // (and thus re-used or deleted) by another app with the same tag_id.
+    let rel_props = match app {
+        Some(_) => "{label: $label, app: $app}",
+        None => "{label: $label}",
+    };
+
+    let cypher = format!(
+        "MATCH (tagged_used:User {{id: $tagged_user_id}})
+        MATCH (tagger:User {{id: $tagger_user_id}})
         // Check if tag already existed
-        OPTIONAL MATCH (tagger)-[existing:TAGGED {label: $label}]->(tagged_used)
-        MERGE (tagger)-[t:TAGGED {label: $label}]->(tagged_used)
+        OPTIONAL MATCH (tagger)-[existing:TAGGED {rel_props}]->(tagged_used)
+        MERGE (tagger)-[t:TAGGED {rel_props}]->(tagged_used)
         ON CREATE SET t.indexed_at = $indexed_at,
                       t.id = $tag_id
         // Returns true if the user tag relationship already existed
-        RETURN existing IS NOT NULL AS flag;",
-    )
-    .param("tagger_user_id", tagger_user_id)
-    .param("tagged_user_id", tagged_user_id)
-    .param("tag_id", tag_id)
-    .param("label", label)
-    .param("indexed_at", indexed_at)
+        RETURN existing IS NOT NULL AS flag;"
+    );
+
+    let mut query = Query::new("create_user_tag", &cypher)
+        .param("tagger_user_id", tagger_user_id)
+        .param("tagged_user_id", tagged_user_id)
+        .param("tag_id", tag_id)
+        .param("label", label)
+        .param("indexed_at", indexed_at);
+
+    if let Some(a) = app {
+        query = query.param("app", a);
+    }
+
+    query
 }
 
 /// Creates a `TAGGED` relationship between a user and a generic Resource node.

--- a/nexus-common/src/models/tag/traits/collection.rs
+++ b/nexus-common/src/models/tag/traits/collection.rs
@@ -317,6 +317,10 @@ where
     /// - `label` - A string slice representing the label of the tag.
     /// - `indexed_at` - A 64-bit integer representing the timestamp (milliseconds)
     ///   when the tag was indexed.
+    /// - `app` - The app namespace the tag was created from (e.g., "mapky") when the tag
+    ///   originates from an app-specific path. When `Some`, the `app` property is set on
+    ///   the TAGGED edge so that subsequent app-scoped deletes can locate it. When `None`,
+    ///   no `app` property is stored — matching the standard pubky.app tag behavior.
     async fn put_to_graph(
         tagger_user_id: &str,
         tagged_user_id: &str,
@@ -324,6 +328,7 @@ where
         tag_id: &str,
         label: &str,
         indexed_at: i64,
+        app: Option<&str>,
     ) -> GraphResult<OperationOutcome> {
         let query = match extra_param {
             Some(post_id) => queries::put::create_post_tag(
@@ -333,6 +338,7 @@ where
                 tag_id,
                 label,
                 indexed_at,
+                app,
             ),
             None => queries::put::create_user_tag(
                 tagger_user_id,
@@ -340,6 +346,7 @@ where
                 tag_id,
                 label,
                 indexed_at,
+                app,
             ),
         };
         execute_graph_operation(query).await

--- a/nexus-watcher/src/events/handlers/tag.rs
+++ b/nexus-watcher/src/events/handlers/tag.rs
@@ -393,11 +393,20 @@ async fn put_sync_user(
 }
 
 #[tracing::instrument(name = "tag.del", skip_all, fields(user_id = %user_id, tag_id = %tag_id))]
-pub async fn del(user_id: PubkyId, tag_id: String) -> Result<(), EventProcessorError> {
+pub async fn del(
+    user_id: PubkyId,
+    tag_id: String,
+    app: Option<String>,
+) -> Result<(), EventProcessorError> {
     debug!("Deleting tag: {} -> {}", user_id, tag_id);
 
-    // 1. Read target from graph WITHOUT deleting the edge
-    let Some(row) = fetch_row_from_graph(queries::get::get_tag_target(&user_id, &tag_id)).await?
+    // 1. Read target from graph WITHOUT deleting the edge.
+    //    Pass `app` so the lookup is scoped to the correct app namespace and
+    //    cannot accidentally match a TAGGED relationship from a different app
+    //    that happens to share the same tag_id.
+    let Some(row) =
+        fetch_row_from_graph(queries::get::get_tag_target(&user_id, &tag_id, app.as_deref()))
+            .await?
     else {
         // Edge already gone (fully completed on a prior attempt) — idempotent no-op
         return Ok(());

--- a/nexus-watcher/src/events/handlers/tag.rs
+++ b/nexus-watcher/src/events/handlers/tag.rs
@@ -404,9 +404,12 @@ pub async fn del(
     //    Pass `app` so the lookup is scoped to the correct app namespace and
     //    cannot accidentally match a TAGGED relationship from a different app
     //    that happens to share the same tag_id.
-    let Some(row) =
-        fetch_row_from_graph(queries::get::get_tag_target(&user_id, &tag_id, app.as_deref()))
-            .await?
+    let Some(row) = fetch_row_from_graph(queries::get::get_tag_target(
+        &user_id,
+        &tag_id,
+        app.as_deref(),
+    ))
+    .await?
     else {
         // Edge already gone (fully completed on a prior attempt) — idempotent no-op
         return Ok(());

--- a/nexus-watcher/src/events/handlers/tag.rs
+++ b/nexus-watcher/src/events/handlers/tag.rs
@@ -30,6 +30,15 @@ pub async fn sync_put(
     tagger_id: PubkyId,
     tag_id: String,
 ) -> Result<(), EventProcessorError> {
+    sync_put_inner(tag, tagger_id, tag_id, None).await
+}
+
+async fn sync_put_inner(
+    tag: PubkyAppTag,
+    tagger_id: PubkyId,
+    tag_id: String,
+    app: Option<&str>,
+) -> Result<(), EventProcessorError> {
     debug!("Indexing new tag: {} -> {}", tagger_id, tag_id);
 
     // Parse the embeded URI to extract author_id and post_id using parse_tagged_post_uri
@@ -42,12 +51,14 @@ pub async fn sync_put(
         Resource::Post(post_id) => {
             // Place the tag on post
             put_sync_post(
-                tagger_id, user_id, &post_id, &tag_id, &tag.label, &tag.uri, indexed_at,
+                tagger_id, user_id, &post_id, &tag_id, &tag.label, &tag.uri, indexed_at, app,
             )
             .await
         }
         // If no post_id in the tagged URI, we place tag to a user.
-        Resource::User => put_sync_user(tagger_id, user_id, &tag_id, &tag.label, indexed_at).await,
+        Resource::User => {
+            put_sync_user(tagger_id, user_id, &tag_id, &tag.label, indexed_at, app).await
+        }
         other => Err(EventProcessorError::generic(format!(
             "The tagged resource is not Post or User, instead is: {other:?}"
         ))),
@@ -71,8 +82,11 @@ pub async fn sync_put_resource(
     let category = classify_uri(&tag.uri);
     match category {
         UriCategory::InternalKnown => {
-            // The tagged URI is a known Post/User — delegate to existing flow
-            sync_put(tag, tagger_id, tag_id).await
+            // The tagged URI is a known Post/User — delegate to existing flow,
+            // but propagate `app` so the TAGGED edge carries the app namespace.
+            // Without this, the symmetric DEL path (which passes Some(app)) would
+            // fail to locate the edge and silently no-op.
+            sync_put_inner(tag, tagger_id, tag_id, Some(&app)).await
         }
         UriCategory::InternalUnknown | UriCategory::External => {
             let (normalized, scheme) =
@@ -195,6 +209,7 @@ async fn put_sync_resource(
 /// - `post_uri` - A `String` representing the homeserver URI of the tagged post.
 /// - `indexed_at` - A 64-bit integer representing the timestamp when the post was indexed.
 ///
+#[allow(clippy::too_many_arguments)]
 async fn put_sync_post(
     tagger_user_id: PubkyId,
     author_id: PubkyId,
@@ -203,6 +218,7 @@ async fn put_sync_post(
     tag_label: &str,
     post_uri: &str,
     indexed_at: i64,
+    app: Option<&str>,
 ) -> Result<(), EventProcessorError> {
     match TagPost::put_to_graph(
         &tagger_user_id,
@@ -211,6 +227,7 @@ async fn put_sync_post(
         tag_id,
         tag_label,
         indexed_at,
+        app,
     )
     .await?
     {
@@ -323,6 +340,7 @@ async fn put_sync_user(
     tag_id: &str,
     tag_label: &str,
     indexed_at: i64,
+    app: Option<&str>,
 ) -> Result<(), EventProcessorError> {
     match TagUser::put_to_graph(
         &tagger_user_id,
@@ -331,6 +349,7 @@ async fn put_sync_user(
         tag_id,
         tag_label,
         indexed_at,
+        app,
     )
     .await?
     {

--- a/nexus-watcher/src/events/handlers/tag.rs
+++ b/nexus-watcher/src/events/handlers/tag.rs
@@ -3,7 +3,9 @@ use crate::events::EventProcessorError;
 
 use chrono::Utc;
 use nexus_common::db::kv::{RedisResult, ScoreAction};
-use nexus_common::db::{fetch_row_from_graph, queries, OperationOutcome, RedisOps};
+use nexus_common::db::{
+    fetch_key_from_graph, fetch_row_from_graph, queries, OperationOutcome, RedisOps,
+};
 use nexus_common::models::homeserver::Homeserver;
 use nexus_common::models::notification::Notification;
 use nexus_common::models::post::search::PostsByTagSearch;
@@ -448,7 +450,7 @@ pub async fn del(
             .await?;
         }
         (None, None, None, Some(res_id)) => {
-            del_sync_resource(user_id.clone(), &res_id, &label, app.as_deref()).await?;
+            del_sync_resource(user_id.clone(), &tag_id, &res_id, &label, app.as_deref()).await?;
         }
         _ => {
             debug!("DEL-Tag: Unexpected combination of tag details");
@@ -630,17 +632,35 @@ async fn del_sync_post(
 /// Timeline entries are only removed when taggers count reaches zero.
 async fn del_sync_resource(
     tagger_id: PubkyId,
+    tag_id: &str,
     resource_id: &str,
     tag_label: &str,
     app: Option<&str>,
 ) -> Result<(), EventProcessorError> {
+    // This must happen before Redis cleanup because graph deletion intentionally
+    // runs last to preserve retry safety if a Redis operation fails.
+    let has_other_tag = fetch_key_from_graph(
+        queries::get::has_other_resource_tag_by_label(
+            tagger_id.as_str(),
+            resource_id,
+            tag_label,
+            tag_id,
+            app,
+        ),
+        "has_other_tag",
+    )
+    .await?
+    .unwrap_or(false);
+
     // Step 1: Decrement scores and remove tagger from sets
     let score_results = tokio::join!(
         TagResource::update_index_score(resource_id, None, tag_label, ScoreAction::Decrement(1.0)),
         async {
-            TagResource(vec![tagger_id.to_string()])
-                .del_from_index(resource_id, None, tag_label)
-                .await?;
+            if !has_other_tag {
+                TagResource(vec![tagger_id.to_string()])
+                    .del_from_index(resource_id, None, tag_label)
+                    .await?;
+            }
             Ok::<(), EventProcessorError>(())
         },
         ResourceStream::update_global_taggers_count(resource_id, ScoreAction::Decrement(1.0)),

--- a/nexus-watcher/src/events/handlers/tag.rs
+++ b/nexus-watcher/src/events/handlers/tag.rs
@@ -452,7 +452,15 @@ pub async fn del(
                 TagUser::check_set_member(&[&tagged_id, &label], user_id.as_str())
                     .await?
                     .1;
-            del_sync_user(user_id.clone(), &tagged_id, &label, tagger_in_index).await?;
+            del_sync_user(
+                user_id.clone(),
+                &tag_id,
+                &tagged_id,
+                &label,
+                app.as_deref(),
+                tagger_in_index,
+            )
+            .await?;
         }
         (None, Some(post_id), Some(author_id), None) => {
             let tagger_in_index =
@@ -461,9 +469,11 @@ pub async fn del(
                     .1;
             del_sync_post(
                 user_id.clone(),
+                &tag_id,
                 &post_id,
                 &author_id,
                 &label,
+                app.as_deref(),
                 tagger_in_index,
             )
             .await?;
@@ -484,10 +494,28 @@ pub async fn del(
 
 async fn del_sync_user(
     tagger_id: PubkyId,
+    tag_id: &str,
     tagged_id: &str,
     tag_label: &str,
+    app: Option<&str>,
     tagger_in_index: bool,
 ) -> Result<(), EventProcessorError> {
+    // Post/User tag Redis indexes are app-agnostic. If another graph edge from
+    // the same tagger still uses this label on this target, keep the shared
+    // tagger set member so the remaining edge stays visible in cached views.
+    let has_other_tag = fetch_key_from_graph(
+        queries::get::has_other_user_tag_by_label(
+            tagger_id.as_str(),
+            tagged_id,
+            tag_label,
+            tag_id,
+            app,
+        ),
+        "has_other_tag",
+    )
+    .await?
+    .unwrap_or(false);
+
     let indexing_results = nexus_common::traced_join!(
         tracing::info_span!("index.delete", phase = "tag_user");
         // Guarded: Update user counts in the tagged
@@ -515,10 +543,12 @@ async fn del_sync_user(
             Ok::<(), EventProcessorError>(())
         },
         async {
-            // Idempotent: Remove tagger from the user taggers list (SREM)
-            TagUser(vec![tagger_id.to_string()])
-                .del_from_index(tagged_id, None, tag_label)
-                .await?;
+            if !has_other_tag {
+                // Idempotent: Remove tagger from the user taggers list (SREM)
+                TagUser(vec![tagger_id.to_string()])
+                    .del_from_index(tagged_id, None, tag_label)
+                    .await?;
+            }
             Ok::<(), EventProcessorError>(())
         },
         // Guarded: notification
@@ -541,11 +571,30 @@ async fn del_sync_user(
 
 async fn del_sync_post(
     tagger_id: PubkyId,
+    tag_id: &str,
     post_id: &str,
     author_id: &str,
     tag_label: &str,
+    app: Option<&str>,
     tagger_in_index: bool,
 ) -> Result<(), EventProcessorError> {
+    // Post/User tag Redis indexes are app-agnostic. If another graph edge from
+    // the same tagger still uses this label on this target, keep the shared
+    // tagger set member so the remaining edge stays visible in cached views.
+    let has_other_tag = fetch_key_from_graph(
+        queries::get::has_other_post_tag_by_label(
+            tagger_id.as_str(),
+            author_id,
+            post_id,
+            tag_label,
+            tag_id,
+            app,
+        ),
+        "has_other_tag",
+    )
+    .await?
+    .unwrap_or(false);
+
     let post_key_slice: &[&str] = &[author_id, post_id];
     let tag_post = TagPost(vec![tagger_id.to_string()]);
     let post_uri = post_uri_builder(author_id.to_string(), post_id.to_string());
@@ -608,10 +657,12 @@ async fn del_sync_post(
             Ok::<(), EventProcessorError>(())
         },
         async {
-            // Idempotent: Delete the tagger from the tag list (SREM)
-            tag_post
-                .del_from_index(author_id, Some(post_id), tag_label)
-                .await?;
+            if !has_other_tag {
+                // Idempotent: Delete the tagger from the tag list (SREM)
+                tag_post
+                    .del_from_index(author_id, Some(post_id), tag_label)
+                    .await?;
+            }
             // NOTE: The tag search index depends on the post taggers collection to delete
             // Delete post from global label timeline
             PostsByTagSearch::del_from_index(author_id, post_id, tag_label).await?;

--- a/nexus-watcher/src/events/handlers/universal_tag.rs
+++ b/nexus-watcher/src/events/handlers/universal_tag.rs
@@ -70,7 +70,7 @@ async fn handle_put(info: AppTagInfo) -> Result<(), EventProcessorError> {
 }
 
 async fn handle_del(info: AppTagInfo) -> Result<(), EventProcessorError> {
-    tag::del(info.user_id, info.tag_id).await
+    tag::del(info.user_id, info.tag_id, Some(info.app)).await
 }
 
 /// Try to parse a URI as an app-specific tag path.

--- a/nexus-watcher/src/events/mod.rs
+++ b/nexus-watcher/src/events/mod.rs
@@ -107,7 +107,7 @@ pub async fn handle_del_event(event: &Event) -> Result<(), EventProcessorError> 
         Resource::Bookmark(bookmark_id) => {
             handlers::bookmark::del(user_id, bookmark_id.clone()).await?
         }
-        Resource::Tag(tag_id) => handlers::tag::del(user_id, tag_id.clone()).await?,
+        Resource::Tag(tag_id) => handlers::tag::del(user_id, tag_id.clone(), None).await?,
         Resource::File(file_id) => {
             handlers::file::del(&user_id, file_id.clone(), event.files_path.clone()).await?
         }

--- a/nexus-watcher/src/events/moderation.rs
+++ b/nexus-watcher/src/events/moderation.rs
@@ -42,7 +42,7 @@ impl Moderation {
                     "Moderation tag '{}' detected. Deleting tag {}:{}",
                     moderator_tag.label, user_id, tag_id
                 );
-                handlers::tag::del(user_id, tag_id).await
+                handlers::tag::del(user_id, tag_id, None).await
             }
             Resource::User => {
                 // Delete the user profile and return the result

--- a/nexus-watcher/tests/event_processor/tags/del_idempotent.rs
+++ b/nexus-watcher/tests/event_processor/tags/del_idempotent.rs
@@ -93,7 +93,7 @@ async fn test_tag_post_del_retry_no_double_decrement() -> Result<()> {
 
     // Retry: call del handler directly — should delete graph without double-decrement
     let tagger_pubky_id = PubkyId::from(tagger_kp.public_key());
-    handlers::tag::del(tagger_pubky_id, tag_id.to_string()).await?;
+    handlers::tag::del(tagger_pubky_id, tag_id.to_string(), None).await?;
 
     // Verify final state: graph edge deleted, counters still 0
     let post_tag = find_post_tag(&author_id, &post_id, label).await?;
@@ -160,14 +160,14 @@ async fn test_tag_post_del_replay_after_success_skips() -> Result<()> {
 
     // First delete via handler (should succeed)
     let tagger_pubky_id = PubkyId::from(tagger_kp.public_key());
-    handlers::tag::del(tagger_pubky_id.clone(), tag_id.to_string()).await?;
+    handlers::tag::del(tagger_pubky_id.clone(), tag_id.to_string(), None).await?;
 
     // Verify fully deleted state
     let post_tag = find_post_tag(&author_id, &post_id, label).await?;
     assert!(post_tag.is_none());
 
     // Replay: call del again — should succeed as idempotent no-op
-    handlers::tag::del(tagger_pubky_id, tag_id.to_string()).await?;
+    handlers::tag::del(tagger_pubky_id, tag_id.to_string(), None).await?;
 
     // Cleanup
     test.cleanup_post(&author_kp, &post_path).await?;

--- a/nexus-watcher/tests/event_processor/tags/del_idempotent.rs
+++ b/nexus-watcher/tests/event_processor/tags/del_idempotent.rs
@@ -63,6 +63,7 @@ async fn test_tag_post_del_retry_no_double_decrement() -> Result<()> {
         tag_id,
         label,
         OLD_INDEXED_AT,
+        None,
     )
     .await?;
     assert!(matches!(outcome, OperationOutcome::CreatedOrDeleted));
@@ -153,6 +154,7 @@ async fn test_tag_post_del_replay_after_success_skips() -> Result<()> {
         tag_id,
         label,
         OLD_INDEXED_AT,
+        None,
     )
     .await?;
     TagPost::add_tagger_to_index(&author_id, Some(&post_id), &tagger_id, label).await?;

--- a/nexus-watcher/tests/event_processor/tags/mod.rs
+++ b/nexus-watcher/tests/event_processor/tags/mod.rs
@@ -10,6 +10,7 @@ mod post_put;
 mod resource_dedup;
 mod resource_del;
 mod resource_internal_known;
+mod resource_multi_app_del;
 mod resource_put;
 mod resource_utils;
 mod retry_post_tag;

--- a/nexus-watcher/tests/event_processor/tags/resource_internal_known.rs
+++ b/nexus-watcher/tests/event_processor/tags/resource_internal_known.rs
@@ -3,6 +3,9 @@ use super::utils::find_post_tag;
 use crate::event_processor::utils::watcher::WatcherTest;
 use anyhow::Result;
 use chrono::Utc;
+use nexus_common::db::{fetch_row_from_graph, queries};
+use nexus_common::models::tag::post::TagPost;
+use nexus_common::models::tag::traits::TagCollection;
 use pubky::Keypair;
 use pubky::ResourcePath;
 use pubky_app_specs::traits::HashId;
@@ -82,6 +85,113 @@ async fn test_resource_tag_internal_known_delegates_to_post() -> Result<()> {
     );
 
     // Cleanup
+    test.cleanup_post(&user_kp, &post_path).await?;
+    test.cleanup_user(&user_kp).await?;
+
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_internal_known_app_tag_delete_preserves_other_app_post_tag_cache() -> Result<()> {
+    let mut test = WatcherTest::setup().await?;
+
+    let user_kp = Keypair::random();
+    let user = PubkyAppUser {
+        bio: Some("test_internal_known_app_tag_delete_preserves_cache".to_string()),
+        image: None,
+        links: None,
+        name: "Watcher:ResourceTag:InternalKnown:Cache".to_string(),
+        status: None,
+    };
+    let user_id = test.create_user(&user_kp, &user).await?;
+
+    let post = PubkyAppPost {
+        content: "Watcher:ResourceTag:InternalKnown:Cache:Post".to_string(),
+        kind: PubkyAppPost::default().kind,
+        parent: None,
+        embed: None,
+        attachments: None,
+    };
+    let (post_id, post_path) = test.create_post(&user_kp, &post).await?;
+
+    let label = "internal-known-cache-test";
+    let tag = PubkyAppTag {
+        uri: post_uri_builder(user_id.clone(), post_id.clone()),
+        label: label.to_string(),
+        created_at: Utc::now().timestamp_millis(),
+    };
+    let tag_id = tag.create_id();
+    let mapky_path: ResourcePath = format!("/pub/mapky/tags/{tag_id}").parse()?;
+    let eventky_path: ResourcePath = format!("/pub/eventky.app/tags/{tag_id}").parse()?;
+
+    test.put(&user_kp, &mapky_path, &tag).await?;
+    test.put(&user_kp, &eventky_path, &tag).await?;
+
+    let mapky_edge = fetch_row_from_graph(queries::get::get_tag_target(
+        &user_id,
+        &tag_id,
+        Some("mapky"),
+    ))
+    .await?;
+    assert!(
+        mapky_edge.is_some(),
+        "mapky post tag edge should exist before delete"
+    );
+
+    let eventky_edge = fetch_row_from_graph(queries::get::get_tag_target(
+        &user_id,
+        &tag_id,
+        Some("eventky.app"),
+    ))
+    .await?;
+    assert!(
+        eventky_edge.is_some(),
+        "eventky.app post tag edge should exist before delete"
+    );
+
+    test.del(&user_kp, &mapky_path).await?;
+
+    let mapky_edge_after_del = fetch_row_from_graph(queries::get::get_tag_target(
+        &user_id,
+        &tag_id,
+        Some("mapky"),
+    ))
+    .await?;
+    assert!(
+        mapky_edge_after_del.is_none(),
+        "mapky post tag edge should be deleted"
+    );
+
+    let eventky_edge_after_del = fetch_row_from_graph(queries::get::get_tag_target(
+        &user_id,
+        &tag_id,
+        Some("eventky.app"),
+    ))
+    .await?;
+    assert!(
+        eventky_edge_after_del.is_some(),
+        "eventky.app post tag edge should remain after mapky delete"
+    );
+
+    let post_tag_after_app_del = find_post_tag(&user_id, &post_id, label)
+        .await?
+        .expect("eventky.app post tag should remain in graph after mapky delete");
+    assert_eq!(post_tag_after_app_del.taggers_count, 1);
+
+    let cache_post_tag =
+        TagPost::get_from_index(&user_id, Some(&post_id), None, None, None, None, false)
+            .await?
+            .expect("eventky.app post tag should remain in Redis after mapky delete");
+    assert_eq!(cache_post_tag.len(), 1);
+    assert_eq!(cache_post_tag[0].label, label);
+    assert_eq!(cache_post_tag[0].taggers_count, 1);
+    assert_eq!(cache_post_tag[0].taggers[0], user_id);
+
+    test.del(&user_kp, &eventky_path).await?;
+
+    let post_tag_final = find_post_tag(&user_id, &post_id, label).await?;
+    assert!(post_tag_final.is_none());
+
     test.cleanup_post(&user_kp, &post_path).await?;
     test.cleanup_user(&user_kp).await?;
 

--- a/nexus-watcher/tests/event_processor/tags/resource_internal_known.rs
+++ b/nexus-watcher/tests/event_processor/tags/resource_internal_known.rs
@@ -70,8 +70,18 @@ async fn test_resource_tag_internal_known_delegates_to_post() -> Result<()> {
         "InternalKnown URI should NOT create a Resource node"
     );
 
-    // Cleanup
+    // Regression: deleting the universal tag at the app-specific path must
+    // actually remove the TAGGED edge. The DEL handler scopes the lookup by
+    // `app`, so the PUT must persist the same `app` namespace on the edge.
     test.del(&user_kp, &custom_path).await?;
+
+    let post_tag_after_del = find_post_tag(&user_id, &post_id, label).await?;
+    assert!(
+        post_tag_after_del.is_none(),
+        "Universal tag DEL on InternalKnown URI should remove the TAGGED edge"
+    );
+
+    // Cleanup
     test.cleanup_post(&user_kp, &post_path).await?;
     test.cleanup_user(&user_kp).await?;
 

--- a/nexus-watcher/tests/event_processor/tags/resource_multi_app_del.rs
+++ b/nexus-watcher/tests/event_processor/tags/resource_multi_app_del.rs
@@ -1,0 +1,185 @@
+/// Test: same label across different app namespaces — deletion of each tag is
+/// correctly scoped to its own app namespace.
+///
+/// Scenario
+/// --------
+/// A single user creates three tags that all share the same `label`:
+///   1. A standard pubky.app user tag   — targets another user
+///   2. A "mapky" universal tag          — targets an external URI
+///   3. An "eventky.app" universal tag   — targets the same external URI with
+///      identical content, intentionally producing the **same `tag_id`** as
+///      the mapky tag.  This is the adversarial case that exposed the bug:
+///      without an app-scoped graph lookup, deleting the mapky tag could
+///      accidentally operate on the eventky.app TAGGED relationship instead.
+///
+/// The test verifies that deleting each tag removes only that tag and leaves
+/// the remaining two untouched.
+use super::resource_utils::{
+    compute_resource_id, count_resource_tags, find_resource_tag_by_app,
+};
+use super::utils::find_user_tag;
+use crate::event_processor::utils::watcher::{HomeserverHashIdPath, WatcherTest};
+use anyhow::Result;
+use chrono::Utc;
+use nexus_common::models::resource::tag::TagResource;
+use nexus_common::models::tag::traits::TagCollection;
+use pubky::Keypair;
+use pubky::ResourcePath;
+use pubky_app_specs::traits::HashId;
+use pubky_app_specs::{PubkyAppTag, PubkyAppUser};
+
+#[tokio_shared_rt::test(shared)]
+async fn test_universal_tag_del_scoped_to_app_namespace() -> Result<()> {
+    let mut test = WatcherTest::setup().await?;
+
+    // ── Users ────────────────────────────────────────────────────────────────
+    let tagger_kp = Keypair::random();
+    let tagger_user = PubkyAppUser {
+        bio: Some("test_universal_tag_del_scoped".to_string()),
+        image: None,
+        links: None,
+        name: "Watcher:MultiAppDel:Tagger".to_string(),
+        status: None,
+    };
+    test.create_user(&tagger_kp, &tagger_user).await?;
+
+    let target_kp = Keypair::random();
+    let target_user = PubkyAppUser {
+        bio: None,
+        image: None,
+        links: None,
+        name: "Watcher:MultiAppDel:Target".to_string(),
+        status: None,
+    };
+    let target_user_id = test.create_user(&target_kp, &target_user).await?;
+
+    let label = "shared-label";
+
+    // ── Tag 1: standard pubky.app user tag ──────────────────────────────────
+    let pubky_app_tag = PubkyAppTag {
+        uri: format!("pubky://{target_user_id}/pub/pubky.app/profile.json"),
+        label: label.to_string(),
+        created_at: Utc::now().timestamp_millis(),
+    };
+    let pubky_app_path = pubky_app_tag.hs_path();
+    test.put(&tagger_kp, &pubky_app_path, &pubky_app_tag)
+        .await?;
+
+    // ── Tags 2 & 3: two universal tags with *identical* content ─────────────
+    // Identical content → identical tag_id.  This is the adversarial case:
+    // both TAGGED relationships will carry the same `id` property but
+    // different `app` properties ("mapky" vs "eventky.app").
+    let external_uri = "https://example.com/multi-app-del-target";
+    let resource_id = compute_resource_id(external_uri);
+
+    let shared_tag = PubkyAppTag {
+        uri: external_uri.to_string(),
+        label: label.to_string(),
+        created_at: Utc::now().timestamp_millis(),
+    };
+    let shared_tag_id = shared_tag.create_id();
+
+    let mapky_path: ResourcePath = format!("/pub/mapky/tags/{shared_tag_id}").parse()?;
+    let eventky_path: ResourcePath = format!("/pub/eventky.app/tags/{shared_tag_id}").parse()?;
+
+    test.put(&tagger_kp, &mapky_path, &shared_tag).await?;
+    test.put(&tagger_kp, &eventky_path, &shared_tag).await?;
+
+    // ── Baseline assertions ──────────────────────────────────────────────────
+    // Both universal tags should exist as separate TAGGED relationships.
+    let tag_count = count_resource_tags(&resource_id).await?;
+    assert_eq!(
+        tag_count, 2,
+        "Should have 2 TAGGED relationships (one per app)"
+    );
+
+    let mapky_tag = find_resource_tag_by_app(&resource_id, label, "mapky").await?;
+    assert!(
+        mapky_tag.is_some(),
+        "mapky tag should exist before any deletions"
+    );
+
+    let eventky_tag = find_resource_tag_by_app(&resource_id, label, "eventky.app").await?;
+    assert!(
+        eventky_tag.is_some(),
+        "eventky.app tag should exist before any deletions"
+    );
+
+    let user_tag_before = find_user_tag(&target_user_id, label).await?;
+    assert!(
+        user_tag_before.is_some(),
+        "pubky.app user tag should exist before any deletions"
+    );
+
+    // ── Step 1: Delete the mapky tag ─────────────────────────────────────────
+    test.del(&tagger_kp, &mapky_path).await?;
+
+    let tag_count_after_mapky = count_resource_tags(&resource_id).await?;
+    assert_eq!(
+        tag_count_after_mapky, 1,
+        "Should have 1 TAGGED relationship after mapky delete"
+    );
+
+    let mapky_tag_after = find_resource_tag_by_app(&resource_id, label, "mapky").await?;
+    assert!(
+        mapky_tag_after.is_none(),
+        "mapky tag should be gone after delete"
+    );
+
+    let eventky_tag_after_mapky = find_resource_tag_by_app(&resource_id, label, "eventky.app").await?;
+    assert!(
+        eventky_tag_after_mapky.is_some(),
+        "eventky.app tag must NOT be affected by mapky delete"
+    );
+
+    let user_tag_after_mapky = find_user_tag(&target_user_id, label).await?;
+    assert!(
+        user_tag_after_mapky.is_some(),
+        "pubky.app user tag must NOT be affected by mapky delete"
+    );
+
+    // ── Step 2: Delete the eventky.app tag ──────────────────────────────────
+    test.del(&tagger_kp, &eventky_path).await?;
+
+    let tag_count_after_eventky = count_resource_tags(&resource_id).await?;
+    assert_eq!(
+        tag_count_after_eventky, 0,
+        "Should have 0 TAGGED relationships after both universal deletes"
+    );
+
+    let eventky_tag_after = find_resource_tag_by_app(&resource_id, label, "eventky.app").await?;
+    assert!(
+        eventky_tag_after.is_none(),
+        "eventky.app tag should be gone after delete"
+    );
+
+    // Resource-level Redis index should reflect zero taggers
+    let cache_tags =
+        TagResource::get_from_index(&resource_id, None, None, None, None, None, false).await?;
+    let is_empty = cache_tags.is_none_or(|v| v.is_empty() || v[0].taggers_count == 0);
+    assert!(
+        is_empty,
+        "TagResource cache should be empty after all universal tag deletions"
+    );
+
+    let user_tag_after_eventky = find_user_tag(&target_user_id, label).await?;
+    assert!(
+        user_tag_after_eventky.is_some(),
+        "pubky.app user tag must NOT be affected by eventky.app delete"
+    );
+
+    // ── Step 3: Delete the standard pubky.app user tag ─────────────────────
+    test.del(&tagger_kp, &pubky_app_path).await?;
+
+    let user_tag_final = find_user_tag(&target_user_id, label).await?;
+    assert!(
+        user_tag_final.is_none(),
+        "pubky.app user tag should be gone after its own delete"
+    );
+
+    // ── Cleanup ──────────────────────────────────────────────────────────────
+    test.cleanup_user(&tagger_kp).await?;
+    test.cleanup_user(&target_kp).await?;
+
+    Ok(())
+}

--- a/nexus-watcher/tests/event_processor/tags/resource_multi_app_del.rs
+++ b/nexus-watcher/tests/event_processor/tags/resource_multi_app_del.rs
@@ -14,9 +14,7 @@
 ///
 /// The test verifies that deleting each tag removes only that tag and leaves
 /// the remaining two untouched.
-use super::resource_utils::{
-    compute_resource_id, count_resource_tags, find_resource_tag_by_app,
-};
+use super::resource_utils::{compute_resource_id, count_resource_tags, find_resource_tag_by_app};
 use super::utils::find_user_tag;
 use crate::event_processor::utils::watcher::{HomeserverHashIdPath, WatcherTest};
 use anyhow::Result;
@@ -126,7 +124,8 @@ async fn test_universal_tag_del_scoped_to_app_namespace() -> Result<()> {
         "mapky tag should be gone after delete"
     );
 
-    let eventky_tag_after_mapky = find_resource_tag_by_app(&resource_id, label, "eventky.app").await?;
+    let eventky_tag_after_mapky =
+        find_resource_tag_by_app(&resource_id, label, "eventky.app").await?;
     assert!(
         eventky_tag_after_mapky.is_some(),
         "eventky.app tag must NOT be affected by mapky delete"

--- a/nexus-watcher/tests/event_processor/tags/resource_multi_app_del.rs
+++ b/nexus-watcher/tests/event_processor/tags/resource_multi_app_del.rs
@@ -1,3 +1,15 @@
+use super::resource_utils::{compute_resource_id, count_resource_tags, find_resource_tag_by_app};
+use super::utils::find_user_tag;
+use crate::event_processor::utils::watcher::{HomeserverHashIdPath, WatcherTest};
+use anyhow::Result;
+use chrono::Utc;
+use nexus_common::models::resource::tag::TagResource;
+use nexus_common::models::tag::traits::TagCollection;
+use pubky::Keypair;
+use pubky::ResourcePath;
+use pubky_app_specs::traits::HashId;
+use pubky_app_specs::{PubkyAppTag, PubkyAppUser};
+
 /// Test: same label across different app namespaces — deletion of each tag is
 /// correctly scoped to its own app namespace.
 ///
@@ -14,18 +26,6 @@
 ///
 /// The test verifies that deleting each tag removes only that tag and leaves
 /// the remaining two untouched.
-use super::resource_utils::{compute_resource_id, count_resource_tags, find_resource_tag_by_app};
-use super::utils::find_user_tag;
-use crate::event_processor::utils::watcher::{HomeserverHashIdPath, WatcherTest};
-use anyhow::Result;
-use chrono::Utc;
-use nexus_common::models::resource::tag::TagResource;
-use nexus_common::models::tag::traits::TagCollection;
-use pubky::Keypair;
-use pubky::ResourcePath;
-use pubky_app_specs::traits::HashId;
-use pubky_app_specs::{PubkyAppTag, PubkyAppUser};
-
 #[tokio_shared_rt::test(shared)]
 async fn test_universal_tag_del_scoped_to_app_namespace() -> Result<()> {
     let mut test = WatcherTest::setup().await?;

--- a/nexus-watcher/tests/event_processor/tags/resource_multi_app_del.rs
+++ b/nexus-watcher/tests/event_processor/tags/resource_multi_app_del.rs
@@ -8,7 +8,7 @@ use nexus_common::models::tag::traits::TagCollection;
 use pubky::Keypair;
 use pubky::ResourcePath;
 use pubky_app_specs::traits::HashId;
-use pubky_app_specs::{PubkyAppTag, PubkyAppUser};
+use pubky_app_specs::{PubkyAppTag, PubkyAppUser, PubkyId};
 
 /// Test: same label across different app namespaces — deletion of each tag is
 /// correctly scoped to its own app namespace.
@@ -32,6 +32,7 @@ async fn test_universal_tag_del_scoped_to_app_namespace() -> Result<()> {
 
     // ── Users ────────────────────────────────────────────────────────────────
     let tagger_kp = Keypair::random();
+    let tagger_id = PubkyId::from(tagger_kp.public_key());
     let tagger_user = PubkyAppUser {
         bio: Some("test_universal_tag_del_scoped".to_string()),
         image: None,
@@ -135,6 +136,19 @@ async fn test_universal_tag_del_scoped_to_app_namespace() -> Result<()> {
     assert!(
         user_tag_after_mapky.is_some(),
         "pubky.app user tag must NOT be affected by mapky delete"
+    );
+
+    // Resource-level Redis index should still expose the remaining app tag.
+    let cache_tags_after_mapky =
+        TagResource::get_from_index(&resource_id, None, None, None, None, None, false).await?;
+    let remaining_cache_tag = cache_tags_after_mapky
+        .as_deref()
+        .and_then(|tags| tags.iter().find(|tag| tag.label == label));
+    assert!(
+        remaining_cache_tag.is_some_and(|tag| {
+            tag.taggers_count == 1 && tag.taggers.iter().any(|id| id == tagger_id.as_str())
+        }),
+        "TagResource cache should keep the remaining app tag after mapky delete"
     );
 
     // ── Step 2: Delete the eventky.app tag ──────────────────────────────────

--- a/nexus-watcher/tests/event_processor/tags/resource_utils.rs
+++ b/nexus-watcher/tests/event_processor/tags/resource_utils.rs
@@ -69,6 +69,32 @@ pub fn compute_resource_id(uri: &str) -> String {
     nexus_common::models::resource::resource_id(&normalized)
 }
 
+/// Find a Resource tag in the graph database, filtered by both label and app
+pub async fn find_resource_tag_by_app(
+    resource_id: &str,
+    label: &str,
+    app: &str,
+) -> Result<Option<ResourceTagResult>> {
+    let query = Query::new(
+        "resource_tag_by_app_query",
+        "
+        MATCH (tagger:User)-[t:TAGGED {label: $label, app: $app}]->(r:Resource {id: $resource_id})
+        RETURN {
+            label: t.label,
+            app: t.app,
+            tagger: tagger.id,
+            uri: r.uri,
+            scheme: r.scheme
+        } AS details
+        ",
+    )
+    .param("resource_id", resource_id)
+    .param("label", label)
+    .param("app", app);
+    let result = fetch_key_from_graph(query, "details").await.unwrap();
+    Ok(result)
+}
+
 fn resource_tag_query(resource_id: &str, label: &str) -> Query {
     Query::new(
         "resource_tag_query",


### PR DESCRIPTION
When a user has TAGGED relationships with the same `tag_id` across different app namespaces (possible when two apps store identical tag content, producing the same hash-derived ID), `get_tag_target` returned an arbitrary match and deletion could operate on the wrong relationship.

## Root cause

`get_tag_target` matched solely on `(user_id, tag_id)` with no `app` filter, while `delete_tag` already had the correct `WHERE tag.app = $app` / `WHERE tag.app IS NULL` scoping. `universal_tag::handle_del` also never forwarded the known `app` name down to `tag::del`.

## Changes

- **`nexus-common` — `get_tag_target`**: add `app: Option<&str>` parameter; inject `WHERE tag.app = $app` (universal) or `WHERE tag.app IS NULL` (standard pubky.app), consistent with `delete_tag`.
- **`nexus-watcher` — `tag::del`**: accept `app: Option<String>`, thread it into `get_tag_target`.
- **`universal_tag::handle_del`**: pass `Some(info.app)` instead of dropping the known app.
- **`handle_del_event` / `moderation.rs`**: pass `None` — standard pubky.app tags carry no app property.
- **`del_idempotent.rs`**: update direct `tag::del` call sites to pass `None`.

## Test — `resource_multi_app_del.rs`

Adversarial scenario: one user creates 3 tags sharing the same label —
- 1 standard pubky.app user tag
- 2 universal tags (`mapky`, `eventky.app`) with **identical content → same `tag_id`**

Verifies that deleting each tag removes only its own `TAGGED` relationship and leaves the other two intact.