### PR TITLE
feat: check user homeserver before processing default hs event

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,4 +33,5 @@ jobs:
           cache-on-failure: true
 
       - name: Run clippy
-        run: cargo clippy --tests -- -D warnings # Fail on clippy warnings (checks main code and tests)
+        # `--all-features` so test-only doubles gated behind `test-utils` (e.g. `MockPkdnsResolver`) are linted.
+        run: cargo clippy --tests --all-features -- -D warnings

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
 
       # This test suite uses the TEST_PUBKY_CONNECTION_STRING env variable
       - name: Run WATCHER integration tests
-        run: cargo nextest run -p nexus-watcher --no-fail-fast
+        run: cargo nextest run -p nexus-watcher --features test-utils --no-fail-fast
 
       - name: Tear down Docker Compose
         if: always()

--- a/README.md
+++ b/README.md
@@ -153,13 +153,14 @@ cargo nextest run -p nexus-webapi --no-fail-fast
 
 # nexus-watcher tests need the Postgres Connection URL as env variable, adjust it as needed
 # export TEST_PUBKY_CONNECTION_STRING=postgres://test_user:test_pass@localhost:5432/postgres?pubky-test=true
-cargo nextest run -p nexus-watcher --no-fail-fast
+# `--features test-utils` exposes in-crate test doubles to the integration tests
+cargo nextest run -p nexus-watcher --features test-utils --no-fail-fast
 ```
 
 To test specific feature(s):
 
 ```bash
-cargo nextest run -p nexus-watcher files::create --no-fail-fast
+cargo nextest run -p nexus-watcher --features test-utils files::create --no-fail-fast
 ```
 
 ## 🚀 Benchmarking

--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -440,6 +440,19 @@ pub fn get_user_homeserver(user_id: &str) -> Query {
     .param("user_id", user_id.to_string())
 }
 
+/// Returns the homeserver a user is bound to and whether that mapping is stale.
+///
+/// One row when a `HOSTED_BY` edge exists; no row when the user has none, so the
+/// caller can distinguish "bound (here or elsewhere)" from "no mapping yet".
+pub fn get_user_hosting(user_id: &str) -> Query {
+    Query::new(
+        "get_user_hosting",
+        "MATCH (u:User {id: $user_id})-[r:HOSTED_BY]->(hs:Homeserver)
+         RETURN { homeserver_id: hs.id, stale: coalesce(r.stale, false) } AS hosting",
+    )
+    .param("user_id", user_id.to_string())
+}
+
 /// Retrieves all user IDs actively hosted on a given homeserver.
 ///
 /// Excludes users whose mapping is marked `stale` — i.e. whose published

--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -440,10 +440,7 @@ pub fn get_user_homeserver(user_id: &str) -> Query {
     .param("user_id", user_id.to_string())
 }
 
-/// Returns the homeserver a user is bound to and whether that mapping is stale.
-///
-/// One row when a `HOSTED_BY` edge exists; no row when the user has none, so the
-/// caller can distinguish "bound (here or elsewhere)" from "no mapping yet".
+/// Returns the user's `HOSTED_BY` mapping (`homeserver_id`, `stale`); empty when unmapped.
 pub fn get_user_hosting(user_id: &str) -> Query {
     Query::new(
         "get_user_hosting",

--- a/nexus-watcher/Cargo.toml
+++ b/nexus-watcher/Cargo.toml
@@ -7,6 +7,12 @@ homepage = "https://github.com/pubky/pubky-nexus"
 repository = "https://github.com/pubky/pubky-nexus"
 license = "MIT"
 
+[features]
+# Exposes in-crate test doubles (e.g. `MockPkdnsResolver`) to the integration
+# test target, which can't see `#[cfg(test)]` items across the crate boundary.
+# Enable with `--features test-utils` when running `nexus-watcher` tests.
+test-utils = []
+
 [dependencies]
 async-trait = { workspace = true }
 chrono = { workspace = true }

--- a/nexus-watcher/src/service/indexer/homeserver.rs
+++ b/nexus-watcher/src/service/indexer/homeserver.rs
@@ -1,10 +1,12 @@
 use super::TEventProcessor;
 use crate::events::retry::RetryScheduler;
 use crate::events::EventHandler;
-use nexus_common::db::PubkyConnector;
-use nexus_common::models::event::EventProcessorError;
+use crate::service::user_hs_resolver::PkdnsHomeserverResolver;
+use nexus_common::db::{fetch_key_from_graph, queries, PubkyConnector};
+use nexus_common::models::event::{Event, EventProcessorError};
 use nexus_common::models::homeserver::Homeserver;
 use pubky::Method;
+use serde::Deserialize;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::watch::Receiver;
@@ -22,6 +24,16 @@ pub struct HsEventProcessor {
     pub shutdown_rx: Receiver<bool>,
     /// Scheduler used to enqueue failed events onto the retry queue
     pub retry_scheduler: Arc<RetryScheduler>,
+    /// Resolves a user's published homeserver from PKDNS. Used as a fallback to
+    /// authorize events from users that have no `HOSTED_BY` mapping yet.
+    pub user_hs_resolver: Arc<dyn PkdnsHomeserverResolver>,
+}
+
+/// A user's `HOSTED_BY` mapping as read by the event gate.
+#[derive(Deserialize)]
+struct UserHosting {
+    homeserver_id: String,
+    stale: bool,
 }
 
 #[async_trait::async_trait]
@@ -44,6 +56,57 @@ impl TEventProcessor for HsEventProcessor {
 
     fn homeserver_id(&self) -> Option<&str> {
         Some(self.homeserver.id.as_ref())
+    }
+
+    /// Refuses event lines for users that are no longer hosted on this homeserver.
+    ///
+    /// A homeserver may keep emitting events for a user after the user has
+    /// re-pointed (or unpublished) their `_pubky` record in PKDNS. We only index
+    /// a line when the user still resolves to this homeserver:
+    /// - `HOSTED_BY` edge to this HS and not `stale` → process (cheap graph read).
+    /// - `HOSTED_BY` edge that diverges (points elsewhere, or here but `stale`) → refuse.
+    /// - No edge yet (new/unresolved user) → fall back to a live PKDNS lookup.
+    #[tracing::instrument(
+        name = "event.gate",
+        skip_all,
+        fields(user = %event.parsed_uri.user_id(), hs = %self.homeserver.id)
+    )]
+    async fn should_process_event(&self, event: &Event) -> Result<bool, EventProcessorError> {
+        let user_id = event.parsed_uri.user_id();
+
+        // Single read of the user's mapping (bound homeserver + stale flag).
+        let hosting: Option<UserHosting> =
+            fetch_key_from_graph(queries::get::get_user_hosting(user_id), "hosting").await?;
+
+        match hosting {
+            // Active here: edge to this homeserver and not stale → process.
+            Some(h) if h.homeserver_id == self.homeserver.id.as_ref() && !h.stale => Ok(true),
+            // Mapping diverges (points elsewhere, or here but stale). Switching is
+            // unsupported — refuse.
+            Some(_) => {
+                warn!("User mapping diverges from this homeserver; refusing event");
+                Ok(false)
+            }
+            // No mapping yet (new/unresolved user): authorize against PKDNS directly.
+            None => {
+                let resolved = self
+                    .user_hs_resolver
+                    .resolve_homeserver(&user_id.to_public_key())
+                    .await
+                    .map_err(|e| EventProcessorError::client_error(e.to_string()))?;
+
+                match resolved {
+                    Some(ref resolved_hs) if *resolved_hs == self.homeserver.id => Ok(true),
+                    // `None` here conflates "user has no published HS" with "DHT lookup flaked" —
+                    // both refuse silently. Blocked on https://github.com/pubky/pubky-core/issues/408
+                    // to distinguish them at the SDK boundary so flakes can be retried instead.
+                    _ => {
+                        warn!("User does not point to this homeserver in PKDNS; refusing event");
+                        Ok(false)
+                    }
+                }
+            }
+        }
     }
 
     async fn run_internal(self: Arc<Self>) -> Result<(), EventProcessorError> {

--- a/nexus-watcher/src/service/indexer/homeserver.rs
+++ b/nexus-watcher/src/service/indexer/homeserver.rs
@@ -24,8 +24,7 @@ pub struct HsEventProcessor {
     pub shutdown_rx: Receiver<bool>,
     /// Scheduler used to enqueue failed events onto the retry queue
     pub retry_scheduler: Arc<RetryScheduler>,
-    /// Resolves a user's published homeserver from PKDNS. Used as a fallback to
-    /// authorize events from users that have no `HOSTED_BY` mapping yet.
+    /// PKDNS fallback for users with no `HOSTED_BY` mapping yet.
     pub user_hs_resolver: Arc<dyn PkdnsHomeserverResolver>,
 }
 
@@ -58,14 +57,8 @@ impl TEventProcessor for HsEventProcessor {
         Some(self.homeserver.id.as_ref())
     }
 
-    /// Refuses event lines for users that are no longer hosted on this homeserver.
-    ///
-    /// A homeserver may keep emitting events for a user after the user has
-    /// re-pointed (or unpublished) their `_pubky` record in PKDNS. We only index
-    /// a line when the user still resolves to this homeserver:
-    /// - `HOSTED_BY` edge to this HS and not `stale` → process (cheap graph read).
-    /// - `HOSTED_BY` edge that diverges (points elsewhere, or here but `stale`) → refuse.
-    /// - No edge yet (new/unresolved user) → fall back to a live PKDNS lookup.
+    /// Refuses events for users no longer hosted here. Graph fast-path on `HOSTED_BY`;
+    /// PKDNS fallback when no mapping exists.
     #[tracing::instrument(
         name = "event.gate",
         skip_all,
@@ -74,20 +67,17 @@ impl TEventProcessor for HsEventProcessor {
     async fn should_process_event(&self, event: &Event) -> Result<bool, EventProcessorError> {
         let user_id = event.parsed_uri.user_id();
 
-        // Single read of the user's mapping (bound homeserver + stale flag).
         let hosting: Option<UserHosting> =
             fetch_key_from_graph(queries::get::get_user_hosting(user_id), "hosting").await?;
 
         match hosting {
-            // Active here: edge to this homeserver and not stale → process.
             Some(h) if h.homeserver_id == self.homeserver.id.as_ref() && !h.stale => Ok(true),
-            // Mapping diverges (points elsewhere, or here but stale). Switching is
-            // unsupported — refuse.
+            // Diverges (elsewhere or stale): switching unsupported.
             Some(_) => {
                 warn!("User mapping diverges from this homeserver; refusing event");
                 Ok(false)
             }
-            // No mapping yet (new/unresolved user): authorize against PKDNS directly.
+            // No mapping yet: fall back to PKDNS.
             None => {
                 let resolved = self
                     .user_hs_resolver

--- a/nexus-watcher/src/service/indexer/mod.rs
+++ b/nexus-watcher/src/service/indexer/mod.rs
@@ -135,12 +135,28 @@ pub trait TEventProcessor: Send + Sync + 'static {
                 warn!("Unrecognized event URI: {reason}");
             }
             Ok(ParseResult::Parsed(event)) => {
+                // Gate errors bypass `handle_error` and stop the whole batch (cursor not advanced,
+                // replays next tick) — a single-user PKDNS/graph failure stalls the watcher until it recovers.
+                if !self.should_process_event(&event).await? {
+                    debug!("Refusing event after pre-check: {}", event.uri);
+                    return Ok(());
+                }
                 debug!("Processing event: {:?}", event);
                 self.handle_event(&event).await?;
             }
         }
 
         Ok(())
+    }
+
+    /// Pre-check invoked after a line is parsed into an actionable [`Event`] but
+    /// before it is handed to [`Self::handle_event`].
+    ///
+    /// Returning `Ok(false)` skips the event without error; `Err` propagates and
+    /// stops the batch (so the cursor is not advanced and the batch replays).
+    /// Default: process every event.
+    async fn should_process_event(&self, _event: &Event) -> Result<bool, EventProcessorError> {
+        Ok(true)
     }
 
     /// Handles an error of event processing from event processing (e.g. logging, scheduling retries).

--- a/nexus-watcher/src/service/indexer/mod.rs
+++ b/nexus-watcher/src/service/indexer/mod.rs
@@ -149,12 +149,8 @@ pub trait TEventProcessor: Send + Sync + 'static {
         Ok(())
     }
 
-    /// Pre-check invoked after a line is parsed into an actionable [`Event`] but
-    /// before it is handed to [`Self::handle_event`].
-    ///
-    /// Returning `Ok(false)` skips the event without error; `Err` propagates and
-    /// stops the batch (so the cursor is not advanced and the batch replays).
-    /// Default: process every event.
+    /// Pre-check between parse and `handle_event`. `Ok(false)` skips the event;
+    /// `Err` stops the batch (cursor not advanced — batch replays).
     async fn should_process_event(&self, _event: &Event) -> Result<bool, EventProcessorError> {
         Ok(true)
     }

--- a/nexus-watcher/src/service/runner/homeserver.rs
+++ b/nexus-watcher/src/service/runner/homeserver.rs
@@ -2,6 +2,7 @@ use super::TEventProcessorRunner;
 use crate::events::retry::RetryScheduler;
 use crate::events::{DefaultEventHandler, EventHandler, Moderation};
 use crate::service::indexer::{HsEventProcessor, TEventProcessor};
+use crate::service::user_hs_resolver::PubkyConnectorResolver;
 use nexus_common::models::homeserver::Homeserver;
 use nexus_common::types::DynError;
 use nexus_common::WatcherConfig;
@@ -60,6 +61,7 @@ impl TEventProcessorRunner for HsEventProcessorRunner {
             event_handler: self.event_handler.clone(),
             shutdown_rx: self.shutdown_rx.clone(),
             retry_scheduler: self.retry_scheduler.clone(),
+            user_hs_resolver: Arc::new(PubkyConnectorResolver),
         }))
     }
 

--- a/nexus-watcher/src/service/user_hs_resolver.rs
+++ b/nexus-watcher/src/service/user_hs_resolver.rs
@@ -42,6 +42,30 @@ impl PkdnsHomeserverResolver for PubkyConnectorResolver {
     }
 }
 
+/// Test [`PkdnsHomeserverResolver`] returning a fixed result for any user, so
+/// the resolver loop and the HsEventProcessor PKDNS fallback can be driven
+/// without touching the DHT. Gated so it never ships in production builds.
+#[cfg(any(test, feature = "test-utils"))]
+pub struct MockPkdnsResolver {
+    result: Option<PubkyId>,
+}
+
+#[cfg(any(test, feature = "test-utils"))]
+impl MockPkdnsResolver {
+    /// Resolves every user to `result` (or to nothing when `None`).
+    pub fn new(result: Option<PubkyId>) -> Self {
+        Self { result }
+    }
+}
+
+#[cfg(any(test, feature = "test-utils"))]
+#[async_trait::async_trait]
+impl PkdnsHomeserverResolver for MockPkdnsResolver {
+    async fn resolve_homeserver(&self, _user_pk: &PublicKey) -> Result<Option<PubkyId>, DynError> {
+        Ok(self.result.clone())
+    }
+}
+
 pub struct UserHsResolverRunner {
     resolver: Box<dyn PkdnsHomeserverResolver>,
     ttl_ms: u64,
@@ -278,22 +302,6 @@ mod tests {
         StackManager::setup(&StackConfig::default()).await
     }
 
-    /// Resolver stub returning a fixed PKDNS result, so `resolve_user` can be
-    /// driven without touching the DHT.
-    struct MockResolver {
-        result: Option<PubkyId>,
-    }
-
-    #[async_trait::async_trait]
-    impl PkdnsHomeserverResolver for MockResolver {
-        async fn resolve_homeserver(
-            &self,
-            _user_pk: &PublicKey,
-        ) -> Result<Option<PubkyId>, DynError> {
-            Ok(self.result.clone())
-        }
-    }
-
     /// Helper: a random homeserver id.
     fn random_hs_id() -> PubkyId {
         PubkyId::from(Keypair::random().public_key())
@@ -494,9 +502,7 @@ mod tests {
 
         create_test_user(&user_id).await?;
 
-        let resolver = MockResolver {
-            result: Some(hs_id.clone()),
-        };
+        let resolver = MockPkdnsResolver::new(Some(hs_id.clone()));
         resolve_user(&resolver, &user_pk).await?;
 
         assert_eq!(
@@ -520,7 +526,7 @@ mod tests {
 
         create_test_user(&user_id).await?;
 
-        let resolver = MockResolver { result: None };
+        let resolver = MockPkdnsResolver::new(None);
         resolve_user(&resolver, &user_pk).await?;
 
         assert_eq!(get_user_homeserver(&user_id).await?, None);
@@ -545,9 +551,7 @@ mod tests {
         exec_single_row(queries::put::set_user_homeserver(&user_id, &stored_hs)).await?;
 
         // DHT now points at a different homeserver
-        let resolver = MockResolver {
-            result: Some(new_hs.clone()),
-        };
+        let resolver = MockPkdnsResolver::new(Some(new_hs.clone()));
         resolve_user(&resolver, &user_pk).await?;
 
         // Binding unchanged, and the user is indexed on neither homeserver
@@ -580,7 +584,7 @@ mod tests {
         exec_single_row(queries::put::set_user_homeserver(&user_id, &stored_hs)).await?;
 
         // DHT no longer publishes a homeserver
-        let resolver = MockResolver { result: None };
+        let resolver = MockPkdnsResolver::new(None);
         resolve_user(&resolver, &user_pk).await?;
 
         assert_eq!(
@@ -615,9 +619,7 @@ mod tests {
             .contains(&user_id));
 
         // DHT points back at the stored homeserver
-        let resolver = MockResolver {
-            result: Some(stored_hs.clone()),
-        };
+        let resolver = MockPkdnsResolver::new(Some(stored_hs.clone()));
         resolve_user(&resolver, &user_pk).await?;
 
         assert!(get_user_ids_by_homeserver(&stored_hs)

--- a/nexus-watcher/src/service/user_hs_resolver.rs
+++ b/nexus-watcher/src/service/user_hs_resolver.rs
@@ -42,9 +42,7 @@ impl PkdnsHomeserverResolver for PubkyConnectorResolver {
     }
 }
 
-/// Test [`PkdnsHomeserverResolver`] returning a fixed result for any user, so
-/// the resolver loop and the HsEventProcessor PKDNS fallback can be driven
-/// without touching the DHT. Gated so it never ships in production builds.
+/// Test [`PkdnsHomeserverResolver`] returning a fixed result without touching the DHT.
 #[cfg(any(test, feature = "test-utils"))]
 pub struct MockPkdnsResolver {
     result: Option<PubkyId>,

--- a/nexus-watcher/tests/service/hs_event_processor.rs
+++ b/nexus-watcher/tests/service/hs_event_processor.rs
@@ -1,24 +1,29 @@
 use crate::service::utils::common::create_mock_handler;
-use crate::service::utils::{new_in_memory_store, setup, TEST_USER_ID};
+use crate::service::utils::{mock_resolver, new_in_memory_store, setup, TEST_USER_ID};
 use anyhow::Result;
+use nexus_common::db::graph::Query;
+use nexus_common::db::{exec_single_row, queries};
 use nexus_common::models::event::EventProcessorError;
 use nexus_common::models::homeserver::Homeserver;
 use nexus_watcher::events::retry::{InitialBackoff, RetryScheduler, RetryStore};
 use nexus_watcher::events::EventHandler;
+use nexus_watcher::service::user_hs_resolver::PkdnsHomeserverResolver;
 use nexus_watcher::service::HsEventProcessor;
+use pubky::Keypair;
 use pubky_app_specs::{post_uri_builder, PubkyId};
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::watch;
 
-const TEST_HS_ID: &str = "1hb71xx9km3f4pw5izsy1gn19ff1uuuqonw4mcygzobwkryujoiy";
-
-/// Assemble an [`HsEventProcessor`] for tests. Tests bypass `poll_events` by
-/// calling `process_event_lines` directly with constructed event lines.
-fn build_processor(
+/// Assemble an [`HsEventProcessor`] on the given homeserver with an injected
+/// PKDNS resolver. Tests bypass `poll_events` by calling `process_event_lines`
+/// directly with constructed event lines.
+fn build_processor_with(
+    hs_id: &str,
     store: Arc<dyn RetryStore>,
     event_handler: Arc<dyn EventHandler>,
     shutdown_rx: watch::Receiver<bool>,
+    user_hs_resolver: Arc<dyn PkdnsHomeserverResolver>,
 ) -> Arc<HsEventProcessor> {
     let retry_scheduler = Arc::new(RetryScheduler::new(
         store,
@@ -27,7 +32,7 @@ fn build_processor(
             transient_ms: 10_000,
         },
     ));
-    let hs_id = PubkyId::try_from(TEST_HS_ID).expect("Valid test Pubky ID");
+    let hs_id = PubkyId::try_from(hs_id).expect("Valid test Pubky ID");
 
     Arc::new(HsEventProcessor {
         homeserver: Homeserver::new(hs_id),
@@ -36,7 +41,49 @@ fn build_processor(
         event_handler,
         shutdown_rx,
         retry_scheduler,
+        user_hs_resolver,
     })
+}
+
+/// Processor on a fresh random homeserver, with a PKDNS mock that resolves
+/// every user back to that homeserver. Event-URI users have no `HOSTED_BY`
+/// mapping, so the gate falls back to PKDNS and passes — letting these
+/// batch-behaviour tests run without graph setup, with no shared identifier
+/// between the user and homeserver roles.
+fn build_processor(
+    store: Arc<dyn RetryStore>,
+    event_handler: Arc<dyn EventHandler>,
+    shutdown_rx: watch::Receiver<bool>,
+) -> Arc<HsEventProcessor> {
+    let hs_id = random_id();
+    build_processor_with(
+        &hs_id,
+        store,
+        event_handler,
+        shutdown_rx,
+        mock_resolver(Some(&hs_id)),
+    )
+}
+
+/// Returns a fresh random Pubky z32 id (used for both users and homeservers).
+fn random_id() -> String {
+    Keypair::random().public_key().to_z32()
+}
+
+/// Creates a bare `User` graph node so a `HOSTED_BY` edge can be attached to it.
+async fn create_user_node(user_id: &str) -> Result<()> {
+    let query = Query::new(
+        "test_create_user",
+        "MERGE (u:User {id: $id}) SET u.name = 'test', u.indexed_at = 0 RETURN u",
+    )
+    .param("id", user_id.to_string());
+    exec_single_row(query).await?;
+    Ok(())
+}
+
+async fn delete_user_node(user_id: &str) -> Result<()> {
+    exec_single_row(queries::del::delete_user(user_id)).await?;
+    Ok(())
 }
 
 // ============================================================================
@@ -126,7 +173,8 @@ async fn test_retry_event_carries_origin_homeserver_id() -> Result<()> {
         .await?
         .expect("Retryable failure must enqueue a RetryEvent");
     assert_eq!(
-        retry_event.origin_homeserver_id, TEST_HS_ID,
+        retry_event.origin_homeserver_id,
+        processor.homeserver.id.to_string(),
         "Enqueued retry must carry the origin homeserver id"
     );
 
@@ -192,6 +240,196 @@ async fn test_batch_stops_on_infrastructure_error() -> Result<()> {
         store.get(&second_uri).await?.is_none(),
         "Second event must not be queued — batch should have stopped at the first failure"
     );
+
+    let _ = shutdown_tx.send(true);
+    Ok(())
+}
+
+// ============================================================================
+// PKDNS / HOSTED_BY gate
+// The default homeserver may keep emitting events for a user after that user
+// re-points (or unpublishes) their `_pubky` record. `should_process_event`
+// must refuse such lines, so the watcher stops indexing users no longer hosted
+// here. These tests exercise each branch of that gate.
+// ============================================================================
+
+/// Drives one PUT event for `user_id` through the gate and returns how many
+/// times the handler was invoked (1 = processed, 0 = refused).
+async fn run_single_event(
+    processor: Arc<HsEventProcessor>,
+    handler: Arc<crate::utils::MockEventHandler>,
+    user_id: &str,
+) -> Result<usize> {
+    let uri = post_uri_builder(user_id.to_string(), "gatepost".to_string());
+    let result = processor
+        .process_event_lines(vec![format!("PUT {uri}")])
+        .await;
+    assert!(result.is_ok(), "gate must skip, not error: {result:?}");
+    Ok(handler.get_handle_count())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_processes_event_when_actively_hosted_here() -> Result<()> {
+    setup().await?;
+
+    let hs_id = random_id();
+    let user_id = random_id();
+    create_user_node(&user_id).await?;
+    // Fresh, non-stale mapping to this homeserver.
+    exec_single_row(queries::put::set_user_homeserver(&user_id, &hs_id)).await?;
+
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let handler = create_mock_handler(Ok(()), None);
+    // Resolver must not be consulted on the graph fast path.
+    let processor = build_processor_with(
+        &hs_id,
+        new_in_memory_store(),
+        handler.clone(),
+        shutdown_rx,
+        mock_resolver(None),
+    );
+
+    let handled = run_single_event(processor, handler, &user_id).await?;
+    assert_eq!(handled, 1, "actively hosted user must be processed");
+
+    delete_user_node(&user_id).await?;
+    let _ = shutdown_tx.send(true);
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_refuses_event_when_mapping_is_stale() -> Result<()> {
+    setup().await?;
+
+    let hs_id = random_id();
+    let user_id = random_id();
+    create_user_node(&user_id).await?;
+    exec_single_row(queries::put::set_user_homeserver(&user_id, &hs_id)).await?;
+    // User switched away / unpublished: resolver marked the mapping stale.
+    exec_single_row(queries::put::set_user_homeserver_stale(&user_id, true)).await?;
+
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let handler = create_mock_handler(Ok(()), None);
+    // Even if PKDNS still claimed this HS, a stale mapping must refuse.
+    let processor = build_processor_with(
+        &hs_id,
+        new_in_memory_store(),
+        handler.clone(),
+        shutdown_rx,
+        mock_resolver(Some(&hs_id)),
+    );
+
+    let handled = run_single_event(processor, handler, &user_id).await?;
+    assert_eq!(handled, 0, "stale mapping must refuse the event");
+
+    delete_user_node(&user_id).await?;
+    let _ = shutdown_tx.send(true);
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_refuses_event_when_bound_to_another_homeserver() -> Result<()> {
+    setup().await?;
+
+    let hs_id = random_id();
+    let other_hs_id = random_id();
+    let user_id = random_id();
+    create_user_node(&user_id).await?;
+    // Bound to a different homeserver than the one processing the event.
+    exec_single_row(queries::put::set_user_homeserver(&user_id, &other_hs_id)).await?;
+
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let handler = create_mock_handler(Ok(()), None);
+    let processor = build_processor_with(
+        &hs_id,
+        new_in_memory_store(),
+        handler.clone(),
+        shutdown_rx,
+        mock_resolver(Some(&hs_id)),
+    );
+
+    let handled = run_single_event(processor, handler, &user_id).await?;
+    assert_eq!(handled, 0, "user bound elsewhere must be refused");
+
+    delete_user_node(&user_id).await?;
+    let _ = shutdown_tx.send(true);
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_processes_event_via_pkdns_fallback_when_no_mapping() -> Result<()> {
+    setup().await?;
+
+    let hs_id = random_id();
+    // Fresh user with no HOSTED_BY edge: gate falls back to PKDNS, which points here.
+    let user_id = random_id();
+
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let handler = create_mock_handler(Ok(()), None);
+    let processor = build_processor_with(
+        &hs_id,
+        new_in_memory_store(),
+        handler.clone(),
+        shutdown_rx,
+        mock_resolver(Some(&hs_id)),
+    );
+
+    let handled = run_single_event(processor, handler, &user_id).await?;
+    assert_eq!(
+        handled, 1,
+        "unmapped user pointing here in PKDNS is processed"
+    );
+
+    let _ = shutdown_tx.send(true);
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_refuses_event_via_pkdns_fallback_when_points_elsewhere() -> Result<()> {
+    setup().await?;
+
+    let hs_id = random_id();
+    let other_hs_id = random_id();
+    // Fresh user with no HOSTED_BY edge whose PKDNS record points to another HS.
+    let user_id = random_id();
+
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let handler = create_mock_handler(Ok(()), None);
+    let processor = build_processor_with(
+        &hs_id,
+        new_in_memory_store(),
+        handler.clone(),
+        shutdown_rx,
+        mock_resolver(Some(&other_hs_id)),
+    );
+
+    let handled = run_single_event(processor, handler, &user_id).await?;
+    assert_eq!(handled, 0, "unmapped user pointing elsewhere is refused");
+
+    let _ = shutdown_tx.send(true);
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_refuses_event_via_pkdns_fallback_when_no_record() -> Result<()> {
+    setup().await?;
+
+    let hs_id = random_id();
+    // Fresh user with no HOSTED_BY edge and no published PKDNS record.
+    let user_id = random_id();
+
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let handler = create_mock_handler(Ok(()), None);
+    let processor = build_processor_with(
+        &hs_id,
+        new_in_memory_store(),
+        handler.clone(),
+        shutdown_rx,
+        mock_resolver(None),
+    );
+
+    let handled = run_single_event(processor, handler, &user_id).await?;
+    assert_eq!(handled, 0, "unmapped user with no PKDNS record is refused");
 
     let _ = shutdown_tx.send(true);
     Ok(())

--- a/nexus-watcher/tests/service/hs_event_processor.rs
+++ b/nexus-watcher/tests/service/hs_event_processor.rs
@@ -45,11 +45,8 @@ fn build_processor_with(
     })
 }
 
-/// Processor on a fresh random homeserver, with a PKDNS mock that resolves
-/// every user back to that homeserver. Event-URI users have no `HOSTED_BY`
-/// mapping, so the gate falls back to PKDNS and passes — letting these
-/// batch-behaviour tests run without graph setup, with no shared identifier
-/// between the user and homeserver roles.
+/// Processor on a fresh random homeserver with a PKDNS mock that resolves every user
+/// back to it, so gate falls back to PKDNS and passes without graph setup.
 fn build_processor(
     store: Arc<dyn RetryStore>,
     event_handler: Arc<dyn EventHandler>,
@@ -247,10 +244,8 @@ async fn test_batch_stops_on_infrastructure_error() -> Result<()> {
 
 // ============================================================================
 // PKDNS / HOSTED_BY gate
-// The default homeserver may keep emitting events for a user after that user
-// re-points (or unpublishes) their `_pubky` record. `should_process_event`
-// must refuse such lines, so the watcher stops indexing users no longer hosted
-// here. These tests exercise each branch of that gate.
+// Default HS may keep emitting events after a user re-points their `_pubky`
+// record. These tests exercise each branch of `should_process_event`.
 // ============================================================================
 
 /// Drives one PUT event for `user_id` through the gate and returns how many

--- a/nexus-watcher/tests/service/utils/common.rs
+++ b/nexus-watcher/tests/service/utils/common.rs
@@ -1,12 +1,21 @@
 use crate::utils::MockEventHandler;
 use nexus_common::models::event::EventProcessorError;
 use nexus_watcher::events::retry::{InMemoryRetryStore, RetryStore};
+use nexus_watcher::service::user_hs_resolver::{MockPkdnsResolver, PkdnsHomeserverResolver};
+use pubky_app_specs::PubkyId;
 use std::sync::{Arc, Mutex};
 
 pub const TEST_USER_ID: &str = "uo7jgkykft4885n8cruizwy6khw71mnu5pq3ay9i8pw1ymcn85ko";
 
 pub fn new_in_memory_store() -> Arc<dyn RetryStore> {
     Arc::new(InMemoryRetryStore::new())
+}
+
+/// Builds a [`MockPkdnsResolver`] resolving every user to `hs_id` (or to nothing
+/// when `None`).
+pub fn mock_resolver(hs_id: Option<&str>) -> Arc<dyn PkdnsHomeserverResolver> {
+    let result = hs_id.map(|id| PubkyId::try_from(id).expect("valid pubky id"));
+    Arc::new(MockPkdnsResolver::new(result))
 }
 
 /// Create a mock event handler with an invocation counter.

--- a/nexus-watcher/tests/service/utils/mod.rs
+++ b/nexus-watcher/tests/service/utils/mod.rs
@@ -5,7 +5,7 @@ mod processor_runner;
 mod result;
 mod setup;
 
-pub use common::{create_mock_handler, new_in_memory_store, TEST_USER_ID};
+pub use common::{create_mock_handler, mock_resolver, new_in_memory_store, TEST_USER_ID};
 pub use key_based_event_source::MockKeyBasedEventSource;
 pub use processor::{
     create_mock_event_processors, create_random_homeservers_and_persist, MockEventProcessor,


### PR DESCRIPTION
Gates the default-homeserver indexer so it only processes events for users that still resolve to this homeserver:
- Graph path (cheap): read the user's HOSTED_BY mapping — process only if it points to this HS and is not stale; refuse if it diverges (points elsewhere, or here but stale).
- PKDNS fallback: if there's no mapping yet (new/unresolved user), resolve the homeserver live from PKDNS and process only if it matches.

Currently there is no way to distinct no pkds record from resolve failure - we may need https://github.com/pubky/pubky-core/issues/408 to add proper error handling instead of skipping user events.
