### PR TITLE
Introduce, handle `HsEventsStreamRateLimitExhausted` event processor error

### DIFF
--- a/nexus-common/src/db/graph/error.rs
+++ b/nexus-common/src/db/graph/error.rs
@@ -36,7 +36,7 @@ pub enum GraphError {
 
 impl GraphError {
     #[allow(clippy::match_like_matches_macro)]
-    pub fn is_infrastructure_err(&self) -> bool {
+    pub fn should_not_retry_now(&self) -> bool {
         match self {
             GraphError::ConnectionNotInitialized => true,
             GraphError::QueryFailed(_) => true,

--- a/nexus-common/src/db/kv/error.rs
+++ b/nexus-common/src/db/kv/error.rs
@@ -29,7 +29,7 @@ pub enum RedisError {
 
 impl RedisError {
     #[allow(clippy::match_like_matches_macro)]
-    pub fn is_infrastructure_err(&self) -> bool {
+    pub fn should_not_retry_now(&self) -> bool {
         match self {
             RedisError::ConnectionNotInitialized => true,
             RedisError::ConnectionPoolError(_) => true,

--- a/nexus-common/src/models/event/errors.rs
+++ b/nexus-common/src/models/event/errors.rs
@@ -137,6 +137,13 @@ impl EventProcessorError {
         match self {
             Self::GraphQueryFailed(true, _) => true,
             Self::IndexOperationFailed(true, _) => true,
+
+            // If connections to a HS fail with 429 despite the internal retry with backoff,
+            // then the HS is seen as having an unreasonable behavior or configuration.
+            // It is treated as infrastructure error because making further calls to this HS
+            // to fetch events for any other users of this HS will result in the same error
+            Self::PubkyClientError(PubkyClientError::TooManyRequests429 { .. }) => true,
+
             _ => false,
         }
     }

--- a/nexus-common/src/models/event/errors.rs
+++ b/nexus-common/src/models/event/errors.rs
@@ -39,6 +39,11 @@ pub enum EventProcessorError {
     #[error("PubkyClientError: {0}")]
     PubkyClientError(#[from] PubkyClientError),
 
+    /// A homeserver's /events-stream keeps returning 429 Too Many Requests
+    /// even after all internal backoff retries were exhausted.
+    #[error("HS /events-stream rate limit exhausted (429 after all backoff retries)")]
+    HsEventsStreamRateLimitExhausted,
+
     #[error("MediaProcessor: {0}")]
     MediaProcessorError(String),
 
@@ -137,12 +142,7 @@ impl EventProcessorError {
         match self {
             Self::GraphQueryFailed(true, _) => true,
             Self::IndexOperationFailed(true, _) => true,
-
-            // If connections to a HS fail with 429 despite the internal retry with backoff,
-            // then the HS is seen as having an unreasonable behavior or configuration.
-            // It is treated as infrastructure error because making further calls to this HS
-            // to fetch events for any other users of this HS will result in the same error
-            Self::PubkyClientError(PubkyClientError::TooManyRequests429 { .. }) => true,
+            Self::HsEventsStreamRateLimitExhausted => true,
 
             _ => false,
         }
@@ -160,6 +160,7 @@ impl EventProcessorError {
             Self::InvalidEventLine(_) => false,
             Self::SkipIndexing => false,
             Self::UserIdMismatch { .. } => false,
+            Self::HsEventsStreamRateLimitExhausted => false,
             _ => true,
         }
     }

--- a/nexus-common/src/models/event/errors.rs
+++ b/nexus-common/src/models/event/errors.rs
@@ -9,7 +9,7 @@ use crate::models::error::ModelError;
 #[derive(Error, Debug, Clone, Serialize, Deserialize)]
 pub enum EventProcessorError {
     /// Failed to execute query in the graph database
-    #[error("GraphQueryFailed (is_infrastructure_err: {0}): {1}")]
+    #[error("GraphQueryFailed (should_not_retry_now: {0}): {1}")]
     GraphQueryFailed(bool, String),
 
     /// The event could not be indexed due to missing graph dependencies
@@ -17,7 +17,7 @@ pub enum EventProcessorError {
     MissingDependency { dependency: Vec<String> },
 
     /// Failed to complete indexing due to a Redis operation error
-    #[error("IndexOperationFailed (is_infrastructure_err: {0}): Indexing incomplete due to Redis error: {1}")]
+    #[error("IndexOperationFailed (should_not_retry_now: {0}): Indexing incomplete due to Redis error: {1}")]
     IndexOperationFailed(bool, String),
 
     /// The event appears to be unindexed. Verify the event in the retry queue
@@ -62,12 +62,12 @@ impl From<ModelError> for EventProcessorError {
     fn from(e: ModelError) -> Self {
         match e {
             ModelError::GraphOperationFailed(source) => {
-                let is_infrastructure_err = source.is_infrastructure_err();
-                EventProcessorError::GraphQueryFailed(is_infrastructure_err, source.to_string())
+                let should_not_retry_now = source.should_not_retry_now();
+                EventProcessorError::GraphQueryFailed(should_not_retry_now, source.to_string())
             }
             ModelError::KvOperationFailed(source) => {
-                let is_infrastructure_err = source.is_infrastructure_err();
-                EventProcessorError::IndexOperationFailed(is_infrastructure_err, source.to_string())
+                let should_not_retry_now = source.should_not_retry_now();
+                EventProcessorError::IndexOperationFailed(should_not_retry_now, source.to_string())
             }
             ModelError::MediaProcessorError(source) => {
                 EventProcessorError::MediaProcessorError(source.to_string())
@@ -94,15 +94,15 @@ impl From<std::io::Error> for EventProcessorError {
 
 impl From<RedisError> for EventProcessorError {
     fn from(e: RedisError) -> Self {
-        let is_infrastructure_err = e.is_infrastructure_err();
-        EventProcessorError::IndexOperationFailed(is_infrastructure_err, e.to_string())
+        let should_not_retry_now = e.should_not_retry_now();
+        EventProcessorError::IndexOperationFailed(should_not_retry_now, e.to_string())
     }
 }
 
 impl From<GraphError> for EventProcessorError {
     fn from(e: GraphError) -> Self {
-        let is_infrastructure_err = e.is_infrastructure_err();
-        EventProcessorError::GraphQueryFailed(is_infrastructure_err, e.to_string())
+        let should_not_retry_now = e.should_not_retry_now();
+        EventProcessorError::GraphQueryFailed(should_not_retry_now, e.to_string())
     }
 }
 
@@ -133,12 +133,12 @@ impl EventProcessorError {
         Self::InternalError(source.to_string())
     }
 
-    /// Returns whether or not this is an infrastructure error.
+    /// Returns whether or not we should refrain from retrying this error right now.
     ///
-    /// These are the kinds of errors that are expected to be thrown again,
+    /// These are the kinds of errors that are expected to be thrown again
     /// if the event processor caller continues processing other events.
     #[allow(clippy::match_like_matches_macro)]
-    pub fn is_infrastructure(&self) -> bool {
+    pub fn should_not_retry_now(&self) -> bool {
         match self {
             Self::GraphQueryFailed(true, _) => true,
             Self::IndexOperationFailed(true, _) => true,

--- a/nexus-watcher/src/events/retry/processor.rs
+++ b/nexus-watcher/src/events/retry/processor.rs
@@ -141,10 +141,10 @@ impl RetryProcessor {
                 warn!("Event {ev_uri} failed with non-retryable error, dead-lettering: {e}");
                 self.store.remove(index_key).await?;
             }
-            Err(e) if e.is_infrastructure() => {
-                // Infrastructure errors (Neo4j/Redis failures) must NOT count against the
-                // application-level max_retries limit.  Reschedule with backoff but do NOT
-                // increment retry_count, then propagate to stop the current batch.
+            Err(e) if e.should_not_retry_now() => {
+                // Errors we should not retry right now (e.g. Neo4j/Redis failures) must NOT count
+                // against the application-level max_retries limit.  Reschedule with backoff but do
+                // NOT increment retry_count, then propagate to stop the current batch.
                 self.reschedule(&retry_event, index_key, &e, false).await?;
                 return Err(e);
             }
@@ -164,8 +164,8 @@ impl RetryProcessor {
     /// Reschedule an event for retry with exponential backoff.
     ///
     /// When `increment_count` is `true` the retry budget is consumed (application-level
-    /// errors).  When `false` the counter stays unchanged — used for infrastructure
-    /// errors that should not count against the retry limit.
+    /// errors).  When `false` the counter stays unchanged — used for errors that
+    /// should not be retried right now, which should not count against the retry limit.
     async fn reschedule(
         &self,
         retry_event: &RetryEvent,

--- a/nexus-watcher/src/service/indexer/homeserver.rs
+++ b/nexus-watcher/src/service/indexer/homeserver.rs
@@ -104,7 +104,7 @@ impl HsEventProcessor {
     /// Processes a batch of event lines retrieved from the homeserver.
     ///
     /// This function implements the retry logic:
-    /// - On infrastructure error: stops the batch, cursor is not saved, next tick replays from same position
+    /// - On error that should not be retried right now: stops the batch, cursor is not saved, next tick replays from same position
     /// - On MissingDependency: stores event in retry queue, continues processing
     /// - On 404 (blob not found): skips indexing, continues processing
     /// - On InvalidEventLine/SkipIndexing: logs and continues

--- a/nexus-watcher/src/service/indexer/key_based.rs
+++ b/nexus-watcher/src/service/indexer/key_based.rs
@@ -235,7 +235,7 @@ impl KeyBasedEventProcessor {
                 Ok(events) => return Ok(events),
                 Err(err) if err.is_too_many_requests() => {
                     let Some(backoff_secs) = FETCH_EVENTS_429_BACKOFF_SECS.get(retry_index) else {
-                        return Err(err);
+                        return Err(EventProcessorError::HsEventsStreamRateLimitExhausted);
                     };
 
                     warn!(

--- a/nexus-watcher/src/service/indexer/key_based.rs
+++ b/nexus-watcher/src/service/indexer/key_based.rs
@@ -121,13 +121,13 @@ impl TEventProcessor for KeyBasedEventProcessor {
 
             if let Err(err) = self.process_user(&hs_pk, &hs_id, user_pk, *cursor).await {
                 let user_id = user_pk.z32();
-                if err.is_infrastructure() {
+                if err.should_not_retry_now() {
                     error!(
                         hs_id = %hs_id,
                         user = %user_id,
                         action = "abort_hs",
                         error = ?err,
-                        "Infrastructure error while processing user; aborting homeserver run",
+                        "Got should-not-retry-now error while processing user; aborting homeserver run",
                     );
                     return Err(err);
                 }
@@ -137,7 +137,7 @@ impl TEventProcessor for KeyBasedEventProcessor {
                     user = %user_id,
                     action = "skip_user",
                     error = ?err,
-                    "Non-infrastructure user error; continuing with next user",
+                    "Got error while processing user: continuing with next user",
                 );
             }
         }

--- a/nexus-watcher/src/service/indexer/mod.rs
+++ b/nexus-watcher/src/service/indexer/mod.rs
@@ -146,14 +146,14 @@ pub trait TEventProcessor: Send + Sync + 'static {
     /// Returns:
     /// - `Ok(())` - Continue processing the batch (non-retryable errors are dropped, retryable
     ///   ones are queued for retry)
-    /// - `Err(e)` - Stop processing and return error (for infrastructure errors)
+    /// - `Err(e)` - Stop processing and return error (for errors that should not be retried right now)
     async fn handle_error(
         &self,
         event: &Event,
         error: EventProcessorError,
     ) -> Result<(), EventProcessorError> {
-        if error.is_infrastructure() {
-            warn!("Infrastructure error, stopping batch: {error}");
+        if error.should_not_retry_now() {
+            warn!("Got error which not retry now, stopping batch: {error}");
             return Err(error);
         }
 

--- a/nexus-watcher/tests/service/hs_event_processor.rs
+++ b/nexus-watcher/tests/service/hs_event_processor.rs
@@ -95,8 +95,8 @@ async fn test_batch_continues_after_single_failure() -> Result<()> {
 
 // ============================================================================
 // Infrastructure error stops the batch
-// Infrastructure errors propagate out of `handle_error`, short-circuiting the
-// loop so the cursor is not advanced past unprocessed events.
+// Errors that should not be retried right now propagate out of `handle_error`,
+// short-circuiting the loop so the cursor is not advanced past unprocessed events.
 // ============================================================================
 
 #[tokio_shared_rt::test(shared)]
@@ -113,7 +113,7 @@ async fn test_batch_stops_on_infrastructure_error() -> Result<()> {
     let store = new_in_memory_store();
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
-    // Scope the infrastructure error to the first event only. The handler
+    // Scope the should-not-retry-now error to the first event only. The handler
     // returns Ok(()) for non-matching events, so if the batch continued past
     // the first failure, the second event would succeed. The invocation
     // counter provides the definitive proof: handle_count == 1 proves the
@@ -131,7 +131,7 @@ async fn test_batch_stops_on_infrastructure_error() -> Result<()> {
     let result = processor.process_event_lines(lines).await;
     assert!(
         result.is_err(),
-        "Infrastructure error must propagate and stop the batch"
+        "Should-not-retry-now error must propagate and stop the batch"
     );
 
     // Definitive proof: handler was called exactly once, so the batch stopped
@@ -139,13 +139,13 @@ async fn test_batch_stops_on_infrastructure_error() -> Result<()> {
     assert_eq!(
         handler.get_handle_count(),
         1,
-        "Handler must be called exactly once — batch stopped on infrastructure error"
+        "Handler must be called exactly once — batch stopped on should-not-retry-now error"
     );
 
-    // Infrastructure errors bypass the retry scheduler entirely.
+    // Should-not-retry-now errors bypass the retry scheduler entirely.
     assert!(
         store.get(&first_uri).await?.is_none(),
-        "Infrastructure errors must not be queued for retry"
+        "Should-not-retry-now errors must not be queued for retry"
     );
     assert!(
         store.get(&second_uri).await?.is_none(),

--- a/nexus-watcher/tests/service/key_based_event_processor.rs
+++ b/nexus-watcher/tests/service/key_based_event_processor.rs
@@ -301,9 +301,9 @@ async fn key_based_processor_persists_last_safe_cursor_before_mismatch() -> Resu
     Ok(())
 }
 
-/// Verifies infrastructure fetch errors abort the homeserver run immediately.
+/// Verifies fetch errors that should not be retried right now abort the homeserver run immediately.
 #[tokio_shared_rt::test(shared)]
-async fn key_based_processor_aborts_on_infrastructure_fetch_error() -> Result<(), DynError> {
+async fn key_based_processor_aborts_on_not_retry_now_fetch_error() -> Result<(), DynError> {
     setup().await?;
 
     let (_hs_keypair, homeserver) = create_homeserver().await?;
@@ -322,17 +322,16 @@ async fn key_based_processor_aborts_on_infrastructure_fetch_error() -> Result<()
 
     let err = processor.run().await.unwrap_err();
 
-    assert_internal_infrastructure_index_operation_failed(err);
+    assert_internal_not_retry_now_index_operation_failed(err);
     assert_eq!(source.calls().await.len(), 1);
     assert_eq!(handler.get_handle_count(), 0);
 
     Ok(())
 }
 
-/// Verifies non-infrastructure fetch errors skip only the affected user.
+/// Verifies retryable fetch errors skip only the affected user.
 #[tokio_shared_rt::test(shared)]
-async fn key_based_processor_continues_after_non_infrastructure_fetch_error() -> Result<(), DynError>
-{
+async fn key_based_processor_continues_after_retryable_fetch_error() -> Result<(), DynError> {
     setup().await?;
 
     let (_hs_keypair, homeserver) = create_homeserver().await?;
@@ -437,9 +436,9 @@ async fn key_based_processor_aborts_homeserver_after_exhausted_429_retries() -> 
     Ok(())
 }
 
-/// Verifies infrastructure handler failures abort without advancing the cursor.
+/// Verifies not-retry-now handler failures abort without advancing the cursor.
 #[tokio_shared_rt::test(shared)]
-async fn key_based_processor_aborts_and_keeps_cursor_on_infrastructure_handler_error(
+async fn key_based_processor_aborts_and_keeps_cursor_on_not_retry_now_handler_error(
 ) -> Result<(), DynError> {
     setup().await?;
 
@@ -466,7 +465,7 @@ async fn key_based_processor_aborts_and_keeps_cursor_on_infrastructure_handler_e
 
     let err = processor.run().await.unwrap_err();
 
-    assert_internal_infrastructure_index_operation_failed(err);
+    assert_internal_not_retry_now_index_operation_failed(err);
     assert_eq!(handler.get_handle_count(), 1);
     assert_eq!(user_cursor(&user_id, &hs_id).await?, None);
 
@@ -676,10 +675,10 @@ fn assert_internal_index_operation_failed(err: RunError) {
     }
 }
 
-fn assert_internal_infrastructure_index_operation_failed(err: RunError) {
+fn assert_internal_not_retry_now_index_operation_failed(err: RunError) {
     match err {
         RunError::Internal(EventProcessorError::IndexOperationFailed(true, _)) => {}
-        other => panic!("expected internal infrastructure index operation failure, got {other:?}"),
+        other => panic!("expected internal not-retry-now index operation failure, got {other:?}"),
     }
 }
 

--- a/nexus-watcher/tests/service/key_based_event_processor.rs
+++ b/nexus-watcher/tests/service/key_based_event_processor.rs
@@ -404,6 +404,39 @@ async fn key_based_processor_retries_429_fetch_errors_with_backoff() -> Result<(
     Ok(())
 }
 
+/// Verifies exhausted 429 retries abort the homeserver run instead of moving to later users.
+#[tokio_shared_rt::test(shared)]
+async fn key_based_processor_aborts_homeserver_after_exhausted_429_retries() -> Result<(), DynError>
+{
+    setup().await?;
+
+    let (_hs_keypair, homeserver) = create_homeserver().await?;
+    create_user_on_homeserver(&homeserver).await?;
+    create_user_on_homeserver(&homeserver).await?;
+    let source = Arc::new(
+        MockKeyBasedEventSource::default()
+            .with_results(vec![
+                Err(too_many_requests_error()),
+                Err(too_many_requests_error()),
+                Err(too_many_requests_error()),
+                Err(too_many_requests_error()),
+            ])
+            .await,
+    );
+    let handler = create_mock_handler(Ok(()), None);
+    let processor = processor(homeserver, handler.clone(), source.clone());
+
+    let err = processor.run().await.unwrap_err();
+
+    assert_internal_too_many_requests(err);
+    let calls = source.calls().await;
+    assert_eq!(calls.len(), 4); // First call + 3 retries with backoff
+    assert!(calls.iter().all(|user_id| user_id == &calls[0]));
+    assert_eq!(handler.get_handle_count(), 0);
+
+    Ok(())
+}
+
 /// Verifies infrastructure handler failures abort without advancing the cursor.
 #[tokio_shared_rt::test(shared)]
 async fn key_based_processor_aborts_and_keeps_cursor_on_infrastructure_handler_error(
@@ -647,6 +680,13 @@ fn assert_internal_infrastructure_index_operation_failed(err: RunError) {
     match err {
         RunError::Internal(EventProcessorError::IndexOperationFailed(true, _)) => {}
         other => panic!("expected internal infrastructure index operation failure, got {other:?}"),
+    }
+}
+
+fn assert_internal_too_many_requests(err: RunError) {
+    match err {
+        RunError::Internal(err) if err.is_too_many_requests() => {}
+        other => panic!("expected internal 429 error, got {other:?}"),
     }
 }
 

--- a/nexus-watcher/tests/service/key_based_event_processor.rs
+++ b/nexus-watcher/tests/service/key_based_event_processor.rs
@@ -428,7 +428,7 @@ async fn key_based_processor_aborts_homeserver_after_exhausted_429_retries() -> 
 
     let err = processor.run().await.unwrap_err();
 
-    assert_internal_too_many_requests(err);
+    assert_internal_hs_rate_limit_exhausted(err);
     let calls = source.calls().await;
     assert_eq!(calls.len(), 4); // First call + 3 retries with backoff
     assert!(calls.iter().all(|user_id| user_id == &calls[0]));
@@ -683,10 +683,12 @@ fn assert_internal_infrastructure_index_operation_failed(err: RunError) {
     }
 }
 
-fn assert_internal_too_many_requests(err: RunError) {
+fn assert_internal_hs_rate_limit_exhausted(err: RunError) {
     match err {
-        RunError::Internal(err) if err.is_too_many_requests() => {}
-        other => panic!("expected internal 429 error, got {other:?}"),
+        RunError::Internal(EventProcessorError::HsEventsStreamRateLimitExhausted) => {}
+        other => {
+            panic!("expected internal HsEventsStreamRateLimitExhausted error, got {other:?}")
+        }
     }
 }
 

--- a/nexus-watcher/tests/service/retry_processor.rs
+++ b/nexus-watcher/tests/service/retry_processor.rs
@@ -193,9 +193,9 @@ async fn test_backoff_exponential_growth() -> Result<()> {
 // ============================================================================
 // Infrastructure error at max_retries does NOT dead-letter
 // This is the key regression test for the P2 Infrastructure bug.
-// Even when retry_count >= max_retries, an infrastructure error must NOT be
-// dead-lettered — it must be re-queued with retry_count unchanged so the
-// event can be retried indefinitely until the infrastructure recovers.
+// Even when retry_count >= max_retries, an error that should not be retried
+// right now must NOT be dead-lettered — it must be re-queued with retry_count
+// unchanged so the event can be retried indefinitely until the infrastructure recovers.
 // ============================================================================
 
 #[tokio_shared_rt::test(shared)]
@@ -223,7 +223,7 @@ async fn test_infrastructure_error_at_max_retries_does_not_dead_letter() -> Resu
         create_test_config(10, 50, 60, 3600, 60, 3600),
         create_mock_handler(
             Err(EventProcessorError::GraphQueryFailed(
-                true, // is_infrastructure = true
+                true, // should_not_retry_now = true
                 "Database connection failed".to_string(),
             )),
             Some(post_id),
@@ -231,27 +231,27 @@ async fn test_infrastructure_error_at_max_retries_does_not_dead_letter() -> Resu
         shutdown_rx,
     );
 
-    // Process through the public API — infrastructure error must NOT dead-letter
+    // Process through the public API — should_not_retry_now error must NOT dead-letter
     let result = processor.run_internal().await;
     assert!(
         result.is_err(),
-        "Infrastructure error should propagate, not dead-letter"
+        "Should-not-retry-now error should propagate, not dead-letter"
     );
 
     // Verify event was NOT removed — it should still be in the queue for retry
     let updated_event = store.get(&resource_key).await?.expect(
-        "Event must NOT be dead-lettered; infrastructure errors don't count against max_retries",
+        "Event must NOT be dead-lettered; should-not-retry-now errors don't count against max_retries",
     );
 
     assert_eq!(
         updated_event.retry_count, 10,
-        "retry_count must remain 10 (unchanged) — infrastructure errors do not increment retry_count"
+        "retry_count must remain 10 (unchanged) — should-not-retry-now errors do not increment retry_count"
     );
 
     // next_retry_at should have been advanced with backoff
     assert!(
         updated_event.next_retry_at > now,
-        "next_retry_at should be in the future after infrastructure error backoff"
+        "next_retry_at should be in the future after should-not-retry-now error backoff"
     );
 
     let _ = shutdown_tx.send(true);
@@ -423,9 +423,10 @@ async fn test_retry_404_removes_from_queue() -> Result<()> {
 
 // ============================================================================
 // Infrastructure error schedules retry without incrementing retry_count
-// Handler returns infrastructure error, event is re-queued WITHOUT incrementing
-// retry_count — infrastructure failures must not consume the application-level
-// retry budget.  next_retry_at is still advanced via exponential backoff.
+// Handler returns error that should not be retried right now, event is re-queued
+// WITHOUT incrementing retry_count — such failures must not consume the
+// application-level retry budget.  next_retry_at is still advanced via
+// exponential backoff.
 // ============================================================================
 
 #[tokio_shared_rt::test(shared)]
@@ -446,14 +447,14 @@ async fn test_transient_error_schedules_retry() -> Result<()> {
     );
     store.put(&resource_key, &retry_event).await?;
 
-    // Create processor with handler that returns infrastructure error
+    // Create processor with handler that returns should_not_retry_now error
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
     let processor = build_processor(
         store.clone(),
         create_test_config(10, 50, 60, 3600, 60, 3600),
         create_mock_handler(
             Err(EventProcessorError::GraphQueryFailed(
-                true, // is_infrastructure = true
+                true, // should_not_retry_now = true
                 "Database connection failed".to_string(),
             )),
             Some(post_id),
@@ -461,12 +462,15 @@ async fn test_transient_error_schedules_retry() -> Result<()> {
         shutdown_rx,
     );
 
-    // Process through the public API - this will propagate the infrastructure error
+    // Process through the public API - this will propagate the should_not_retry_now error
     let result = processor.run_internal().await;
-    assert!(result.is_err(), "Infrastructure error should propagate");
+    assert!(
+        result.is_err(),
+        "Should-not-retry-now error should propagate"
+    );
 
-    // Verify event was re-queued with retry_count UNCHANGED (infrastructure errors
-    // do not consume the application-level retry budget).
+    // Verify event was re-queued with retry_count UNCHANGED (should-not-retry-now
+    // errors do not consume the application-level retry budget).
     let updated_event = store
         .get(&resource_key)
         .await?
@@ -474,7 +478,7 @@ async fn test_transient_error_schedules_retry() -> Result<()> {
 
     assert_eq!(
         updated_event.retry_count, 0,
-        "Retry count should remain 0 for infrastructure errors"
+        "Retry count should remain 0 for should-not-retry-now errors"
     );
 
     // Verify next_retry_at is set with transient backoff (60 seconds = 60000 ms)
@@ -561,7 +565,8 @@ async fn test_missing_dependency_schedules_retry() -> Result<()> {
 // ============================================================================
 // Dead-letter after max transient retries
 // Event with retry_count >= max_retries for an APPLICATION error is removed
-// without retrying.  Infrastructure errors NO LONGER count against max_retries.
+// without retrying.  Errors we should not retry right now NO LONGER count
+// against max_retries.
 // Uses a Generic error (application-level transient) to test the dead-letter path.
 // ============================================================================
 
@@ -796,7 +801,8 @@ async fn test_shutdown_interrupts_batch() -> Result<()> {
 
 // ============================================================================
 // Infrastructure error stops batch
-// Infrastructure error from processing propagates up, halting the batch
+// Error that should not be retried right now from processing propagates up,
+// halting the batch
 // ============================================================================
 
 #[tokio_shared_rt::test(shared)]
@@ -822,10 +828,10 @@ async fn test_infrastructure_error_stops_batch() -> Result<()> {
         store.put(&resource_key, &retry_event).await?;
     }
 
-    // Create processor with handler that returns infrastructure error for our events only
+    // Create processor with handler that returns should_not_retry_now error for our events only
     let handler = create_mock_handler(
         Err(EventProcessorError::GraphQueryFailed(
-            true, // is_infrastructure = true
+            true, // should_not_retry_now = true
             "Critical database failure".to_string(),
         )),
         Some("infrastop"),
@@ -838,33 +844,31 @@ async fn test_infrastructure_error_stops_batch() -> Result<()> {
         shutdown_rx,
     );
 
-    // Run the processor - should propagate infrastructure error
+    // Run the processor - should propagate should_not_retry_now error
     let result: Result<(), EventProcessorError> = processor.run_internal().await;
 
     // Verify the error propagated up
     assert!(
         result.is_err(),
-        "Processor should propagate infrastructure error"
+        "Processor should propagate should-not-retry-now error"
     );
 
-    // Handler called exactly once — infrastructure error halted the batch
+    // Handler called exactly once — should_not_retry_now error halted the batch
     // after the first event, so remaining events were never reached.
     assert_eq!(
         handler.get_handle_count(),
         1,
-        "Handler must be called exactly once — batch stopped on infrastructure error"
+        "Handler must be called exactly once — batch stopped on should-not-retry-now error"
     );
 
-    // Verify the error is an infrastructure error
+    // Verify the error is a should-not-retry-now error
     let err = result.unwrap_err();
     assert!(
-        err.is_infrastructure(),
-        "Error should be an infrastructure error"
+        err.should_not_retry_now(),
+        "Error should be a should-not-retry-now error"
     );
 
-    // InMemoryRetryStore sorts same-score events lexicographically by key,
-    // matching Redis sorted-set semantics. So event 0 is processed first.
-    // Infrastructure errors do NOT increment retry_count — they preserve the
+    // Should-not-retry-now errors do NOT increment retry_count — they preserve the
     // application-level retry budget.
     let first_key = post_uri_builder(TEST_USER_ID.to_string(), "infrastop0".to_string());
     let first_event = store
@@ -873,7 +877,7 @@ async fn test_infrastructure_error_stops_batch() -> Result<()> {
         .expect("First event should still be in queue (re-queued after error)");
     assert_eq!(
         first_event.retry_count, 0,
-        "First event should have retry_count unchanged (infrastructure errors do not increment retry_count)"
+        "First event should have retry_count unchanged (should-not-retry-now errors do not increment retry_count)"
     );
 
     // Remaining events should be untouched (retry_count still 0)


### PR DESCRIPTION
When a `KeyBasedEventProcessor` tries to fetch events of a user, but repeatedly gets 429 error, to the point that all backoff retry attempts are exhausted, this results in a `PubkyClientError::TooManyRequests429` error.

This PR marks this error type as infrastructure error, to prevent the `KeyBasedEventProcessor` from attempting to fetch events for the next user, if any.