### PR TITLE
Add `UserHsResolverRunner`, keep inner `shutdown_rx` clone

### DIFF
--- a/nexus-watcher/src/service/mod.rs
+++ b/nexus-watcher/src/service/mod.rs
@@ -11,6 +11,7 @@ pub use constants::{PROCESSING_TIMEOUT_SECS, WATCHER_CONFIG_FILE_NAME};
 pub use indexer::{HsEventProcessor, KeyBasedEventProcessor, RunError, TEventProcessor};
 pub use runner::{HsEventProcessorRunner, KeyBasedEventProcessorRunner, TEventProcessorRunner};
 pub(crate) use task_runner::{run_periodic_tasks, PeriodicTask};
+pub use user_hs_resolver::UserHsResolverRunner;
 
 /// Sleep interval for the retry processor (10 seconds)
 const RETRY_PROCESSOR_SLEEP: u64 = 10_000;
@@ -92,13 +93,16 @@ impl NexusWatcher {
 
         let watcher_sleep = config.watcher_sleep;
         let hs_resolver_sleep = config.hs_resolver_sleep;
-        let hs_resolver_ttl = config.hs_resolver_ttl;
 
         let hs_runner = Arc::new(HsEventProcessorRunner::from_config(
             &config,
             shutdown_rx.clone(),
         ));
         let key_based_runner = Arc::new(KeyBasedEventProcessorRunner::from_config(
+            &config,
+            shutdown_rx.clone(),
+        ));
+        let user_hs_resolver_runner = Arc::new(UserHsResolverRunner::from_config(
             &config,
             shutdown_rx.clone(),
         ));
@@ -115,12 +119,9 @@ impl NexusWatcher {
                 let runner = key_based_runner.clone();
                 async move { runner.run().await.map(|_| ()) }
             }),
-            PeriodicTask::new("user-hs-resolver", hs_resolver_sleep, {
-                let shutdown_rx = shutdown_rx.clone();
-                move || {
-                    let mut shutdown_rx = shutdown_rx.clone();
-                    async move { user_hs_resolver::run(hs_resolver_ttl, &mut shutdown_rx).await }
-                }
+            PeriodicTask::new("user-hs-resolver", hs_resolver_sleep, move || {
+                let runner = user_hs_resolver_runner.clone();
+                async move { runner.run().await }
             }),
             PeriodicTask::new("retry-processor", RETRY_PROCESSOR_SLEEP, move || {
                 let processor = retry_processor.clone();

--- a/nexus-watcher/src/service/user_hs_resolver.rs
+++ b/nexus-watcher/src/service/user_hs_resolver.rs
@@ -7,6 +7,7 @@ use nexus_common::db::{
     exec_single_row, fetch_key_from_graph, queries, GraphResult, PubkyConnector,
 };
 use nexus_common::types::DynError;
+use nexus_common::WatcherConfig;
 use opentelemetry::global;
 use opentelemetry::metrics::Histogram;
 use pubky::PublicKey;
@@ -16,6 +17,25 @@ use tokio::sync::watch::Receiver;
 use tracing::{debug, error, info, warn};
 
 static HS_RESOLVER_METRICS: LazyLock<HsResolverMetrics> = LazyLock::new(HsResolverMetrics::new);
+
+pub struct UserHsResolverRunner {
+    ttl_ms: u64,
+    shutdown_rx: Receiver<bool>,
+}
+
+impl UserHsResolverRunner {
+    pub fn from_config(config: &WatcherConfig, shutdown_rx: Receiver<bool>) -> Self {
+        Self {
+            ttl_ms: config.hs_resolver_ttl,
+            shutdown_rx,
+        }
+    }
+
+    pub async fn run(&self) -> Result<(), DynError> {
+        let mut shutdown_rx = self.shutdown_rx.clone();
+        run(self.ttl_ms, &mut shutdown_rx).await
+    }
+}
 
 /// Main entry point for one cycle of the periodic task.
 ///


### PR DESCRIPTION
This PR proposes a modification to #868 , which would bring the `user-hs-resolver` task in line with how the other `NexusWatcher` startup tasks are initialized and triggered.