### PR TITLE
test: use temp dir for static files in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3196,6 +3196,7 @@ dependencies = [
  "rand 0.10.1",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-shared-rt",

--- a/nexus-common/src/config/mod.rs
+++ b/nexus-common/src/config/mod.rs
@@ -16,18 +16,6 @@ pub fn get_files_dir_pathbuf() -> PathBuf {
         .clone()
 }
 
-// All the tests run inside their own crate therefore the default directory does not apply
-pub const FILES_DIR_TEST: &str = "./static/files";
-static FILES_DIR_TEST_PATHBUF: OnceLock<PathBuf> = OnceLock::new();
-pub fn get_files_dir_test_pathbuf() -> PathBuf {
-    FILES_DIR_TEST_PATHBUF
-        .get_or_init(|| {
-            validate_and_expand_path(PathBuf::from(FILES_DIR_TEST))
-                .expect("Hardcoded FILES_DIR_TEST should be a valid directory path")
-        })
-        .clone()
-}
-
 mod api;
 mod daemon;
 pub mod file;

--- a/nexus-watcher/Cargo.toml
+++ b/nexus-watcher/Cargo.toml
@@ -27,4 +27,5 @@ base32 = "0.5"
 httpc-test = "0.1.10"
 pubky-testnet = { workspace = true }
 rand = "0.10.1"
+tempfile = { workspace = true }
 tokio-shared-rt = { workspace = true }

--- a/nexus-watcher/tests/event_processor/files/create.rs
+++ b/nexus-watcher/tests/event_processor/files/create.rs
@@ -5,7 +5,6 @@ use nexus_common::models::event::Event;
 use pubky::Keypair;
 use pubky_app_specs::traits::{HasIdPath, HashId};
 use pubky_app_specs::{blob_uri_builder, PubkyAppBlob, PubkyAppFile, PubkyAppUser};
-use std::path::Path;
 
 #[tokio_shared_rt::test(shared)]
 async fn test_put_pubkyapp_file() -> Result<()> {
@@ -48,9 +47,9 @@ async fn test_put_pubkyapp_file() -> Result<()> {
     let result_file = assert_file_details(&user_id, &file_id, &blob_absolute_url, &file).await;
 
     // Assert: Ensure it's created
-    let blob_static_path = format!("./static/files/{}", result_file.urls.main.clone());
+    let blob_static_path = test.temp_dir.path().join(&result_file.urls.main);
     assert!(
-        Path::new(&blob_static_path).exists(),
+        blob_static_path.exists(),
         "File have to exist after PUT event"
     );
     let (_, events_in_redis_after) = Event::get_events_from_redis(None, 1000).await.unwrap();

--- a/nexus-watcher/tests/event_processor/files/create.rs
+++ b/nexus-watcher/tests/event_processor/files/create.rs
@@ -5,6 +5,7 @@ use nexus_common::models::event::Event;
 use pubky::Keypair;
 use pubky_app_specs::traits::{HasIdPath, HashId};
 use pubky_app_specs::{blob_uri_builder, PubkyAppBlob, PubkyAppFile, PubkyAppUser};
+use std::path::Path;
 
 #[tokio_shared_rt::test(shared)]
 async fn test_put_pubkyapp_file() -> Result<()> {
@@ -47,10 +48,9 @@ async fn test_put_pubkyapp_file() -> Result<()> {
     let result_file = assert_file_details(&user_id, &file_id, &blob_absolute_url, &file).await;
 
     // Assert: Ensure it's created
-    let blob_static_path = test.temp_dir.path().join(&result_file.urls.main);
     assert!(
-        blob_static_path.exists(),
-        "File have to exist after PUT event"
+        Path::new(&result_file.urls.main).exists(),
+        "File must exist after PUT event"
     );
     let (_, events_in_redis_after) = Event::get_events_from_redis(None, 1000).await.unwrap();
     assert!(events_in_redis_after > events_in_redis_before);

--- a/nexus-watcher/tests/event_processor/files/create.rs
+++ b/nexus-watcher/tests/event_processor/files/create.rs
@@ -5,7 +5,6 @@ use nexus_common::models::event::Event;
 use pubky::Keypair;
 use pubky_app_specs::traits::{HasIdPath, HashId};
 use pubky_app_specs::{blob_uri_builder, PubkyAppBlob, PubkyAppFile, PubkyAppUser};
-use std::path::Path;
 
 #[tokio_shared_rt::test(shared)]
 async fn test_put_pubkyapp_file() -> Result<()> {
@@ -48,9 +47,10 @@ async fn test_put_pubkyapp_file() -> Result<()> {
     let result_file = assert_file_details(&user_id, &file_id, &blob_absolute_url, &file).await;
 
     // Assert: Ensure it's created
+    let blob_static_path = test.temp_dir.path().join(&result_file.urls.main);
     assert!(
-        Path::new(&result_file.urls.main).exists(),
-        "File must exist after PUT event"
+        blob_static_path.exists(),
+        "File have to exist after PUT event"
     );
     let (_, events_in_redis_after) = Event::get_events_from_redis(None, 1000).await.unwrap();
     assert!(events_in_redis_after > events_in_redis_before);

--- a/nexus-watcher/tests/event_processor/files/delete.rs
+++ b/nexus-watcher/tests/event_processor/files/delete.rs
@@ -10,6 +10,7 @@ use pubky_app_specs::{
     traits::{HasIdPath, HashId},
     PubkyAppBlob, PubkyAppFile, PubkyAppUser, PubkyId,
 };
+use std::path::Path;
 
 #[tokio_shared_rt::test(shared)]
 async fn test_delete_pubkyapp_file() -> Result<()> {
@@ -49,10 +50,10 @@ async fn test_delete_pubkyapp_file() -> Result<()> {
     let (file_id, file_path) = test.create_file(&user_kp, &file).await?;
 
     let result_file = assert_file_details(&user_id, &file_id, &blob_absolute_url, &file).await;
+    let file_path_on_disk = result_file.urls.main.clone();
 
-    let blob_static_path = test.temp_dir.path().join(&result_file.urls.main);
     assert!(
-        blob_static_path.exists(),
+        Path::new(&file_path_on_disk).exists(),
         "File have to exist after PUT event"
     );
 
@@ -78,14 +79,8 @@ async fn test_delete_pubkyapp_file() -> Result<()> {
     assert!(result_file.is_none());
 
     // Assert: Ensure it's deleted
-    let blob_static_path = test
-        .temp_dir
-        .path()
-        .join(&user_id)
-        .join(&file_id)
-        .join("main");
     assert!(
-        !blob_static_path.exists(),
+        !Path::new(&file_path_on_disk).exists(),
         "File cannot exist after DEL event"
     );
 

--- a/nexus-watcher/tests/event_processor/files/delete.rs
+++ b/nexus-watcher/tests/event_processor/files/delete.rs
@@ -78,12 +78,6 @@ async fn test_delete_pubkyapp_file() -> Result<()> {
     assert!(result_file.is_none());
 
     // Assert: Ensure it's deleted
-    let blob_static_path = test
-        .temp_dir
-        .path()
-        .join(&user_id)
-        .join(&file_id)
-        .join("main");
     assert!(
         !blob_static_path.exists(),
         "File cannot exist after DEL event"

--- a/nexus-watcher/tests/event_processor/files/delete.rs
+++ b/nexus-watcher/tests/event_processor/files/delete.rs
@@ -1,7 +1,6 @@
-use crate::event_processor::utils::watcher::WatcherTest;
+use crate::event_processor::utils::watcher::{assert_file_details, WatcherTest};
 use anyhow::Result;
 use chrono::Utc;
-use nexus_common::get_files_dir_test_pathbuf;
 use nexus_common::models::event::Event;
 use nexus_common::models::{file::FileDetails, traits::Collection};
 use nexus_watcher::events::handlers;
@@ -11,7 +10,6 @@ use pubky_app_specs::{
     traits::{HasIdPath, HashId},
     PubkyAppBlob, PubkyAppFile, PubkyAppUser, PubkyId,
 };
-use std::path::Path;
 
 #[tokio_shared_rt::test(shared)]
 async fn test_delete_pubkyapp_file() -> Result<()> {
@@ -50,6 +48,14 @@ async fn test_delete_pubkyapp_file() -> Result<()> {
 
     let (file_id, file_path) = test.create_file(&user_kp, &file).await?;
 
+    let result_file = assert_file_details(&user_id, &file_id, &blob_absolute_url, &file).await;
+
+    let blob_static_path = test.temp_dir.path().join(&result_file.urls.main);
+    assert!(
+        blob_static_path.exists(),
+        "File have to exist after PUT event"
+    );
+
     // Act
     let files_before_delete = FileDetails::get_by_ids(&[&[&user_id, &file_id]])
         .await
@@ -72,9 +78,14 @@ async fn test_delete_pubkyapp_file() -> Result<()> {
     assert!(result_file.is_none());
 
     // Assert: Ensure it's deleted
-    let blob_static_path = format!("./static/files/{}/{}/main", &user_id, &file_id);
+    let blob_static_path = test
+        .temp_dir
+        .path()
+        .join(&user_id)
+        .join(&file_id)
+        .join("main");
     assert!(
-        !Path::new(&blob_static_path).exists(),
+        !blob_static_path.exists(),
         "File cannot exist after DEL event"
     );
 
@@ -122,7 +133,8 @@ async fn test_delete_pubkyapp_file_is_idempotent() -> Result<()> {
 
     // Simulate a replay: call the DEL handler again directly (e.g. crash between FS delete and store_event)
     let user_pubky_id = PubkyId::try_from(user_id.as_str()).map_err(anyhow::Error::msg)?;
-    let result = handlers::file::del(&user_pubky_id, file_id, get_files_dir_test_pathbuf()).await;
+    let result =
+        handlers::file::del(&user_pubky_id, file_id, test.temp_dir.path().to_path_buf()).await;
 
     assert!(
         result.is_ok(),

--- a/nexus-watcher/tests/event_processor/files/delete.rs
+++ b/nexus-watcher/tests/event_processor/files/delete.rs
@@ -10,7 +10,6 @@ use pubky_app_specs::{
     traits::{HasIdPath, HashId},
     PubkyAppBlob, PubkyAppFile, PubkyAppUser, PubkyId,
 };
-use std::path::Path;
 
 #[tokio_shared_rt::test(shared)]
 async fn test_delete_pubkyapp_file() -> Result<()> {
@@ -50,10 +49,10 @@ async fn test_delete_pubkyapp_file() -> Result<()> {
     let (file_id, file_path) = test.create_file(&user_kp, &file).await?;
 
     let result_file = assert_file_details(&user_id, &file_id, &blob_absolute_url, &file).await;
-    let file_path_on_disk = result_file.urls.main.clone();
 
+    let blob_static_path = test.temp_dir.path().join(&result_file.urls.main);
     assert!(
-        Path::new(&file_path_on_disk).exists(),
+        blob_static_path.exists(),
         "File have to exist after PUT event"
     );
 
@@ -79,8 +78,14 @@ async fn test_delete_pubkyapp_file() -> Result<()> {
     assert!(result_file.is_none());
 
     // Assert: Ensure it's deleted
+    let blob_static_path = test
+        .temp_dir
+        .path()
+        .join(&user_id)
+        .join(&file_id)
+        .join("main");
     assert!(
-        !Path::new(&file_path_on_disk).exists(),
+        !blob_static_path.exists(),
         "File cannot exist after DEL event"
     );
 

--- a/nexus-watcher/tests/event_processor/posts/del_with_attachments.rs
+++ b/nexus-watcher/tests/event_processor/posts/del_with_attachments.rs
@@ -1,7 +1,5 @@
-use std::path::Path;
-
 use super::utils::find_post_details;
-use crate::event_processor::utils::watcher::WatcherTest;
+use crate::event_processor::utils::watcher::{assert_file_details, WatcherTest};
 use anyhow::Result;
 use chrono::Utc;
 use nexus_common::models::{file::FileDetails, traits::Collection};
@@ -50,7 +48,17 @@ async fn test_homeserver_del_post_with_attachments() -> Result<()> {
         };
         let (file_id, file_path) = test.create_file(&user_kp, &file).await?;
         file_paths.push(file_path);
-        file_ids.push(file_id);
+        file_ids.push(file_id.clone());
+
+        // Assert: Ensure file is created correctly in DB
+        let result_file = assert_file_details(&user_id, &file_id, &blob_absolute_url, &file).await;
+
+        // Assert: Ensure file exists on filesystem
+        let blob_static_path = test.temp_dir.path().join(&result_file.urls.main);
+        assert!(
+            blob_static_path.exists(),
+            "File have to exist after PUT event"
+        );
     }
 
     let post_attachments: Vec<String> = file_ids
@@ -79,18 +87,30 @@ async fn test_homeserver_del_post_with_attachments() -> Result<()> {
     test.cleanup_file(&user_kp, &file_paths[0]).await?;
     test.cleanup_file(&user_kp, &file_paths[1]).await?;
 
-    for file_id in file_ids {
-        let files = FileDetails::get_by_ids(&[&[&user_id, &file_id]])
+    // Assert: Ensure post is deleted
+    let err = find_post_details(&user_id, &post_id).await.unwrap_err();
+    assert!(
+        err.to_string().contains("Post node not found"),
+        "Post should be deleted after DEL event"
+    );
+
+    for file_id in &file_ids {
+        let files = FileDetails::get_by_ids(&[&[&user_id, file_id]])
             .await
             .expect("Failed to fetch files from Nexus");
 
         let result_file = files[0].as_ref();
         assert!(result_file.is_none());
 
-        // Assert: Ensure it's deleted
-        let blob_static_path = format!("./static/files/{}/{}/main", &user_id, &file_id);
+        // Assert: Ensure it's deleted from filesystem
+        let blob_static_path = test
+            .temp_dir
+            .path()
+            .join(&user_id)
+            .join(file_id)
+            .join("main");
         assert!(
-            !Path::new(&blob_static_path).exists(),
+            !blob_static_path.exists(),
             "File cannot exist after DEL event"
         );
     }

--- a/nexus-watcher/tests/event_processor/utils/watcher.rs
+++ b/nexus-watcher/tests/event_processor/utils/watcher.rs
@@ -139,7 +139,7 @@ impl WatcherTest {
 
         // Initialize the test-scoped EventProcessorRunner; mirrors the standard processor behavior
         let event_processor_runner =
-            Self::create_test_event_processor_runner(homeserver_id.clone(), files_path.clone());
+            Self::create_test_event_processor_runner(homeserver_id.clone(), files_path);
 
         Ok(Self {
             testnet,

--- a/nexus-watcher/tests/event_processor/utils/watcher.rs
+++ b/nexus-watcher/tests/event_processor/utils/watcher.rs
@@ -56,7 +56,7 @@ pub struct WatcherTest {
     pub event_processor_runner: EventProcessorRunner,
     /// Whether to ensure event processing is complete
     pub ensure_event_processing: bool,
-    /// Temp directory for static files. Kept alive so the directory is not deleted.
+    /// Keeps the static files temp dir alive for the test.
     pub temp_dir: TempDir,
 }
 
@@ -115,7 +115,7 @@ impl WatcherTest {
             return Err(Error::msg(format!("could not initialise the stack, {e:?}")));
         }
 
-        let temp_dir = TempDir::new().expect("Failed to create temp directory for test files");
+        let temp_dir = TempDir::new()?;
         let files_path = temp_dir.path().to_path_buf();
 
         // WARNING: testnet initialization is time expensive, we only init one per process

--- a/nexus-watcher/tests/event_processor/utils/watcher.rs
+++ b/nexus-watcher/tests/event_processor/utils/watcher.rs
@@ -3,7 +3,6 @@ use base32::{encode, Alphabet};
 use chrono::Utc;
 use nexus_common::db::PubkyConnector;
 use nexus_common::get_files_dir_pathbuf;
-use nexus_common::get_files_dir_test_pathbuf;
 use nexus_common::models::event::{Event, EventProcessorError, ParseResult};
 use nexus_common::models::file::FileDetails;
 use nexus_common::models::homeserver::Homeserver;
@@ -23,9 +22,11 @@ use pubky_app_specs::{
     PubkyAppFile, PubkyAppFollow, PubkyAppPost, PubkyAppUser, PubkyId,
 };
 use pubky_testnet::Testnet;
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
+use tempfile::TempDir;
 use tracing::debug;
 
 use crate::event_processor::utils::default_moderation_tests;
@@ -55,6 +56,8 @@ pub struct WatcherTest {
     pub event_processor_runner: EventProcessorRunner,
     /// Whether to ensure event processing is complete
     pub ensure_event_processing: bool,
+    /// Temp directory for static files. Kept alive so the directory is not deleted.
+    pub temp_dir: TempDir,
 }
 
 impl WatcherTest {
@@ -75,7 +78,10 @@ impl WatcherTest {
     ///
     /// # Returns
     /// Returns a fully configured `EventProcessorRunner` ready for use in tests.
-    fn create_test_event_processor_runner(default_homeserver: PubkyId) -> EventProcessorRunner {
+    fn create_test_event_processor_runner(
+        default_homeserver: PubkyId,
+        files_path: PathBuf,
+    ) -> EventProcessorRunner {
         let moderation = Arc::new(default_moderation_tests());
 
         let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
@@ -83,7 +89,7 @@ impl WatcherTest {
         EventProcessorRunner {
             limit: 1000,
             monitored_homeservers_limit: 100,
-            files_path: get_files_dir_test_pathbuf(),
+            files_path,
             tracer_name: "test".to_string(),
             moderation,
             shutdown_rx,
@@ -109,6 +115,9 @@ impl WatcherTest {
             return Err(Error::msg(format!("could not initialise the stack, {e:?}")));
         }
 
+        let temp_dir = TempDir::new().expect("Failed to create temp directory for test files");
+        let files_path = temp_dir.path().to_path_buf();
+
         // WARNING: testnet initialization is time expensive, we only init one per process
         // TODO: Maybe we should create a single testnet network (singleton and push there more homeservers)
         // This can be further sped up by using Testnet::new_unseeded() with pubky-testnet 0.7.x
@@ -130,13 +139,15 @@ impl WatcherTest {
         }
 
         // Initialize the test-scoped EventProcessorRunner; mirrors the standard processor behavior
-        let event_processor_runner = Self::create_test_event_processor_runner(pubky_id);
+        let event_processor_runner =
+            Self::create_test_event_processor_runner(pubky_id, files_path.clone());
 
         Ok(Self {
             testnet,
             homeserver_id,
             event_processor_runner,
             ensure_event_processing: true,
+            temp_dir,
         })
     }
 

--- a/nexus-webapi/tests/files/image.rs
+++ b/nexus-webapi/tests/files/image.rs
@@ -5,7 +5,7 @@ use crate::utils::server::TestServiceServer;
 use anyhow::Result;
 use nexus_common::media::FileVariant;
 use nexus_common::models::{file::FileDetails, traits::Collection};
-use tokio::fs::create_dir_all;
+use tokio::fs::{copy, create_dir_all};
 
 const IMAGE_BLOB_NAME: &str = "SynonymLogo.png";
 const BLOB_PATH: &str = "tests/files/blobs";
@@ -26,10 +26,11 @@ async fn test_static_image_serving_main() -> Result<()> {
 
     create_dir_all(&test_image_dir_path).await?;
     // copy the image from mocks folder to static folder
-    std::fs::copy(
+    copy(
         PathBuf::from(BLOB_PATH).join(IMAGE_BLOB_NAME),
         &full_image_path,
-    )?;
+    )
+    .await?;
 
     let files = FileDetails::get_by_ids(vec![vec![USER_PUBKY, FILE_ID].as_slice()].as_slice())
         .await
@@ -69,10 +70,11 @@ async fn test_static_image_serving_feed() -> Result<()> {
 
     create_dir_all(&test_image_dir_path).await?;
     // copy the image from mocks folder to static folder
-    std::fs::copy(
+    copy(
         PathBuf::from(BLOB_PATH).join(IMAGE_BLOB_NAME),
         &full_image_path,
-    )?;
+    )
+    .await?;
 
     let files = FileDetails::get_by_ids(vec![vec![USER_PUBKY, FILE_ID].as_slice()].as_slice())
         .await
@@ -119,10 +121,11 @@ async fn test_static_image_serving_small() -> Result<()> {
 
     create_dir_all(&test_image_dir_path).await?;
     // copy the image from mocks folder to static folder
-    std::fs::copy(
+    copy(
         PathBuf::from(BLOB_PATH).join(IMAGE_BLOB_NAME),
         &full_image_path,
-    )?;
+    )
+    .await?;
 
     let files = FileDetails::get_by_ids(vec![vec![USER_PUBKY, FILE_ID].as_slice()].as_slice())
         .await

--- a/nexus-webapi/tests/files/image.rs
+++ b/nexus-webapi/tests/files/image.rs
@@ -1,7 +1,4 @@
-use std::{
-    fs::{self},
-    path::PathBuf,
-};
+use std::path::PathBuf;
 
 use crate::utils::host_url;
 use crate::utils::server::TestServiceServer;
@@ -27,16 +24,9 @@ async fn test_static_image_serving_main() -> Result<()> {
         .join(FILE_ID);
     let full_image_path = test_image_dir_path.join("main");
 
-    // make sure directory exists
-    let exists = match fs::metadata(&test_image_dir_path) {
-        Err(_) => false,
-        Ok(metadata) => metadata.is_dir(),
-    };
-    if !exists {
-        create_dir_all(&test_image_dir_path).await?;
-    }
+    create_dir_all(&test_image_dir_path).await?;
     // copy the image from mocks folder to static folder
-    fs::copy(
+    std::fs::copy(
         PathBuf::from(BLOB_PATH).join(IMAGE_BLOB_NAME),
         &full_image_path,
     )?;
@@ -77,16 +67,9 @@ async fn test_static_image_serving_feed() -> Result<()> {
         .join(FILE_ID);
     let full_image_path = test_image_dir_path.join("main");
 
-    // make sure directory exists
-    let exists = match fs::metadata(&test_image_dir_path) {
-        Err(_) => false,
-        Ok(metadata) => metadata.is_dir(),
-    };
-    if !exists {
-        create_dir_all(&test_image_dir_path).await?;
-    }
+    create_dir_all(&test_image_dir_path).await?;
     // copy the image from mocks folder to static folder
-    fs::copy(
+    std::fs::copy(
         PathBuf::from(BLOB_PATH).join(IMAGE_BLOB_NAME),
         &full_image_path,
     )?;
@@ -134,16 +117,9 @@ async fn test_static_image_serving_small() -> Result<()> {
         .join(FILE_ID);
     let full_image_path = test_image_dir_path.join("main");
 
-    // make sure directory exists
-    let exists = match fs::metadata(&test_image_dir_path) {
-        Err(_) => false,
-        Ok(metadata) => metadata.is_dir(),
-    };
-    if !exists {
-        create_dir_all(&test_image_dir_path).await?;
-    }
+    create_dir_all(&test_image_dir_path).await?;
     // copy the image from mocks folder to static folder
-    fs::copy(
+    std::fs::copy(
         PathBuf::from(BLOB_PATH).join(IMAGE_BLOB_NAME),
         &full_image_path,
     )?;

--- a/nexus-webapi/tests/files/image.rs
+++ b/nexus-webapi/tests/files/image.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use crate::utils::host_url;
+use crate::utils::server::TestServiceServer;
 use anyhow::Result;
 use nexus_common::media::FileVariant;
 use nexus_common::models::{file::FileDetails, traits::Collection};
@@ -18,12 +19,16 @@ const USER_PUBKY: &str = "y4euc58gnmxun9wo87gwmanu6kztt9pgw1zz1yp1azp7trrsjamy";
 #[tokio_shared_rt::test(shared)]
 async fn test_static_image_serving_main() -> Result<()> {
     let client = httpc_test::new_client(host_url().await)?;
-
-    let test_image_dir_path = format!("static/files/{USER_PUBKY}/{FILE_ID}");
-    let full_image_path = format!("{}/main", test_image_dir_path.clone());
+    let test_image_dir_path = TestServiceServer::get_test_server()
+        .await
+        .temp_dir
+        .path()
+        .join(USER_PUBKY)
+        .join(FILE_ID);
+    let full_image_path = test_image_dir_path.join("main");
 
     // make sure directory exists
-    let exists = match fs::metadata(test_image_dir_path.clone()) {
+    let exists = match fs::metadata(&test_image_dir_path) {
         Err(_) => false,
         Ok(metadata) => metadata.is_dir(),
     };
@@ -64,12 +69,16 @@ async fn test_static_image_serving_main() -> Result<()> {
 #[tokio_shared_rt::test(shared)]
 async fn test_static_image_serving_feed() -> Result<()> {
     let client = httpc_test::new_client(host_url().await)?;
-
-    let test_image_dir_path = format!("static/files/{USER_PUBKY}/{FILE_ID}");
-    let full_image_path = format!("{}/main", test_image_dir_path.clone());
+    let test_image_dir_path = TestServiceServer::get_test_server()
+        .await
+        .temp_dir
+        .path()
+        .join(USER_PUBKY)
+        .join(FILE_ID);
+    let full_image_path = test_image_dir_path.join("main");
 
     // make sure directory exists
-    let exists = match fs::metadata(test_image_dir_path.clone()) {
+    let exists = match fs::metadata(&test_image_dir_path) {
         Err(_) => false,
         Ok(metadata) => metadata.is_dir(),
     };
@@ -117,12 +126,16 @@ async fn test_static_image_serving_feed() -> Result<()> {
 #[tokio_shared_rt::test(shared)]
 async fn test_static_image_serving_small() -> Result<()> {
     let client = httpc_test::new_client(host_url().await)?;
-
-    let test_image_dir_path = format!("static/files/{USER_PUBKY}/{FILE_ID}");
-    let full_image_path = format!("{}/main", test_image_dir_path.clone());
+    let test_image_dir_path = TestServiceServer::get_test_server()
+        .await
+        .temp_dir
+        .path()
+        .join(USER_PUBKY)
+        .join(FILE_ID);
+    let full_image_path = test_image_dir_path.join("main");
 
     // make sure directory exists
-    let exists = match fs::metadata(test_image_dir_path.clone()) {
+    let exists = match fs::metadata(&test_image_dir_path) {
         Err(_) => false,
         Ok(metadata) => metadata.is_dir(),
     };

--- a/nexus-webapi/tests/files/static_file.rs
+++ b/nexus-webapi/tests/files/static_file.rs
@@ -80,9 +80,7 @@ async fn test_static_serving_dl_param() -> Result<()> {
     file.write_all(b"Hello, world!")?;
 
     let url_path = format!("static/files/{test_file_user}/{test_file_id}/{test_file_name}");
-    let res = client
-        .do_get(format!("/{}?dl", url_path.as_str()).as_str())
-        .await?;
+    let res = client.do_get(&format!("/{url_path}?dl")).await?;
 
     assert_eq!(res.status(), 200);
     assert_eq!(

--- a/nexus-webapi/tests/files/static_file.rs
+++ b/nexus-webapi/tests/files/static_file.rs
@@ -1,7 +1,4 @@
-use std::{
-    fs::{self, File},
-    io::Write,
-};
+use std::{fs::File, io::Write};
 
 use crate::utils::host_url;
 use crate::utils::server::TestServiceServer;
@@ -33,14 +30,7 @@ async fn test_static_serving() -> Result<()> {
 
     let full_file_path = test_file_dir.join(test_file_name);
 
-    let exists = match fs::metadata(&test_file_dir) {
-        Err(_) => false,
-        Ok(metadata) => metadata.is_dir(),
-    };
-
-    if !exists {
-        create_dir_all(&test_file_dir).await?;
-    }
+    create_dir_all(&test_file_dir).await?;
 
     let mut file = File::create(&full_file_path)?;
     file.write_all(b"Hello, world!")?;
@@ -86,14 +76,7 @@ async fn test_static_serving_dl_param() -> Result<()> {
 
     let full_file_path = test_file_dir.join(test_file_name);
 
-    let exists = match fs::metadata(&test_file_dir) {
-        Err(_) => false,
-        Ok(metadata) => metadata.is_dir(),
-    };
-
-    if !exists {
-        create_dir_all(&test_file_dir).await?;
-    }
+    create_dir_all(&test_file_dir).await?;
 
     let mut file = File::create(&full_file_path)?;
     file.write_all(b"Hello, world!")?;

--- a/nexus-webapi/tests/files/static_file.rs
+++ b/nexus-webapi/tests/files/static_file.rs
@@ -36,9 +36,7 @@ async fn test_static_serving() -> Result<()> {
     file.write_all(b"Hello, world!")?;
 
     let url_path = format!("static/files/{test_file_user}/{test_file_id}/{test_file_name}");
-    let res = client
-        .do_get(&format!("/{url_path}"))
-        .await?;
+    let res = client.do_get(&format!("/{url_path}")).await?;
 
     assert_eq!(res.status(), 200);
     assert_eq!(

--- a/nexus-webapi/tests/files/static_file.rs
+++ b/nexus-webapi/tests/files/static_file.rs
@@ -3,11 +3,11 @@ use std::{
     io::Write,
 };
 
+use crate::utils::host_url;
+use crate::utils::server::TestServiceServer;
 use anyhow::Result;
 use nexus_common::models::{file::FileDetails, traits::Collection};
 use tokio::fs::create_dir_all;
-
-use crate::utils::host_url;
 
 #[tokio_shared_rt::test(shared)]
 async fn test_static_serving() -> Result<()> {
@@ -23,25 +23,31 @@ async fn test_static_serving() -> Result<()> {
 
     let result_file = files[0].as_ref().expect("Created file was not found.");
 
-    let test_file_path = format!("static/files/{test_file_user}/{test_file_id}");
+    let test_file_dir = TestServiceServer::get_test_server()
+        .await
+        .temp_dir
+        .path()
+        .join(test_file_user)
+        .join(test_file_id);
     let test_file_name = "main";
 
-    let full_path = format!("{}/{}", test_file_path.clone(), test_file_name);
+    let full_file_path = test_file_dir.join(test_file_name);
 
-    let exists = match fs::metadata(test_file_path.clone()) {
+    let exists = match fs::metadata(&test_file_dir) {
         Err(_) => false,
         Ok(metadata) => metadata.is_dir(),
     };
 
     if !exists {
-        create_dir_all(test_file_path.clone()).await?;
+        create_dir_all(&test_file_dir).await?;
     }
 
-    let mut file = File::create(full_path.as_str())?;
+    let mut file = File::create(&full_file_path)?;
     file.write_all(b"Hello, world!")?;
 
+    let url_path = format!("static/files/{test_file_user}/{test_file_id}/{test_file_name}");
     let res = client
-        .do_get(format!("/{}", full_path.as_str()).as_str())
+        .do_get(format!("/{}", url_path.as_str()).as_str())
         .await?;
 
     assert_eq!(res.status(), 200);
@@ -70,25 +76,31 @@ async fn test_static_serving_dl_param() -> Result<()> {
 
     let result_file = files[0].as_ref().expect("Created file was not found.");
 
-    let test_file_path = format!("static/files/{test_file_user}/{test_file_id}");
+    let test_file_dir = TestServiceServer::get_test_server()
+        .await
+        .temp_dir
+        .path()
+        .join(test_file_user)
+        .join(test_file_id);
     let test_file_name = "main";
 
-    let full_path = format!("{}/{}", test_file_path.clone(), test_file_name);
+    let full_file_path = test_file_dir.join(test_file_name);
 
-    let exists = match fs::metadata(test_file_path.clone()) {
+    let exists = match fs::metadata(&test_file_dir) {
         Err(_) => false,
         Ok(metadata) => metadata.is_dir(),
     };
 
     if !exists {
-        create_dir_all(test_file_path.clone()).await?;
+        create_dir_all(&test_file_dir).await?;
     }
 
-    let mut file = File::create(full_path.as_str())?;
+    let mut file = File::create(&full_file_path)?;
     file.write_all(b"Hello, world!")?;
 
+    let url_path = format!("static/files/{test_file_user}/{test_file_id}/{test_file_name}");
     let res = client
-        .do_get(format!("/{}?dl", full_path.as_str()).as_str())
+        .do_get(format!("/{}?dl", url_path.as_str()).as_str())
         .await?;
 
     assert_eq!(res.status(), 200);

--- a/nexus-webapi/tests/files/static_file.rs
+++ b/nexus-webapi/tests/files/static_file.rs
@@ -37,7 +37,7 @@ async fn test_static_serving() -> Result<()> {
 
     let url_path = format!("static/files/{test_file_user}/{test_file_id}/{test_file_name}");
     let res = client
-        .do_get(format!("/{}", url_path.as_str()).as_str())
+        .do_get(&format!("/{url_path}"))
         .await?;
 
     assert_eq!(res.status(), 200);

--- a/nexus-webapi/tests/utils/server.rs
+++ b/nexus-webapi/tests/utils/server.rs
@@ -12,7 +12,7 @@ use tokio::sync::OnceCell;
 pub struct TestServiceServer {
     pub nexus_api: NexusApi,
     pub testnet: pubky_testnet::Testnet,
-    /// Temp directory for static files. Kept alive so the directory is not deleted.
+    /// Keeps the static files temp dir alive for the test.
     pub temp_dir: TempDir,
 }
 

--- a/nexus-webapi/tests/utils/server.rs
+++ b/nexus-webapi/tests/utils/server.rs
@@ -1,8 +1,9 @@
 use std::net::SocketAddr;
 
 use anyhow::Result;
-use nexus_common::{get_files_dir_test_pathbuf, ApiConfig};
+use nexus_common::ApiConfig;
 use nexus_webapi::{api_context::ApiContextBuilder, NexusApi, NexusApiBuilder};
+use tempfile::TempDir;
 use tokio::sync::OnceCell;
 
 /// Util backend server for testing.
@@ -11,6 +12,8 @@ use tokio::sync::OnceCell;
 pub struct TestServiceServer {
     pub nexus_api: NexusApi,
     pub testnet: pubky_testnet::Testnet,
+    /// Temp directory for static files. Kept alive so the directory is not deleted.
+    pub temp_dir: TempDir,
 }
 
 /// [TestServiceServer] with no key republisher
@@ -24,8 +27,12 @@ impl TestServiceServer {
         TEST_SERVER
             .get_or_init(|| async {
                 let testnet = pubky_testnet::Testnet::new().await.unwrap();
-                let nexus_api = Self::start_server(&testnet, false).await.unwrap();
-                TestServiceServer { nexus_api, testnet }
+                let (nexus_api, temp_dir) = Self::start_server(&testnet, false).await.unwrap();
+                TestServiceServer {
+                    nexus_api,
+                    testnet,
+                    temp_dir,
+                }
             })
             .await
     }
@@ -38,8 +45,12 @@ impl TestServiceServer {
         TEST_SERVER_WITH_KEY_REPUBLISHER
             .get_or_init(|| async {
                 let testnet = pubky_testnet::Testnet::new().await.unwrap();
-                let nexus_api = Self::start_server(&testnet, true).await.unwrap();
-                TestServiceServer { nexus_api, testnet }
+                let (nexus_api, temp_dir) = Self::start_server(&testnet, true).await.unwrap();
+                TestServiceServer {
+                    nexus_api,
+                    testnet,
+                    temp_dir,
+                }
             })
             .await
     }
@@ -47,7 +58,7 @@ impl TestServiceServer {
     async fn start_server(
         testnet: &pubky_testnet::Testnet,
         enable_key_republisher: bool,
-    ) -> Result<NexusApi> {
+    ) -> Result<(NexusApi, TempDir)> {
         let test_api_config = ApiConfig {
             // When we define the sockets, use local port 0 so OS assigns an available port
             public_addr: SocketAddr::from(([127, 0, 0, 1], 0)),
@@ -55,8 +66,10 @@ impl TestServiceServer {
             ..Default::default()
         };
 
-        // Every time we start a test server, use a new temp config dir, which is automatically removed after the tests
-        let temp_config_dir = tempfile::TempDir::new_in(".")?;
+        // Separate temp directories: one for config (keypair), one for static files
+        let temp_config_dir = TempDir::new()?;
+        let temp_dir = TempDir::new()?;
+
         let api_context = ApiContextBuilder::from_config_dir(temp_config_dir.path().to_path_buf())
             .api_config(test_api_config)
             .pkarr_builder(testnet.pkarr_client_builder())
@@ -64,13 +77,13 @@ impl TestServiceServer {
             .await
             .expect("Failed to create ApiContext");
         let nexus_builder = NexusApiBuilder::new(api_context)
-            .files_path(get_files_dir_test_pathbuf())
+            .files_path(temp_dir.path().to_path_buf())
             .enable_key_republisher(enable_key_republisher);
 
         let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
         let _ = shutdown_tx.send(true); // We want the test server to return right away after start()
         let nexus_api = nexus_builder.start(Some(shutdown_rx)).await.unwrap();
 
-        Ok(nexus_api)
+        Ok((nexus_api, temp_dir))
     }
 }


### PR DESCRIPTION
Removes a hardcoded files dir for tests and switches to temp folders. Temp folders should be created in temp system directory so they will eventually be pruned. 

Right know files created by tests are kept under ever-growing `nexus-wracher/static/files` and `nexus-webapi/static/files`.