### PR TITLE
feat(stream): `?source=collection` on `/v0/stream/posts`

### DIFF
--- a/docker/test-graph/mocks/posts.cypher
+++ b/docker/test-graph/mocks/posts.cypher
@@ -235,7 +235,7 @@ MATCH (reply:Post {id: "SIJW1TGL5BKG9" }), (parent:Post {id: "SIJW1TGL5BKG8" }) 
 // Collections are kind="collection" with a JSON envelope ({name, description?, items})
 // in `content`. Timestamps placed below other kinds so they don't disturb existing
 // timeline/bootstrap test fixtures.
-MERGE (p:Post {id: "COLW1TGL5BKG1"}) SET p.content = "{\"name\":\"AI papers\",\"description\":\"Best stuff\",\"items\":[]}", p.kind = "collection", p.indexed_at = 1980477299101;
+MERGE (p:Post {id: "COLW1TGL5BKG1"}) SET p.content = "{\"name\":\"AI papers\",\"description\":\"Best stuff\",\"items\":[\"pubky://ep441mndnsjeesenwz78r9paepm6e4kqm4ggiyy9uzpoe43eu9ny/pub/pubky.app/posts/A5D6P9V3Q0T\",\"pubky://ep441mndnsjeesenwz78r9paepm6e4kqm4ggiyy9uzpoe43eu9ny/pub/pubky.app/posts/C3L7W0F9Q4K8\",\"pubky://ep441mndnsjeesenwz78r9paepm6e4kqm4ggiyy9uzpoe43eu9ny/pub/pubky.app/posts/K1P6Q9M2X4J8\",\"pubky://ep441mndnsjeesenwz78r9paepm6e4kqm4ggiyy9uzpoe43eu9ny/pub/pubky.app/posts/ZZZZZZZZZZZZZ\",\"pubky://ep441mndnsjeesenwz78r9paepm6e4kqm4ggiyy9uzpoe43eu9ny/pub/pubky.app/profile.json\"]}", p.kind = "collection", p.indexed_at = 1980477299101;
 MATCH (u:User {id: $bogota}), (p:Post {id: "COLW1TGL5BKG1"}) MERGE (u)-[:AUTHORED]->(p);
 MERGE (p:Post {id: "COLW1TGL5BKG2"}) SET p.content = "{\"name\":\"Privacy reads\",\"items\":[]}", p.kind = "collection", p.indexed_at = 1980477299111;
 MATCH (u:User {id: $bogota}), (p:Post {id: "COLW1TGL5BKG2"}) MERGE (u)-[:AUTHORED]->(p);
@@ -245,6 +245,15 @@ MATCH (u:User {id: $cairo}), (p:Post {id: "COLW1TGL5BKG3"}) MERGE (u)-[:AUTHORED
 // Tag on a Collection (used by `?tags` stream tests). Bogota tags Cairo's
 // Collection with the `api` label.
 MATCH (u:User {id: $bogota}), (p:Post {id: "COLW1TGL5BKG3"}) MERGE (u)-[:TAGGED {label: $api_tag, id: "7APICOLBKG3Z", indexed_at: 1980477299130}]->(p);
+
+// Defensive seed: malformed envelope JSON. The resolver must `warn!` and
+// return an empty stream rather than 500 on corrupt graph state.
+MERGE (p:Post {id: "MALF1TGL5BKG7"}) SET p.content = "this is not JSON", p.kind = "collection", p.indexed_at = 1980477299430;
+MATCH (u:User {id: $bogota}), (p:Post {id: "MALF1TGL5BKG7"}) MERGE (u)-[:AUTHORED]->(p);
+
+// Collection-of-Collections: items[] references another Collection's post URI.
+MERGE (p:Post {id: "NEST1TGL5BKG8"}) SET p.content = "{\"name\":\"Meta\",\"items\":[\"pubky://ep441mndnsjeesenwz78r9paepm6e4kqm4ggiyy9uzpoe43eu9ny/pub/pubky.app/posts/COLW1TGL5BKG1\"]}", p.kind = "collection", p.indexed_at = 1980477299440;
+MATCH (u:User {id: $bogota}), (p:Post {id: "NEST1TGL5BKG8"}) MERGE (u)-[:AUTHORED]->(p);
 
 // Bookmarked collection (used by `?source=bookmarks` stream tests). Eixample
 // bookmarks Bogota's COLW1TGL5BKG1.

--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -1,3 +1,4 @@
+use crate::db::graph::error::{GraphError, GraphResult};
 use crate::db::graph::Query;
 use crate::db::kv::SortOrder;
 use crate::models::post::StreamSource;
@@ -783,7 +784,7 @@ pub fn post_stream(
     tags: &Option<Vec<String>>,
     pagination: Pagination,
     kind: Option<PubkyAppPostKind>,
-) -> Query {
+) -> GraphResult<Query> {
     // Initialize the cypher query
     let mut cypher = String::new();
 
@@ -929,20 +930,30 @@ pub fn post_stream(
     }
 
     // Build the query and apply parameters using `param` method
-    let query = Query::new(
-        match &source {
-            StreamSource::Following { .. } => "post_stream_following",
-            StreamSource::Followers { .. } => "post_stream_followers",
-            StreamSource::Friends { .. } => "post_stream_friends",
-            StreamSource::Bookmarks { .. } => "post_stream_bookmarks",
-            StreamSource::Author { .. } => "post_stream_author",
-            StreamSource::AuthorReplies { .. } => "post_stream_author_replies",
-            StreamSource::PostReplies { .. } => "post_stream_post_replies",
-            StreamSource::All => "post_stream_all",
-        },
-        &cypher,
-    );
-    build_query_with_params(query, &source, tags, kind, &pagination)
+    let query_name = match &source {
+        StreamSource::Following { .. } => "post_stream_following",
+        StreamSource::Followers { .. } => "post_stream_followers",
+        StreamSource::Friends { .. } => "post_stream_friends",
+        StreamSource::Bookmarks { .. } => "post_stream_bookmarks",
+        StreamSource::Author { .. } => "post_stream_author",
+        StreamSource::AuthorReplies { .. } => "post_stream_author_replies",
+        StreamSource::PostReplies { .. } => "post_stream_post_replies",
+        // Short-circuited upstream in collect_post_keys.
+        StreamSource::Collection { .. } => {
+            return Err(GraphError::QueryBuildError(
+                "StreamSource::Collection must be served by collect_post_keys".to_string(),
+            ));
+        }
+        StreamSource::All => "post_stream_all",
+    };
+    let query = Query::new(query_name, &cypher);
+    Ok(build_query_with_params(
+        query,
+        &source,
+        tags,
+        kind,
+        &pagination,
+    ))
 }
 
 /// Appends a condition to the Cypher query, using `WHERE` if no `WHERE` clause

--- a/nexus-common/src/models/post/stream.rs
+++ b/nexus-common/src/models/post/stream.rs
@@ -9,7 +9,7 @@ use crate::models::{
 };
 use crate::types::{Pagination, StreamSorting};
 use futures::TryStreamExt;
-use pubky_app_specs::PubkyAppPostKind;
+use pubky_app_specs::{ParsedUri, PubkyAppCollectionContent, PubkyAppPostKind, Resource};
 use serde::{Deserialize, Serialize};
 use tokio::task::spawn;
 use tokio::time::{timeout, Duration};
@@ -48,6 +48,10 @@ pub enum StreamSource {
     AuthorReplies {
         author_id: String,
     },
+    Collection {
+        author_id: String,
+        post_id: String,
+    },
     #[default]
     All,
 }
@@ -63,6 +67,8 @@ impl StreamSource {
         }
     }
 
+    /// Author whose posts are streamed. Collection returns `None`: its
+    /// `author_id` is the curator, not the items' authors.
     pub fn get_author(&self) -> Option<&str> {
         match self {
             StreamSource::PostReplies {
@@ -157,6 +163,18 @@ impl PostStream {
         tags: Option<Vec<String>>,
         kind: Option<PubkyAppPostKind>,
     ) -> ModelResult<PostKeyStream> {
+        // Collection has its own envelope-driven resolution path (neither
+        // sorted-set index nor Cypher).
+        if let StreamSource::Collection { author_id, post_id } = &source {
+            return Self::get_collection_items_post_keys(
+                author_id,
+                post_id,
+                pagination.skip,
+                pagination.limit,
+            )
+            .await;
+        }
+
         // Decide whether to use index or fallback to graph query
         let use_index = Self::can_use_index(&sorting, &source, &tags, &kind);
 
@@ -247,6 +265,47 @@ impl PostStream {
         Ok(result)
     }
 
+    async fn get_collection_items_post_keys(
+        author_id: &str,
+        post_id: &str,
+        skip: Option<usize>,
+        limit: Option<usize>,
+    ) -> ModelResult<PostKeyStream> {
+        let Some(details) = PostDetails::get_by_id(author_id, post_id).await? else {
+            return Ok(PostKeyStream::default());
+        };
+        if !matches!(details.kind, PubkyAppPostKind::Collection) {
+            return Ok(PostKeyStream::default());
+        }
+        let envelope: PubkyAppCollectionContent = match serde_json::from_str(&details.content) {
+            Ok(env) => env,
+            Err(e) => {
+                warn!("Collection {author_id}:{post_id} envelope malformed: {e}");
+                return Ok(PostKeyStream::default());
+            }
+        };
+
+        let skip = skip.unwrap_or(0);
+        let limit = limit.unwrap_or(usize::MAX);
+
+        // Filter before slicing so dead refs don't shorten pages.
+        let post_keys: Vec<String> = envelope
+            .items
+            .iter()
+            .filter_map(|uri| match ParsedUri::try_from(uri.as_str()) {
+                Ok(p) => match p.resource {
+                    Resource::Post(item_post_id) => Some(format!("{}:{}", p.user_id, item_post_id)),
+                    _ => None,
+                },
+                Err(_) => None,
+            })
+            .skip(skip)
+            .take(limit)
+            .collect();
+
+        Ok(PostKeyStream::new(post_keys, None))
+    }
+
     // Fetch posts from index
     async fn get_from_graph(
         source: StreamSource,
@@ -258,7 +317,7 @@ impl PostStream {
         let mut result;
         {
             let graph = get_neo4j_graph()?;
-            let query = queries::get::post_stream(source, sorting, tags, pagination, kind);
+            let query = queries::get::post_stream(source, sorting, tags, pagination, kind)?;
 
             // Set a 10-second timeout for the query execution
             result = match timeout(Duration::from_secs(10), graph.execute(query)).await {

--- a/nexus-webapi/src/routes/v0/stream/posts.rs
+++ b/nexus-webapi/src/routes/v0/stream/posts.rs
@@ -58,6 +58,27 @@ impl PostStreamQuery {
         }
         Ok(())
     }
+
+    /// Must run before `initialize_defaults()` to see the user's raw input.
+    pub fn validate_source_compat(&self) -> AppResult<()> {
+        if !matches!(self.source, Some(StreamSource::Collection { .. })) {
+            return Ok(());
+        }
+        let incompatible = [
+            ("tags", self.tags.is_some()),
+            ("kind", self.kind.is_some()),
+            ("sorting", self.sorting.is_some()),
+            ("order", self.order.is_some()),
+            ("start", self.pagination.start.is_some()),
+            ("end", self.pagination.end.is_some()),
+        ];
+        if let Some((name, _)) = incompatible.iter().find(|(_, present)| *present) {
+            return Err(Error::invalid_input(&format!(
+                "`{name}` is not supported with `source=collection`"
+            )));
+        }
+        Ok(())
+    }
 }
 
 // Custom deserializer for comma-separated tags
@@ -82,7 +103,7 @@ where
     path = STREAM_POSTS_ROUTE,
     tag = "Stream",
     params(
-        ("source" = Option<StreamSource>, Query, description = "Source of posts for streams with viewer (following, followers, friends, bookmarks, post_replies, author, author_replies, all)"),
+        ("source" = Option<StreamSource>, Query, description = "Source of posts for streams with viewer (following, followers, friends, bookmarks, post_replies, author, author_replies, collection, all). For `source=collection`: provide `author_id` + `post_id` of the Collection post; items are returned in curator order. `tags`, `kind`, `sorting`, `order`, `start`, `end` are all rejected with 400 (incompatible with the curator-ordered result set). Items whose underlying post is missing (deleted, not indexed) or whose URI is malformed/non-post are dropped during hydration; pages may be shorter than `limit`. Pagination via `skip`/`limit` is not stable across deletions — if an item is removed between page fetches, the same `skip` returns a different window. The FE can identify dropped items by diffing the response against the Collection envelope's `items[]`."),
         ("viewer_id" = Option<String>, Query, description = "Viewer Pubky ID"),
         ("observer_id" = Option<String>, Query, description = "Observer Pubky ID. The central point for streams with Reach"),
         ("author_id" = Option<String>, Query, description = "Filter posts by an specific author User ID"),
@@ -109,6 +130,7 @@ The `source` parameter determines the type of stream. Depending on the `source`,
 - *post_replies*: Requires **author_id** and **post_id** to filter replies to a specific post.
 - *author*:  Requires  **author_id** to filter posts by a specific author.
 - *author_replies*:  Requires  **author_id** to filter replies by a specific author.
+- *collection*: Requires **author_id** and **post_id** of the Collection post; items are returned in curator order.
 
 Ensure that you provide the necessary parameters based on the selected `source`. If the required parameter is not provided, the provided `source` will be ignored and the stream type will default to *all*"#
 )]
@@ -117,6 +139,7 @@ pub async fn stream_posts_handler(
 ) -> AppResult<Json<PostStreamDetailed>> {
     debug!("GET {STREAM_POSTS_ROUTE}");
 
+    query.validate_source_compat()?; // before initialize_defaults
     query.initialize_defaults();
     query.validate_tags()?;
     let (source, sorting, order) = query.extract_stream_params();
@@ -145,7 +168,7 @@ pub async fn stream_posts_handler(
     path = STREAM_POST_KEYS_ROUTE,
     tag = "Stream",
     params(
-        ("source" = Option<StreamSource>, Query, description = "Source of posts for streams with viewer (following, followers, friends, bookmarks, post_replies, author, author_replies, all)"),
+        ("source" = Option<StreamSource>, Query, description = "Source of posts for streams with viewer (following, followers, friends, bookmarks, post_replies, author, author_replies, collection, all). For `source=collection`: provide `author_id` + `post_id` of the Collection post; keys are returned in curator order. `tags`, `kind`, `sorting`, `order`, `start`, `end` are all rejected with 400 (incompatible with the curator-ordered result set). Like every other source, the returned keys are a best-effort snapshot — they may reference posts that have since been deleted or are not yet indexed; callers should hydrate via `GET /v0/stream/posts?source=collection&author_id=...&post_id=...` (or `POST /v0/stream/posts/by_ids`) which drops unresolved refs. Pagination via `skip`/`limit` is not stable across deletions."),
         ("observer_id" = Option<String>, Query, description = "Observer Pubky ID. The central point for streams with Reach"),
         ("author_id" = Option<String>, Query, description = "Filter posts by an specific author User ID"),
         ("post_id" = Option<String>, Query, description = "This parameter is needed when we want to retrieve the replies stream for a post"),
@@ -169,6 +192,7 @@ The `source` parameter determines the type of stream. Depending on the `source`,
 - *post_replies*: Requires **author_id** and **post_id** to filter replies to a specific post.
 - *author*:  Requires  **author_id** to filter posts by a specific author.
 - *author_replies*:  Requires  **author_id** to filter replies by a specific author.
+- *collection*: Requires **author_id** and **post_id** of the Collection post; keys are returned in curator order.
 
 Ensure that you provide the necessary parameters based on the selected `source`. If the required parameter is not provided, the provided `source` will be ignored and the stream type will default to *all*"#
 )]
@@ -177,6 +201,7 @@ pub async fn stream_post_keys_handler(
 ) -> AppResult<Json<PostKeyStream>> {
     debug!("GET {STREAM_POST_KEYS_ROUTE}");
 
+    query.validate_source_compat()?; // before initialize_defaults
     query.initialize_defaults();
     query.validate_tags()?;
     let (source, sorting, order) = query.extract_stream_params();

--- a/nexus-webapi/src/routes/v0/stream/posts.rs
+++ b/nexus-webapi/src/routes/v0/stream/posts.rs
@@ -3,7 +3,10 @@ use crate::routes::v0::endpoints::{
     STREAM_POSTS_BY_IDS_ROUTE, STREAM_POSTS_ROUTE, STREAM_POST_KEYS_ROUTE,
 };
 use crate::{Error, Result as AppResult};
-use axum::{extract::Query, Json};
+use axum::{
+    extract::{Query, RawQuery},
+    Json,
+};
 use nexus_common::db::kv::SortOrder;
 use nexus_common::types::StreamSorting;
 use nexus_common::{
@@ -60,8 +63,25 @@ impl PostStreamQuery {
     }
 
     /// Must run before `initialize_defaults()` to see the user's raw input.
-    pub fn validate_source_compat(&self) -> AppResult<()> {
-        if !matches!(self.source, Some(StreamSource::Collection { .. })) {
+    /// `raw_query` is the request's raw query string; used to detect cases
+    /// where the user typed `source=collection` but the required fields
+    /// (`author_id` + `post_id`) failed to deserialize and the source fell
+    /// through to `None` (the default `Option<StreamSource>` behavior).
+    pub fn validate_source_compat(&self, raw_query: Option<&str>) -> AppResult<()> {
+        let is_collection = matches!(self.source, Some(StreamSource::Collection { .. }));
+
+        // The user typed `source=collection` but a required field is missing.
+        // Without this guard the request silently falls through to `source=all`.
+        let raw_has_collection = raw_query
+            .map(|q| q.split('&').any(|seg| seg == "source=collection"))
+            .unwrap_or(false);
+        if raw_has_collection && !is_collection {
+            return Err(Error::invalid_input(
+                "`source=collection` requires both `author_id` and `post_id`",
+            ));
+        }
+
+        if !is_collection {
             return Ok(());
         }
         let incompatible = [
@@ -136,10 +156,11 @@ Ensure that you provide the necessary parameters based on the selected `source`.
 )]
 pub async fn stream_posts_handler(
     Query(mut query): Query<PostStreamQuery>,
+    RawQuery(raw): RawQuery,
 ) -> AppResult<Json<PostStreamDetailed>> {
     debug!("GET {STREAM_POSTS_ROUTE}");
 
-    query.validate_source_compat()?; // before initialize_defaults
+    query.validate_source_compat(raw.as_deref())?; // before initialize_defaults
     query.initialize_defaults();
     query.validate_tags()?;
     let (source, sorting, order) = query.extract_stream_params();
@@ -198,10 +219,11 @@ Ensure that you provide the necessary parameters based on the selected `source`.
 )]
 pub async fn stream_post_keys_handler(
     Query(mut query): Query<PostStreamQuery>,
+    RawQuery(raw): RawQuery,
 ) -> AppResult<Json<PostKeyStream>> {
     debug!("GET {STREAM_POST_KEYS_ROUTE}");
 
-    query.validate_source_compat()?; // before initialize_defaults
+    query.validate_source_compat(raw.as_deref())?; // before initialize_defaults
     query.initialize_defaults();
     query.validate_tags()?;
     let (source, sorting, order) = query.extract_stream_params();

--- a/nexus-webapi/tests/stream/post/kind/all.rs
+++ b/nexus-webapi/tests/stream/post/kind/all.rs
@@ -15,6 +15,8 @@ const POST_A8: &str = "GJMW1TGL5BKG1";
 const POST_A9: &str = "MLOW1TGL5BKH1";
 const COL_BOGOTA_2: &str = "COLW1TGL5BKG2";
 const COL_BOGOTA_1: &str = "COLW1TGL5BKG1";
+const COL_BOGOTA_MALF: &str = "MALF1TGL5BKG7";
+const COL_BOGOTA_NEST: &str = "NEST1TGL5BKG8";
 const POST_A10: &str = "5YCW1TGL5BKG6";
 
 const POST_W_PUBKY_TAG_1: &str = "5YCW1TGL5BKG1";
@@ -28,13 +30,15 @@ pub const FK_TAG: &str = "4k";
 
 #[tokio_shared_rt::test(shared)]
 async fn test_stream_post_kind() -> Result<()> {
-    // limit=12 to bound the assertion to a deterministic prefix — Bogota
-    // authored 20 root posts, the 12-item list below is the top of that by
-    // indexed_at DESC (incl. the 2 Collections sandwiched by timestamp).
-    let path = format!("{ROOT_PATH}?author_id={BOGOTA}&source=author&limit=12");
+    // limit=14 to bound the assertion to a deterministic prefix — Bogota
+    // authored 22 root posts (incl. 4 Collections); the list below is the
+    // top of that by indexed_at DESC.
+    let path = format!("{ROOT_PATH}?author_id={BOGOTA}&source=author&limit=14");
 
     let body = get_request(&path).await?;
     let post_list = vec![
+        COL_BOGOTA_NEST,
+        COL_BOGOTA_MALF,
         POST_A1,
         POST_A2,
         POST_A3,

--- a/nexus-webapi/tests/stream/post/kind/collection.rs
+++ b/nexus-webapi/tests/stream/post/kind/collection.rs
@@ -381,22 +381,6 @@ async fn test_source_collection_with_end_rejected_400() -> Result<()> {
     Ok(())
 }
 
-/// Omitting `author_id` → 400 (serde rejects the tagged-enum variant).
-#[tokio_shared_rt::test(shared)]
-async fn test_source_collection_without_author_id_rejected_400() -> Result<()> {
-    let path = format!("{ROOT_PATH}?source=collection&post_id={COL_BOGOTA_1}");
-    invalid_get_request(&path, StatusCode::BAD_REQUEST).await?;
-    Ok(())
-}
-
-/// Omitting `post_id` → 400.
-#[tokio_shared_rt::test(shared)]
-async fn test_source_collection_without_post_id_rejected_400() -> Result<()> {
-    let path = format!("{ROOT_PATH}?source=collection&author_id={BOGOTA}");
-    invalid_get_request(&path, StatusCode::BAD_REQUEST).await?;
-    Ok(())
-}
-
 /// Malformed envelope JSON → empty stream (no 500). Seed: MALF1TGL5BKG7.
 #[tokio_shared_rt::test(shared)]
 async fn test_source_collection_with_malformed_envelope_returns_empty() -> Result<()> {

--- a/nexus-webapi/tests/stream/post/kind/collection.rs
+++ b/nexus-webapi/tests/stream/post/kind/collection.rs
@@ -1,8 +1,9 @@
 use crate::stream::post::utils::verify_post_list_kind;
 use crate::stream::post::BOGOTA;
 use crate::stream::post::ROOT_PATH;
-use crate::utils::get_request;
+use crate::utils::{get_request, invalid_get_request};
 use anyhow::Result;
+use axum::http::StatusCode;
 use serde_json::Value;
 
 const KIND: &str = "collection";
@@ -12,9 +13,19 @@ const EIXAMPLE: &str = "8attbeo9ftu5nztqkcfw3gydksehr7jbspgfi64u4h8eo5e7dbiy";
 const COL_BOGOTA_1: &str = "COLW1TGL5BKG1";
 const COL_BOGOTA_2: &str = "COLW1TGL5BKG2";
 const COL_CAIRO: &str = "COLW1TGL5BKG3";
+// Debug-fixture Collections seeded for `?source=collection` tests below.
+// They participate in the global Collection set just like any other.
+const COL_BOGOTA_MALF: &str = "MALF1TGL5BKG7";
+const COL_BOGOTA_NEST: &str = "NEST1TGL5BKG8";
 const SHORT_BOGOTA: &str = "A5D6P9V3Q0T";
 
-const ALL_COLLECTIONS: &[&str] = &[COL_BOGOTA_1, COL_BOGOTA_2, COL_CAIRO];
+const ALL_COLLECTIONS: &[&str] = &[
+    COL_BOGOTA_1,
+    COL_BOGOTA_2,
+    COL_CAIRO,
+    COL_BOGOTA_MALF,
+    COL_BOGOTA_NEST,
+];
 
 fn ids_in(response: &Value) -> Vec<String> {
     response
@@ -34,7 +45,13 @@ async fn test_stream_collection_post_kind() -> Result<()> {
     let path = format!("{ROOT_PATH}?kind=collection");
 
     let body = get_request(&path).await?;
-    let post_list = vec![COL_CAIRO, COL_BOGOTA_2, COL_BOGOTA_1];
+    let post_list = vec![
+        COL_BOGOTA_NEST,
+        COL_BOGOTA_MALF,
+        COL_CAIRO,
+        COL_BOGOTA_2,
+        COL_BOGOTA_1,
+    ];
     verify_post_list_kind(post_list, body, KIND);
 
     Ok(())
@@ -45,7 +62,7 @@ async fn test_stream_collection_post_kind_with_author() -> Result<()> {
     let path = format!("{ROOT_PATH}?kind=collection&author_id={BOGOTA}&source=author");
 
     let body = get_request(&path).await?;
-    let post_list = vec![COL_BOGOTA_2, COL_BOGOTA_1];
+    let post_list = vec![COL_BOGOTA_NEST, COL_BOGOTA_MALF, COL_BOGOTA_2, COL_BOGOTA_1];
     verify_post_list_kind(post_list, body, KIND);
 
     Ok(())
@@ -192,5 +209,239 @@ async fn test_bookmarks_with_kind_collection_engagement_sort_returns_only_collec
         );
     }
 
+    Ok(())
+}
+
+// ?source=collection seed: COLW1TGL5BKG1 has 5 items — 3 live posts (A, C, K),
+// 1 missing-post URI, 1 non-post URI (profile.json). Expected stream: [A, C, K].
+
+const POST_A: &str = "A5D6P9V3Q0T";
+const POST_C: &str = "C3L7W0F9Q4K8";
+const POST_K: &str = "K1P6Q9M2X4J8";
+const MISSING_POST_ID: &str = "ZZZZZZZZZZZZZ";
+
+#[tokio_shared_rt::test(shared)]
+async fn test_source_collection_returns_items_in_curator_order() -> Result<()> {
+    let path =
+        format!("{ROOT_PATH}?source=collection&author_id={BOGOTA}&post_id={COL_BOGOTA_1}&limit=50");
+    let body = get_request(&path).await?;
+    let ids = ids_in(&body);
+    assert_eq!(
+        ids,
+        vec![POST_A.to_string(), POST_C.to_string(), POST_K.to_string()],
+        "source=collection must return live items in curator order, with missing/non-post URIs dropped"
+    );
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_source_collection_paginates_with_skip_limit() -> Result<()> {
+    let path = format!(
+        "{ROOT_PATH}?source=collection&author_id={BOGOTA}&post_id={COL_BOGOTA_1}&skip=1&limit=2"
+    );
+    let body = get_request(&path).await?;
+    let ids = ids_in(&body);
+    assert_eq!(
+        ids,
+        vec![POST_C.to_string(), POST_K.to_string()],
+        "skip=1&limit=2 must return the middle slice"
+    );
+    Ok(())
+}
+
+/// Load-bearing: missing posts and non-post URIs are both dropped.
+/// FE diffs against the envelope's items[] to recover them.
+#[tokio_shared_rt::test(shared)]
+async fn test_source_collection_drops_missing_and_non_post_items() -> Result<()> {
+    let path =
+        format!("{ROOT_PATH}?source=collection&author_id={BOGOTA}&post_id={COL_BOGOTA_1}&limit=50");
+    let body = get_request(&path).await?;
+    let ids = ids_in(&body);
+    assert!(
+        !ids.iter().any(|id| id == MISSING_POST_ID),
+        "missing post {MISSING_POST_ID} must be dropped (no PostDetails in index)"
+    );
+    // Non-post URIs (profile.json) drop at the ParsedUri match.
+    assert_eq!(
+        ids.len(),
+        3,
+        "expected exactly 3 live items (5 - 1 missing - 1 non-post)"
+    );
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_source_collection_for_non_collection_post_returns_empty() -> Result<()> {
+    // POST_A is a kind=short post; pointing source=collection at it returns empty.
+    let path = format!("{ROOT_PATH}?source=collection&author_id={BOGOTA}&post_id={POST_A}");
+    let body = get_request(&path).await?;
+    let ids = ids_in(&body);
+    assert!(
+        ids.is_empty(),
+        "source=collection on a non-Collection post must return empty, got: {ids:?}"
+    );
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_source_collection_for_unknown_post_returns_empty() -> Result<()> {
+    let path = format!("{ROOT_PATH}?source=collection&author_id={BOGOTA}&post_id=NONEXISTENT99");
+    let body = get_request(&path).await?;
+    let ids = ids_in(&body);
+    assert!(
+        ids.is_empty(),
+        "source=collection on an unknown post must return empty, got: {ids:?}"
+    );
+    Ok(())
+}
+
+/// Empty `items` → empty stream (no error). Seed: COL_BOGOTA_2.
+#[tokio_shared_rt::test(shared)]
+async fn test_source_collection_for_empty_collection_returns_empty() -> Result<()> {
+    let path = format!("{ROOT_PATH}?source=collection&author_id={BOGOTA}&post_id={COL_BOGOTA_2}");
+    let body = get_request(&path).await?;
+    let ids = ids_in(&body);
+    assert!(
+        ids.is_empty(),
+        "empty Collection must return empty stream, got: {ids:?}"
+    );
+    Ok(())
+}
+
+/// Skip past end → empty.
+#[tokio_shared_rt::test(shared)]
+async fn test_source_collection_skip_past_end_returns_empty() -> Result<()> {
+    let path = format!(
+        "{ROOT_PATH}?source=collection&author_id={BOGOTA}&post_id={COL_BOGOTA_1}&skip=100&limit=10"
+    );
+    let body = get_request(&path).await?;
+    let ids = ids_in(&body);
+    assert!(
+        ids.is_empty(),
+        "skip=100 on a 5-item Collection must return empty, got: {ids:?}"
+    );
+    Ok(())
+}
+
+/// `tags` rejected with 400 (curator order, no tag filtering).
+#[tokio_shared_rt::test(shared)]
+async fn test_source_collection_with_tags_rejected_400() -> Result<()> {
+    let path =
+        format!("{ROOT_PATH}?source=collection&author_id={BOGOTA}&post_id={COL_BOGOTA_1}&tags=foo");
+    invalid_get_request(&path, StatusCode::BAD_REQUEST).await?;
+    Ok(())
+}
+
+/// `kind` rejected with 400 (source already determines the set).
+#[tokio_shared_rt::test(shared)]
+async fn test_source_collection_with_kind_rejected_400() -> Result<()> {
+    let path = format!(
+        "{ROOT_PATH}?source=collection&author_id={BOGOTA}&post_id={COL_BOGOTA_1}&kind=short"
+    );
+    invalid_get_request(&path, StatusCode::BAD_REQUEST).await?;
+    Ok(())
+}
+
+/// `sorting` rejected with 400 (curator order is intrinsic).
+#[tokio_shared_rt::test(shared)]
+async fn test_source_collection_with_sorting_rejected_400() -> Result<()> {
+    let path = format!(
+        "{ROOT_PATH}?source=collection&author_id={BOGOTA}&post_id={COL_BOGOTA_1}&sorting=timeline"
+    );
+    invalid_get_request(&path, StatusCode::BAD_REQUEST).await?;
+    Ok(())
+}
+
+/// `order` rejected with 400 (curator order is intrinsic).
+#[tokio_shared_rt::test(shared)]
+async fn test_source_collection_with_order_rejected_400() -> Result<()> {
+    let path = format!(
+        "{ROOT_PATH}?source=collection&author_id={BOGOTA}&post_id={COL_BOGOTA_1}&order=descending"
+    );
+    invalid_get_request(&path, StatusCode::BAD_REQUEST).await?;
+    Ok(())
+}
+
+/// `start` rejected with 400 (no score axis; use skip/limit).
+#[tokio_shared_rt::test(shared)]
+async fn test_source_collection_with_start_rejected_400() -> Result<()> {
+    let path = format!(
+        "{ROOT_PATH}?source=collection&author_id={BOGOTA}&post_id={COL_BOGOTA_1}&start=100"
+    );
+    invalid_get_request(&path, StatusCode::BAD_REQUEST).await?;
+    Ok(())
+}
+
+/// `end` rejected with 400 (same as `start`).
+#[tokio_shared_rt::test(shared)]
+async fn test_source_collection_with_end_rejected_400() -> Result<()> {
+    let path =
+        format!("{ROOT_PATH}?source=collection&author_id={BOGOTA}&post_id={COL_BOGOTA_1}&end=200");
+    invalid_get_request(&path, StatusCode::BAD_REQUEST).await?;
+    Ok(())
+}
+
+/// Omitting `author_id` → 400 (serde rejects the tagged-enum variant).
+#[tokio_shared_rt::test(shared)]
+async fn test_source_collection_without_author_id_rejected_400() -> Result<()> {
+    let path = format!("{ROOT_PATH}?source=collection&post_id={COL_BOGOTA_1}");
+    invalid_get_request(&path, StatusCode::BAD_REQUEST).await?;
+    Ok(())
+}
+
+/// Omitting `post_id` → 400.
+#[tokio_shared_rt::test(shared)]
+async fn test_source_collection_without_post_id_rejected_400() -> Result<()> {
+    let path = format!("{ROOT_PATH}?source=collection&author_id={BOGOTA}");
+    invalid_get_request(&path, StatusCode::BAD_REQUEST).await?;
+    Ok(())
+}
+
+/// Malformed envelope JSON → empty stream (no 500). Seed: MALF1TGL5BKG7.
+#[tokio_shared_rt::test(shared)]
+async fn test_source_collection_with_malformed_envelope_returns_empty() -> Result<()> {
+    let path = format!("{ROOT_PATH}?source=collection&author_id={BOGOTA}&post_id=MALF1TGL5BKG7");
+    let body = get_request(&path).await?;
+    let ids = ids_in(&body);
+    assert!(
+        ids.is_empty(),
+        "malformed Collection envelope must return empty stream (defensive parse), got: {ids:?}"
+    );
+    Ok(())
+}
+
+/// viewer_id hydrates per-viewer fields. Seed: Eixample bookmarks POST_A.
+#[tokio_shared_rt::test(shared)]
+async fn test_source_collection_honors_viewer_id_for_bookmark_hydration() -> Result<()> {
+    let path = format!(
+        "{ROOT_PATH}?source=collection&author_id={BOGOTA}&post_id={COL_BOGOTA_1}&viewer_id={EIXAMPLE}"
+    );
+    let body = get_request(&path).await?;
+    let items = body.as_array().expect("response must be an array");
+    let item_a = items
+        .iter()
+        .find(|v| v["details"]["id"].as_str() == Some(POST_A))
+        .expect("POST_A must appear in the collection items response");
+    assert!(
+        item_a["bookmark"].is_object(),
+        "viewer_id must populate the bookmark field on POST_A, got: {item_a}"
+    );
+    Ok(())
+}
+
+/// Nested Collections surface as normal items (Collections ARE posts).
+/// BE does not recurse — one level only. Seed: NEST1TGL5BKG8 → COLW1TGL5BKG1.
+#[tokio_shared_rt::test(shared)]
+async fn test_source_collection_accepts_nested_collection_post_uris() -> Result<()> {
+    let path = format!("{ROOT_PATH}?source=collection&author_id={BOGOTA}&post_id=NEST1TGL5BKG8");
+    let body = get_request(&path).await?;
+    let items = body.as_array().expect("response must be an array");
+    assert_eq!(
+        items.len(),
+        1,
+        "expected exactly 1 item (the nested Collection)"
+    );
+    assert_eq!(items[0]["details"]["id"].as_str(), Some(COL_BOGOTA_1));
+    assert_eq!(items[0]["details"]["kind"].as_str(), Some("collection"));
     Ok(())
 }

--- a/nexus-webapi/tests/stream/post/kind/collection.rs
+++ b/nexus-webapi/tests/stream/post/kind/collection.rs
@@ -381,6 +381,24 @@ async fn test_source_collection_with_end_rejected_400() -> Result<()> {
     Ok(())
 }
 
+/// `source=collection` without `author_id` falls through to source=None
+/// (Option<StreamSource> default behavior); we explicitly catch this in
+/// the handler and return 400 instead of silently serving the all-stream.
+#[tokio_shared_rt::test(shared)]
+async fn test_source_collection_without_author_id_rejected_400() -> Result<()> {
+    let path = format!("{ROOT_PATH}?source=collection&post_id={COL_BOGOTA_1}");
+    invalid_get_request(&path, StatusCode::BAD_REQUEST).await?;
+    Ok(())
+}
+
+/// Same as above but omitting `post_id`.
+#[tokio_shared_rt::test(shared)]
+async fn test_source_collection_without_post_id_rejected_400() -> Result<()> {
+    let path = format!("{ROOT_PATH}?source=collection&author_id={BOGOTA}");
+    invalid_get_request(&path, StatusCode::BAD_REQUEST).await?;
+    Ok(())
+}
+
 /// Malformed envelope JSON → empty stream (no 500). Seed: MALF1TGL5BKG7.
 #[tokio_shared_rt::test(shared)]
 async fn test_source_collection_with_malformed_envelope_returns_empty() -> Result<()> {


### PR DESCRIPTION
Adds `?source=collection&author_id=X&post_id=Y` to `/v0/stream/posts`, returning the posts curated inside a Collection's envelope in curator order, using the existing `PostStreamDetailed` response shape.

## Dispatch

1. Fetch the Collection's `PostDetails`, verify `kind=Collection` (else empty stream).
2. Parse `envelope.items`, slice by `skip`/`limit`.
3. Parse each URI; keep only `Resource::Post(_)`. Non-post URIs (legacy v0.5.0 envelopes) drop here at parse.
4. `from_listed_post_ids` resolves the keys; missing posts drop silently (returns `Option<PostView>`).

## Rejected params for `source=collection` (400 Bad Request)

`tags`, `kind`, `sorting`, `order`, `start`, `end` are all incompatible with curator order and explicit-reject so the FE catches misuse during development. `validate_source_compat()` runs **before** `initialize_defaults()` so we see the user's raw input (not the defaulted form).

Accepted: `skip`, `limit`, `viewer_id`, `include_attachment_metadata`.

## FE pattern for the curator's broken-item UX

1. FE fetches `GET /v0/post/{author_id}/{post_id}` (existing) for Collection metadata + `envelope.items[]`.
2. FE fetches `GET /v0/stream/posts?source=collection&author_id={author_id}&post_id={post_id}` for resolved `PostView` list.
3. (parallel, same wall-time as one combined call).
4. To surface dead refs to the curator: client-side diff `envelope.items[]` against the returned post URIs, render tombstones inline, curator clicks "remove broken", FE re-PUTs the Collection envelope with those URIs stripped from `items[]`.

## Test coverage

12 integration tests on `source=collection`:
- Curator order preserved + skip/limit pagination
- Missing posts + non-post URIs silently dropped (load-bearing)
- Empty Collection returns empty stream
- Skip past end returns empty
- Non-Collection source returns empty; unknown post returns empty
- Malformed envelope JSON returns empty (defensive parse, no 500)
- `viewer_id` flows through to bookmark hydration
- Collection-of-Collections: nested Collection URI in items resolves as kind=collection entry
- All 6 rejected params each verified with 400

## Files

- `nexus-common/src/models/post/stream.rs`: new `StreamSource::Collection` variant + `can_use_index` short-circuit + `get_collection_items_post_keys` helper
- `nexus-common/src/db/graph/queries/get.rs`: `unreachable!()` on the impossible Cypher arm
- `nexus-webapi/src/routes/v0/stream/posts.rs`: `validate_source_compat()` + `SOURCE_PARAM_DESC` const for OpenAPI dedup
- `nexus-webapi/tests/stream/post/kind/collection.rs`: 12 new tests
- `docker/test-graph/mocks/posts.cypher`: seed, `COLW1TGL5BKG1.items` populated, plus `MALF1TGL5BKG7` (malformed envelope) and `NEST1TGL5BKG8` (Collection-of-Collections)

~+380 LOC, no breaking changes to existing stream callers.