### PR TITLE
[`univ-tag-del` A] Add moderation tests for Universal Tags, fix `apply_moderation`

### DIFF
--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -128,10 +128,14 @@ pub fn get_post_replies(author_id: &str, post_id: &str) -> Query {
 
 // Read the target details for a tag without deleting the TAGGED edge.
 // Used in tag del to read before graph-last deletion.
-pub fn get_tag_target(user_id: &str, tag_id: &str) -> Query {
-    Query::new(
-        "get_tag_target",
-        "MATCH (user:User {id: $user_id})-[tag:TAGGED {id: $tag_id}]->(target)
+pub fn get_tag_target(user_id: &str, tag_id: &str, app: Option<&str>) -> Query {
+    let app_filter = match app {
+        Some(_) => "\n    WHERE tag.app = $app",
+        None => "\n    WHERE tag.app IS NULL",
+    };
+
+    let cypher = format!(
+        "MATCH (user:User {{id: $user_id}})-[tag:TAGGED {{id: $tag_id}}]->(target){app_filter}
          OPTIONAL MATCH (target)<-[:AUTHORED]-(author:User)
          WITH CASE WHEN target:User THEN target.id ELSE null END AS user_id,
               CASE WHEN target:Post THEN target.id ELSE null END AS post_id,
@@ -139,10 +143,18 @@ pub fn get_tag_target(user_id: &str, tag_id: &str) -> Query {
               CASE WHEN target:Resource THEN target.id ELSE null END AS resource_id,
               tag.label AS label,
               tag.app AS app
-         RETURN user_id, post_id, author_id, resource_id, label, app",
-    )
-    .param("user_id", user_id)
-    .param("tag_id", tag_id)
+         RETURN user_id, post_id, author_id, resource_id, label, app"
+    );
+
+    let mut query = Query::new("get_tag_target", &cypher)
+        .param("user_id", user_id)
+        .param("tag_id", tag_id);
+
+    if let Some(a) = app {
+        query = query.param("app", a);
+    }
+
+    query
 }
 
 // Get all the tags/taggers that a post has received (used for edit/delete notifications)

--- a/nexus-watcher/src/events/handlers/tag.rs
+++ b/nexus-watcher/src/events/handlers/tag.rs
@@ -402,22 +402,48 @@ async fn put_sync_user(
 #[tracing::instrument(name = "tag.del", skip_all, fields(tag_uri = %tag_uri))]
 pub async fn del(tag_uri: &str) -> Result<(), EventProcessorError> {
     let tag_storage_uri = parse_tag_storage_uri(tag_uri)?;
-    let user_id = tag_storage_uri.user_id;
-    let tag_id = tag_storage_uri.tag_id;
-    let app = tag_storage_uri.app;
+    // Prefix these vars with arg_ to indicate they were extracted from the argument tag URI
+    // Similarly named vars will be used in Step 2 below, reading fields from the query result
+    let arg_user_id = tag_storage_uri.user_id;
+    let arg_tag_id = tag_storage_uri.tag_id;
+    let arg_app = tag_storage_uri.app;
 
-    debug!("Deleting tag: {} -> {} (app={app:?})", user_id, tag_id);
+    debug!("Deleting tag: {arg_user_id} -> {arg_tag_id} (app={arg_app:?})");
 
     // 1. Read target from graph WITHOUT deleting the edge
-    let Some(row) = fetch_row_from_graph(queries::get::get_tag_target(
-        &user_id,
-        &tag_id,
-        app.as_deref(),
+    let row = match fetch_row_from_graph(queries::get::get_tag_target(
+        &arg_user_id,
+        &arg_tag_id,
+        arg_app.as_deref(),
     ))
     .await?
-    else {
-        // Edge already gone (fully completed on a prior attempt) — idempotent no-op
-        return Ok(());
+    {
+        Some(row) => row,
+        None if arg_app.is_some() => {
+            // App-specific tags that target known Pubky resources are indexed
+            // through the standard Post/User tag flow, where TAGGED has no app.
+            let Some(row) = fetch_row_from_graph(queries::get::get_tag_target(
+                &arg_user_id,
+                &arg_tag_id,
+                None,
+            ))
+            .await?
+            else {
+                // Edge already gone (fully completed on a prior attempt) - idempotent no-op
+                return Ok(());
+            };
+
+            let resource_id: Option<String> = row.get("resource_id").unwrap_or(None);
+            if resource_id.is_some() {
+                return Ok(());
+            }
+
+            row
+        }
+        None => {
+            // Edge already gone (fully completed on a prior attempt) - idempotent no-op
+            return Ok(());
+        }
     };
 
     let tagged_user_id: Option<String> = row.get("user_id").unwrap_or(None);
@@ -433,18 +459,18 @@ pub async fn del(tag_uri: &str) -> Result<(), EventProcessorError> {
     match (tagged_user_id, post_id, author_id, resource_id) {
         (Some(tagged_id), None, None, None) => {
             let tagger_in_index =
-                TagUser::check_set_member(&[&tagged_id, &label], user_id.as_str())
+                TagUser::check_set_member(&[&tagged_id, &label], arg_user_id.as_str())
                     .await?
                     .1;
-            del_sync_user(user_id.clone(), &tagged_id, &label, tagger_in_index).await?;
+            del_sync_user(arg_user_id.clone(), &tagged_id, &label, tagger_in_index).await?;
         }
         (None, Some(post_id), Some(author_id), None) => {
             let tagger_in_index =
-                TagPost::check_set_member(&[&author_id, &post_id, &label], user_id.as_str())
+                TagPost::check_set_member(&[&author_id, &post_id, &label], arg_user_id.as_str())
                     .await?
                     .1;
             del_sync_post(
-                user_id.clone(),
+                arg_user_id.clone(),
                 &post_id,
                 &author_id,
                 &label,
@@ -453,7 +479,7 @@ pub async fn del(tag_uri: &str) -> Result<(), EventProcessorError> {
             .await?;
         }
         (None, None, None, Some(res_id)) => {
-            del_sync_resource(user_id.clone(), &res_id, &label, app.as_deref()).await?;
+            del_sync_resource(arg_user_id.clone(), &res_id, &label, app.as_deref()).await?;
         }
         _ => {
             debug!("DEL-Tag: Unexpected combination of tag details");
@@ -461,7 +487,12 @@ pub async fn del(tag_uri: &str) -> Result<(), EventProcessorError> {
     }
 
     // 3. Graph deletion LAST — ensures data survives for retry if Redis ops fail
-    fetch_row_from_graph(queries::del::delete_tag(&user_id, &tag_id, app.as_deref())).await?;
+    fetch_row_from_graph(queries::del::delete_tag(
+        &arg_user_id,
+        &arg_tag_id,
+        app.as_deref(),
+    ))
+    .await?;
 
     Ok(())
 }

--- a/nexus-watcher/src/events/handlers/tag.rs
+++ b/nexus-watcher/src/events/handlers/tag.rs
@@ -22,6 +22,13 @@ use tracing::debug;
 
 use super::utils::post_relationships_is_reply;
 
+#[derive(Debug)]
+struct TagStorageUri {
+    user_id: PubkyId,
+    tag_id: String,
+    app: Option<String>,
+}
+
 #[tracing::instrument(name = "tag.put", skip_all, fields(user_id = %tagger_id, tag_id = %tag_id))]
 pub async fn sync_put(
     tag: PubkyAppTag,
@@ -392,12 +399,22 @@ async fn put_sync_user(
     }
 }
 
-#[tracing::instrument(name = "tag.del", skip_all, fields(user_id = %user_id, tag_id = %tag_id))]
-pub async fn del(user_id: PubkyId, tag_id: String) -> Result<(), EventProcessorError> {
-    debug!("Deleting tag: {} -> {}", user_id, tag_id);
+#[tracing::instrument(name = "tag.del", skip_all, fields(tag_uri = %tag_uri))]
+pub async fn del(tag_uri: &str) -> Result<(), EventProcessorError> {
+    let tag_storage_uri = parse_tag_storage_uri(tag_uri)?;
+    let user_id = tag_storage_uri.user_id;
+    let tag_id = tag_storage_uri.tag_id;
+    let app = tag_storage_uri.app;
+
+    debug!("Deleting tag: {} -> {} (app={app:?})", user_id, tag_id);
 
     // 1. Read target from graph WITHOUT deleting the edge
-    let Some(row) = fetch_row_from_graph(queries::get::get_tag_target(&user_id, &tag_id)).await?
+    let Some(row) = fetch_row_from_graph(queries::get::get_tag_target(
+        &user_id,
+        &tag_id,
+        app.as_deref(),
+    ))
+    .await?
     else {
         // Edge already gone (fully completed on a prior attempt) — idempotent no-op
         return Ok(());
@@ -447,6 +464,59 @@ pub async fn del(user_id: PubkyId, tag_id: String) -> Result<(), EventProcessorE
     fetch_row_from_graph(queries::del::delete_tag(&user_id, &tag_id, app.as_deref())).await?;
 
     Ok(())
+}
+
+pub fn is_tag_storage_uri(tag_uri: &str) -> bool {
+    parse_tag_storage_uri(tag_uri).is_ok()
+}
+
+fn parse_tag_storage_uri(tag_uri: &str) -> Result<TagStorageUri, EventProcessorError> {
+    if let Ok(parsed_uri) = ParsedUri::try_from(tag_uri) {
+        return match parsed_uri.resource {
+            Resource::Tag(tag_id) => Ok(TagStorageUri {
+                user_id: parsed_uri.user_id,
+                tag_id,
+                app: None,
+            }),
+            other => Err(EventProcessorError::generic(format!(
+                "Expected tag URI, found resource: {other:?}"
+            ))),
+        };
+    }
+
+    let rest = tag_uri
+        .get(..8)
+        .filter(|prefix| prefix.eq_ignore_ascii_case("pubky://"))
+        .and_then(|_| tag_uri.get(8..))
+        .ok_or_else(|| EventProcessorError::generic(format!("Invalid tag URI: {tag_uri}")))?;
+
+    let slash_pos = rest
+        .find('/')
+        .ok_or_else(|| EventProcessorError::generic(format!("Invalid tag URI: {tag_uri}")))?;
+    let user_id_str = &rest[..slash_pos];
+    let path = rest[slash_pos..]
+        .strip_prefix("/pub/")
+        .ok_or_else(|| EventProcessorError::generic(format!("Invalid tag URI: {tag_uri}")))?;
+    let tags_pos = path
+        .find("/tags/")
+        .ok_or_else(|| EventProcessorError::generic(format!("Invalid tag URI: {tag_uri}")))?;
+    let app = &path[..tags_pos];
+    let tag_id = &path[tags_pos + 6..];
+
+    if app.is_empty() || app.contains('/') || tag_id.is_empty() || tag_id.contains('/') {
+        return Err(EventProcessorError::generic(format!(
+            "Invalid tag URI: {tag_uri}"
+        )));
+    }
+
+    let user_id = PubkyId::try_from(user_id_str).map_err(EventProcessorError::generic)?;
+    let app = (app != "pubky.app").then(|| app.to_string());
+
+    Ok(TagStorageUri {
+        user_id,
+        tag_id: tag_id.to_string(),
+        app,
+    })
 }
 
 async fn del_sync_user(

--- a/nexus-watcher/src/events/handlers/tag.rs
+++ b/nexus-watcher/src/events/handlers/tag.rs
@@ -484,38 +484,13 @@ fn parse_tag_storage_uri(tag_uri: &str) -> Result<TagStorageUri, EventProcessorE
         };
     }
 
-    let rest = tag_uri
-        .get(..8)
-        .filter(|prefix| prefix.eq_ignore_ascii_case("pubky://"))
-        .and_then(|_| tag_uri.get(8..))
+    let info = super::universal_tag::try_parse_app_tag_path(tag_uri)
         .ok_or_else(|| EventProcessorError::generic(format!("Invalid tag URI: {tag_uri}")))?;
-
-    let slash_pos = rest
-        .find('/')
-        .ok_or_else(|| EventProcessorError::generic(format!("Invalid tag URI: {tag_uri}")))?;
-    let user_id_str = &rest[..slash_pos];
-    let path = rest[slash_pos..]
-        .strip_prefix("/pub/")
-        .ok_or_else(|| EventProcessorError::generic(format!("Invalid tag URI: {tag_uri}")))?;
-    let tags_pos = path
-        .find("/tags/")
-        .ok_or_else(|| EventProcessorError::generic(format!("Invalid tag URI: {tag_uri}")))?;
-    let app = &path[..tags_pos];
-    let tag_id = &path[tags_pos + 6..];
-
-    if app.is_empty() || app.contains('/') || tag_id.is_empty() || tag_id.contains('/') {
-        return Err(EventProcessorError::generic(format!(
-            "Invalid tag URI: {tag_uri}"
-        )));
-    }
-
-    let user_id = PubkyId::try_from(user_id_str).map_err(EventProcessorError::generic)?;
-    let app = (app != "pubky.app").then(|| app.to_string());
 
     Ok(TagStorageUri {
-        user_id,
-        tag_id: tag_id.to_string(),
-        app,
+        user_id: info.user_id,
+        tag_id: info.tag_id,
+        app: Some(info.app),
     })
 }
 

--- a/nexus-watcher/src/events/handlers/universal_tag.rs
+++ b/nexus-watcher/src/events/handlers/universal_tag.rs
@@ -70,7 +70,7 @@ async fn handle_put(info: AppTagInfo) -> Result<(), EventProcessorError> {
 }
 
 async fn handle_del(info: AppTagInfo) -> Result<(), EventProcessorError> {
-    tag::del(info.user_id, info.tag_id).await
+    tag::del(&info.uri).await
 }
 
 /// Try to parse a URI as an app-specific tag path.

--- a/nexus-watcher/src/events/handlers/universal_tag.rs
+++ b/nexus-watcher/src/events/handlers/universal_tag.rs
@@ -95,10 +95,8 @@ pub(super) fn try_parse_app_tag_path(uri: &str) -> Option<AppTagInfo> {
     // Expected: /pub/<app>/tags/<tag_id>
     let path = path.strip_prefix(PUBLIC_PATH)?;
 
-    // Split on /tags/
-    let tags_pos = path.find("/tags/")?;
-    let app = &path[..tags_pos];
-    let tag_id = &path[tags_pos + 6..]; // skip "/tags/"
+    // Expected: <app>/tags/<tag_id> . Split on /tags/
+    let (app, tag_id) = path.split_once("/tags/")?;
 
     // Skip if app is APP_PATH — those go through the standard flow
     if app == APP_PATH.trim_end_matches('/') {

--- a/nexus-watcher/src/events/handlers/universal_tag.rs
+++ b/nexus-watcher/src/events/handlers/universal_tag.rs
@@ -98,7 +98,7 @@ pub(super) fn try_parse_app_tag_path(uri: &str) -> Option<AppTagInfo> {
     // Expected: <app>/tags/<tag_id> . Split on /tags/
     let (app, tag_id) = path.split_once("/tags/")?;
 
-    // Skip if app is APP_PATH — those go through the standard flow
+    // Skip pubky.app; normal event parsing handles it
     if app == APP_PATH.trim_end_matches('/') {
         return None;
     }

--- a/nexus-watcher/src/events/handlers/universal_tag.rs
+++ b/nexus-watcher/src/events/handlers/universal_tag.rs
@@ -1,6 +1,6 @@
 use nexus_common::db::PubkyConnector;
 use nexus_common::models::event::{EventProcessorError, EventType};
-use pubky_app_specs::{PubkyAppTag, PubkyId};
+use pubky_app_specs::{PubkyAppTag, PubkyId, APP_PATH, PROTOCOL, PUBLIC_PATH};
 use tracing::debug;
 
 use super::tag;
@@ -79,11 +79,11 @@ async fn handle_del(info: AppTagInfo) -> Result<(), EventProcessorError> {
 /// Returns None if:
 /// - Not a pubky:// URI
 /// - Not a */tags/* path
-/// - App is "pubky.app" (handled by the standard event flow)
-fn try_parse_app_tag_path(uri: &str) -> Option<AppTagInfo> {
+/// - App is `APP_PATH` (handled by the standard event flow)
+pub(super) fn try_parse_app_tag_path(uri: &str) -> Option<AppTagInfo> {
     // Case-insensitive scheme check per RFC 3986 (safe UTF-8 access)
-    let rest = match uri.get(..8) {
-        Some(prefix) if prefix.eq_ignore_ascii_case("pubky://") => &uri[8..],
+    let rest = match uri.get(..PROTOCOL.len()) {
+        Some(prefix) if prefix.eq_ignore_ascii_case(PROTOCOL) => &uri[PROTOCOL.len()..],
         _ => return None,
     };
 
@@ -93,15 +93,15 @@ fn try_parse_app_tag_path(uri: &str) -> Option<AppTagInfo> {
     let path = &rest[slash_pos..]; // starts with /
 
     // Expected: /pub/<app>/tags/<tag_id>
-    let path = path.strip_prefix("/pub/")?;
+    let path = path.strip_prefix(PUBLIC_PATH)?;
 
     // Split on /tags/
     let tags_pos = path.find("/tags/")?;
     let app = &path[..tags_pos];
     let tag_id = &path[tags_pos + 6..]; // skip "/tags/"
 
-    // Skip if app is pubky.app — those go through the standard flow
-    if app == "pubky.app" {
+    // Skip if app is APP_PATH — those go through the standard flow
+    if app == APP_PATH.trim_end_matches('/') {
         return None;
     }
 

--- a/nexus-watcher/src/events/mod.rs
+++ b/nexus-watcher/src/events/mod.rs
@@ -107,7 +107,7 @@ pub async fn handle_del_event(event: &Event) -> Result<(), EventProcessorError> 
         Resource::Bookmark(bookmark_id) => {
             handlers::bookmark::del(user_id, bookmark_id.clone()).await?
         }
-        Resource::Tag(tag_id) => handlers::tag::del(user_id, tag_id.clone()).await?,
+        Resource::Tag(_) => handlers::tag::del(&event.uri).await?,
         Resource::File(file_id) => {
             handlers::file::del(&user_id, file_id.clone(), event.files_path.clone()).await?
         }

--- a/nexus-watcher/src/events/moderation.rs
+++ b/nexus-watcher/src/events/moderation.rs
@@ -22,6 +22,14 @@ impl Moderation {
         moderator_tag: PubkyAppTag,
         files_path: PathBuf,
     ) -> Result<(), EventProcessorError> {
+        if handlers::tag::is_tag_storage_uri(&moderator_tag.uri) {
+            info!(
+                "Moderation tag '{}' detected. Deleting moderated tag {}",
+                moderator_tag.label, moderator_tag.uri
+            );
+            return handlers::tag::del(&moderator_tag.uri).await;
+        }
+
         // Parse the embeded URI to extract author_id and post_id using parse_tagged_post_uri
         let parsed_uri = ParsedUri::try_from(moderator_tag.uri.as_str())
             .map_err(EventProcessorError::generic)?;
@@ -42,7 +50,7 @@ impl Moderation {
                     "Moderation tag '{}' detected. Deleting tag {}:{}",
                     moderator_tag.label, user_id, tag_id
                 );
-                handlers::tag::del(user_id, tag_id).await
+                handlers::tag::del(&moderator_tag.uri).await
             }
             Resource::User => {
                 // Delete the user profile and return the result

--- a/nexus-watcher/src/events/moderation.rs
+++ b/nexus-watcher/src/events/moderation.rs
@@ -22,12 +22,13 @@ impl Moderation {
         moderator_tag: PubkyAppTag,
         files_path: PathBuf,
     ) -> Result<(), EventProcessorError> {
+        let lahel = moderator_tag.label;
+        let moderated_uri = &moderator_tag.uri;
+
+        // ParsedUri does not handle app-specific tag storage paths (Universal Tags), so they must be intercepted first.
         if handlers::tag::is_tag_storage_uri(&moderator_tag.uri) {
-            info!(
-                "Moderation tag '{}' detected. Deleting moderated tag {}",
-                moderator_tag.label, moderator_tag.uri
-            );
-            return handlers::tag::del(&moderator_tag.uri).await;
+            info!("Moderation tag '{lahel}' detected. Deleting moderated tag {moderated_uri}",);
+            return handlers::tag::del(moderated_uri).await;
         }
 
         // Parse the embeded URI to extract author_id and post_id using parse_tagged_post_uri
@@ -37,35 +38,19 @@ impl Moderation {
 
         match parsed_uri.resource {
             Resource::Post(post_id) => {
-                // Delete the post and return the result
-                info!(
-                    "Moderation tag '{}' detected. Deleting post {}:{}",
-                    moderator_tag.label, user_id, post_id
-                );
+                info!("Moderation tag '{lahel}' detected. Deleting post {user_id}:{post_id}");
                 handlers::post::sync_del(user_id, post_id).await
             }
             Resource::Tag(tag_id) => {
-                // Delete the tag and return the result
-                info!(
-                    "Moderation tag '{}' detected. Deleting tag {}:{}",
-                    moderator_tag.label, user_id, tag_id
-                );
+                info!("Moderation tag '{lahel}' detected. Deleting tag {user_id}:{tag_id}");
                 handlers::tag::del(&moderator_tag.uri).await
             }
             Resource::User => {
-                // Delete the user profile and return the result
-                info!(
-                    "Moderation tag '{}' detected. Deleting user profile {}",
-                    moderator_tag.label, user_id
-                );
+                info!("Moderation tag '{lahel}' detected. Deleting user profile {user_id}");
                 handlers::user::del(user_id).await
             }
             Resource::File(file_id) => {
-                // Delete the file and return the result
-                info!(
-                    "Moderation tag '{}' detected. Deleting file {}:{}",
-                    moderator_tag.label, user_id, file_id
-                );
+                info!("Moderation tag '{lahel}' detected. Deleting file {user_id}:{file_id}");
                 handlers::file::del(&user_id, file_id, files_path).await
             }
             _ => Ok(()),

--- a/nexus-watcher/tests/event_processor/tags/del_idempotent.rs
+++ b/nexus-watcher/tests/event_processor/tags/del_idempotent.rs
@@ -10,7 +10,7 @@ use nexus_common::models::tag::traits::{TagCollection, TaggersCollection};
 use nexus_common::models::user::UserCounts;
 use nexus_watcher::events::handlers;
 use pubky::Keypair;
-use pubky_app_specs::{PubkyAppPost, PubkyAppUser, PubkyId};
+use pubky_app_specs::{tag_uri_builder, PubkyAppPost, PubkyAppUser};
 
 /// Use indexed_at far in the past so TAGGED edges don't interfere with
 /// hot-tags tests that query this_month/today timeframes.
@@ -92,8 +92,8 @@ async fn test_tag_post_del_retry_no_double_decrement() -> Result<()> {
     assert_eq!(find_post_counts(&author_id, &post_id).await.tags, 0);
 
     // Retry: call del handler directly — should delete graph without double-decrement
-    let tagger_pubky_id = PubkyId::from(tagger_kp.public_key());
-    handlers::tag::del(tagger_pubky_id, tag_id.to_string()).await?;
+    let tag_uri = tag_uri_builder(tagger_id.clone(), tag_id.to_string());
+    handlers::tag::del(&tag_uri).await?;
 
     // Verify final state: graph edge deleted, counters still 0
     let post_tag = find_post_tag(&author_id, &post_id, label).await?;
@@ -159,15 +159,15 @@ async fn test_tag_post_del_replay_after_success_skips() -> Result<()> {
     UserCounts::increment(&tagger_id, "tagged", None).await?;
 
     // First delete via handler (should succeed)
-    let tagger_pubky_id = PubkyId::from(tagger_kp.public_key());
-    handlers::tag::del(tagger_pubky_id.clone(), tag_id.to_string()).await?;
+    let tag_uri = tag_uri_builder(tagger_id.clone(), tag_id.to_string());
+    handlers::tag::del(&tag_uri).await?;
 
     // Verify fully deleted state
     let post_tag = find_post_tag(&author_id, &post_id, label).await?;
     assert!(post_tag.is_none());
 
     // Replay: call del again — should succeed as idempotent no-op
-    handlers::tag::del(tagger_pubky_id, tag_id.to_string()).await?;
+    handlers::tag::del(&tag_uri).await?;
 
     // Cleanup
     test.cleanup_post(&author_kp, &post_path).await?;

--- a/nexus-watcher/tests/event_processor/tags/mod.rs
+++ b/nexus-watcher/tests/event_processor/tags/mod.rs
@@ -1,5 +1,6 @@
 mod del_idempotent;
 mod fail_index;
+mod moderated;
 mod multi_user;
 mod post_del;
 mod post_del_notification;

--- a/nexus-watcher/tests/event_processor/tags/moderated.rs
+++ b/nexus-watcher/tests/event_processor/tags/moderated.rs
@@ -1,0 +1,249 @@
+use super::resource_utils::{compute_resource_id, find_resource_tag};
+use super::utils::find_post_tag;
+use crate::event_processor::utils::watcher::{HomeserverHashIdPath, WatcherTest};
+use anyhow::Result;
+use chrono::Utc;
+use pubky::{recovery_file, Keypair, ResourcePath};
+use pubky_app_specs::traits::HashId;
+use pubky_app_specs::{post_uri_builder, tag_uri_builder, PubkyAppPost, PubkyAppTag, PubkyAppUser};
+use tokio::fs;
+
+const MODERATION_LABEL: &str = "label_to_moderate";
+
+#[tokio_shared_rt::test(shared)]
+async fn test_moderation_deletes_pubky_app_tag() -> Result<()> {
+    let mut test = WatcherTest::setup().await?;
+    let moderator_kp = create_moderator(&mut test).await?;
+    let (_author_kp, author_id, post_id) = create_author_and_post(&mut test).await?;
+    let (tagger_kp, tagger_id) = create_tagger(&mut test, "pubky-app").await?;
+
+    let label = "moderate-pubky-app-tag";
+    let tag_uri = put_pubky_app_post_tag(
+        &mut test, &tagger_kp, &tagger_id, &author_id, &post_id, label,
+    )
+    .await?;
+
+    let post_tag = find_post_tag(&author_id, &post_id, label)
+        .await?
+        .expect("post tag should exist before moderation");
+    assert_eq!(post_tag.taggers_count, 1);
+
+    moderate_tag(&mut test, &moderator_kp, &tag_uri).await?;
+
+    let post_tag = find_post_tag(&author_id, &post_id, label).await?;
+    assert!(post_tag.is_none(), "pubky.app tag should be moderated");
+
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_moderation_deletes_universal_tag() -> Result<()> {
+    let mut test = WatcherTest::setup().await?;
+    let moderator_kp = create_moderator(&mut test).await?;
+    let (tagger_kp, tagger_id) = create_tagger(&mut test, "universal").await?;
+
+    let target_uri = format!("https://example.com/moderate-universal/{tagger_id}");
+    let label = "moderate-universal-tag";
+    let (tag_uri, resource_id) = put_universal_resource_tag(
+        &mut test,
+        &tagger_kp,
+        &tagger_id,
+        "mapky",
+        &target_uri,
+        label,
+    )
+    .await?;
+
+    assert!(
+        find_resource_tag(&resource_id, label).await?.is_some(),
+        "universal tag should exist before moderation"
+    );
+
+    moderate_tag(&mut test, &moderator_kp, &tag_uri).await?;
+
+    assert!(
+        find_resource_tag(&resource_id, label).await?.is_none(),
+        "universal tag should be moderated"
+    );
+
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_moderation_keeps_same_label_universal_tag_from_same_user() -> Result<()> {
+    let mut test = WatcherTest::setup().await?;
+    let moderator_kp = create_moderator(&mut test).await?;
+    let (_author_kp, author_id, post_id) = create_author_and_post(&mut test).await?;
+    let (tagger_kp, tagger_id) = create_tagger(&mut test, "same-user").await?;
+
+    let label = "shared-moderation-label-same-user";
+    let pubky_app_tag_uri = put_pubky_app_post_tag(
+        &mut test, &tagger_kp, &tagger_id, &author_id, &post_id, label,
+    )
+    .await?;
+    let target_uri = format!("https://example.com/same-user/{tagger_id}");
+    let (_universal_tag_uri, resource_id) = put_universal_resource_tag(
+        &mut test,
+        &tagger_kp,
+        &tagger_id,
+        "mapky",
+        &target_uri,
+        label,
+    )
+    .await?;
+
+    moderate_tag(&mut test, &moderator_kp, &pubky_app_tag_uri).await?;
+
+    assert!(
+        find_post_tag(&author_id, &post_id, label).await?.is_none(),
+        "targeted pubky.app tag should be moderated"
+    );
+    assert!(
+        find_resource_tag(&resource_id, label).await?.is_some(),
+        "same-label universal tag from same user should remain"
+    );
+
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_moderation_keeps_same_label_pubky_app_tag_from_different_user() -> Result<()> {
+    let mut test = WatcherTest::setup().await?;
+    let moderator_kp = create_moderator(&mut test).await?;
+    let (_author_kp, author_id, post_id) = create_author_and_post(&mut test).await?;
+    let (pubky_tagger_kp, pubky_tagger_id) =
+        create_tagger(&mut test, "different-user-pubky").await?;
+    let (universal_tagger_kp, universal_tagger_id) =
+        create_tagger(&mut test, "different-user-universal").await?;
+
+    let label = "shared-moderation-label-different-user";
+    put_pubky_app_post_tag(
+        &mut test,
+        &pubky_tagger_kp,
+        &pubky_tagger_id,
+        &author_id,
+        &post_id,
+        label,
+    )
+    .await?;
+    let target_uri = format!("https://example.com/different-user/{universal_tagger_id}");
+    let (universal_tag_uri, resource_id) = put_universal_resource_tag(
+        &mut test,
+        &universal_tagger_kp,
+        &universal_tagger_id,
+        "mapky",
+        &target_uri,
+        label,
+    )
+    .await?;
+
+    moderate_tag(&mut test, &moderator_kp, &universal_tag_uri).await?;
+
+    assert!(
+        find_resource_tag(&resource_id, label).await?.is_none(),
+        "targeted universal tag should be moderated"
+    );
+    let post_tag = find_post_tag(&author_id, &post_id, label)
+        .await?
+        .expect("same-label pubky.app tag from another user should remain");
+    assert_eq!(post_tag.taggers_count, 1);
+    assert!(post_tag.taggers.contains(&pubky_tagger_id));
+
+    Ok(())
+}
+
+async fn create_moderator(test: &mut WatcherTest) -> Result<Keypair> {
+    let moderator_recovery_file =
+        fs::read("./tests/event_processor/utils/moderator_key.pkarr").await?;
+    let moderator_kp = recovery_file::decrypt_recovery_file(&moderator_recovery_file, "password")?;
+    let moderator = test_user("Watcher:TagModerate:Moderator", "moderator");
+    test.create_user(&moderator_kp, &moderator).await?;
+    Ok(moderator_kp)
+}
+
+async fn create_author_and_post(test: &mut WatcherTest) -> Result<(Keypair, String, String)> {
+    let author_kp = Keypair::random();
+    let author = test_user("Watcher:TagModerate:Author", "author");
+    let author_id = test.create_user(&author_kp, &author).await?;
+    let post = PubkyAppPost {
+        content: format!("Watcher:TagModerate:Post:{author_id}"),
+        kind: PubkyAppPost::default().kind,
+        parent: None,
+        embed: None,
+        attachments: None,
+    };
+    let (post_id, _) = test.create_post(&author_kp, &post).await?;
+    Ok((author_kp, author_id, post_id))
+}
+
+async fn create_tagger(test: &mut WatcherTest, suffix: &str) -> Result<(Keypair, String)> {
+    let tagger_kp = Keypair::random();
+    let tagger = test_user(&format!("Watcher:TagModerate:Tagger:{suffix}"), suffix);
+    let tagger_id = test.create_user(&tagger_kp, &tagger).await?;
+    Ok((tagger_kp, tagger_id))
+}
+
+async fn put_pubky_app_post_tag(
+    test: &mut WatcherTest,
+    tagger_kp: &Keypair,
+    tagger_id: &str,
+    author_id: &str,
+    post_id: &str,
+    label: &str,
+) -> Result<String> {
+    let tag = PubkyAppTag {
+        uri: post_uri_builder(author_id.to_string(), post_id.to_string()),
+        label: label.to_string(),
+        created_at: Utc::now().timestamp_millis(),
+    };
+    let tag_id = tag.create_id();
+    let tag_uri = tag_uri_builder(tagger_id.to_string(), tag_id);
+    let tag_path = tag.hs_path();
+    test.put(tagger_kp, &tag_path, tag).await?;
+    Ok(tag_uri)
+}
+
+async fn put_universal_resource_tag(
+    test: &mut WatcherTest,
+    tagger_kp: &Keypair,
+    tagger_id: &str,
+    app: &str,
+    target_uri: &str,
+    label: &str,
+) -> Result<(String, String)> {
+    let tag = PubkyAppTag {
+        uri: target_uri.to_string(),
+        label: label.to_string(),
+        created_at: Utc::now().timestamp_millis(),
+    };
+    let tag_id = tag.create_id();
+    let resource_id = compute_resource_id(target_uri);
+    let tag_uri = format!("pubky://{tagger_id}/pub/{app}/tags/{tag_id}");
+    let tag_path: ResourcePath = format!("/pub/{app}/tags/{tag_id}").parse()?;
+    test.put(tagger_kp, &tag_path, tag).await?;
+    Ok((tag_uri, resource_id))
+}
+
+async fn moderate_tag(
+    test: &mut WatcherTest,
+    moderator_kp: &Keypair,
+    target_tag_uri: &str,
+) -> Result<()> {
+    let tag = PubkyAppTag {
+        uri: target_tag_uri.to_string(),
+        label: MODERATION_LABEL.to_string(),
+        created_at: Utc::now().timestamp_millis(),
+    };
+    let tag_path = tag.hs_path();
+    test.put(moderator_kp, &tag_path, tag).await
+}
+
+fn test_user(name: &str, bio: &str) -> PubkyAppUser {
+    PubkyAppUser {
+        bio: Some(bio.to_string()),
+        image: None,
+        links: None,
+        name: name.to_string(),
+        status: None,
+    }
+}

--- a/nexus-watcher/tests/event_processor/tags/moderated.rs
+++ b/nexus-watcher/tests/event_processor/tags/moderated.rs
@@ -17,7 +17,7 @@ async fn test_moderation_deletes_pubky_app_tag() -> Result<()> {
     let (_author_kp, author_id, post_id) = create_author_and_post(&mut test).await?;
     let (tagger_kp, tagger_id) = create_tagger(&mut test, "pubky-app").await?;
 
-    let label = "moderate-pubky-app-tag";
+    let label = "mod_pubky_app";
     let tag_uri = put_pubky_app_post_tag(
         &mut test, &tagger_kp, &tagger_id, &author_id, &post_id, label,
     )
@@ -43,7 +43,7 @@ async fn test_moderation_deletes_universal_tag() -> Result<()> {
     let (tagger_kp, tagger_id) = create_tagger(&mut test, "universal").await?;
 
     let target_uri = format!("https://example.com/moderate-universal/{tagger_id}");
-    let label = "moderate-universal-tag";
+    let label = "mod_universal";
     let (tag_uri, resource_id) = put_universal_resource_tag(
         &mut test,
         &tagger_kp,
@@ -76,7 +76,7 @@ async fn test_moderation_keeps_same_label_universal_tag_from_same_user() -> Resu
     let (_author_kp, author_id, post_id) = create_author_and_post(&mut test).await?;
     let (tagger_kp, tagger_id) = create_tagger(&mut test, "same-user").await?;
 
-    let label = "shared-moderation-label-same-user";
+    let label = "mod_same_user";
     let pubky_app_tag_uri = put_pubky_app_post_tag(
         &mut test, &tagger_kp, &tagger_id, &author_id, &post_id, label,
     )
@@ -116,7 +116,7 @@ async fn test_moderation_keeps_same_label_pubky_app_tag_from_different_user() ->
     let (universal_tagger_kp, universal_tagger_id) =
         create_tagger(&mut test, "different-user-universal").await?;
 
-    let label = "shared-moderation-label-different-user";
+    let label = "mod_diff_user";
     put_pubky_app_post_tag(
         &mut test,
         &pubky_tagger_kp,
@@ -156,14 +156,14 @@ async fn create_moderator(test: &mut WatcherTest) -> Result<Keypair> {
     let moderator_recovery_file =
         fs::read("./tests/event_processor/utils/moderator_key.pkarr").await?;
     let moderator_kp = recovery_file::decrypt_recovery_file(&moderator_recovery_file, "password")?;
-    let moderator = test_user("Watcher:TagModerate:Moderator", "moderator");
+    let moderator = test_user("Mod:Moderator", "moderator");
     test.create_user(&moderator_kp, &moderator).await?;
     Ok(moderator_kp)
 }
 
 async fn create_author_and_post(test: &mut WatcherTest) -> Result<(Keypair, String, String)> {
     let author_kp = Keypair::random();
-    let author = test_user("Watcher:TagModerate:Author", "author");
+    let author = test_user("Mod:Author", "author");
     let author_id = test.create_user(&author_kp, &author).await?;
     let post = PubkyAppPost {
         content: format!("Watcher:TagModerate:Post:{author_id}"),
@@ -178,7 +178,7 @@ async fn create_author_and_post(test: &mut WatcherTest) -> Result<(Keypair, Stri
 
 async fn create_tagger(test: &mut WatcherTest, suffix: &str) -> Result<(Keypair, String)> {
     let tagger_kp = Keypair::random();
-    let tagger = test_user(&format!("Watcher:TagModerate:Tagger:{suffix}"), suffix);
+    let tagger = test_user("Mod:Tagger", suffix);
     let tagger_id = test.create_user(&tagger_kp, &tagger).await?;
     Ok((tagger_kp, tagger_id))
 }

--- a/nexus-watcher/tests/event_processor/tags/moderated.rs
+++ b/nexus-watcher/tests/event_processor/tags/moderated.rs
@@ -167,10 +167,7 @@ async fn create_author_and_post(test: &mut WatcherTest) -> Result<(Keypair, Stri
     let author_id = test.create_user(&author_kp, &author).await?;
     let post = PubkyAppPost {
         content: format!("Watcher:TagModerate:Post:{author_id}"),
-        kind: PubkyAppPost::default().kind,
-        parent: None,
-        embed: None,
-        attachments: None,
+        ..Default::default()
     };
     let (post_id, _) = test.create_post(&author_kp, &post).await?;
     Ok((author_kp, author_id, post_id))
@@ -241,9 +238,7 @@ async fn moderate_tag(
 fn test_user(name: &str, bio: &str) -> PubkyAppUser {
     PubkyAppUser {
         bio: Some(bio.to_string()),
-        image: None,
-        links: None,
         name: name.to_string(),
-        status: None,
+        ..Default::default()
     }
 }

--- a/nexus-watcher/tests/event_processor/tags/moderated.rs
+++ b/nexus-watcher/tests/event_processor/tags/moderated.rs
@@ -70,6 +70,34 @@ async fn test_moderation_deletes_universal_tag() -> Result<()> {
 }
 
 #[tokio_shared_rt::test(shared)]
+async fn test_moderation_deletes_app_specific_known_post_tag() -> Result<()> {
+    let mut test = WatcherTest::setup().await?;
+    let moderator_kp = create_moderator(&mut test).await?;
+    let (_author_kp, author_id, post_id) = create_author_and_post(&mut test).await?;
+    let (tagger_kp, tagger_id) = create_tagger(&mut test, "known-post").await?;
+
+    let label = "mod_known_post";
+    let tag_uri = put_app_specific_post_tag(
+        &mut test, &tagger_kp, &tagger_id, "mapky", &author_id, &post_id, label,
+    )
+    .await?;
+
+    assert!(
+        find_post_tag(&author_id, &post_id, label).await?.is_some(),
+        "app-specific known post tag should exist before moderation"
+    );
+
+    moderate_tag(&mut test, &moderator_kp, &tag_uri).await?;
+
+    assert!(
+        find_post_tag(&author_id, &post_id, label).await?.is_none(),
+        "app-specific known post tag should be moderated"
+    );
+
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
 async fn test_moderation_keeps_same_label_universal_tag_from_same_user() -> Result<()> {
     let mut test = WatcherTest::setup().await?;
     let moderator_kp = create_moderator(&mut test).await?;
@@ -196,6 +224,27 @@ async fn put_pubky_app_post_tag(
     let tag_id = tag.create_id();
     let tag_uri = tag_uri_builder(tagger_id.to_string(), tag_id);
     let tag_path = tag.hs_path();
+    test.put(tagger_kp, &tag_path, tag).await?;
+    Ok(tag_uri)
+}
+
+async fn put_app_specific_post_tag(
+    test: &mut WatcherTest,
+    tagger_kp: &Keypair,
+    tagger_id: &str,
+    app: &str,
+    author_id: &str,
+    post_id: &str,
+    label: &str,
+) -> Result<String> {
+    let tag = PubkyAppTag {
+        uri: post_uri_builder(author_id.to_string(), post_id.to_string()),
+        label: label.to_string(),
+        created_at: Utc::now().timestamp_millis(),
+    };
+    let tag_id = tag.create_id();
+    let tag_uri = format!("pubky://{tagger_id}/pub/{app}/tags/{tag_id}");
+    let tag_path: ResourcePath = format!("/pub/{app}/tags/{tag_id}").parse()?;
     test.put(tagger_kp, &tag_path, tag).await?;
     Ok(tag_uri)
 }

--- a/nexus-watcher/tests/event_processor/tags/resource_internal_known.rs
+++ b/nexus-watcher/tests/event_processor/tags/resource_internal_known.rs
@@ -48,8 +48,8 @@ async fn test_resource_tag_internal_known_delegates_to_post() -> Result<()> {
     let tag_id = tag.create_id();
 
     // Store at /pub/mapky/tags/ instead of /pub/pubky.app/tags/
-    let custom_path: ResourcePath = format!("/pub/mapky/tags/{tag_id}").parse()?;
-    test.put(&user_kp, &custom_path, &tag).await?;
+    let universal_tag_path: ResourcePath = format!("/pub/mapky/tags/{tag_id}").parse()?;
+    test.put(&user_kp, &universal_tag_path, &tag).await?;
 
     // Verify: should be indexed as a POST tag (existing flow), not a Resource
     let post_tag = find_post_tag(&user_id, &post_id, label).await?;
@@ -70,8 +70,14 @@ async fn test_resource_tag_internal_known_delegates_to_post() -> Result<()> {
         "InternalKnown URI should NOT create a Resource node"
     );
 
-    // Cleanup
-    test.del(&user_kp, &custom_path).await?;
+    // Deleting the app-specific tag by URI should remove the tag from DB
+    test.del(&user_kp, &universal_tag_path).await?;
+    let post_tag = find_post_tag(&user_id, &post_id, label).await?;
+    assert!(
+        post_tag.is_none(),
+        "InternalKnown app-specific tag should be deleted from Post tag indexes"
+    );
+
     test.cleanup_post(&user_kp, &post_path).await?;
     test.cleanup_user(&user_kp).await?;
 


### PR DESCRIPTION
This PR (A) adds moderation tags for Universal Tags.

Adding these tests revealed a bug in `apply_moderation`: when a moderator's tag had its `uri` field pointing to a Universal Tag URI (e.g., `pubky://<user_id>/pub/mapky/tags/<tag_id>`), it failed silently because `ParsedUri::try_from` rejects URIs where the app segment isn't pubky.app.

Therefore, this PR also (B) fixes this `apply_moderation` bug.

---

Detailed list of changes made:
- `tag::del` now takes the full tag URI (`&str`) instead of (`user_id`, `tag_id`).
- Added app-aware tag URI parsing for `pubky://<user>/pub/<app>/tags/<tag_id>`.
- `apply_moderation` now detects tag storage URIs before calling `ParsedUri`, fixing Universal Tag moderation.
- `get_tag_target` now scopes by app, matching `delete_tag`.
- Updated standard DEL and universal-tag DEL handlers to pass the full URI.
- Updated direct `tag::del` tests to use `tag_uri_builder`.
- Added moderation tests for:
  - Deleting a pubky.app tag.
  - Deleting a Universal Tag.
  - Same-label pubky.app and Universal Tag from the same user.
  - Same-label pubky.app and Universal Tag from different users.