### PR TITLE
Simplify Redis ops (read/write) for user cursor handling

### DIFF
--- a/nexus-common/src/models/user/cursor.rs
+++ b/nexus-common/src/models/user/cursor.rs
@@ -1,0 +1,94 @@
+use serde::{Deserialize, Serialize};
+
+use crate::db::kv::RedisResult;
+use crate::db::RedisOps;
+
+const USER_HS_CURSOR: [&str; 2] = ["Users", "Homeservers"];
+
+/// Redis key parts for per-user homeserver cursor storage: `["Users", "Homeservers", <user_id>]`.
+pub type UserHsCursorKey<'a> = [&'a str; 3];
+
+/// Builds the Redis key path for per-user homeserver cursor storage.
+pub fn user_hs_cursor_key(user_id: &str) -> UserHsCursorKey<'_> {
+    [USER_HS_CURSOR[0], USER_HS_CURSOR[1], user_id]
+}
+
+/// Per-user event cursor for a homeserver's event stream.
+///
+/// A marker type that owns the Redis read/write operations for cursors; it holds
+/// no data, the cursor values live in Redis sorted sets. `Serialize`/`Deserialize`
+/// are only present to satisfy the [`RedisOps`] trait bounds.
+#[derive(Serialize, Deserialize)]
+pub struct UserHsCursor;
+
+#[async_trait::async_trait]
+impl RedisOps for UserHsCursor {}
+
+impl UserHsCursor {
+    /// Batch-reads each user's stored event cursor for `hs_id`, returning `0`
+    /// for users with no cursor entry yet (newly ingested).
+    ///
+    /// Each user's cursor lives in its own `USER_HS_CURSOR` sorted set (keyed by
+    /// user ID) with the homeserver ID as the member; all lookups are batched
+    /// into a single `check_sorted_set_members` pipeline call. Redis errors are
+    /// propagated instead of silently rewinding to 0.
+    ///
+    /// The cursor is stored as the score (f64), exact for integer values up to
+    /// 2^53 — practically unreachable for monotonic event IDs.
+    pub async fn read(user_ids: &[&str], hs_id: &str) -> RedisResult<Vec<u64>> {
+        let keys: Vec<UserHsCursorKey> = user_ids.iter().map(|u| user_hs_cursor_key(u)).collect();
+        let pairs: Vec<(&[&str], &[&str])> = keys
+            .iter()
+            .map(|k| (k.as_slice(), std::slice::from_ref(&hs_id)))
+            .collect();
+        let scores = Self::check_sorted_set_members(None, &pairs).await?;
+        Ok(scores.into_iter().map(|s| s.unwrap_or(0) as u64).collect())
+    }
+
+    /// Persists a single user's event cursor for `hs_id` to its `USER_HS_CURSOR` sorted set.
+    pub async fn write(user_id: &str, hs_id: &str, cursor: u64) -> RedisResult<()> {
+        let key = user_hs_cursor_key(user_id);
+        Self::put_index_sorted_set(&key, &[(cursor as f64, hs_id)], None, None).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pubky::Keypair;
+    use pubky_app_specs::PubkyId;
+
+    use crate::{types::DynError, StackConfig, StackManager};
+
+    /// `write` persists a per-user cursor that `read` reads back, missing entries
+    /// default to 0, and re-writing overwrites the value.
+    #[tokio_shared_rt::test(shared)]
+    async fn test_hs_cursor_read_write_roundtrip() -> Result<(), DynError> {
+        StackManager::setup(&StackConfig::default()).await?;
+
+        // Random IDs keep the test isolated from mock data and other tests.
+        let user_with_cursor = PubkyId::from(Keypair::random().public_key()).to_string();
+        let user_without_cursor = PubkyId::from(Keypair::random().public_key()).to_string();
+        let hs_id = PubkyId::from(Keypair::random().public_key()).to_string();
+
+        // A user with no stored cursor reads back as 0.
+        let cursors = UserHsCursor::read(&[user_with_cursor.as_str()], &hs_id).await?;
+        assert_eq!(cursors, vec![0]);
+
+        // A written cursor round-trips; a user without an entry stays at 0.
+        UserHsCursor::write(&user_with_cursor, &hs_id, 42).await?;
+        let cursors = UserHsCursor::read(
+            &[user_with_cursor.as_str(), user_without_cursor.as_str()],
+            &hs_id,
+        )
+        .await?;
+        assert_eq!(cursors, vec![42, 0]);
+
+        // Writing again overwrites the previous value.
+        UserHsCursor::write(&user_with_cursor, &hs_id, 100).await?;
+        let cursors = UserHsCursor::read(&[user_with_cursor.as_str()], &hs_id).await?;
+        assert_eq!(cursors, vec![100]);
+
+        Ok(())
+    }
+}

--- a/nexus-common/src/models/user/details.rs
+++ b/nexus-common/src/models/user/details.rs
@@ -1,4 +1,4 @@
-use super::UserSearch;
+use super::{UserHsCursor, UserSearch};
 use crate::db::graph::Query;
 use crate::db::kv::RedisResult;
 use crate::db::{exec_single_row, queries, GraphResult, PubkyConnector, RedisOps};
@@ -11,16 +11,6 @@ use pubky_app_specs::{PubkyAppUser, PubkyAppUserLink, PubkyId};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json;
 use utoipa::ToSchema;
-
-const USER_HS_CURSOR: [&str; 2] = ["Users", "Homeservers"];
-
-/// Redis key parts for per-user homeserver cursor storage: `["Users", "Homeservers", <user_id>]`.
-pub type UserHsCursorKey<'a> = [&'a str; 3];
-
-/// Builds the Redis key path for per-user homeserver cursor storage
-pub fn user_hs_cursor_key(user_id: &str) -> UserHsCursorKey<'_> {
-    [USER_HS_CURSOR[0], USER_HS_CURSOR[1], user_id]
-}
 
 #[async_trait]
 impl RedisOps for UserDetails {}
@@ -172,35 +162,9 @@ impl UserDetails {
             .inspect_err(|e| tracing::error!("Failed to ingest user {user_id}: {e}"))?;
 
         // Store the start point of the homeserver cursor
-        Self::write_hs_cursor(user_id, hs_id, 0).await?;
+        UserHsCursor::write(user_id, hs_id, 0).await?;
 
         Ok(())
-    }
-
-    /// Batch-reads each user's stored event cursor for `hs_id`, returning `0`
-    /// for users with no cursor entry yet (newly ingested).
-    ///
-    /// Each user's cursor lives in its own `USER_HS_CURSOR` sorted set (keyed by
-    /// user ID) with the homeserver ID as the member; all lookups are batched
-    /// into a single `check_sorted_set_members` pipeline call. Redis errors are
-    /// propagated instead of silently rewinding to 0.
-    ///
-    /// The cursor is stored as the score (f64), exact for integer values up to
-    /// 2^53 — practically unreachable for monotonic event IDs.
-    pub async fn read_hs_cursors(user_ids: &[&str], hs_id: &str) -> RedisResult<Vec<u64>> {
-        let keys: Vec<UserHsCursorKey> = user_ids.iter().map(|u| user_hs_cursor_key(u)).collect();
-        let pairs: Vec<(&[&str], &[&str])> = keys
-            .iter()
-            .map(|k| (k.as_slice(), std::slice::from_ref(&hs_id)))
-            .collect();
-        let scores = Self::check_sorted_set_members(None, &pairs).await?;
-        Ok(scores.into_iter().map(|s| s.unwrap_or(0) as u64).collect())
-    }
-
-    /// Persists a single user's event cursor for `hs_id` to its `USER_HS_CURSOR` sorted set.
-    pub async fn write_hs_cursor(user_id: &str, hs_id: &str, cursor: u64) -> RedisResult<()> {
-        let key = user_hs_cursor_key(user_id);
-        Self::put_index_sorted_set(&key, &[(cursor as f64, hs_id)], None, None).await
     }
 }
 
@@ -208,9 +172,6 @@ impl UserDetails {
 mod tests {
     use super::*;
     use neo4rs::{BoltInteger, BoltList, BoltMap, BoltNode, BoltString, BoltType, Node};
-    use pubky::Keypair;
-
-    use crate::{types::DynError, StackConfig, StackManager};
 
     /// Deserializing a UserDetails from a BoltNode without the links property
     /// should succeed with links: None. Neo4j drops null properties from nodes,
@@ -240,37 +201,5 @@ mod tests {
             .expect("should deserialize without links property (Neo4j drops null properties)");
         assert_eq!(details.name, "Dave");
         assert!(details.links.is_none());
-    }
-
-    /// `write_hs_cursor` persists a per-user cursor that `read_hs_cursors` reads
-    /// back, missing entries default to 0, and re-writing overwrites the value.
-    #[tokio_shared_rt::test(shared)]
-    async fn test_hs_cursor_read_write_roundtrip() -> Result<(), DynError> {
-        StackManager::setup(&StackConfig::default()).await?;
-
-        // Random IDs keep the test isolated from mock data and other tests.
-        let user_with_cursor = PubkyId::from(Keypair::random().public_key()).to_string();
-        let user_without_cursor = PubkyId::from(Keypair::random().public_key()).to_string();
-        let hs_id = PubkyId::from(Keypair::random().public_key()).to_string();
-
-        // A user with no stored cursor reads back as 0.
-        let cursors = UserDetails::read_hs_cursors(&[user_with_cursor.as_str()], &hs_id).await?;
-        assert_eq!(cursors, vec![0]);
-
-        // A written cursor round-trips; a user without an entry stays at 0.
-        UserDetails::write_hs_cursor(&user_with_cursor, &hs_id, 42).await?;
-        let cursors = UserDetails::read_hs_cursors(
-            &[user_with_cursor.as_str(), user_without_cursor.as_str()],
-            &hs_id,
-        )
-        .await?;
-        assert_eq!(cursors, vec![42, 0]);
-
-        // Writing again overwrites the previous value.
-        UserDetails::write_hs_cursor(&user_with_cursor, &hs_id, 100).await?;
-        let cursors = UserDetails::read_hs_cursors(&[user_with_cursor.as_str()], &hs_id).await?;
-        assert_eq!(cursors, vec![100]);
-
-        Ok(())
     }
 }

--- a/nexus-common/src/models/user/details.rs
+++ b/nexus-common/src/models/user/details.rs
@@ -177,6 +177,32 @@ impl UserDetails {
 
         Ok(())
     }
+
+    /// Batch-reads each user's stored event cursor for `hs_id`, returning `0`
+    /// for users with no cursor entry yet (newly ingested).
+    ///
+    /// Each user's cursor lives in its own `USER_HS_CURSOR` sorted set (keyed by
+    /// user ID) with the homeserver ID as the member; all lookups are batched
+    /// into a single `check_sorted_set_members` pipeline call. Redis errors are
+    /// propagated instead of silently rewinding to 0.
+    ///
+    /// The cursor is stored as the score (f64), exact for integer values up to
+    /// 2^53 — practically unreachable for monotonic event IDs.
+    pub async fn read_hs_cursors(user_ids: &[&str], hs_id: &str) -> RedisResult<Vec<u64>> {
+        let keys: Vec<UserHsCursorKey> = user_ids.iter().map(|u| user_hs_cursor_key(u)).collect();
+        let pairs: Vec<(&[&str], &[&str])> = keys
+            .iter()
+            .map(|k| (k.as_slice(), std::slice::from_ref(&hs_id)))
+            .collect();
+        let scores = Self::check_sorted_set_members(None, &pairs).await?;
+        Ok(scores.into_iter().map(|s| s.unwrap_or(0) as u64).collect())
+    }
+
+    /// Persists a single user's event cursor for `hs_id` to its `USER_HS_CURSOR` sorted set.
+    pub async fn write_hs_cursor(user_id: &str, hs_id: &str, cursor: u64) -> RedisResult<()> {
+        let key = user_hs_cursor_key(user_id);
+        Self::put_index_sorted_set(&key, &[(cursor as f64, hs_id)], None, None).await
+    }
 }
 
 #[cfg(test)]

--- a/nexus-common/src/models/user/details.rs
+++ b/nexus-common/src/models/user/details.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use serde_json;
 use utoipa::ToSchema;
 
-pub const USER_HS_CURSOR: [&str; 2] = ["Users", "Homeservers"];
+const USER_HS_CURSOR: [&str; 2] = ["Users", "Homeservers"];
 
 /// Redis key parts for per-user homeserver cursor storage: `["Users", "Homeservers", <user_id>]`.
 pub type UserHsCursorKey<'a> = [&'a str; 3];
@@ -208,6 +208,9 @@ impl UserDetails {
 mod tests {
     use super::*;
     use neo4rs::{BoltInteger, BoltList, BoltMap, BoltNode, BoltString, BoltType, Node};
+    use pubky::Keypair;
+
+    use crate::{types::DynError, StackConfig, StackManager};
 
     /// Deserializing a UserDetails from a BoltNode without the links property
     /// should succeed with links: None. Neo4j drops null properties from nodes,
@@ -237,5 +240,37 @@ mod tests {
             .expect("should deserialize without links property (Neo4j drops null properties)");
         assert_eq!(details.name, "Dave");
         assert!(details.links.is_none());
+    }
+
+    /// `write_hs_cursor` persists a per-user cursor that `read_hs_cursors` reads
+    /// back, missing entries default to 0, and re-writing overwrites the value.
+    #[tokio_shared_rt::test(shared)]
+    async fn test_hs_cursor_read_write_roundtrip() -> Result<(), DynError> {
+        StackManager::setup(&StackConfig::default()).await?;
+
+        // Random IDs keep the test isolated from mock data and other tests.
+        let user_with_cursor = PubkyId::from(Keypair::random().public_key()).to_string();
+        let user_without_cursor = PubkyId::from(Keypair::random().public_key()).to_string();
+        let hs_id = PubkyId::from(Keypair::random().public_key()).to_string();
+
+        // A user with no stored cursor reads back as 0.
+        let cursors = UserDetails::read_hs_cursors(&[user_with_cursor.as_str()], &hs_id).await?;
+        assert_eq!(cursors, vec![0]);
+
+        // A written cursor round-trips; a user without an entry stays at 0.
+        UserDetails::write_hs_cursor(&user_with_cursor, &hs_id, 42).await?;
+        let cursors = UserDetails::read_hs_cursors(
+            &[user_with_cursor.as_str(), user_without_cursor.as_str()],
+            &hs_id,
+        )
+        .await?;
+        assert_eq!(cursors, vec![42, 0]);
+
+        // Writing again overwrites the previous value.
+        UserDetails::write_hs_cursor(&user_with_cursor, &hs_id, 100).await?;
+        let cursors = UserDetails::read_hs_cursors(&[user_with_cursor.as_str()], &hs_id).await?;
+        assert_eq!(cursors, vec![100]);
+
+        Ok(())
     }
 }

--- a/nexus-common/src/models/user/details.rs
+++ b/nexus-common/src/models/user/details.rs
@@ -172,8 +172,7 @@ impl UserDetails {
             .inspect_err(|e| tracing::error!("Failed to ingest user {user_id}: {e}"))?;
 
         // Store the start point of the homeserver cursor
-        let key = user_hs_cursor_key(user_id);
-        Self::put_index_sorted_set(&key, &[(0.0, hs_id)], None, None).await?;
+        Self::write_hs_cursor(user_id, hs_id, 0).await?;
 
         Ok(())
     }

--- a/nexus-common/src/models/user/mod.rs
+++ b/nexus-common/src/models/user/mod.rs
@@ -9,7 +9,7 @@ mod tags;
 mod view;
 
 pub use counts::UserCounts;
-pub use details::{user_hs_cursor_key, UserDetails, UserHsCursorKey, USER_HS_CURSOR};
+pub use details::{user_hs_cursor_key, UserDetails, UserHsCursorKey};
 pub use influencers::Influencers;
 pub use relationship::Relationship;
 pub use search::{UserSearch, USER_NAME_KEY_PARTS};

--- a/nexus-common/src/models/user/mod.rs
+++ b/nexus-common/src/models/user/mod.rs
@@ -1,4 +1,5 @@
 mod counts;
+mod cursor;
 mod details;
 //mod id;
 mod influencers;
@@ -9,7 +10,8 @@ mod tags;
 mod view;
 
 pub use counts::UserCounts;
-pub use details::{user_hs_cursor_key, UserDetails, UserHsCursorKey};
+pub use cursor::{user_hs_cursor_key, UserHsCursor, UserHsCursorKey};
+pub use details::UserDetails;
 pub use influencers::Influencers;
 pub use relationship::Relationship;
 pub use search::{UserSearch, USER_NAME_KEY_PARTS};

--- a/nexus-watcher/src/service/indexer/key_based.rs
+++ b/nexus-watcher/src/service/indexer/key_based.rs
@@ -4,7 +4,7 @@ use futures::StreamExt;
 use nexus_common::db::PubkyConnector;
 use nexus_common::models::event::{Event, EventProcessorError};
 use nexus_common::models::homeserver::Homeserver;
-use nexus_common::models::user::UserDetails;
+use nexus_common::models::user::UserHsCursor;
 use pubky::{Event as StreamEvent, EventCursor, PublicKey};
 use tokio::sync::watch::Receiver;
 use tracing::{debug, error, info, warn};
@@ -166,7 +166,7 @@ impl KeyBasedEventProcessor {
         }
 
         let user_id_strs: Vec<&str> = valid_users.iter().map(|(_, id)| *id).collect();
-        let cursors = UserDetails::read_hs_cursors(&user_id_strs, hs_id).await?;
+        let cursors = UserHsCursor::read(&user_id_strs, hs_id).await?;
 
         let users = valid_users
             .into_iter()
@@ -202,8 +202,7 @@ impl KeyBasedEventProcessor {
             .await;
 
         if let Some(cursor_val) = latest_cursor {
-            if let Err(write_err) = UserDetails::write_hs_cursor(&user_id, hs_id, cursor_val).await
-            {
+            if let Err(write_err) = UserHsCursor::write(&user_id, hs_id, cursor_val).await {
                 error!(
                     hs_id = %hs_id,
                     user = %user_id,

--- a/nexus-watcher/src/service/indexer/key_based.rs
+++ b/nexus-watcher/src/service/indexer/key_based.rs
@@ -1,10 +1,10 @@
 use std::{path::PathBuf, sync::Arc, time::Duration};
 
 use futures::StreamExt;
-use nexus_common::db::{PubkyConnector, RedisOps};
+use nexus_common::db::PubkyConnector;
 use nexus_common::models::event::{Event, EventProcessorError};
 use nexus_common::models::homeserver::Homeserver;
-use nexus_common::models::user::{user_hs_cursor_key, UserDetails, UserHsCursorKey};
+use nexus_common::models::user::UserDetails;
 use pubky::{Event as StreamEvent, EventCursor, PublicKey};
 use tokio::sync::watch::Receiver;
 use tracing::{debug, error, info, warn};
@@ -166,12 +166,12 @@ impl KeyBasedEventProcessor {
         }
 
         let user_id_strs: Vec<&str> = valid_users.iter().map(|(_, id)| *id).collect();
-        let cursors = Self::read_users_cursors(&user_id_strs, hs_id).await?;
+        let cursors = UserDetails::read_hs_cursors(&user_id_strs, hs_id).await?;
 
         let users = valid_users
             .into_iter()
             .zip(cursors)
-            .map(|((pk, _), cursor)| (pk, cursor))
+            .map(|((pk, _), cursor)| (pk, EventCursor::new(cursor)))
             .collect();
 
         Ok(users)
@@ -202,7 +202,8 @@ impl KeyBasedEventProcessor {
             .await;
 
         if let Some(cursor_val) = latest_cursor {
-            if let Err(write_err) = Self::write_user_cursor(&user_id, hs_id, cursor_val).await {
+            if let Err(write_err) = UserDetails::write_hs_cursor(&user_id, hs_id, cursor_val).await
+            {
                 error!(
                     hs_id = %hs_id,
                     user = %user_id,
@@ -314,51 +315,6 @@ impl KeyBasedEventProcessor {
             });
         }
 
-        Ok(())
-    }
-
-    /// Reads per-user event cursors from the `USER_HS_CURSOR` sorted sets in Redis.
-    ///
-    /// Each user's cursor lives in its own sorted set (keyed by user ID) with
-    /// the homeserver ID as the member. All lookups are batched into a single
-    /// `check_sorted_set_members` pipeline call.
-    ///
-    /// Returns `EventCursor(0)` for users with no cursor entry (newly ingested).
-    /// Propagates Redis errors instead of silently rewinding to 0.
-    ///
-    /// The cursor is stored as the score (f64) of the homeserver member.
-    /// f64 is exact for integer values up to 2^53 (~9 quadrillion), which is
-    /// practically unreachable for monotonically incrementing event IDs.
-    async fn read_users_cursors(
-        user_ids: &[&str],
-        hs_id: &str,
-    ) -> Result<Vec<EventCursor>, EventProcessorError> {
-        let keys: Vec<UserHsCursorKey<'_>> = user_ids
-            .iter()
-            .map(|user_id| user_hs_cursor_key(user_id))
-            .collect();
-        let member: [&str; 1] = [hs_id];
-        let pairs: Vec<(&[&str], &[&str])> = keys
-            .iter()
-            .map(|k| (k.as_slice(), member.as_slice()))
-            .collect();
-
-        let scores = UserDetails::check_sorted_set_members(None, &pairs).await?;
-
-        Ok(scores
-            .into_iter()
-            .map(|s| EventCursor::new(s.unwrap_or(0) as u64))
-            .collect())
-    }
-
-    /// Persists the per-user event cursor back to the `USER_HS_CURSOR` sorted set.
-    async fn write_user_cursor(
-        user_id: &str,
-        hs_id: &str,
-        cursor: u64,
-    ) -> Result<(), EventProcessorError> {
-        let key = user_hs_cursor_key(user_id);
-        UserDetails::put_index_sorted_set(&key, &[(cursor as f64, hs_id)], None, None).await?;
         Ok(())
     }
 }


### PR DESCRIPTION
This PR relocated the per-user cursor Redis plumbing from the indexer into the model layer that owns the key schema.