### PR TITLE
Remove graph fallback from `Homeserver::get_by_id`

### DIFF
--- a/nexus-common/src/models/homeserver.rs
+++ b/nexus-common/src/models/homeserver.rs
@@ -82,16 +82,13 @@ impl Homeserver {
     }
 
     pub async fn get_by_id(homeserver_id: PubkyId) -> ModelResult<Option<Homeserver>> {
-        match Homeserver::get_from_index(&homeserver_id).await? {
-            Some(hs) => Ok(Some(hs)),
-            None => match Self::get_from_graph(&homeserver_id).await? {
-                Some(hs_from_graph) => {
-                    hs_from_graph.put_to_index().await?;
-                    Ok(Some(hs_from_graph))
-                }
-                None => Ok(None),
-            },
-        }
+        // No graph fallback. A cache miss (or a Redis read error silently
+        // surfaced as `Ok(None)` by `json::get`) is treated as a failure
+        // and propagated to the caller, which puts the homeserver into
+        // backoff. The previous behaviour rebuilt from the graph (which
+        // does not store the cursor) and wrote cursor=0 back to Redis,
+        // silently overwriting the real value on a transient Redis hiccup.
+        Ok(Self::get_from_index(&homeserver_id).await?)
     }
 
     /// Verifies if homeserver exists in the graph, or persists it if missing


### PR DESCRIPTION
Hotfix for the cursor regression on 2026-05-11. See issue #860 for the full incident analysis.

`Homeserver::get_by_id` no longer falls back to the graph on a cache miss. `Ok(None)` propagates straight to `EventProcessorRunner::build`, which already converts it into `FailedToBuild`, and `HomeserverBackoff` parks the homeserver until the cache is back. The previous behaviour rebuilt the homeserver from Neo4j (which does not store the cursor) and wrote `cursor="0000000000000"` back to Redis, silently overwriting the real cursor whenever `json::get` swallowed a Redis read error as `Ok(None)`. That is what produced the year-old notification bleed last week.

Trade-off: a genuine "graph has the homeserver, cache does not" state (cache wiped, partial-failure during `persist_if_unknown`) is now an operator-intervention case instead of self-healing. Given the alternative is silently re-indexing a year of events, that is the correct trade.

#662 stays open as the follow-up that adds the `validate_cursor_change` monotonicity invariant for the other backward-write classes (in-flight batch overwrite in `processor.rs:111-115`, malformed `cursor:` line from a homeserver response, future backward writes). This hotfix and #662 are complementary, not redundant.