### PR TITLE
feat: block switching from 3rd party HS

### DIFF
--- a/nexus-common/src/db/graph/queries/del.rs
+++ b/nexus-common/src/db/graph/queries/del.rs
@@ -106,16 +106,6 @@ pub fn delete_tag(user_id: &str, tag_id: &str, app: Option<&str>) -> Query {
     query
 }
 
-/// Removes the `HOSTED_BY` relationship from a user, if one exists.
-pub fn remove_user_homeserver(user_id: &str) -> Query {
-    Query::new(
-        "remove_user_homeserver",
-        "MATCH (u:User {id: $user_id})-[r:HOSTED_BY]->(:Homeserver)
-         DELETE r;",
-    )
-    .param("user_id", user_id.to_string())
-}
-
 /// Deletes a file node and all its relationships
 /// # Arguments
 /// * `owner_id` - The unique identifier of the user who owns the file

--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -393,8 +393,8 @@ pub fn get_homeserver_by_id(id: &str) -> Query {
 pub fn get_all_homeservers_with_active_users() -> Query {
     Query::new(
         "get_all_homeservers_with_active_users",
-        "MATCH (u:User)-[:HOSTED_BY]->(hs:Homeserver)
-        WHERE u.name <> '[DELETED]'
+        "MATCH (u:User)-[r:HOSTED_BY]->(hs:Homeserver)
+        WHERE u.name <> '[DELETED]' AND NOT coalesce(r.stale, false)
         WITH hs.id AS id, count(u) AS active_users
         ORDER BY active_users DESC
         RETURN collect(id) AS homeservers_list",
@@ -418,12 +418,26 @@ pub fn get_users_needing_hs_resolution(ttl_ms: u64) -> Query {
     .param("ttl_ms", ttl_ms as i64)
 }
 
-/// Retrieves all user IDs hosted on a given homeserver.
+/// Retrieves the homeserver ID a user is currently hosted on, if any.
+pub fn get_user_homeserver(user_id: &str) -> Query {
+    Query::new(
+        "get_user_homeserver",
+        "MATCH (u:User {id: $user_id})-[:HOSTED_BY]->(hs:Homeserver)
+         RETURN hs.id AS homeserver_id",
+    )
+    .param("user_id", user_id.to_string())
+}
+
+/// Retrieves all user IDs actively hosted on a given homeserver.
+///
+/// Excludes users whose mapping is marked `stale` — i.e. whose published
+/// homeserver has diverged from the stored one — so the watcher stops
+/// indexing them until the mapping realigns.
 pub fn get_users_by_homeserver(hs_id: &str) -> Query {
     Query::new(
         "get_users_by_homeserver",
-        "MATCH (u:User)-[:HOSTED_BY]->(:Homeserver {id: $hs_id})
-         WHERE u.name <> '[DELETED]'
+        "MATCH (u:User)-[r:HOSTED_BY]->(:Homeserver {id: $hs_id})
+         WHERE u.name <> '[DELETED]' AND NOT coalesce(r.stale, false)
          RETURN collect(u.id) AS user_ids",
     )
     .param("hs_id", hs_id.to_string())

--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -433,9 +433,9 @@ pub fn get_user_homeserver(user_id: &str) -> Query {
 /// Excludes users whose mapping is marked `stale` — i.e. whose published
 /// homeserver has diverged from the stored one — so the watcher stops
 /// indexing them until the mapping realigns.
-pub fn get_users_by_homeserver(hs_id: &str) -> Query {
+pub fn get_active_users_by_homeserver(hs_id: &str) -> Query {
     Query::new(
-        "get_users_by_homeserver",
+        "get_active_users_by_homeserver",
         "MATCH (u:User)-[r:HOSTED_BY]->(:Homeserver {id: $hs_id})
          WHERE u.name <> '[DELETED]' AND NOT coalesce(r.stale, false)
          RETURN collect(u.id) AS user_ids",

--- a/nexus-common/src/db/graph/queries/put.rs
+++ b/nexus-common/src/db/graph/queries/put.rs
@@ -392,3 +392,20 @@ pub fn set_user_homeserver(user_id: &str, homeserver_id: &str) -> Query {
     .param("user_id", user_id.to_string())
     .param("hs_id", homeserver_id.to_string())
 }
+
+/// Toggles the `stale` flag on a user's existing `HOSTED_BY` relationship and
+/// refreshes `resolved_at`.
+///
+/// Homeserver switching is not fully implemented, so the bound homeserver is
+/// never changed. Instead, when the published homeserver diverges (changed or
+/// removed) the mapping is marked stale to pause indexing; when it realigns the
+/// flag is cleared to resume.
+pub fn set_user_homeserver_stale(user_id: &str, stale: bool) -> Query {
+    Query::new(
+        "set_user_homeserver_stale",
+        "MATCH (u:User {id: $user_id})-[r:HOSTED_BY]->(:Homeserver)
+         SET r.stale = $stale, r.resolved_at = timestamp()",
+    )
+    .param("user_id", user_id.to_string())
+    .param("stale", stale)
+}

--- a/nexus-watcher/src/service/mod.rs
+++ b/nexus-watcher/src/service/mod.rs
@@ -104,6 +104,7 @@ impl NexusWatcher {
         ));
         let user_hs_resolver_runner = Arc::new(UserHsResolverRunner::from_config(
             &config,
+            Box::new(user_hs_resolver::PubkyConnectorResolver),
             shutdown_rx.clone(),
         ));
 

--- a/nexus-watcher/src/service/user_hs_resolver.rs
+++ b/nexus-watcher/src/service/user_hs_resolver.rs
@@ -464,8 +464,8 @@ mod tests {
     async fn test_get_user_homeserver() -> Result<(), DynError> {
         setup().await?;
 
-        let user_id = "get_user_hs_test_user";
-        let hs_id = "get_user_hs_test_hs";
+        let user_id = Keypair::random().public_key().z32();
+        let hs_id = Keypair::random().public_key().z32();
 
         create_test_user(user_id).await?;
 

--- a/nexus-watcher/src/service/user_hs_resolver.rs
+++ b/nexus-watcher/src/service/user_hs_resolver.rs
@@ -18,14 +18,45 @@ use tracing::{debug, error, info, warn};
 
 static HS_RESOLVER_METRICS: LazyLock<HsResolverMetrics> = LazyLock::new(HsResolverMetrics::new);
 
+/// Resolves a user's currently published homeserver from PKDNS/DHT.
+///
+/// Abstracted behind a trait so the resolver loop can be driven with a mock in
+/// tests instead of hitting the network.
+#[async_trait::async_trait]
+pub trait PkdnsHomeserverResolver: Send + Sync {
+    /// Returns the homeserver published for `user_pk`, or `None` if none is
+    /// currently published.
+    async fn resolve_homeserver(&self, user_pk: &PublicKey) -> Result<Option<PubkyId>, DynError>;
+}
+
+/// Production resolver backed by the shared [`PubkyConnector`].
+pub struct PubkyConnectorResolver;
+
+#[async_trait::async_trait]
+impl PkdnsHomeserverResolver for PubkyConnectorResolver {
+    async fn resolve_homeserver(&self, user_pk: &PublicKey) -> Result<Option<PubkyId>, DynError> {
+        let pubky = PubkyConnector::get()?;
+        let Some(hs_pk) = pubky.get_homeserver_of(user_pk).await else {
+            return Ok(None);
+        };
+        Ok(Some(PubkyId::try_from(&hs_pk.into_inner().to_z32())?))
+    }
+}
+
 pub struct UserHsResolverRunner {
+    resolver: Box<dyn PkdnsHomeserverResolver>,
     ttl_ms: u64,
     shutdown_rx: Receiver<bool>,
 }
 
 impl UserHsResolverRunner {
-    pub fn from_config(config: &WatcherConfig, shutdown_rx: Receiver<bool>) -> Self {
+    pub fn from_config(
+        config: &WatcherConfig,
+        resolver: Box<dyn PkdnsHomeserverResolver>,
+        shutdown_rx: Receiver<bool>,
+    ) -> Self {
         Self {
+            resolver,
             ttl_ms: config.hs_resolver_ttl,
             shutdown_rx,
         }
@@ -33,7 +64,7 @@ impl UserHsResolverRunner {
 
     pub async fn run(&self) -> Result<(), DynError> {
         let mut shutdown_rx = self.shutdown_rx.clone();
-        run(self.ttl_ms, &mut shutdown_rx).await
+        run(self.resolver.as_ref(), self.ttl_ms, &mut shutdown_rx).await
     }
 }
 
@@ -44,7 +75,11 @@ impl UserHsResolverRunner {
 ///
 /// `shutdown_rx` cancels the in-flight resolution on shutdown; cancelled users
 /// get re-picked-up on the next run via TTL.
-pub async fn run(ttl_ms: u64, shutdown_rx: &mut Receiver<bool>) -> Result<(), DynError> {
+pub async fn run(
+    resolver: &dyn PkdnsHomeserverResolver,
+    ttl_ms: u64,
+    shutdown_rx: &mut Receiver<bool>,
+) -> Result<(), DynError> {
     let user_ids = get_users_needing_resolution(ttl_ms).await?;
     if user_ids.is_empty() {
         debug!("No users need homeserver resolution");
@@ -91,7 +126,7 @@ pub async fn run(ttl_ms: u64, shutdown_rx: &mut Receiver<bool>) -> Result<(), Dy
                 info!("Shutdown detected; HS resolver stopping after {processed}/{attempted} users");
                 break;
             }
-            result = resolve_user(&user_pk) => {
+            result = resolve_user(resolver, &user_pk) => {
                 if let Err(e) = result {
                     failed += 1;
                     warn!("Failed to resolve HS for user {}: {e}", user_pk.z32());
@@ -151,26 +186,54 @@ async fn get_users_needing_resolution(ttl_ms: u64) -> GraphResult<Vec<String>> {
 }
 
 /// Resolves a single user's homeserver and persists the HOSTED_BY relationship.
-async fn resolve_user(user_pk: &PublicKey) -> Result<(), DynError> {
-    let pubky = PubkyConnector::get()?;
-
+///
+/// Homeserver switching is not fully implemented, so the bound homeserver is
+/// never changed once set:
+/// - No stored mapping: store whatever the DHT resolves (if anything).
+/// - Stored mapping, DHT still points at it: clear any `stale` flag (resume indexing).
+/// - Stored mapping, DHT changed or returns nothing: mark the mapping `stale`
+///   so the watcher stops indexing the user until the DHT realigns.
+async fn resolve_user(
+    resolver: &dyn PkdnsHomeserverResolver,
+    user_pk: &PublicKey,
+) -> Result<(), DynError> {
     let user_id = user_pk.z32();
-    let Some(hs_pk) = pubky.get_homeserver_of(user_pk).await else {
-        // No PKDNS record: remove stale HOSTED_BY edge
-        let query = queries::del::remove_user_homeserver(&user_id);
-        exec_single_row(query).await?;
 
-        debug!("User {user_id} has no published homeserver, removed HOSTED_BY");
+    let resolved_hs_id = resolver.resolve_homeserver(user_pk).await?;
+
+    let Some(stored_hs_id) = get_user_homeserver(&user_id).await? else {
+        // First-time resolution: store whatever the DHT resolves.
+        let Some(hs_id) = resolved_hs_id else {
+            debug!("User {user_id} has no published homeserver");
+            return Ok(());
+        };
+        exec_single_row(queries::put::set_user_homeserver(&user_id, &hs_id)).await?;
+        debug!("User {user_id} -> HS {hs_id}");
         return Ok(());
     };
 
-    let hs_id = PubkyId::try_from(&hs_pk.into_inner().to_z32())?;
+    // Already bound to a homeserver: toggle the stale flag instead of switching.
+    let still_matches = resolved_hs_id
+        .as_ref()
+        .is_some_and(|hs_id| hs_id.as_ref() == stored_hs_id.as_str());
+    if still_matches {
+        exec_single_row(queries::put::set_user_homeserver_stale(&user_id, false)).await?;
+        debug!("User {user_id} still hosted on {stored_hs_id}, mapping active");
+    } else {
+        exec_single_row(queries::put::set_user_homeserver_stale(&user_id, true)).await?;
+        warn!(
+            "User {user_id} homeserver changed or was removed (stored {stored_hs_id}); \
+             switching unsupported, mapping marked stale and indexing paused"
+        );
+    }
 
-    let query = queries::put::set_user_homeserver(&user_id, &hs_id);
-    exec_single_row(query).await?;
-
-    debug!("User {user_id} -> HS {hs_id}");
     Ok(())
+}
+
+/// Returns the homeserver ID a user is currently assigned to, if any.
+async fn get_user_homeserver(user_id: &str) -> GraphResult<Option<String>> {
+    let query = queries::get::get_user_homeserver(user_id);
+    fetch_key_from_graph(query, "homeserver_id").await
 }
 
 /// Returns all user IDs hosted on a given homeserver.
@@ -214,6 +277,27 @@ mod tests {
 
     async fn setup() -> Result<(), DynError> {
         StackManager::setup(&StackConfig::default()).await
+    }
+
+    /// Resolver stub returning a fixed PKDNS result, so `resolve_user` can be
+    /// driven without touching the DHT.
+    struct MockResolver {
+        result: Option<PubkyId>,
+    }
+
+    #[async_trait::async_trait]
+    impl PkdnsHomeserverResolver for MockResolver {
+        async fn resolve_homeserver(
+            &self,
+            _user_pk: &PublicKey,
+        ) -> Result<Option<PubkyId>, DynError> {
+            Ok(self.result.clone())
+        }
+    }
+
+    /// Helper: a random homeserver id.
+    fn random_hs_id() -> PubkyId {
+        PubkyId::from(Keypair::random().public_key())
     }
 
     /// Helper: create a User node in the graph
@@ -372,6 +456,173 @@ mod tests {
         cleanup_test_user(user_a).await?;
         cleanup_test_user(user_b).await?;
         cleanup_test_user(user_c).await?;
+
+        Ok(())
+    }
+
+    #[tokio_shared_rt::test(shared)]
+    async fn test_get_user_homeserver() -> Result<(), DynError> {
+        setup().await?;
+
+        let user_id = "get_user_hs_test_user";
+        let hs_id = "get_user_hs_test_hs";
+
+        create_test_user(user_id).await?;
+
+        // No HOSTED_BY edge yet
+        assert_eq!(get_user_homeserver(user_id).await?, None);
+
+        // After assignment the current homeserver is returned
+        exec_single_row(queries::put::set_user_homeserver(user_id, hs_id)).await?;
+        assert_eq!(get_user_homeserver(user_id).await?, Some(hs_id.to_string()));
+
+        cleanup_test_user(user_id).await?;
+
+        Ok(())
+    }
+
+    /// First-time resolution stores whatever the DHT resolves.
+    #[tokio_shared_rt::test(shared)]
+    async fn test_resolve_user_first_time_sets_homeserver() -> Result<(), DynError> {
+        setup().await?;
+
+        let user_pk = Keypair::random().public_key();
+        let user_id = user_pk.z32();
+        let hs_id = random_hs_id();
+
+        create_test_user(&user_id).await?;
+
+        let resolver = MockResolver {
+            result: Some(hs_id.clone()),
+        };
+        resolve_user(&resolver, &user_pk).await?;
+
+        assert_eq!(
+            get_user_homeserver(&user_id).await?,
+            Some(hs_id.to_string())
+        );
+        assert!(get_user_ids_by_homeserver(&hs_id).await?.contains(&user_id));
+
+        cleanup_test_user(&user_id).await?;
+
+        Ok(())
+    }
+
+    /// A user with no published homeserver and no stored mapping is left alone.
+    #[tokio_shared_rt::test(shared)]
+    async fn test_resolve_user_first_time_no_homeserver_noop() -> Result<(), DynError> {
+        setup().await?;
+
+        let user_pk = Keypair::random().public_key();
+        let user_id = user_pk.z32();
+
+        create_test_user(&user_id).await?;
+
+        let resolver = MockResolver { result: None };
+        resolve_user(&resolver, &user_pk).await?;
+
+        assert_eq!(get_user_homeserver(&user_id).await?, None);
+
+        cleanup_test_user(&user_id).await?;
+
+        Ok(())
+    }
+
+    /// When the published homeserver changes, the binding is kept but marked
+    /// stale so the user stops being indexed; the new homeserver is never set.
+    #[tokio_shared_rt::test(shared)]
+    async fn test_resolve_user_change_keeps_binding_and_marks_stale() -> Result<(), DynError> {
+        setup().await?;
+
+        let user_pk = Keypair::random().public_key();
+        let user_id = user_pk.z32();
+        let stored_hs = random_hs_id();
+        let new_hs = random_hs_id();
+
+        create_test_user(&user_id).await?;
+        exec_single_row(queries::put::set_user_homeserver(&user_id, &stored_hs)).await?;
+
+        // DHT now points at a different homeserver
+        let resolver = MockResolver {
+            result: Some(new_hs.clone()),
+        };
+        resolve_user(&resolver, &user_pk).await?;
+
+        // Binding unchanged, and the user is indexed on neither homeserver
+        assert_eq!(
+            get_user_homeserver(&user_id).await?,
+            Some(stored_hs.to_string())
+        );
+        assert!(!get_user_ids_by_homeserver(&stored_hs)
+            .await?
+            .contains(&user_id));
+        assert!(!get_user_ids_by_homeserver(&new_hs)
+            .await?
+            .contains(&user_id));
+
+        cleanup_test_user(&user_id).await?;
+
+        Ok(())
+    }
+
+    /// When the homeserver is unpublished, the binding is kept but marked stale.
+    #[tokio_shared_rt::test(shared)]
+    async fn test_resolve_user_unpublished_keeps_binding_and_marks_stale() -> Result<(), DynError> {
+        setup().await?;
+
+        let user_pk = Keypair::random().public_key();
+        let user_id = user_pk.z32();
+        let stored_hs = random_hs_id();
+
+        create_test_user(&user_id).await?;
+        exec_single_row(queries::put::set_user_homeserver(&user_id, &stored_hs)).await?;
+
+        // DHT no longer publishes a homeserver
+        let resolver = MockResolver { result: None };
+        resolve_user(&resolver, &user_pk).await?;
+
+        assert_eq!(
+            get_user_homeserver(&user_id).await?,
+            Some(stored_hs.to_string())
+        );
+        assert!(!get_user_ids_by_homeserver(&stored_hs)
+            .await?
+            .contains(&user_id));
+
+        cleanup_test_user(&user_id).await?;
+
+        Ok(())
+    }
+
+    /// When the DHT realigns with the stored homeserver, the stale flag clears
+    /// and the user is indexed again.
+    #[tokio_shared_rt::test(shared)]
+    async fn test_resolve_user_realign_clears_stale() -> Result<(), DynError> {
+        setup().await?;
+
+        let user_pk = Keypair::random().public_key();
+        let user_id = user_pk.z32();
+        let stored_hs = random_hs_id();
+
+        create_test_user(&user_id).await?;
+        exec_single_row(queries::put::set_user_homeserver(&user_id, &stored_hs)).await?;
+        // Start from a stale mapping
+        exec_single_row(queries::put::set_user_homeserver_stale(&user_id, true)).await?;
+        assert!(!get_user_ids_by_homeserver(&stored_hs)
+            .await?
+            .contains(&user_id));
+
+        // DHT points back at the stored homeserver
+        let resolver = MockResolver {
+            result: Some(stored_hs.clone()),
+        };
+        resolve_user(&resolver, &user_pk).await?;
+
+        assert!(get_user_ids_by_homeserver(&stored_hs)
+            .await?
+            .contains(&user_id));
+
+        cleanup_test_user(&user_id).await?;
 
         Ok(())
     }

--- a/nexus-watcher/src/service/user_hs_resolver.rs
+++ b/nexus-watcher/src/service/user_hs_resolver.rs
@@ -238,7 +238,7 @@ async fn get_user_homeserver(user_id: &str) -> GraphResult<Option<String>> {
 
 /// Returns all user IDs hosted on a given homeserver.
 pub async fn get_user_ids_by_homeserver(hs_id: &str) -> GraphResult<Vec<String>> {
-    let query = queries::get::get_users_by_homeserver(hs_id);
+    let query = queries::get::get_active_users_by_homeserver(hs_id);
     let maybe_user_ids = fetch_key_from_graph(query, "user_ids").await?;
     Ok(maybe_user_ids.unwrap_or_default())
 }

--- a/nexus-watcher/src/service/user_hs_resolver.rs
+++ b/nexus-watcher/src/service/user_hs_resolver.rs
@@ -656,47 +656,4 @@ mod tests {
             );
         }
     }
-
-    #[tokio_shared_rt::test(shared)]
-    async fn test_remove_user_homeserver() -> Result<(), DynError> {
-        setup().await?;
-
-        let user_id = "remove_hosted_by_test_user";
-        let hs_id = "remove_hosted_by_test_hs";
-
-        create_test_user(user_id).await?;
-
-        // Assign a homeserver
-        exec_single_row(queries::put::set_user_homeserver(user_id, hs_id)).await?;
-        let users = get_user_ids_by_homeserver(hs_id).await?;
-        assert!(
-            users.contains(&user_id.to_string()),
-            "user should be hosted"
-        );
-
-        // Remove the HOSTED_BY edge
-        exec_single_row(queries::del::remove_user_homeserver(user_id)).await?;
-
-        // User is no longer listed on that homeserver
-        let users = get_user_ids_by_homeserver(hs_id).await?;
-        assert!(
-            !users.contains(&user_id.to_string()),
-            "user should no longer be hosted after removal"
-        );
-
-        // User now needs resolution again (no HOSTED_BY edge)
-        let needing = get_users_needing_resolution(3_600_000).await?;
-        assert!(
-            needing.contains(&user_id.to_string()),
-            "user without HOSTED_BY should need resolution"
-        );
-
-        // Removing again is a no-op (no error)
-        exec_single_row(queries::del::remove_user_homeserver(user_id)).await?;
-
-        // Cleanup
-        cleanup_test_user(user_id).await?;
-
-        Ok(())
-    }
 }

--- a/nexus-watcher/src/service/user_hs_resolver.rs
+++ b/nexus-watcher/src/service/user_hs_resolver.rs
@@ -24,8 +24,7 @@ static HS_RESOLVER_METRICS: LazyLock<HsResolverMetrics> = LazyLock::new(HsResolv
 /// tests instead of hitting the network.
 #[async_trait::async_trait]
 pub trait PkdnsHomeserverResolver: Send + Sync {
-    /// Returns the homeserver published for `user_pk`, or `None` if none is
-    /// currently published.
+    /// Returns the HS published for `user_pk`, if any is currently published.
     async fn resolve_homeserver(&self, user_pk: &PublicKey) -> Result<Option<PubkyId>, DynError>;
 }
 

--- a/nexus-watcher/src/service/user_hs_resolver.rs
+++ b/nexus-watcher/src/service/user_hs_resolver.rs
@@ -466,16 +466,19 @@ mod tests {
         let user_id = Keypair::random().public_key().z32();
         let hs_id = Keypair::random().public_key().z32();
 
-        create_test_user(user_id).await?;
+        create_test_user(&user_id).await?;
 
         // No HOSTED_BY edge yet
-        assert_eq!(get_user_homeserver(user_id).await?, None);
+        assert_eq!(get_user_homeserver(&user_id).await?, None);
 
         // After assignment the current homeserver is returned
-        exec_single_row(queries::put::set_user_homeserver(user_id, hs_id)).await?;
-        assert_eq!(get_user_homeserver(user_id).await?, Some(hs_id.to_string()));
+        exec_single_row(queries::put::set_user_homeserver(&user_id, &hs_id)).await?;
+        assert_eq!(
+            get_user_homeserver(&user_id).await?,
+            Some(hs_id.to_string())
+        );
 
-        cleanup_test_user(user_id).await?;
+        cleanup_test_user(&user_id).await?;
 
         Ok(())
     }

--- a/nexus-watcher/tests/homeserver/active_homeservers.rs
+++ b/nexus-watcher/tests/homeserver/active_homeservers.rs
@@ -113,3 +113,34 @@ async fn test_get_all_active_homeservers() -> Result<(), DynError> {
     test.cleanup_user(&kp_b2).await?;
     Ok(())
 }
+
+/// A homeserver whose only user has a stale mapping must drop off the active list.
+#[tokio_shared_rt::test(shared)]
+async fn test_stale_users_excluded_from_active_homeservers() -> Result<(), DynError> {
+    let mut test = WatcherTest::setup().await?;
+
+    let hs = create_orphan_hs().await?;
+    let kp = Keypair::random();
+    let user_id = test
+        .create_user(&kp, &make_test_user("Watcher:ActiveHS:Stale"))
+        .await?;
+    exec_single_row(queries::put::set_user_homeserver(&user_id, &hs)).await?;
+
+    // With an active mapping the homeserver is listed.
+    let hs_ids = Homeserver::get_all_active_from_graph().await?;
+    assert!(
+        hs_ids.contains(&hs.to_string()),
+        "HS with an active user should be listed"
+    );
+
+    // Marking the only user stale drops the homeserver off the active list.
+    exec_single_row(queries::put::set_user_homeserver_stale(&user_id, true)).await?;
+    let hs_ids = Homeserver::get_all_active_from_graph().await?;
+    assert!(
+        !hs_ids.contains(&hs.to_string()),
+        "HS with only stale users should be excluded"
+    );
+
+    test.cleanup_user(&kp).await?;
+    Ok(())
+}


### PR DESCRIPTION
Disallow changing Homeserver for the third party homeserver's users that were already indexed by Nexus.