### PR TITLE
chore: remove unused await

### DIFF
--- a/nexus-watcher/src/events/mod.rs
+++ b/nexus-watcher/src/events/mod.rs
@@ -81,7 +81,7 @@ pub async fn handle_put_event(
             handlers::bookmark::sync_put(user_id, bookmark, bookmark_id).await?
         }
         (PubkyAppObject::Tag(tag), Resource::Tag(tag_id)) => {
-            if moderation.should_delete(&tag, user_id.clone()).await {
+            if moderation.should_delete(&tag, user_id.clone()) {
                 moderation
                     .apply_moderation(tag, event.files_path.clone())
                     .await?

--- a/nexus-watcher/src/events/moderation.rs
+++ b/nexus-watcher/src/events/moderation.rs
@@ -26,7 +26,7 @@ impl Moderation {
     ///
     /// Returns `true` if the tag was applied by the moderator and matches
     /// a moderated tag label.
-    pub async fn should_delete(&self, tag: &PubkyAppTag, tagger_id: PubkyId) -> bool {
+    pub fn should_delete(&self, tag: &PubkyAppTag, tagger_id: PubkyId) -> bool {
         tagger_id == self.id && self.tags.contains(&tag.label)
     }
 


### PR DESCRIPTION
This PR removes the `await` on `Moderation::should_delete`, since it is not `async`.