### PR TITLE
Bump neo4j to 5.26.26

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   neo4j:
-    image: neo4j:5.26.25-community
+    image: neo4j:5.26.26-community
     container_name: neo4j
     restart: unless-stopped
     ports:


### PR DESCRIPTION
This PR bumps `neo4j` to the latest 5.26.26. The changelog is available [here](https://github.com/neo4j/neo4j/wiki/Neo4j-5.26-changelog).

It stays on the 5.26 LTS branch but brings the latest fixes and improvements.
