### PR TITLE
chore: bump pubky-app-specs to 0.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4016,9 +4016,9 @@ dependencies = [
 
 [[package]]
 name = "pubky-app-specs"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f249e0db615adcafddff9f757414874cba374173a942a1f79c7835ce876f78d"
+checksum = "e116ac50205f5afa2869f56e27e342dd8e6f5b97b951395c69c269b2b333ee5f"
 dependencies = [
  "base32",
  "blake3",
@@ -4028,6 +4028,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
+ "tsify-next",
  "url",
  "utoipa",
  "wasm-bindgen",
@@ -5037,6 +5038,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6196,6 +6208,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tsify-next"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d0f2208feeb5f7a6edb15a2389c14cd42480ef6417318316bb866da5806a61d"
+dependencies = [
+ "serde",
+ "serde-wasm-bindgen",
+ "tsify-next-macros",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "tsify-next-macros"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81253930d0d388a3ab8fa4ae56da9973ab171ef833d1be2e9080fc3ce502bd6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6601,7 +6637,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ redis = "1.0.4"
 opentelemetry = "0.31"
 opentelemetry_sdk = { version = "0.31", features = ["rt-tokio"] }
 pubky = "0.8.0"
-pubky-app-specs = { version = "0.5.1", features = ["openapi"] }
+pubky-app-specs = { version = "0.5.2", features = ["openapi"] }
 pubky-testnet = "0.8.0"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.149"


### PR DESCRIPTION
## Summary

Bumps `pubky-app-specs` 0.5.1 → 0.5.2. The 0.5.2 release adds:
- optional `cover_image: Option<String>` field on `PubkyAppCollectionContent` (general-attachment URL validation: protocol allowlist + length cap)
- `skip_serializing_if = "Option::is_none"` on `description` + `cover_image` so absent fields are omitted from the envelope JSON (matches the Tsify-generated TS types)
- TS interface for `PubkyAppCollectionContent` generated via Tsify (wasm32-only — no native effect)

No API surface changes consumed by Nexus — pure dependency bump.

## Test plan

- [x] `cargo build --workspace --all-targets` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [ ] CI workspace test suite