### PR TITLE
refactor: consolidate event parsing

### DIFF
--- a/nexus-common/src/models/event/mod.rs
+++ b/nexus-common/src/models/event/mod.rs
@@ -137,7 +137,7 @@ impl Event {
         // standard pubky-app-specs URIs and universal tag URIs from other apps.
         let parsed_uri = match HomeserverParsedUri::try_from(uri.as_str()) {
             Ok(parsed) => parsed,
-            Err(e) => return Ok(ParseResult::unrecognized_uri(event_type, uri, e.into())),
+            Err(e) => return Ok(ParseResult::unrecognized_uri(event_type, uri, e)),
         };
 
         if let HomeserverParsedUri::AppSpec { resource, .. } = &parsed_uri {

--- a/nexus-common/src/models/event/mod.rs
+++ b/nexus-common/src/models/event/mod.rs
@@ -106,7 +106,7 @@ impl Event {
         let uri = parts[1].to_string();
         let event_line = line.to_string();
 
-        Self::build(event_type, uri, event_line, files_path)
+        Self::parse_event_parts(event_type, uri, event_line, files_path)
     }
 
     /// Constructs a nexus [`Event`] directly from a [`StreamEvent`], avoiding
@@ -121,13 +121,13 @@ impl Event {
         debug!("New stream event: {event_type} {uri}");
 
         let event_line = format!("{event_type} {uri}");
-        match Self::build(event_type, uri, event_line, files_path)? {
+        match Self::parse_event_parts(event_type, uri, event_line, files_path)? {
             ParseResult::Parsed(event) => Ok(Some(event)),
             ParseResult::Skipped | ParseResult::UnrecognizedUri { .. } => Ok(None),
         }
     }
 
-    fn build(
+    fn parse_event_parts(
         event_type: EventType,
         uri: String,
         event_line: String,
@@ -137,20 +137,10 @@ impl Event {
         // standard pubky-app-specs URIs and universal tag URIs from other apps.
         let parsed_uri = match HomeserverParsedUri::try_from(uri.as_str()) {
             Ok(parsed) => parsed,
-            Err(e) => {
-                return Ok(ParseResult::unrecognized_uri(
-                    event_type,
-                    uri,
-                    e.to_string(),
-                ))
-            }
+            Err(e) => return Ok(ParseResult::unrecognized_uri(event_type, uri, e.into())),
         };
 
-        if let HomeserverParsedUri::AppSpec {
-            user_id: _,
-            resource,
-        } = &parsed_uri
-        {
+        if let HomeserverParsedUri::AppSpec { resource, .. } = &parsed_uri {
             match resource {
                 Resource::Unknown => {
                     return Err(EventProcessorError::InvalidEventLine(format!(

--- a/nexus-common/src/models/event/mod.rs
+++ b/nexus-common/src/models/event/mod.rs
@@ -103,43 +103,10 @@ impl Event {
             ))),
         }?;
 
-        // Validate and parse the URI using HomeserverParsedUri
-        // This handles both standard pubky-app-specs URIs (pubky.app) and
-        // universal tag URIs from other apps (e.g., eventky.app, mapky)
         let uri = parts[1].to_string();
-        let homeserver_parsed_uri = match HomeserverParsedUri::try_from(uri.as_str()) {
-            Ok(parsed) => parsed,
-            Err(e) => {
-                let reason = e.to_string();
-                return Ok(ParseResult::unrecognized_uri(event_type, uri, reason));
-            }
-        };
-
-        let resource = homeserver_parsed_uri.resource().clone();
-
-        match resource {
-            // Unknown resource
-            Resource::Unknown => {
-                return Err(EventProcessorError::InvalidEventLine(format!(
-                    "Unknown resource in URI: {uri}"
-                )))
-            }
-            // Known resources not handled by Nexus
-            Resource::LastRead | Resource::Feed(_) | Resource::Blob(_) => {
-                return Ok(ParseResult::Skipped)
-            }
-            _ => (),
-        };
-
         let event_line = line.to_string();
 
-        Ok(ParseResult::Parsed(Event {
-            uri,
-            event_type,
-            parsed_uri: homeserver_parsed_uri,
-            files_path,
-            event_line,
-        }))
+        Self::build(event_type, uri, event_line, files_path)
     }
 
     /// Constructs a nexus [`Event`] directly from a [`StreamEvent`], avoiding
@@ -154,7 +121,10 @@ impl Event {
         debug!("New stream event: {event_type} {uri}");
 
         let event_line = format!("{event_type} {uri}");
-        Self::build(event_type, uri, event_line, files_path)
+        match Self::build(event_type, uri, event_line, files_path)? {
+            ParseResult::Parsed(event) => Ok(Some(event)),
+            ParseResult::Skipped | ParseResult::UnrecognizedUri { .. } => Ok(None),
+        }
     }
 
     fn build(
@@ -162,10 +132,19 @@ impl Event {
         uri: String,
         event_line: String,
         files_path: PathBuf,
-    ) -> Result<Option<Self>, EventProcessorError> {
-        let parsed_uri = HomeserverParsedUri::try_from(uri.as_str()).map_err(|e| {
-            EventProcessorError::InvalidEventLine(format!("Cannot parse event URI: {e}"))
-        })?;
+    ) -> Result<ParseResult, EventProcessorError> {
+        // Validate and parse the URI using HomeserverParsedUri. This handles both
+        // standard pubky-app-specs URIs and universal tag URIs from other apps.
+        let parsed_uri = match HomeserverParsedUri::try_from(uri.as_str()) {
+            Ok(parsed) => parsed,
+            Err(e) => {
+                return Ok(ParseResult::unrecognized_uri(
+                    event_type,
+                    uri,
+                    e.to_string(),
+                ))
+            }
+        };
 
         if let HomeserverParsedUri::AppSpec {
             user_id: _,
@@ -174,15 +153,18 @@ impl Event {
         {
             match resource {
                 Resource::Unknown => {
-                    debug!("Skipping unrecognised resource: {uri}");
-                    return Ok(None);
+                    return Err(EventProcessorError::InvalidEventLine(format!(
+                        "Unknown resource in URI: {uri}"
+                    )))
                 }
-                Resource::LastRead | Resource::Feed(_) | Resource::Blob(_) => return Ok(None),
+                Resource::LastRead | Resource::Feed(_) | Resource::Blob(_) => {
+                    return Ok(ParseResult::Skipped)
+                }
                 _ => (),
             }
         }
 
-        Ok(Some(Event {
+        Ok(ParseResult::Parsed(Event {
             uri,
             event_type,
             parsed_uri,


### PR DESCRIPTION
This PR refactors event parsing to share URI/resource classification between homeserver event lines and stream events.

`Event::build` now returns `ParseResult`, allowing `parse_event` to delegate common parsing logic directly while `from_stream_event` preserves its existing `Option<Event>` API by mapping skipped or unrecognized events to `None`. 

This removes duplicated match logic and keeps the public method signatures unchanged.