### PR TITLE
fix: bump RetryEvent redis key prefix to V2 for schema break

### DIFF
--- a/nexus-watcher/src/events/retry/event.rs
+++ b/nexus-watcher/src/events/retry/event.rs
@@ -7,9 +7,11 @@ use nexus_common::db::RedisOps;
 
 use crate::events::EventProcessorError;
 
-const RETRY_MANAGER_PREFIX: &str = "RetryManager";
-const RETRY_MANAGER_EVENTS_INDEX: [&str; 1] = ["events"];
-const RETRY_MANAGER_STATE_INDEX: [&str; 1] = ["state"];
+// v2: RetryEvent schema changed incompatibly; bumped prefix so old keys under
+// "RetryManager:*" stay orphaned rather than failing to deserialize.
+pub const RETRY_MANAGER_PREFIX: &str = "RetryManagerV2";
+pub const RETRY_MANAGER_EVENTS_INDEX: [&str; 1] = ["events"];
+pub const RETRY_MANAGER_STATE_INDEX: [&str; 1] = ["state"];
 
 /// Represents an event in the retry queue and it is used to manage events that have failed
 /// to process and need to be retried

--- a/nexus-watcher/src/events/retry/mod.rs
+++ b/nexus-watcher/src/events/retry/mod.rs
@@ -3,7 +3,9 @@ pub mod processor;
 pub mod scheduler;
 pub mod store;
 
-pub use event::RetryEvent;
+pub use event::{
+    RetryEvent, RETRY_MANAGER_EVENTS_INDEX, RETRY_MANAGER_PREFIX, RETRY_MANAGER_STATE_INDEX,
+};
 pub use processor::RetryProcessor;
 pub use scheduler::{InitialBackoff, RetryScheduler};
 pub use store::{InMemoryRetryStore, RedisRetryStore, RetryStore};

--- a/nexus-watcher/tests/service/retry_processor.rs
+++ b/nexus-watcher/tests/service/retry_processor.rs
@@ -5,7 +5,10 @@ use chrono::Utc;
 use nexus_common::config::EventRetryConfig;
 use nexus_common::db::kv::RedisOps;
 use nexus_common::models::event::{EventProcessorError, EventType};
-use nexus_watcher::events::retry::{RedisRetryStore, RetryEvent, RetryProcessor, RetryStore};
+use nexus_watcher::events::retry::{
+    RedisRetryStore, RetryEvent, RetryProcessor, RetryStore, RETRY_MANAGER_EVENTS_INDEX,
+    RETRY_MANAGER_PREFIX,
+};
 use nexus_watcher::events::EventHandler;
 use nexus_watcher::service::TEventProcessor;
 use pubky_app_specs::post_uri_builder;
@@ -688,9 +691,9 @@ async fn test_stale_sorted_set_entry_cleaned_up() -> Result<()> {
     // Manually add a stale entry to the sorted set only (no JSON state).
     let now = Utc::now().timestamp_millis();
     RetryEvent::put_index_sorted_set(
-        &["events"],
+        &RETRY_MANAGER_EVENTS_INDEX,
         &[(now as f64, &resource_key)],
-        Some("RetryManager"),
+        Some(RETRY_MANAGER_PREFIX),
         None,
     )
     .await?;


### PR DESCRIPTION
Due to `RetryEvent` schema change previously stored objects cannot be deserialized anymore. 
There is also no possibility of migrating data because previous model contained only serialized error. 
