### PR TITLE
fix: stop json::get swallowing errors; re-seed homeserver index from graph

### DIFF
--- a/nexus-common/src/db/kv/index/json.rs
+++ b/nexus-common/src/db/kv/index/json.rs
@@ -3,7 +3,7 @@ use crate::db::kv::error::{RedisError, RedisResult};
 use deadpool_redis::redis::Script;
 use deadpool_redis::redis::{AsyncCommands, JsonAsyncCommands};
 use serde::{de::DeserializeOwned, Serialize};
-use tracing::{debug, trace};
+use tracing::debug;
 
 #[derive(Clone, Debug)]
 pub enum JsonAction {
@@ -405,21 +405,17 @@ pub async fn _get_bool(prefix: &str, key: &str) -> RedisResult<Option<bool>> {
     let mut redis_conn = get_redis_conn().await?;
     let index_key = format!("{prefix}:{key}");
 
-    if let Ok(indexed_value) = redis_conn.get::<_, i32>(&index_key).await {
-        trace!(
-            "Restored boolean key: {} with value: {}",
-            index_key,
-            indexed_value
-        );
-        let value = match indexed_value {
-            1 => true,
-            0 => false,
-            _ => return Ok(None), // Invalid value in Redis
-        };
-        return Ok(Some(value));
-    }
+    // Match `get<T>`'s contract: a genuine miss decodes to None, every other
+    // failure propagates via `?`. The previous `if let Ok(_)` shape collapsed
+    // every error into `Ok(None)` (see #860).
+    let indexed_value: Option<i32> = redis_conn.get(&index_key).await?;
 
-    Ok(None)
+    match indexed_value {
+        Some(1) => Ok(Some(true)),
+        Some(0) => Ok(Some(false)),
+        Some(_) => Ok(None), // Invalid value in Redis
+        None => Ok(None),
+    }
 }
 
 /// Deletes multiple keys from Redis.

--- a/nexus-common/src/db/kv/index/json.rs
+++ b/nexus-common/src/db/kv/index/json.rs
@@ -305,19 +305,22 @@ pub async fn get<T: DeserializeOwned + Send + Sync>(
 ) -> RedisResult<Option<T>> {
     let mut redis_conn = get_redis_conn().await?;
     let index_key = format!("{prefix}:{key}");
-    let json_path = path.unwrap_or("$").to_string(); // Ensure path is a String
+    let json_path = path.unwrap_or("$");
 
-    // Use RedisJSON commands to get the value from the specified path
-    if let Ok(indexed_value) = redis_conn
-        .json_get::<String, String, String>(index_key.clone(), json_path)
-        .await
-    {
-        //debug!("Restored key: {} with value: {}", index_key, indexed_value);
-        let value: Vec<T> = from_json_str(&indexed_value)?;
-        return Ok(value.into_iter().next()); // Extract the first element from the Vec
+    // Bind to Option<String>: a genuine Nil reply (key absent) decodes to
+    // None; any other redis-side failure propagates via `?`. The previous
+    // `if let Ok(_)` shape collapsed every failure mode into `Ok(None)`,
+    // which let read-through caches mistake a transient error for a clean
+    // miss and bootstrap a default over real state (see #860).
+    let indexed_value: Option<String> = redis_conn.json_get(index_key, json_path).await?;
+
+    match indexed_value {
+        Some(s) => {
+            let value: Vec<T> = from_json_str(&s)?;
+            Ok(value.into_iter().next())
+        }
+        None => Ok(None),
     }
-
-    Ok(None)
 }
 
 /// Retrieves a list of JSON values from Redis based on a list of keys.
@@ -450,4 +453,72 @@ fn to_json_value<T: Serialize>(value: &T) -> RedisResult<serde_json::Value> {
 
 fn from_json_str<T: DeserializeOwned>(s: &str) -> RedisResult<T> {
     serde_json::from_str(s).map_err(|e| RedisError::DeserializationFailed(Box::new(e)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::get_redis_conn;
+    use crate::{types::DynError, StackConfig, StackManager};
+    use serde::{Deserialize, Serialize};
+
+    const TEST_PREFIX: &str = "JsonGetTest";
+
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct TestPayload {
+        value: u32,
+    }
+
+    #[tokio_shared_rt::test(shared)]
+    async fn test_get_roundtrip_returns_some() -> Result<(), DynError> {
+        StackManager::setup(&StackConfig::default()).await?;
+
+        let key = "roundtrip";
+        del_multiple(TEST_PREFIX, &[key]).await?;
+
+        let payload = TestPayload { value: 42 };
+        put(TEST_PREFIX, key, &payload, None, None).await?;
+
+        let retrieved: Option<TestPayload> = get(TEST_PREFIX, key, None).await?;
+        assert_eq!(retrieved, Some(TestPayload { value: 42 }));
+
+        del_multiple(TEST_PREFIX, &[key]).await?;
+        Ok(())
+    }
+
+    #[tokio_shared_rt::test(shared)]
+    async fn test_get_missing_key_returns_none() -> Result<(), DynError> {
+        StackManager::setup(&StackConfig::default()).await?;
+
+        let key = "missing";
+        del_multiple(TEST_PREFIX, &[key]).await?;
+
+        let retrieved: Option<TestPayload> = get(TEST_PREFIX, key, None).await?;
+        assert!(retrieved.is_none());
+
+        Ok(())
+    }
+
+    // Regression test for #860: a redis-side error from `JSON.GET` must surface
+    // as `Err`, not get collapsed into `Ok(None)`. Storing a plain string at the
+    // key forces `JSON.GET` to reply with a WRONGTYPE error.
+    #[tokio_shared_rt::test(shared)]
+    async fn test_get_on_wrong_type_propagates_err() -> Result<(), DynError> {
+        StackManager::setup(&StackConfig::default()).await?;
+
+        let key = "wrong-type";
+        let full_key = format!("{TEST_PREFIX}:{key}");
+
+        let mut conn = get_redis_conn().await?;
+        let _: () = conn.set(&full_key, "not-a-json-document").await?;
+
+        let result: RedisResult<Option<TestPayload>> = get(TEST_PREFIX, key, None).await;
+        assert!(
+            matches!(result, Err(RedisError::CommandFailed(_))),
+            "expected Err(CommandFailed), got {result:?}"
+        );
+
+        del_multiple(TEST_PREFIX, &[key]).await?;
+        Ok(())
+    }
 }

--- a/nexus-common/src/db/kv/index/json.rs
+++ b/nexus-common/src/db/kv/index/json.rs
@@ -3,7 +3,7 @@ use crate::db::kv::error::{RedisError, RedisResult};
 use deadpool_redis::redis::Script;
 use deadpool_redis::redis::{AsyncCommands, JsonAsyncCommands};
 use serde::{de::DeserializeOwned, Serialize};
-use tracing::debug;
+use tracing::{debug, warn};
 
 #[derive(Clone, Debug)]
 pub enum JsonAction {
@@ -307,11 +307,6 @@ pub async fn get<T: DeserializeOwned + Send + Sync>(
     let index_key = format!("{prefix}:{key}");
     let json_path = path.unwrap_or("$");
 
-    // Bind to Option<String>: a genuine Nil reply (key absent) decodes to
-    // None; any other redis-side failure propagates via `?`. The previous
-    // `if let Ok(_)` shape collapsed every failure mode into `Ok(None)`,
-    // which let read-through caches mistake a transient error for a clean
-    // miss and bootstrap a default over real state (see #860).
     let indexed_value: Option<String> = redis_conn.json_get(index_key, json_path).await?;
 
     match indexed_value {
@@ -405,15 +400,15 @@ pub async fn _get_bool(prefix: &str, key: &str) -> RedisResult<Option<bool>> {
     let mut redis_conn = get_redis_conn().await?;
     let index_key = format!("{prefix}:{key}");
 
-    // Match `get<T>`'s contract: a genuine miss decodes to None, every other
-    // failure propagates via `?`. The previous `if let Ok(_)` shape collapsed
-    // every error into `Ok(None)` (see #860).
     let indexed_value: Option<i32> = redis_conn.get(&index_key).await?;
 
     match indexed_value {
         Some(1) => Ok(Some(true)),
         Some(0) => Ok(Some(false)),
-        Some(_) => Ok(None), // Invalid value in Redis
+        Some(other) => {
+            warn!("Unexpected non-boolean value at key {index_key}: {other}");
+            Ok(None)
+        }
         None => Ok(None),
     }
 }

--- a/nexus-common/src/models/homeserver.rs
+++ b/nexus-common/src/models/homeserver.rs
@@ -20,8 +20,13 @@ use tracing::{info, warn};
 pub struct Homeserver {
     pub id: PubkyId,
 
-    // We persist this field only in the cache, but not in the graph.
-    // Redis has regular snapshots, which ensures we get a recent state in case of RAM data loss (system crash).
+    // Cursor lives in Redis only (not the graph). Redis snapshots can
+    // lag, so a crash may lose recent advancement — the watcher then
+    // resumes from whatever cursor survived in the snapshot and catches
+    // up from the homeserver. We do NOT re-index from scratch on partial
+    // loss; `persist_if_unknown` only re-seeds cursor=0 when the
+    // Homeserver key is missing from Redis entirely (e.g. wiped volume),
+    // never on a routine crash.
     pub cursor: String,
 }
 

--- a/nexus-common/src/models/homeserver.rs
+++ b/nexus-common/src/models/homeserver.rs
@@ -13,7 +13,7 @@ use crate::models::user::UserDetails;
 use pubky_app_specs::ParsedUri;
 use pubky_app_specs::PubkyId;
 use serde::{Deserialize, Serialize};
-use tracing::info;
+use tracing::{info, warn};
 
 /// Represents a homeserver with its public key, URL, and cursor.
 #[derive(Serialize, Deserialize, Debug)]
@@ -91,12 +91,46 @@ impl Homeserver {
         Ok(Self::get_from_index(&homeserver_id).await?)
     }
 
-    /// Verifies if homeserver exists in the graph, or persists it if missing
+    /// Ensures the homeserver is recorded in both the graph and the index.
+    ///
+    /// - First-time install (missing from both): writes a fresh
+    ///   [`Homeserver::new`] to graph and index.
+    /// - Asymmetric state (present in graph, missing from index): re-seeds the
+    ///   index with the default cursor and logs a warning. This is the
+    ///   self-heal path for a wiped Redis volume sitting alongside a persisted
+    ///   Neo4j volume — common in dev/testnet workflows where operators tear
+    ///   down one store but not the other. The watcher will then re-index
+    ///   from `cursor=0`, which is the same recovery the system performs
+    ///   after a Redis crash by design.
+    /// - Both already present: no-op.
+    ///
+    /// Safe to call repeatedly. Relies on `get_from_index` returning a
+    /// reliable `Ok(None)` for genuine cache misses; if the read errors, the
+    /// error propagates and the re-seed never fires.
     pub async fn persist_if_unknown(homeserver_id: PubkyId) -> ModelResult<()> {
-        if Self::get_from_graph(&homeserver_id).await?.is_none() {
-            info!("Persisting new homeserver: {homeserver_id}");
-            let homeserver = Homeserver::new(homeserver_id);
+        let in_graph = Self::get_from_graph(&homeserver_id).await?.is_some();
+        let in_index = Self::get_from_index(&homeserver_id).await?.is_some();
+
+        if in_graph && in_index {
+            return Ok(());
+        }
+
+        let homeserver = Homeserver::new(homeserver_id.clone());
+
+        if !in_graph {
+            info!("Persisting new homeserver to graph: {homeserver_id}");
             homeserver.put_to_graph().await?;
+        }
+
+        if !in_index {
+            if in_graph {
+                warn!(
+                    "Homeserver {homeserver_id} present in graph but missing from index; \
+                     re-seeding index with default cursor — watcher will re-index from 0"
+                );
+            } else {
+                info!("Persisting new homeserver to index: {homeserver_id}");
+            }
             homeserver.put_to_index().await?;
         }
 
@@ -215,6 +249,75 @@ mod tests {
 
         assert_eq!(id, hs_from_index.id);
 
+        Ok(())
+    }
+
+    #[tokio_shared_rt::test(shared)]
+    async fn test_persist_if_unknown_first_time_install_writes_both() -> Result<(), DynError> {
+        StackManager::setup(&StackConfig::default()).await?;
+
+        let keys = Keypair::random();
+        let id = PubkyId::try_from(&keys.public_key().to_z32())?;
+
+        Homeserver::persist_if_unknown(id.clone()).await?;
+
+        assert!(Homeserver::get_from_graph(&id).await?.is_some());
+        assert!(Homeserver::get_from_index(&id).await?.is_some());
+        Ok(())
+    }
+
+    // Regression test for the docker-testnet asymmetric-storage scenario:
+    // graph volume persisted, Redis volume wiped. Before this fix, watcher
+    // looped on "Homeserver not found" forever because get_by_id only reads
+    // the index and persist_if_unknown only wrote when the graph was empty.
+    #[tokio_shared_rt::test(shared)]
+    async fn test_persist_if_unknown_reseeds_index_when_only_graph_has_it() -> Result<(), DynError>
+    {
+        StackManager::setup(&StackConfig::default()).await?;
+
+        let keys = Keypair::random();
+        let id = PubkyId::try_from(&keys.public_key().to_z32())?;
+
+        // Simulate "graph persisted, Redis wiped": write to graph only.
+        Homeserver::new(id.clone()).put_to_graph().await?;
+        assert!(
+            Homeserver::get_from_index(&id).await?.is_none(),
+            "precondition: index should be empty for a fresh keypair"
+        );
+
+        Homeserver::persist_if_unknown(id.clone()).await?;
+
+        let from_index = Homeserver::get_from_index(&id)
+            .await?
+            .expect("index should be re-seeded after persist_if_unknown");
+        assert_eq!(from_index.id, id);
+        assert_eq!(from_index.cursor, "0000000000000");
+        Ok(())
+    }
+
+    #[tokio_shared_rt::test(shared)]
+    async fn test_persist_if_unknown_is_noop_when_both_present() -> Result<(), DynError> {
+        StackManager::setup(&StackConfig::default()).await?;
+
+        let keys = Keypair::random();
+        let id = PubkyId::try_from(&keys.public_key().to_z32())?;
+
+        // Seed both stores with a non-default cursor to prove the no-op
+        // branch doesn't overwrite an existing index entry.
+        Homeserver::new(id.clone()).put_to_graph().await?;
+        Homeserver::try_from_cursor(id.clone(), "1234567890123")?
+            .put_to_index()
+            .await?;
+
+        Homeserver::persist_if_unknown(id.clone()).await?;
+
+        let from_index = Homeserver::get_from_index(&id)
+            .await?
+            .expect("index entry should still be present");
+        assert_eq!(
+            from_index.cursor, "1234567890123",
+            "existing cursor must not be overwritten"
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

Two complementary fixes for the post-#861 homeserver indexing path, motivated by [#860](https://github.com/pubky/pubky-nexus/issues/860) and by the docker-testnet failure mode James hit in #nexus this week:

```
ERROR nexus_watcher::service::traits::tevent_processor_runner:127:
  Failed to build event processor for homeserver: 8pinx…: Homeserver not found
…
Skipping homeserver 8pinx… (in backoff)
```

…on every subsequent docker testnet stack run, with no way to recover except wiping local storage.

## What's in the PR

### 1. `nexus-common/src/db/kv/index/json.rs` — stop `json::get` collapsing Redis errors into `Ok(None)`

The `if let Ok(_)` shape on `json_get` discarded every failure mode — server errors, WRONGTYPE, I/O timeouts, deserialization quirks from the redis crate — into `Ok(None)`, making a transient hiccup indistinguishable from a clean cache miss. That's the silent-swallow #860 called out as the residual fix after #861 removed the `Homeserver::get_by_id` graph fallback.

Binds `json_get` to `Option<String>` so the redis crate's `FromRedisValue` decodes a genuine `Nil` to `None` and propagates every other error via `?`. Same shape as the existing `json_mget` call site a few lines down. No public API change.

The sibling `_get_bool` is `pub` and had the same silent-swallow shape (no callers today, but the divergent contract was a footgun for any future user); it gets the same `Option<i32>` + `?` rewrite for consistency.

This is also a precondition for fix 2: with errors propagating, an `Ok(None)` from `get_from_index` is finally a reliable signal that Redis is *genuinely* empty.

### 2. `nexus-common/src/models/homeserver.rs` — `persist_if_unknown` re-seeds the index when only the graph has the homeserver

`persist_if_unknown` only wrote when the graph was missing the homeserver. Since #861 stopped `get_by_id` from rebuilding the index from the graph, the asymmetric storage state — Neo4j volume persisted, Redis volume wiped — leaves the watcher stuck logging `Homeserver not found` on every tick and parking the homeserver in 60s/3600s backoff with no path back. That state happens every time a docker testnet operator tears one volume down without the other (the common "down -v on one stack, keep the other" workflow), and it's exactly what James reported:

> I'm seeing this on subsequent docker testnet stack runs and nexus doesn't seem to index homeserver. A quick fix is to wipe local storage and start fresh.

This PR restores the self-heal-on-restart behaviour the system was designed around — but only at the bootstrap call site (`NexusWatcher::start` and `maybe_ingest_for_user`), only as a one-shot write, never as a mid-flight `get_by_id` fallback. The watcher then re-indexes from `cursor=0`, which is the same recovery the system already performs after a Redis crash by design. The asymmetric branch logs a warning so operators can see when the heal fires.

Safety analysis:

- **Mid-flight cursor regression** (the bug #861 fixed): not possible. `persist_if_unknown` runs once per homeserver entry — at startup for the config HS, on first sighting for an external HS. It is not on the per-tick `get_by_id` path.
- **Transient Redis hiccup at startup**: with fix 1 in place, a Redis error propagates as `Err` and the re-seed never fires. Without fix 1, a hiccup could trigger a spurious cursor=0 re-seed — which is why the two changes ship together.

## Behaviour change & blast radius

`json::get` (and `_get_bool`):
- Genuine missing key → `Ok(None)` (unchanged).
- Redis error / WRONGTYPE / I/O / deserialization-from-redis → `Err(RedisError::*)` (was `Ok(None)`).

Caller audit walked every direct and indirect caller of `try_from_index_json` / `try_from_index_multiple_json` / `mget`. No caller has a "treat `Ok(None)` as fresh-install, write a default" pattern except `Homeserver::get_by_id` (already guarded by #861) and the bootstrap writes in `UserCounts::sync_put` / `PostCounts::sync_put`, which gate the default write behind a separate `is_none()` check after `?` propagation — a Redis error now aborts the put rather than writing a stale default. Route handlers using read-through caches will surface 5xx on Redis trouble instead of a misleading 404.

`persist_if_unknown`:
- New: graph has the row, index doesn't → re-seed the index with `cursor=0` and `warn!` (the testnet self-heal path).
- Unchanged: graph missing → write to both (first-time bootstrap).
- Unchanged: both present → no-op. Existing cursor is never overwritten.

## Tests

Six new tests, all passing locally (`cargo nextest run -p nexus-common` — 63/63):

`db::kv::index::json::tests`:
- `test_get_roundtrip_returns_some` — put + get round-trip returns `Ok(Some(_))`.
- `test_get_missing_key_returns_none` — unset key still returns `Ok(None)`.
- `test_get_on_wrong_type_propagates_err` — `SET` a plain string at the key, then `JSON.GET` it; asserts `Err(RedisError::CommandFailed(_))`. Direct regression test for #860; before fix 1, this returned `Ok(None)`.

`models::homeserver::tests`:
- `test_persist_if_unknown_first_time_install_writes_both` — preserved behaviour.
- `test_persist_if_unknown_reseeds_index_when_only_graph_has_it` — direct regression test for James's docker-testnet scenario. Before fix 2, the index stayed empty.
- `test_persist_if_unknown_is_noop_when_both_present` — seeds index with a non-default cursor (`1234567890123`), runs `persist_if_unknown`, asserts the cursor is preserved. Confirms steady-state runs don't overwrite real state.

### Verification

- [x] `cargo check --workspace`
- [x] `cargo nextest run -p nexus-common --no-fail-fast` — 63/63 passing including the 6 new tests
- [x] Manual repro of James's scenario passes via `test_persist_if_unknown_reseeds_index_when_only_graph_has_it`

## Out of scope

- PR [#662](https://github.com/pubky/pubky-nexus/pull/662) (`ok300-prevent-hs-reindexing`) adds the monotonic-cursor invariant; #860 calls for it as a separate primary fix and it should be rebased and merged on its own.
- Redis durability in `docker/docker-compose.yml` (default RDB, no AOF). Not changed here; the heal path makes the asymmetry recoverable instead of changing the persistence configuration.
