### PR TITLE
[`univ-tag-del` B] fix: tag deletion for tags pointing to known Pubky resources

### DIFF
--- a/nexus-watcher/src/events/handlers/tag.rs
+++ b/nexus-watcher/src/events/handlers/tag.rs
@@ -402,26 +402,32 @@ async fn put_sync_user(
 #[tracing::instrument(name = "tag.del", skip_all, fields(tag_uri = %tag_uri))]
 pub async fn del(tag_uri: &str) -> Result<(), EventProcessorError> {
     let tag_storage_uri = parse_tag_storage_uri(tag_uri)?;
-    let user_id = tag_storage_uri.user_id;
-    let tag_id = tag_storage_uri.tag_id;
-    let app = tag_storage_uri.app;
+    // Prefix these vars with arg_ to indicate they were extracted from the argument tag URI
+    // Similarly named vars will be used in Step 2 below, reading fields from the query result
+    let arg_user_id = tag_storage_uri.user_id;
+    let arg_tag_id = tag_storage_uri.tag_id;
+    let arg_app = tag_storage_uri.app;
 
-    debug!("Deleting tag: {} -> {} (app={app:?})", user_id, tag_id);
+    debug!("Deleting tag: {arg_user_id} -> {arg_tag_id} (app={arg_app:?})");
 
     // 1. Read target from graph WITHOUT deleting the edge
     let row = match fetch_row_from_graph(queries::get::get_tag_target(
-        &user_id,
-        &tag_id,
-        app.as_deref(),
+        &arg_user_id,
+        &arg_tag_id,
+        arg_app.as_deref(),
     ))
     .await?
     {
         Some(row) => row,
-        None if app.is_some() => {
+        None if arg_app.is_some() => {
             // App-specific tags that target known Pubky resources are indexed
             // through the standard Post/User tag flow, where TAGGED has no app.
-            let Some(row) =
-                fetch_row_from_graph(queries::get::get_tag_target(&user_id, &tag_id, None)).await?
+            let Some(row) = fetch_row_from_graph(queries::get::get_tag_target(
+                &arg_user_id,
+                &arg_tag_id,
+                None,
+            ))
+            .await?
             else {
                 // Edge already gone (fully completed on a prior attempt) - idempotent no-op
                 return Ok(());
@@ -453,18 +459,18 @@ pub async fn del(tag_uri: &str) -> Result<(), EventProcessorError> {
     match (tagged_user_id, post_id, author_id, resource_id) {
         (Some(tagged_id), None, None, None) => {
             let tagger_in_index =
-                TagUser::check_set_member(&[&tagged_id, &label], user_id.as_str())
+                TagUser::check_set_member(&[&tagged_id, &label], arg_user_id.as_str())
                     .await?
                     .1;
-            del_sync_user(user_id.clone(), &tagged_id, &label, tagger_in_index).await?;
+            del_sync_user(arg_user_id.clone(), &tagged_id, &label, tagger_in_index).await?;
         }
         (None, Some(post_id), Some(author_id), None) => {
             let tagger_in_index =
-                TagPost::check_set_member(&[&author_id, &post_id, &label], user_id.as_str())
+                TagPost::check_set_member(&[&author_id, &post_id, &label], arg_user_id.as_str())
                     .await?
                     .1;
             del_sync_post(
-                user_id.clone(),
+                arg_user_id.clone(),
                 &post_id,
                 &author_id,
                 &label,
@@ -473,7 +479,7 @@ pub async fn del(tag_uri: &str) -> Result<(), EventProcessorError> {
             .await?;
         }
         (None, None, None, Some(res_id)) => {
-            del_sync_resource(user_id.clone(), &res_id, &label, app.as_deref()).await?;
+            del_sync_resource(arg_user_id.clone(), &res_id, &label, app.as_deref()).await?;
         }
         _ => {
             debug!("DEL-Tag: Unexpected combination of tag details");
@@ -481,7 +487,12 @@ pub async fn del(tag_uri: &str) -> Result<(), EventProcessorError> {
     }
 
     // 3. Graph deletion LAST — ensures data survives for retry if Redis ops fail
-    fetch_row_from_graph(queries::del::delete_tag(&user_id, &tag_id, app.as_deref())).await?;
+    fetch_row_from_graph(queries::del::delete_tag(
+        &arg_user_id,
+        &arg_tag_id,
+        app.as_deref(),
+    ))
+    .await?;
 
     Ok(())
 }

--- a/nexus-watcher/src/events/handlers/tag.rs
+++ b/nexus-watcher/src/events/handlers/tag.rs
@@ -409,15 +409,35 @@ pub async fn del(tag_uri: &str) -> Result<(), EventProcessorError> {
     debug!("Deleting tag: {} -> {} (app={app:?})", user_id, tag_id);
 
     // 1. Read target from graph WITHOUT deleting the edge
-    let Some(row) = fetch_row_from_graph(queries::get::get_tag_target(
+    let row = match fetch_row_from_graph(queries::get::get_tag_target(
         &user_id,
         &tag_id,
         app.as_deref(),
     ))
     .await?
-    else {
-        // Edge already gone (fully completed on a prior attempt) — idempotent no-op
-        return Ok(());
+    {
+        Some(row) => row,
+        None if app.is_some() => {
+            // App-specific tags that target known Pubky resources are indexed
+            // through the standard Post/User tag flow, where TAGGED has no app.
+            let Some(row) =
+                fetch_row_from_graph(queries::get::get_tag_target(&user_id, &tag_id, None)).await?
+            else {
+                // Edge already gone (fully completed on a prior attempt) - idempotent no-op
+                return Ok(());
+            };
+
+            let resource_id: Option<String> = row.get("resource_id").unwrap_or(None);
+            if resource_id.is_some() {
+                return Ok(());
+            }
+
+            row
+        }
+        None => {
+            // Edge already gone (fully completed on a prior attempt) - idempotent no-op
+            return Ok(());
+        }
     };
 
     let tagged_user_id: Option<String> = row.get("user_id").unwrap_or(None);

--- a/nexus-watcher/tests/event_processor/tags/moderated.rs
+++ b/nexus-watcher/tests/event_processor/tags/moderated.rs
@@ -70,6 +70,34 @@ async fn test_moderation_deletes_universal_tag() -> Result<()> {
 }
 
 #[tokio_shared_rt::test(shared)]
+async fn test_moderation_deletes_app_specific_known_post_tag() -> Result<()> {
+    let mut test = WatcherTest::setup().await?;
+    let moderator_kp = create_moderator(&mut test).await?;
+    let (_author_kp, author_id, post_id) = create_author_and_post(&mut test).await?;
+    let (tagger_kp, tagger_id) = create_tagger(&mut test, "known-post").await?;
+
+    let label = "mod_known_post";
+    let tag_uri = put_app_specific_post_tag(
+        &mut test, &tagger_kp, &tagger_id, "mapky", &author_id, &post_id, label,
+    )
+    .await?;
+
+    assert!(
+        find_post_tag(&author_id, &post_id, label).await?.is_some(),
+        "app-specific known post tag should exist before moderation"
+    );
+
+    moderate_tag(&mut test, &moderator_kp, &tag_uri).await?;
+
+    assert!(
+        find_post_tag(&author_id, &post_id, label).await?.is_none(),
+        "app-specific known post tag should be moderated"
+    );
+
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
 async fn test_moderation_keeps_same_label_universal_tag_from_same_user() -> Result<()> {
     let mut test = WatcherTest::setup().await?;
     let moderator_kp = create_moderator(&mut test).await?;
@@ -199,6 +227,27 @@ async fn put_pubky_app_post_tag(
     let tag_id = tag.create_id();
     let tag_uri = tag_uri_builder(tagger_id.to_string(), tag_id);
     let tag_path = tag.hs_path();
+    test.put(tagger_kp, &tag_path, tag).await?;
+    Ok(tag_uri)
+}
+
+async fn put_app_specific_post_tag(
+    test: &mut WatcherTest,
+    tagger_kp: &Keypair,
+    tagger_id: &str,
+    app: &str,
+    author_id: &str,
+    post_id: &str,
+    label: &str,
+) -> Result<String> {
+    let tag = PubkyAppTag {
+        uri: post_uri_builder(author_id.to_string(), post_id.to_string()),
+        label: label.to_string(),
+        created_at: Utc::now().timestamp_millis(),
+    };
+    let tag_id = tag.create_id();
+    let tag_uri = format!("pubky://{tagger_id}/pub/{app}/tags/{tag_id}");
+    let tag_path: ResourcePath = format!("/pub/{app}/tags/{tag_id}").parse()?;
     test.put(tagger_kp, &tag_path, tag).await?;
     Ok(tag_uri)
 }

--- a/nexus-watcher/tests/event_processor/tags/resource_internal_known.rs
+++ b/nexus-watcher/tests/event_processor/tags/resource_internal_known.rs
@@ -48,8 +48,8 @@ async fn test_resource_tag_internal_known_delegates_to_post() -> Result<()> {
     let tag_id = tag.create_id();
 
     // Store at /pub/mapky/tags/ instead of /pub/pubky.app/tags/
-    let custom_path: ResourcePath = format!("/pub/mapky/tags/{tag_id}").parse()?;
-    test.put(&user_kp, &custom_path, &tag).await?;
+    let universal_tag_path: ResourcePath = format!("/pub/mapky/tags/{tag_id}").parse()?;
+    test.put(&user_kp, &universal_tag_path, &tag).await?;
 
     // Verify: should be indexed as a POST tag (existing flow), not a Resource
     let post_tag = find_post_tag(&user_id, &post_id, label).await?;
@@ -70,8 +70,8 @@ async fn test_resource_tag_internal_known_delegates_to_post() -> Result<()> {
         "InternalKnown URI should NOT create a Resource node"
     );
 
-    // Cleanup
-    test.del(&user_kp, &custom_path).await?;
+    // Deleting the app-specific tag by URI should remove the tag from DB
+    test.del(&user_kp, &universal_tag_path).await?;
     let post_tag = find_post_tag(&user_id, &post_id, label).await?;
     assert!(
         post_tag.is_none(),

--- a/nexus-watcher/tests/event_processor/tags/resource_internal_known.rs
+++ b/nexus-watcher/tests/event_processor/tags/resource_internal_known.rs
@@ -72,6 +72,12 @@ async fn test_resource_tag_internal_known_delegates_to_post() -> Result<()> {
 
     // Cleanup
     test.del(&user_kp, &custom_path).await?;
+    let post_tag = find_post_tag(&user_id, &post_id, label).await?;
+    assert!(
+        post_tag.is_none(),
+        "InternalKnown app-specific tag should be deleted from Post tag indexes"
+    );
+
     test.cleanup_post(&user_kp, &post_path).await?;
     test.cleanup_user(&user_kp).await?;
 


### PR DESCRIPTION
This PR addresses a bug in tag deletion, whereby Universal Tags that point to known Pubky resources (User / Post) would be skipped during deletion or moderation.

This is because when such tags are indexed, `sync_put_resource` delegates `InternalKnown` targets to `sync_put` (`nexus-watcher/src/events/handlers/tag.rs:76`), which creates post/user `TAGGED` edges without `tag.app` (`nexus-common/src/db/graph/queries/put.rs:239`). The new delete path parses `/pub/<app>/tags/<id>` and filters with `tag.app = $app` (`nexus-watcher/src/events/handlers/tag.rs:412`, `nexus-common/src/db/graph/queries/get.rs:132`), so the matching edge is not found and delete/moderation becomes an idempotent no-op. This affects normal DELs for app-specific internal-known tags and moderation tags pointing at those tag URIs.

---

Detailed list of changes made:
- `nexus-watcher/src/events/handlers/tag.rs`: app-specific tag deletes now fall back to the app-less Post/User tag edge used by the existing internal-known PUT flow.
- `nexus-watcher/tests/event_processor/tags/resource_internal_known.rs`: asserts app-specific internal-known DEL removes the Post tag.
- `nexus-watcher/tests/event_processor/tags/moderated.rs`: adds moderation coverage for app-specific known Post tags.