### PR TITLE
Remove duplicate 404 check

### DIFF
--- a/nexus-common/src/db/connectors/pubky.rs
+++ b/nexus-common/src/db/connectors/pubky.rs
@@ -74,11 +74,6 @@ impl From<pubky::Error> for PubkyClientError {
 }
 
 impl PubkyClientError {
-    /// Returns true if this error is a 404 (content not found)
-    pub fn is_404(&self) -> bool {
-        matches!(self, Self::NotFound404 { .. })
-    }
-
     /// Returns true if this error is transient and worth retrying
     pub fn is_retryable(&self) -> bool {
         matches!(

--- a/nexus-common/src/models/event/errors.rs
+++ b/nexus-common/src/models/event/errors.rs
@@ -155,9 +155,4 @@ impl EventProcessorError {
     pub fn is_missing_dependency(&self) -> bool {
         matches!(self, Self::MissingDependency { .. })
     }
-
-    /// Returns whether this error indicates a 404 (content definitively gone)
-    pub fn is_404(&self) -> bool {
-        matches!(self, Self::PubkyClientError(err) if err.is_404())
-    }
 }

--- a/nexus-watcher/src/events/retry/processor.rs
+++ b/nexus-watcher/src/events/retry/processor.rs
@@ -136,10 +136,6 @@ impl RetryProcessor {
                 debug!("Retry successful for event: {ev_uri}");
                 self.store.remove(index_key).await?;
             }
-            Err(e) if e.is_404() => {
-                // Content gone - remove from retry queue
-                self.store.remove(index_key).await?;
-            }
             Err(e) if !e.is_retryable() => {
                 // Non-retryable error (ParseFailed, etc.) - dead-letter immediately
                 warn!("Event {ev_uri} failed with non-retryable error, dead-lettering: {e}");


### PR DESCRIPTION
This PR removes the Client 404 check in `process_retry_event`, since that case is already covered in

```rust
Err(e) if !e.is_retryable() => {
    warn!("Event {ev_uri} failed with non-retryable error, dead-lettering: {e}");
    self.store.remove(index_key).await?;
}
```