### PR TITLE
Simplify config field clamping, embed it in serde deserialization

### DIFF
--- a/nexus-common/src/config/watcher.rs
+++ b/nexus-common/src/config/watcher.rs
@@ -4,8 +4,9 @@ use super::file::ConfigLoader;
 use super::{default_stack, DaemonConfig, StackConfig};
 use async_trait::async_trait;
 use pubky_app_specs::PubkyId;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::fmt::Debug;
+use tracing::warn;
 
 pub const TESTNET: bool = false;
 pub const DEFAULT_TESTNET_HOST: &str = "localhost";
@@ -115,10 +116,15 @@ pub struct WatcherConfig {
 
     /// Maximum number of events to fetch per run from the default homeserver.
     /// Clamped to [MAX_EVENTS_LIMIT] at load time.
+    #[serde(deserialize_with = "deserialize_events_limit")]
     pub events_limit: u16,
 
     /// Maximum events per user per run for key-based (non-default) homeservers.
     /// Clamped to [MAX_KEY_BASED_EVENTS_LIMIT] at load time.
+    #[serde(
+        default = "default_key_based_events_limit",
+        deserialize_with = "deserialize_key_based_events_limit"
+    )]
     pub key_based_events_limit: u16,
 
     /// Maximum number of monitored homeservers
@@ -185,6 +191,36 @@ impl Default for WatcherConfig {
 
 fn default_hs_resolver_sleep() -> u64 {
     DEFAULT_HS_RESOLVER_SLEEP
+}
+
+fn default_key_based_events_limit() -> u16 {
+    DEFAULT_KEY_BASED_EVENTS_LIMIT
+}
+
+fn deserialize_events_limit<'de, D>(deserializer: D) -> Result<u16, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let val = u32::deserialize(deserializer)?;
+    if val > u32::from(MAX_EVENTS_LIMIT) {
+        warn!("events_limit ({val}) exceeds max ({MAX_EVENTS_LIMIT}), clamped");
+        Ok(MAX_EVENTS_LIMIT)
+    } else {
+        Ok(val as u16)
+    }
+}
+
+fn deserialize_key_based_events_limit<'de, D>(deserializer: D) -> Result<u16, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let val = u32::deserialize(deserializer)?;
+    if val > u32::from(MAX_KEY_BASED_EVENTS_LIMIT) {
+        warn!("key_based_events_limit ({val}) exceeds max ({MAX_KEY_BASED_EVENTS_LIMIT}), clamped");
+        Ok(MAX_KEY_BASED_EVENTS_LIMIT)
+    } else {
+        Ok(val as u16)
+    }
 }
 
 fn default_hs_resolver_ttl() -> u64 {

--- a/nexus-common/src/config/watcher.rs
+++ b/nexus-common/src/config/watcher.rs
@@ -4,9 +4,8 @@ use super::file::ConfigLoader;
 use super::{default_stack, DaemonConfig, StackConfig};
 use async_trait::async_trait;
 use pubky_app_specs::PubkyId;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{de::Error, Deserialize, Deserializer, Serialize};
 use std::fmt::Debug;
-use tracing::warn;
 
 pub const TESTNET: bool = false;
 pub const DEFAULT_TESTNET_HOST: &str = "localhost";
@@ -115,12 +114,12 @@ pub struct WatcherConfig {
     pub homeserver: PubkyId,
 
     /// Maximum number of events to fetch per run from the default homeserver.
-    /// Clamped to [MAX_EVENTS_LIMIT] at load time.
+    /// Must not exceed [MAX_EVENTS_LIMIT].
     #[serde(deserialize_with = "deserialize_events_limit")]
     pub events_limit: u16,
 
     /// Maximum events per user per run for key-based (non-default) homeservers.
-    /// Clamped to [MAX_KEY_BASED_EVENTS_LIMIT] at load time.
+    /// Must not exceed [MAX_KEY_BASED_EVENTS_LIMIT].
     #[serde(
         default = "default_key_based_events_limit",
         deserialize_with = "deserialize_key_based_events_limit"
@@ -201,12 +200,12 @@ fn deserialize_events_limit<'de, D>(deserializer: D) -> Result<u16, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let val = u32::deserialize(deserializer)?;
-    if val > u32::from(MAX_EVENTS_LIMIT) {
-        warn!("events_limit ({val}) exceeds max ({MAX_EVENTS_LIMIT}), clamped");
-        Ok(MAX_EVENTS_LIMIT)
+    let val = u16::deserialize(deserializer)?;
+    if val > MAX_EVENTS_LIMIT {
+        let err_msg = format!("events_limit ({val}) exceeds max ({MAX_EVENTS_LIMIT})");
+        Err(D::Error::custom(err_msg))
     } else {
-        Ok(val as u16)
+        Ok(val)
     }
 }
 
@@ -214,12 +213,13 @@ fn deserialize_key_based_events_limit<'de, D>(deserializer: D) -> Result<u16, D:
 where
     D: Deserializer<'de>,
 {
-    let val = u32::deserialize(deserializer)?;
-    if val > u32::from(MAX_KEY_BASED_EVENTS_LIMIT) {
-        warn!("key_based_events_limit ({val}) exceeds max ({MAX_KEY_BASED_EVENTS_LIMIT}), clamped");
-        Ok(MAX_KEY_BASED_EVENTS_LIMIT)
+    let val = u16::deserialize(deserializer)?;
+    if val > MAX_KEY_BASED_EVENTS_LIMIT {
+        let err_msg =
+            format!("key_based_events_limit ({val}) exceeds max ({MAX_KEY_BASED_EVENTS_LIMIT})");
+        Err(D::Error::custom(err_msg))
     } else {
-        Ok(val as u16)
+        Ok(val)
     }
 }
 

--- a/nexus-watcher/src/service/runner/homeserver.rs
+++ b/nexus-watcher/src/service/runner/homeserver.rs
@@ -4,12 +4,11 @@ use crate::events::{DefaultEventHandler, EventHandler, Moderation};
 use crate::service::indexer::{HsEventProcessor, TEventProcessor};
 use nexus_common::models::homeserver::Homeserver;
 use nexus_common::types::DynError;
-use nexus_common::{WatcherConfig, MAX_EVENTS_LIMIT};
+use nexus_common::WatcherConfig;
 use pubky_app_specs::PubkyId;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::watch::Receiver;
-use tracing::warn;
 
 pub struct HsEventProcessorRunner {
     /// See [WatcherConfig::events_limit]
@@ -26,16 +25,8 @@ pub struct HsEventProcessorRunner {
 impl HsEventProcessorRunner {
     /// Creates a new instance from the provided configuration
     pub fn from_config(config: &WatcherConfig, shutdown_rx: Receiver<bool>) -> Self {
-        let limit = config.events_limit.min(MAX_EVENTS_LIMIT);
-        if config.events_limit > MAX_EVENTS_LIMIT {
-            warn!(
-                "events_limit ({}) exceeds max ({}), clamped",
-                config.events_limit, MAX_EVENTS_LIMIT
-            );
-        }
-
         Self {
-            limit,
+            limit: config.events_limit,
             files_path: config.stack.files_path.clone(),
             event_handler: Arc::new(DefaultEventHandler::new(Moderation::from_config(config))),
             shutdown_rx,

--- a/nexus-watcher/src/service/runner/key_based.rs
+++ b/nexus-watcher/src/service/runner/key_based.rs
@@ -7,7 +7,6 @@ use crate::service::stats::{ProcessedStats, ProcessorRunStatus, RunAllProcessors
 use nexus_common::models::homeserver::Homeserver;
 use nexus_common::types::DynError;
 use nexus_common::WatcherConfig;
-use nexus_common::MAX_KEY_BASED_EVENTS_LIMIT;
 use pubky_app_specs::PubkyId;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -39,18 +38,8 @@ pub struct KeyBasedEventProcessorRunner {
 impl KeyBasedEventProcessorRunner {
     /// Creates a new instance from the provided configuration
     pub fn from_config(config: &WatcherConfig, shutdown_rx: Receiver<bool>) -> Self {
-        let limit = config
-            .key_based_events_limit
-            .min(MAX_KEY_BASED_EVENTS_LIMIT);
-        if config.key_based_events_limit > MAX_KEY_BASED_EVENTS_LIMIT {
-            warn!(
-                "key_based_events_limit ({}) exceeds max ({}), clamped",
-                config.key_based_events_limit, MAX_KEY_BASED_EVENTS_LIMIT
-            );
-        }
-
         Self {
-            limit,
+            limit: config.key_based_events_limit,
             monitored_hs_limit: config.monitored_homeservers_limit,
             files_path: config.stack.files_path.clone(),
             event_handler: Arc::new(DefaultEventHandler::new(Moderation::from_config(config))),


### PR DESCRIPTION
This PR simplifies the clamping logic for `events_limit` / `key_based_events_limit` by moving it from the event processor's `from_config` method to the `WatcherConfig` deserialization.