### PR TITLE
fix: validate user ID before handling event in key-based processor

### DIFF
--- a/nexus-common/src/models/event/errors.rs
+++ b/nexus-common/src/models/event/errors.rs
@@ -158,6 +158,7 @@ impl EventProcessorError {
             Self::PubkyClientError(err) => err.is_retryable(),
             Self::InvalidEventLine(_) => false,
             Self::SkipIndexing => false,
+            Self::UserIdMismatch(_) => false,
             _ => true,
         }
     }

--- a/nexus-common/src/models/event/errors.rs
+++ b/nexus-common/src/models/event/errors.rs
@@ -7,6 +7,14 @@ use crate::db::{kv::RedisError, GraphError, PubkyClientError};
 use crate::models::error::ModelError;
 
 #[derive(Error, Debug, Clone, Serialize, Deserialize)]
+#[error("hs_id={hs_id}, expected={expected_user_id}, received={event_user_id}")]
+pub struct UserIdMismatch {
+    pub hs_id: String,
+    pub expected_user_id: String,
+    pub event_user_id: String,
+}
+
+#[derive(Error, Debug, Clone, Serialize, Deserialize)]
 pub enum EventProcessorError {
     /// Failed to execute query in the graph database
     #[error("GraphQueryFailed (is_infrastructure_err: {0}): {1}")]
@@ -27,6 +35,9 @@ pub enum EventProcessorError {
     /// The event could not be parsed from a line
     #[error("InvalidEventLine: {0}")]
     InvalidEventLine(String),
+
+    #[error("HS returned an event for different user than expected: {0}")]
+    UserIdMismatch(UserIdMismatch),
 
     /// The Pubky client could not resolve the pubky
     #[error("PubkyClientError: {0}")]

--- a/nexus-common/src/models/event/errors.rs
+++ b/nexus-common/src/models/event/errors.rs
@@ -7,14 +7,6 @@ use crate::db::{kv::RedisError, GraphError, PubkyClientError};
 use crate::models::error::ModelError;
 
 #[derive(Error, Debug, Clone, Serialize, Deserialize)]
-#[error("hs_id={hs_id}, expected={expected_user_id}, received={event_user_id}")]
-pub struct UserIdMismatch {
-    pub hs_id: String,
-    pub expected_user_id: String,
-    pub event_user_id: String,
-}
-
-#[derive(Error, Debug, Clone, Serialize, Deserialize)]
 pub enum EventProcessorError {
     /// Failed to execute query in the graph database
     #[error("GraphQueryFailed (is_infrastructure_err: {0}): {1}")]
@@ -36,8 +28,12 @@ pub enum EventProcessorError {
     #[error("InvalidEventLine: {0}")]
     InvalidEventLine(String),
 
-    #[error("HS returned an event for different user than expected: {0}")]
-    UserIdMismatch(UserIdMismatch),
+    #[error("HS returned an event for different user than expected: hs_id={hs_id}, expected={expected_user_id}, received={event_user_id}")]
+    UserIdMismatch {
+        hs_id: String,
+        expected_user_id: String,
+        event_user_id: String,
+    },
 
     /// The Pubky client could not resolve the pubky
     #[error("PubkyClientError: {0}")]
@@ -158,7 +154,7 @@ impl EventProcessorError {
             Self::PubkyClientError(err) => err.is_retryable(),
             Self::InvalidEventLine(_) => false,
             Self::SkipIndexing => false,
-            Self::UserIdMismatch(_) => false,
+            Self::UserIdMismatch { .. } => false,
             _ => true,
         }
     }

--- a/nexus-common/src/models/event/mod.rs
+++ b/nexus-common/src/models/event/mod.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use std::{fmt, path::PathBuf};
 use tracing::{debug, error};
 
-pub use errors::EventProcessorError;
+pub use errors::{EventProcessorError, UserIdMismatch};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum EventType {

--- a/nexus-common/src/models/event/mod.rs
+++ b/nexus-common/src/models/event/mod.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use std::{fmt, path::PathBuf};
 use tracing::{debug, error};
 
-pub use errors::{EventProcessorError, UserIdMismatch};
+pub use errors::EventProcessorError;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum EventType {

--- a/nexus-common/src/models/event/mod.rs
+++ b/nexus-common/src/models/event/mod.rs
@@ -161,19 +161,19 @@ impl Event {
             EventProcessorError::InvalidEventLine(format!("Cannot parse event URI: {e}"))
         })?;
 
-        match &parsed_uri {
-            HomeserverParsedUri::AppSpec {
-                user_id: _,
-                resource,
-            } => match resource {
+        if let HomeserverParsedUri::AppSpec {
+            user_id: _,
+            resource,
+        } = &parsed_uri
+        {
+            match resource {
                 Resource::Unknown => {
                     debug!("Skipping unrecognised resource: {uri}");
                     return Ok(None);
                 }
                 Resource::LastRead | Resource::Feed(_) | Resource::Blob(_) => return Ok(None),
                 _ => (),
-            },
-            _ => (),
+            }
         }
 
         Ok(Some(Event {

--- a/nexus-watcher/src/service/indexer/key_based.rs
+++ b/nexus-watcher/src/service/indexer/key_based.rs
@@ -189,6 +189,7 @@ impl KeyBasedEventProcessor {
             .await?;
 
         let user_id = user_pk.z32();
+        let expected_user_id = PubkyId::from(user_pk.clone());
         let mut latest_cursor: Option<u64> = None;
 
         let result: Result<(), EventProcessorError> = async {
@@ -203,7 +204,7 @@ impl KeyBasedEventProcessor {
                 match Event::from_stream_event(&stream_event, self.files_path.clone()) {
                     Ok(Some(event)) => {
                         // Validate event user before handling, since we received it from a 3rd party HS
-                        Self::validate_user_id(hs_id, &event, PubkyId::from(user_pk.clone()))?;
+                        Self::validate_user_id(hs_id, &event, &expected_user_id)?;
 
                         self.handle_event(&event).await?;
                     }
@@ -247,10 +248,10 @@ impl KeyBasedEventProcessor {
     fn validate_user_id(
         hs_id: &str,
         event: &Event,
-        expected_user_id: PubkyId,
+        expected_user_id: &PubkyId,
     ) -> Result<(), EventProcessorError> {
         let event_user_id = event.parsed_uri.user_id();
-        if event_user_id != &expected_user_id {
+        if event_user_id != expected_user_id {
             return Err(EventProcessorError::UserIdMismatch(UserIdMismatch {
                 hs_id: hs_id.into(),
                 expected_user_id: expected_user_id.as_str().into(),

--- a/nexus-watcher/src/service/indexer/key_based.rs
+++ b/nexus-watcher/src/service/indexer/key_based.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use futures::StreamExt;
 use nexus_common::db::{PubkyConnector, RedisOps};
-use nexus_common::models::event::{Event, EventProcessorError};
+use nexus_common::models::event::{Event, EventProcessorError, UserIdMismatch};
 use nexus_common::models::homeserver::Homeserver;
 use nexus_common::models::user::{user_hs_cursor_key, UserDetails};
 use pubky::{EventCursor, PublicKey};
@@ -167,9 +167,7 @@ impl KeyBasedEventProcessor {
                 match Event::from_stream_event(&stream_event, self.files_path.clone()) {
                     Ok(Some(event)) => {
                         // Validate event user before handling, since we received it from a 3rd party HS
-                        if event.parsed_uri.user_id() != &PubkyId::from(user_pk.clone()) {
-                            return Err(EventProcessorError::InvalidEventLine("Unexpected user PK".into()));
-                        }
+                        Self::validate_user_id(hs_id, &event, user_pk)?;
 
                         self.handle_event(&event).await?;
                     }
@@ -208,6 +206,25 @@ impl KeyBasedEventProcessor {
         }
 
         result
+    }
+
+    fn validate_user_id(
+        hs_id: &str,
+        event: &Event,
+        expected_user_pk: &PublicKey,
+    ) -> Result<(), EventProcessorError> {
+        let event_user_id = event.parsed_uri.user_id().to_string();
+        let expected_user_id = expected_user_pk.to_z32();
+
+        if event_user_id != expected_user_id {
+            return Err(EventProcessorError::UserIdMismatch(UserIdMismatch {
+                hs_id: hs_id.into(),
+                expected_user_id,
+                event_user_id,
+            }));
+        }
+
+        Ok(())
     }
 
     /// Reads the per-user event cursor from the `USER_HS_CURSOR` sorted set in Redis.

--- a/nexus-watcher/src/service/indexer/key_based.rs
+++ b/nexus-watcher/src/service/indexer/key_based.rs
@@ -7,6 +7,7 @@ use nexus_common::models::event::{Event, EventProcessorError};
 use nexus_common::models::homeserver::Homeserver;
 use nexus_common::models::user::{user_hs_cursor_key, UserDetails};
 use pubky::{EventCursor, PublicKey};
+use pubky_app_specs::PubkyId;
 use tokio::sync::watch::Receiver;
 use tracing::{debug, error, info};
 
@@ -165,6 +166,11 @@ impl KeyBasedEventProcessor {
 
                 match Event::from_stream_event(&stream_event, self.files_path.clone()) {
                     Ok(Some(event)) => {
+                        // Validate event user before handling, since we received it from a 3rd party HS
+                        if event.parsed_uri.user_id() != &PubkyId::from(user_pk.clone()) {
+                            return Err(EventProcessorError::InvalidEventLine("Unexpected user PK".into()));
+                        }
+
                         self.handle_event(&event).await?;
                     }
                     Ok(None) => { /* resource not handled by Nexus, skip */ }

--- a/nexus-watcher/src/service/indexer/key_based.rs
+++ b/nexus-watcher/src/service/indexer/key_based.rs
@@ -6,7 +6,7 @@ use nexus_common::db::{PubkyConnector, RedisOps};
 use nexus_common::models::event::{Event, EventProcessorError, UserIdMismatch};
 use nexus_common::models::homeserver::Homeserver;
 use nexus_common::models::user::{user_hs_cursor_key, UserDetails};
-use pubky::{EventCursor, PublicKey};
+use pubky::{Event as StreamEvent, EventCursor, PublicKey};
 use pubky_app_specs::PubkyId;
 use tokio::sync::watch::Receiver;
 use tracing::{debug, error, info};
@@ -15,6 +15,47 @@ use super::TEventProcessor;
 use crate::events::retry::RetryScheduler;
 use crate::events::EventHandler;
 use crate::service::user_hs_resolver;
+
+#[async_trait::async_trait]
+pub trait KeyBasedEventSource: Send + Sync + 'static {
+    async fn fetch_events(
+        &self,
+        hs_pk: &PublicKey,
+        user_pk: &PublicKey,
+        cursor: EventCursor,
+        limit: u16,
+    ) -> Result<Vec<StreamEvent>, EventProcessorError>;
+}
+
+pub struct PubkyKeyBasedEventSource;
+
+#[async_trait::async_trait]
+impl KeyBasedEventSource for PubkyKeyBasedEventSource {
+    async fn fetch_events(
+        &self,
+        hs_pk: &PublicKey,
+        user_pk: &PublicKey,
+        cursor: EventCursor,
+        limit: u16,
+    ) -> Result<Vec<StreamEvent>, EventProcessorError> {
+        let pubky = PubkyConnector::get()?;
+        let mut stream = pubky
+            .event_stream_for(hs_pk)
+            .add_users(vec![(user_pk, Some(cursor))])?
+            .limit(limit)
+            .path("/pub/")
+            .subscribe()
+            .await
+            .inspect_err(|e| error!("Failed to subscribe to event stream: {e:?}"))?;
+
+        let mut events = Vec::new();
+        while let Some(result) = stream.next().await {
+            events.push(result?);
+        }
+
+        Ok(events)
+    }
+}
 
 /// Event processor for non-default HSs, where the user-specific `/events-stream` endpoint is used
 pub struct KeyBasedEventProcessor {
@@ -26,6 +67,7 @@ pub struct KeyBasedEventProcessor {
     pub limit: u16,
     pub files_path: PathBuf,
     pub event_handler: Arc<dyn EventHandler>,
+    pub event_source: Arc<dyn KeyBasedEventSource>,
     /// Scheduler used to enqueue failed events onto the retry queue
     pub retry_scheduler: Arc<RetryScheduler>,
     pub shutdown_rx: Receiver<bool>,
@@ -141,27 +183,21 @@ impl KeyBasedEventProcessor {
         user_pk: &PublicKey,
         cursor: EventCursor,
     ) -> Result<(), EventProcessorError> {
-        let pubky = PubkyConnector::get()?;
-        let mut stream = pubky
-            .event_stream_for(hs_pk)
-            .add_users(vec![(user_pk, Some(cursor))])?
-            .limit(self.limit)
-            .path("/pub/")
-            .subscribe()
-            .await
-            .inspect_err(|e| error!("Failed to subscribe to event stream: {e:?}"))?;
+        let stream_events = self
+            .event_source
+            .fetch_events(hs_pk, user_pk, cursor, self.limit)
+            .await?;
 
         let user_id = user_pk.z32();
         let mut latest_cursor: Option<u64> = None;
 
         let result: Result<(), EventProcessorError> = async {
-            while let Some(result) = stream.next().await {
+            for stream_event in stream_events {
                 if *self.shutdown_rx.borrow() {
                     debug!(hs_id = %hs_id, user = %user_id, "Shutdown detected; exiting event loop");
                     break;
                 }
 
-                let stream_event = result?;
                 let cursor_id = stream_event.cursor.id();
 
                 match Event::from_stream_event(&stream_event, self.files_path.clone()) {

--- a/nexus-watcher/src/service/indexer/key_based.rs
+++ b/nexus-watcher/src/service/indexer/key_based.rs
@@ -167,7 +167,7 @@ impl KeyBasedEventProcessor {
                 match Event::from_stream_event(&stream_event, self.files_path.clone()) {
                     Ok(Some(event)) => {
                         // Validate event user before handling, since we received it from a 3rd party HS
-                        Self::validate_user_id(hs_id, &event, user_pk)?;
+                        Self::validate_user_id(hs_id, &event, PubkyId::from(user_pk.clone()))?;
 
                         self.handle_event(&event).await?;
                     }
@@ -211,16 +211,14 @@ impl KeyBasedEventProcessor {
     fn validate_user_id(
         hs_id: &str,
         event: &Event,
-        expected_user_pk: &PublicKey,
+        expected_user_id: PubkyId,
     ) -> Result<(), EventProcessorError> {
-        let event_user_id = event.parsed_uri.user_id().to_string();
-        let expected_user_id = expected_user_pk.to_z32();
-
-        if event_user_id != expected_user_id {
+        let event_user_id = event.parsed_uri.user_id();
+        if event_user_id != &expected_user_id {
             return Err(EventProcessorError::UserIdMismatch(UserIdMismatch {
                 hs_id: hs_id.into(),
-                expected_user_id,
-                event_user_id,
+                expected_user_id: expected_user_id.as_str().into(),
+                event_user_id: event_user_id.as_str().into(),
             }));
         }
 

--- a/nexus-watcher/src/service/indexer/key_based.rs
+++ b/nexus-watcher/src/service/indexer/key_based.rs
@@ -210,12 +210,7 @@ impl KeyBasedEventProcessor {
                     }
                     Ok(None) => { /* resource not handled by Nexus, skip */ }
                     Err(e) => {
-                        error!(
-                            hs_id = %hs_id,
-                            user = %user_id,
-                            cursor = cursor_id,
-                            "Skipping unparseable stream event: {e}",
-                        );
+                        error!(%hs_id, %user_id, %cursor_id, "Skipping unparseable stream event: {e}");
                     }
                 }
 

--- a/nexus-watcher/src/service/indexer/key_based.rs
+++ b/nexus-watcher/src/service/indexer/key_based.rs
@@ -3,11 +3,10 @@ use std::sync::Arc;
 
 use futures::StreamExt;
 use nexus_common::db::{PubkyConnector, RedisOps};
-use nexus_common::models::event::{Event, EventProcessorError, UserIdMismatch};
+use nexus_common::models::event::{Event, EventProcessorError};
 use nexus_common::models::homeserver::Homeserver;
 use nexus_common::models::user::{user_hs_cursor_key, UserDetails};
 use pubky::{Event as StreamEvent, EventCursor, PublicKey};
-use pubky_app_specs::PubkyId;
 use tokio::sync::watch::Receiver;
 use tracing::{debug, error, info};
 
@@ -189,7 +188,6 @@ impl KeyBasedEventProcessor {
             .await?;
 
         let user_id = user_pk.z32();
-        let expected_user_id = PubkyId::from(user_pk.clone());
         let mut latest_cursor: Option<u64> = None;
 
         let result: Result<(), EventProcessorError> = async {
@@ -203,8 +201,8 @@ impl KeyBasedEventProcessor {
 
                 match Event::from_stream_event(&stream_event, self.files_path.clone()) {
                     Ok(Some(event)) => {
-                        // Validate event user before handling, since we received it from a 3rd party HS
-                        Self::validate_user_id(hs_id, &event, &expected_user_id)?;
+                        // External homeservers must not index another user's URI.
+                        Self::validate_user_id(hs_id, &event, &user_id)?;
 
                         self.handle_event(&event).await?;
                     }
@@ -243,15 +241,15 @@ impl KeyBasedEventProcessor {
     fn validate_user_id(
         hs_id: &str,
         event: &Event,
-        expected_user_id: &PubkyId,
+        expected_user_id: &str,
     ) -> Result<(), EventProcessorError> {
-        let event_user_id = event.parsed_uri.user_id();
+        let event_user_id = event.parsed_uri.user_id().as_str();
         if event_user_id != expected_user_id {
-            return Err(EventProcessorError::UserIdMismatch(UserIdMismatch {
+            return Err(EventProcessorError::UserIdMismatch {
                 hs_id: hs_id.into(),
-                expected_user_id: expected_user_id.as_str().into(),
-                event_user_id: event_user_id.as_str().into(),
-            }));
+                expected_user_id: expected_user_id.into(),
+                event_user_id: event_user_id.into(),
+            });
         }
 
         Ok(())

--- a/nexus-watcher/src/service/indexer/mod.rs
+++ b/nexus-watcher/src/service/indexer/mod.rs
@@ -2,7 +2,7 @@ mod homeserver;
 mod key_based;
 
 pub use homeserver::HsEventProcessor;
-pub use key_based::KeyBasedEventProcessor;
+pub use key_based::{KeyBasedEventProcessor, KeyBasedEventSource, PubkyKeyBasedEventSource};
 use nexus_common::models::event::ParseResult;
 use std::{fmt::Display, path::PathBuf, sync::Arc, time::Duration};
 

--- a/nexus-watcher/src/service/runner/key_based.rs
+++ b/nexus-watcher/src/service/runner/key_based.rs
@@ -2,7 +2,9 @@ use super::TEventProcessorRunner;
 use crate::events::retry::RetryScheduler;
 use crate::events::{DefaultEventHandler, EventHandler, Moderation};
 use crate::service::backoff::HomeserverBackoff;
-use crate::service::indexer::{KeyBasedEventProcessor, TEventProcessor};
+use crate::service::indexer::{
+    KeyBasedEventProcessor, KeyBasedEventSource, PubkyKeyBasedEventSource, TEventProcessor,
+};
 use crate::service::stats::{ProcessedStats, ProcessorRunStatus, RunAllProcessorsStats};
 use nexus_common::models::homeserver::Homeserver;
 use nexus_common::types::DynError;
@@ -23,6 +25,7 @@ pub struct KeyBasedEventProcessorRunner {
 
     pub files_path: PathBuf,
     pub event_handler: Arc<dyn EventHandler>,
+    pub event_source: Arc<dyn KeyBasedEventSource>,
     pub shutdown_rx: Receiver<bool>,
 
     /// Default homeserver ID, excluded from the external targets list
@@ -43,6 +46,7 @@ impl KeyBasedEventProcessorRunner {
             monitored_hs_limit: config.monitored_homeservers_limit,
             files_path: config.stack.files_path.clone(),
             event_handler: Arc::new(DefaultEventHandler::new(Moderation::from_config(config))),
+            event_source: Arc::new(PubkyKeyBasedEventSource),
             shutdown_rx,
             default_homeserver: config.homeserver.clone(),
             backoff: Mutex::new(HomeserverBackoff::new(
@@ -87,6 +91,7 @@ impl TEventProcessorRunner for KeyBasedEventProcessorRunner {
             limit: self.limit,
             files_path: self.files_path.clone(),
             event_handler: self.event_handler.clone(),
+            event_source: self.event_source.clone(),
             retry_scheduler: self.retry_scheduler.clone(),
             shutdown_rx: self.shutdown_rx.clone(),
         }))

--- a/nexus-watcher/tests/service/event_processor_prioritization.rs
+++ b/nexus-watcher/tests/service/event_processor_prioritization.rs
@@ -7,8 +7,8 @@ use nexus_common::types::DynError;
 use nexus_watcher::events::retry::{InitialBackoff, RedisRetryStore, RetryScheduler, RetryStore};
 use nexus_watcher::events::{DefaultEventHandler, EventHandler};
 use nexus_watcher::service::backoff::HomeserverBackoff;
-use nexus_watcher::service::KeyBasedEventProcessorRunner;
-use nexus_watcher::service::TEventProcessorRunner;
+use nexus_watcher::service::indexer::PubkyKeyBasedEventSource;
+use nexus_watcher::service::{KeyBasedEventProcessorRunner, TEventProcessorRunner};
 use pubky_app_specs::PubkyId;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -34,6 +34,7 @@ async fn test_event_processor_runner_default_homeserver_excluded() -> Result<(),
         monitored_hs_limit: HS_IDS.len(),
         files_path: PathBuf::from("/tmp/nexus-watcher-test"),
         event_handler,
+        event_source: Arc::new(PubkyKeyBasedEventSource),
         shutdown_rx: tokio::sync::watch::channel(false).1,
         default_homeserver: PubkyId::try_from(HS_IDS[3]).unwrap(),
         backoff: Mutex::new(HomeserverBackoff::default()),

--- a/nexus-watcher/tests/service/key_based_event_processor.rs
+++ b/nexus-watcher/tests/service/key_based_event_processor.rs
@@ -1,0 +1,169 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::Result;
+use chrono::Utc;
+use nexus_common::db::{exec_single_row, queries, RedisOps};
+use nexus_common::models::homeserver::Homeserver;
+use nexus_common::models::user::{user_hs_cursor_key, UserDetails};
+use nexus_common::types::DynError;
+use nexus_watcher::events::retry::{InitialBackoff, RetryScheduler};
+use nexus_watcher::events::EventHandler;
+use nexus_watcher::service::indexer::{KeyBasedEventProcessor, TEventProcessor};
+use pubky::{Event as StreamEvent, EventCursor, EventType, Keypair, PubkyResource, PublicKey};
+use pubky_app_specs::PubkyId;
+
+use crate::service::utils::{
+    create_mock_handler, new_in_memory_store, setup, MockKeyBasedEventSource,
+};
+
+#[tokio_shared_rt::test(shared)]
+async fn key_based_processor_skips_unrecognized_events() -> Result<(), DynError> {
+    setup().await?;
+
+    // Create a homeserver with one hosted user to resolve during the run.
+    let (_hs_keypair, homeserver) = create_homeserver().await?;
+    let user_id = create_user_on_homeserver(&homeserver).await?;
+
+    // Return one unrecognized event followed by one valid pubky.app event for the same user.
+    let source = Arc::new(MockKeyBasedEventSource::default().with_events(vec![vec![
+        stream_event(1, &user_id, "/pub/other.app/profile.json")?,
+        stream_event(2, &user_id, "/pub/pubky.app/profile.json")?,
+    ]]));
+
+    let handler = create_mock_handler(Ok(()), None);
+    let processor = processor(homeserver, handler.clone(), source.clone());
+
+    processor.run().await?;
+
+    // The unrecognized event is skipped, while the valid event is handled.
+    assert_eq!(handler.get_handle_count(), 1);
+
+    // The processor fetched events only for the hosted user.
+    assert_eq!(source.calls(), vec![user_id]);
+
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn key_based_processor_stops_mismatched_user_stream_but_continues_other_users(
+) -> Result<(), DynError> {
+    setup().await?;
+
+    // Create a homeserver with two hosted users to resolve during the run.
+    let (_hs_keypair, homeserver) = create_homeserver().await?;
+    let user_a_id = create_user_on_homeserver(&homeserver).await?;
+    let user_b_id = create_user_on_homeserver(&homeserver).await?;
+
+    // This ID is not hosted on the homeserver; it simulates a malicious or broken event source.
+    let user_c_id = Keypair::random().public_key().to_z32();
+
+    // For the first hosted user, return an event whose URI belongs to a different user.
+    // The following valid event for the same hosted user must not be processed after that mismatch.
+    let source = Arc::new(MockKeyBasedEventSource::default().with_user_events(vec![
+        (
+            user_a_id.clone(),
+            vec![
+                stream_event(1, &user_c_id, "/pub/pubky.app/profile.json")?,
+                stream_event(2, &user_a_id, "/pub/pubky.app/profile.json")?,
+            ],
+        ),
+        // For the second hosted user, return a valid event to prove processing continues.
+        (
+            user_b_id.clone(),
+            vec![stream_event(3, &user_b_id, "/pub/pubky.app/profile.json")?],
+        ),
+    ]));
+
+    // Wire the processor to the user-keyed mock source and handler.
+    let handler = create_mock_handler(Ok(()), None);
+    let hs_id = homeserver.id.to_string();
+    let processor = processor(homeserver, handler.clone(), source.clone());
+
+    // Run one processing pass. User-level mismatches should be logged and skipped, not fail the run.
+    let result = processor.run().await;
+
+    assert!(result.is_ok());
+
+    // Both hosted users were fetched from the same homeserver despite the first user's mismatch.
+    let calls = source.calls();
+    assert_eq!(calls.len(), 2);
+    assert!(calls.contains(&user_a_id));
+    assert!(calls.contains(&user_b_id));
+
+    // Only the other user's event was handled; the valid event after the mismatch was skipped.
+    let handled_uris = handler.get_handled_uris();
+    assert_eq!(handled_uris.len(), 1);
+    assert!(handled_uris.iter().all(|uri| !uri.contains(&user_a_id)));
+    assert!(handled_uris.iter().any(|uri| uri.contains(&user_b_id)));
+
+    // The mismatched user's cursor must not be persisted: the bad event is the first in the
+    // batch, so `latest_cursor` is never set and no write to the USER_HS_CURSOR set should occur.
+    let cursor_a =
+        UserDetails::check_sorted_set_member(None, &user_hs_cursor_key(&user_a_id), &[&hs_id])
+            .await?;
+    assert!(
+        cursor_a.is_none(),
+        "user_a cursor must not be advanced past the mismatched event, got {cursor_a:?}",
+    );
+
+    Ok(())
+}
+
+async fn create_homeserver() -> Result<(Keypair, Homeserver), DynError> {
+    let keypair = Keypair::random();
+    let homeserver_id = PubkyId::try_from(keypair.public_key().to_z32().as_str())?;
+    let homeserver = Homeserver::new(homeserver_id);
+    homeserver.put_to_graph().await?;
+    Ok((keypair, homeserver))
+}
+
+async fn create_user_on_homeserver(homeserver: &Homeserver) -> Result<String, DynError> {
+    let user_id = PubkyId::try_from(Keypair::random().public_key().to_z32().as_str())?;
+    let user = UserDetails {
+        id: user_id.clone(),
+        name: "key-based-processor-test-user".into(),
+        bio: None,
+        status: None,
+        links: None,
+        image: None,
+        indexed_at: Utc::now().timestamp_millis(),
+    };
+
+    exec_single_row(queries::put::create_user(&user)?).await?;
+    exec_single_row(queries::put::set_user_homeserver(&user_id, &homeserver.id)).await?;
+
+    Ok(user_id.to_string())
+}
+
+fn stream_event(cursor: u64, user_id: &str, path: &str) -> Result<StreamEvent, DynError> {
+    let user_pk: PublicKey = user_id.parse()?;
+
+    Ok(StreamEvent {
+        event_type: EventType::Delete,
+        resource: PubkyResource::new(user_pk, path)?,
+        cursor: EventCursor::new(cursor),
+    })
+}
+
+fn processor(
+    homeserver: Homeserver,
+    handler: Arc<dyn EventHandler>,
+    source: Arc<MockKeyBasedEventSource>,
+) -> Arc<KeyBasedEventProcessor> {
+    Arc::new(KeyBasedEventProcessor {
+        homeserver,
+        limit: 100,
+        files_path: PathBuf::from("/tmp/nexus-watcher-test"),
+        event_handler: handler,
+        event_source: source,
+        retry_scheduler: Arc::new(RetryScheduler::new(
+            new_in_memory_store(),
+            InitialBackoff {
+                missing_dep_ms: 60_000,
+                transient_ms: 10_000,
+            },
+        )),
+        shutdown_rx: tokio::sync::watch::channel(false).1,
+    })
+}

--- a/nexus-watcher/tests/service/mod.rs
+++ b/nexus-watcher/tests/service/mod.rs
@@ -1,6 +1,7 @@
 pub mod event_processing_multiple_homeservers;
 pub mod event_processor_prioritization;
 pub mod hs_event_processor;
+pub mod key_based_event_processor;
 pub mod mock_event_processor;
 pub mod retry_processor;
 pub mod signal;

--- a/nexus-watcher/tests/service/utils/common.rs
+++ b/nexus-watcher/tests/service/utils/common.rs
@@ -21,6 +21,7 @@ pub fn create_mock_handler(
         result,
         target_uri_substring: target_substring.map(str::to_string),
         handle_count: Arc::new(Mutex::new(0)),
+        handled_uris: Arc::new(Mutex::new(Vec::new())),
     }
     .into()
 }

--- a/nexus-watcher/tests/service/utils/key_based_event_source.rs
+++ b/nexus-watcher/tests/service/utils/key_based_event_source.rs
@@ -1,0 +1,57 @@
+use std::collections::{HashMap, VecDeque};
+use std::sync::Mutex;
+
+use nexus_common::models::event::EventProcessorError;
+use nexus_watcher::service::indexer::KeyBasedEventSource;
+use pubky::{Event as StreamEvent, EventCursor, PublicKey};
+
+#[derive(Default)]
+pub struct MockKeyBasedEventSource {
+    /// Event batches returned in fetch order.
+    /// Useful when user ordering is not important and tests only care about processor flow.
+    events: Mutex<VecDeque<Vec<StreamEvent>>>,
+
+    /// Event batches returned by requested user ID.
+    /// Useful when graph user ordering is intentionally not part of the assertion.
+    user_events: Mutex<HashMap<String, Vec<StreamEvent>>>,
+
+    /// User IDs requested from the mock, in fetch order.
+    /// Useful for asserting the processor continued to, or stopped before, specific users.
+    calls: Mutex<Vec<String>>,
+}
+
+impl MockKeyBasedEventSource {
+    pub fn with_events(self, events: Vec<Vec<StreamEvent>>) -> Self {
+        *self.events.lock().unwrap() = events.into();
+        self
+    }
+
+    pub fn with_user_events(self, events: Vec<(String, Vec<StreamEvent>)>) -> Self {
+        *self.user_events.lock().unwrap() = events.into_iter().collect();
+        self
+    }
+
+    pub fn calls(&self) -> Vec<String> {
+        self.calls.lock().unwrap().clone()
+    }
+}
+
+#[async_trait::async_trait]
+impl KeyBasedEventSource for MockKeyBasedEventSource {
+    async fn fetch_events(
+        &self,
+        _hs_pk: &PublicKey,
+        user_pk: &PublicKey,
+        _cursor: EventCursor,
+        _limit: u16,
+    ) -> Result<Vec<StreamEvent>, EventProcessorError> {
+        let user_id = user_pk.z32();
+        self.calls.lock().unwrap().push(user_id.clone());
+
+        if let Some(events) = self.user_events.lock().unwrap().remove(&user_id) {
+            return Ok(events);
+        }
+
+        Ok(self.events.lock().unwrap().pop_front().unwrap_or_default())
+    }
+}

--- a/nexus-watcher/tests/service/utils/mod.rs
+++ b/nexus-watcher/tests/service/utils/mod.rs
@@ -1,10 +1,12 @@
 pub mod common;
+mod key_based_event_source;
 mod processor;
 mod processor_runner;
 mod result;
 mod setup;
 
-pub use common::{new_in_memory_store, TEST_USER_ID};
+pub use common::{create_mock_handler, new_in_memory_store, TEST_USER_ID};
+pub use key_based_event_source::MockKeyBasedEventSource;
 pub use processor::{
     create_mock_event_processors, create_random_homeservers_and_persist, MockEventProcessor,
 };

--- a/nexus-watcher/tests/utils/mod.rs
+++ b/nexus-watcher/tests/utils/mod.rs
@@ -14,12 +14,17 @@ pub struct MockEventHandler {
     /// Tracks how many times `handle()` was invoked. Shared via `Arc` so tests
     /// can read the count after processing.
     pub handle_count: Arc<Mutex<usize>>,
+    pub handled_uris: Arc<Mutex<Vec<String>>>,
 }
 
 impl MockEventHandler {
     /// Returns the number of times `handle()` was called.
     pub fn get_handle_count(&self) -> usize {
         *self.handle_count.lock().unwrap()
+    }
+
+    pub fn get_handled_uris(&self) -> Vec<String> {
+        self.handled_uris.lock().unwrap().clone()
     }
 }
 
@@ -28,6 +33,7 @@ impl EventHandler for MockEventHandler {
     async fn handle(&self, event: &Event) -> Result<(), EventProcessorError> {
         // Increment invocation counter on every call
         *self.handle_count.lock().unwrap() += 1;
+        self.handled_uris.lock().unwrap().push(event.uri.clone());
 
         match &self.target_uri_substring {
             Some(s) if !event.uri.contains(s) => Ok(()),


### PR DESCRIPTION
This PR offers a simpler alternative to #843 , to validate user IDs before processing events from 3rd party HSs.