### PR TITLE
refactor: move `is_retryable` error logic to `RetryScheduler`

### DIFF
--- a/nexus-common/src/db/connectors/pubky.rs
+++ b/nexus-common/src/db/connectors/pubky.rs
@@ -78,20 +78,6 @@ impl From<pubky::Error> for PubkyClientError {
     }
 }
 
-impl PubkyClientError {
-    /// Returns true if this error is transient and worth retrying
-    pub fn is_retryable(&self) -> bool {
-        matches!(
-            self,
-            Self::NotInitialized
-                | Self::TooManyRequests429 { .. }
-                | Self::ServerError5xx { .. }
-                | Self::RequestFailed { .. }
-                | Self::PkarrFailed { .. }
-        )
-    }
-}
-
 pub struct PubkyConnector;
 
 impl PubkyConnector {

--- a/nexus-common/src/models/event/errors.rs
+++ b/nexus-common/src/models/event/errors.rs
@@ -141,22 +141,6 @@ impl EventProcessorError {
         }
     }
 
-    /// Returns whether this error is transient and worth queuing for retry.
-    ///
-    /// Default is **retryable**: when in doubt we enqueue rather than drop, since
-    /// `max_retries` bounds the waste on a misclassified deterministic error,
-    /// while silently dropping a misclassified transient error loses data outright.
-    /// Only variants we know to be deterministic at conversion time opt out.
-    pub fn is_retryable(&self) -> bool {
-        match self {
-            Self::PubkyClientError(err) => err.is_retryable(),
-            Self::InvalidEventLine(_) => false,
-            Self::SkipIndexing => false,
-            Self::UserIdMismatch { .. } => false,
-            _ => true,
-        }
-    }
-
     pub fn is_too_many_requests(&self) -> bool {
         matches!(
             self,

--- a/nexus-watcher/src/events/retry/processor.rs
+++ b/nexus-watcher/src/events/retry/processor.rs
@@ -136,7 +136,7 @@ impl RetryProcessor {
                 debug!("Retry successful for event: {ev_uri}");
                 self.store.remove(index_key).await?;
             }
-            Err(e) if !e.is_retryable() => {
+            Err(e) if !RetryScheduler::is_interested_in(&e) => {
                 // Non-retryable error (ParseFailed, etc.) - dead-letter immediately
                 warn!("Event {ev_uri} failed with non-retryable error, dead-lettering: {e}");
                 self.store.remove(index_key).await?;

--- a/nexus-watcher/src/events/retry/processor.rs
+++ b/nexus-watcher/src/events/retry/processor.rs
@@ -136,9 +136,11 @@ impl RetryProcessor {
                 debug!("Retry successful for event: {ev_uri}");
                 self.store.remove(index_key).await?;
             }
-            Err(e) if !RetryScheduler::is_interested_in(&e) => {
-                // Non-retryable error (ParseFailed, etc.) - dead-letter immediately
-                warn!("Event {ev_uri} failed with non-retryable error, dead-lettering: {e}");
+            Err(e) if !RetryScheduler::should_enqueue_related_event(&e) => {
+                // Not worth retrying (ParseFailed, etc.) - dead-letter immediately
+                warn!(
+                    "Event {ev_uri} failed with an error not worth retrying, dead-lettering: {e}"
+                );
                 self.store.remove(index_key).await?;
             }
             Err(e) if e.is_infrastructure() => {

--- a/nexus-watcher/src/events/retry/scheduler.rs
+++ b/nexus-watcher/src/events/retry/scheduler.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use chrono::Utc;
 use tracing::warn;
 
+use nexus_common::db::PubkyClientError;
 use nexus_common::models::event::{Event, EventProcessorError};
 use nexus_common::WatcherConfig;
 
@@ -45,11 +46,21 @@ impl RetryScheduler {
         )
     }
 
-    /// Whether this error is worth queuing. Defaults to interested:
-    /// when in doubt we enqueue (bounded by `max_retries`) rather than drop data.
-    pub fn is_interested_in(error: &EventProcessorError) -> bool {
+    /// Whether the event behind this error should be enqueued for retry.
+    /// When in doubt we enqueue (bounded by `max_retries`) rather than drop data.
+    pub fn should_enqueue_related_event(error: &EventProcessorError) -> bool {
         match error {
-            EventProcessorError::PubkyClientError(err) => err.is_retryable(),
+            EventProcessorError::PubkyClientError(err) => match err {
+                PubkyClientError::NotInitialized
+                | PubkyClientError::TooManyRequests429 { .. }
+                | PubkyClientError::ServerError5xx { .. }
+                | PubkyClientError::RequestFailed { .. }
+                | PubkyClientError::PkarrFailed { .. } => true,
+                PubkyClientError::NotFound404 { .. }
+                | PubkyClientError::AuthenticationFailed { .. }
+                | PubkyClientError::BuildFailed { .. }
+                | PubkyClientError::ParseFailed { .. } => false,
+            },
             EventProcessorError::InvalidEventLine(_) => false,
             EventProcessorError::SkipIndexing => false,
             EventProcessorError::UserIdMismatch { .. } => false,

--- a/nexus-watcher/src/events/retry/scheduler.rs
+++ b/nexus-watcher/src/events/retry/scheduler.rs
@@ -45,6 +45,18 @@ impl RetryScheduler {
         )
     }
 
+    /// Whether this error is worth queuing. Defaults to interested:
+    /// when in doubt we enqueue (bounded by `max_retries`) rather than drop data.
+    pub fn is_interested_in(error: &EventProcessorError) -> bool {
+        match error {
+            EventProcessorError::PubkyClientError(err) => err.is_retryable(),
+            EventProcessorError::InvalidEventLine(_) => false,
+            EventProcessorError::SkipIndexing => false,
+            EventProcessorError::UserIdMismatch { .. } => false,
+            _ => true,
+        }
+    }
+
     pub async fn queue_missing_dep(&self, event: &Event) -> Result<(), EventProcessorError> {
         self.enqueue(event, self.initial.missing_dep_ms, "missing dependency")
             .await

--- a/nexus-watcher/src/service/indexer/mod.rs
+++ b/nexus-watcher/src/service/indexer/mod.rs
@@ -157,7 +157,7 @@ pub trait TEventProcessor: Send + Sync + 'static {
             return Err(error);
         }
 
-        if !error.is_retryable() {
+        if !RetryScheduler::is_interested_in(&error) {
             debug!("Non-retryable error, skipping event {}: {error}", event.uri);
             return Ok(());
         }

--- a/nexus-watcher/src/service/indexer/mod.rs
+++ b/nexus-watcher/src/service/indexer/mod.rs
@@ -144,8 +144,8 @@ pub trait TEventProcessor: Send + Sync + 'static {
     /// Called in the event processing loop.
     ///
     /// Returns:
-    /// - `Ok(())` - Continue processing the batch (non-retryable errors are dropped, retryable
-    ///   ones are queued for retry)
+    /// - `Ok(())` - Continue processing the batch (errors not worth retrying are dropped, the
+    ///   rest are queued for retry)
     /// - `Err(e)` - Stop processing and return error (for infrastructure errors)
     async fn handle_error(
         &self,
@@ -157,8 +157,11 @@ pub trait TEventProcessor: Send + Sync + 'static {
             return Err(error);
         }
 
-        if !RetryScheduler::is_interested_in(&error) {
-            debug!("Non-retryable error, skipping event {}: {error}", event.uri);
+        if !RetryScheduler::should_enqueue_related_event(&error) {
+            debug!(
+                "Error not worth retrying, skipping event {}: {error}",
+                event.uri
+            );
             return Ok(());
         }
 
@@ -169,7 +172,7 @@ pub trait TEventProcessor: Send + Sync + 'static {
         if error.is_missing_dependency() {
             scheduler.queue_missing_dep(event).await
         } else {
-            warn!("Retryable error, queuing event for retry: {error}");
+            warn!("Transient error, queuing event for retry: {error}");
             scheduler.queue_transient(event).await
         }
     }


### PR DESCRIPTION
`RetryScheduler` should determine whether the error signals need for retry handling or not.