### PR TITLE
fix: add `HOSTED_BY` guard for `HsEventProcessor`

### DIFF
--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -1070,8 +1070,9 @@ pub fn user_is_safe_to_delete(user_id: &str) -> Query {
         MATCH (u:User {id: $user_id})
         // Ensures all relationships to the user (u) are checked, counting as 0 if none exist
         OPTIONAL MATCH (u)-[r]-()
-        // Checks if the user has any relationships
-        WITH u, NOT (COUNT(r) = 0) AS flag
+        WITH u, [rel IN collect(r) WHERE rel IS NOT NULL AND type(rel) <> 'HOSTED_BY'] AS relationships
+        // Checks if the user has any relationships besides homeserver ownership metadata
+        WITH u, NOT (size(relationships) = 0) AS flag
         RETURN flag
         ",
     )

--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -1070,7 +1070,7 @@ pub fn user_is_safe_to_delete(user_id: &str) -> Query {
         MATCH (u:User {id: $user_id})
         // Ensures all relationships to the user (u) are checked, counting as 0 if none exist
         OPTIONAL MATCH (u)-[r]-()
-        WITH u, [rel IN collect(r) WHERE rel IS NOT NULL AND type(rel) <> 'HOSTED_BY'] AS relationships
+        WITH u, [rel IN collect(r) WHERE type(rel) <> 'HOSTED_BY'] AS relationships
         // Checks if the user has any relationships besides homeserver ownership metadata
         WITH u, NOT (size(relationships) = 0) AS flag
         RETURN flag

--- a/nexus-watcher/src/service/indexer/homeserver.rs
+++ b/nexus-watcher/src/service/indexer/homeserver.rs
@@ -1,8 +1,8 @@
 use super::TEventProcessor;
 use crate::events::retry::RetryScheduler;
 use crate::events::EventHandler;
-use nexus_common::db::PubkyConnector;
-use nexus_common::models::event::EventProcessorError;
+use nexus_common::db::{fetch_key_from_graph, queries, PubkyConnector};
+use nexus_common::models::event::{Event, EventProcessorError, ParseResult};
 use nexus_common::models::homeserver::Homeserver;
 use pubky::Method;
 use std::path::PathBuf;
@@ -44,6 +44,53 @@ impl TEventProcessor for HsEventProcessor {
 
     fn homeserver_id(&self) -> Option<&str> {
         Some(self.homeserver.id.as_ref())
+    }
+
+    async fn process_event_line(&self, line: &str) -> Result<(), EventProcessorError> {
+        match Event::parse_event(line, self.files_path().clone()) {
+            // Invalid event lines come from untrusted homeservers; treat as bad peer data, not Nexus errors.
+            Err(e) => warn!("{e}"),
+            Ok(ParseResult::Skipped) => {}
+            Ok(ParseResult::UnrecognizedUri { reason, .. }) => {
+                // Should not normally occur; UnknownResource parsing happens in HomeserverParsedUri.
+                warn!("Unrecognized event URI: {reason}");
+            }
+            Ok(ParseResult::Parsed(event)) => {
+                let user_id = event.parsed_uri.user_id();
+                let maybe_homeserver_id: Option<String> = fetch_key_from_graph(
+                    queries::get::get_user_homeserver(user_id),
+                    "homeserver_id",
+                )
+                .await?;
+
+                match maybe_homeserver_id.as_deref() {
+                    None => {
+                        warn!(
+                            %user_id,
+                            event.uri, "User has no HOSTED_BY edge; queuing event for retry"
+                        );
+                        self.retry_scheduler
+                            .queue_missing_dep(&event, self.homeserver.id.as_ref())
+                            .await?;
+                    }
+                    Some(homeserver_id) if homeserver_id != self.homeserver.id.as_ref() => {
+                        debug!(
+                            user_id = %user_id,
+                            event.uri,
+                            event_homeserver_id = homeserver_id,
+                            processor_homeserver_id = %self.homeserver.id,
+                            "Skipping event hosted by a different homeserver"
+                        );
+                    }
+                    Some(_) => {
+                        debug!("Processing event: {:?}", event);
+                        self.handle_event(&event).await?;
+                    }
+                }
+            }
+        }
+
+        Ok(())
     }
 
     async fn run_internal(self: Arc<Self>) -> Result<(), EventProcessorError> {

--- a/nexus-watcher/tests/event_processor/bookmarks/raw.rs
+++ b/nexus-watcher/tests/event_processor/bookmarks/raw.rs
@@ -25,7 +25,7 @@ async fn test_homeserver_bookmark() -> Result<()> {
         status: None,
     };
     let user_id = test.create_user(&user_kp, &user).await?;
-    let (_, events_in_redis_before) = Event::get_events_from_redis(None, 1000).await.unwrap();
+    let (_, events_in_redis_before) = Event::get_events_from_redis(None, 100_000).await.unwrap();
 
     // Step 2: Create a post under that user
     let post = PubkyAppPost {
@@ -60,7 +60,7 @@ async fn test_homeserver_bookmark() -> Result<()> {
     assert_eq!(user_counts.bookmarks, 1);
 
     // INDEX_OP: Assert if the event writes the indexes
-    let (_, events_in_redis_after) = Event::get_events_from_redis(None, 1000).await.unwrap();
+    let (_, events_in_redis_after) = Event::get_events_from_redis(None, 100_000).await.unwrap();
     assert!(events_in_redis_after > events_in_redis_before);
 
     let result_bookmarks = PostStream::get_bookmarked_posts(

--- a/nexus-watcher/tests/event_processor/files/create.rs
+++ b/nexus-watcher/tests/event_processor/files/create.rs
@@ -28,7 +28,7 @@ async fn test_put_pubkyapp_file() -> Result<()> {
     let blob_relative_url = PubkyAppBlob::create_path(&blob_id);
     let blob_absolute_url = blob_uri_builder(user_id.clone(), blob_id);
 
-    let (_, events_in_redis_before) = Event::get_events_from_redis(None, 1000).await.unwrap();
+    let (_, events_in_redis_before) = Event::get_events_from_redis(None, 100_000).await.unwrap();
 
     test.create_file_from_body(&user_kp, blob_relative_url.as_str(), blob.0.clone())
         .await?;
@@ -52,7 +52,7 @@ async fn test_put_pubkyapp_file() -> Result<()> {
         blob_static_path.exists(),
         "File have to exist after PUT event"
     );
-    let (_, events_in_redis_after) = Event::get_events_from_redis(None, 1000).await.unwrap();
+    let (_, events_in_redis_after) = Event::get_events_from_redis(None, 100_000).await.unwrap();
     assert!(events_in_redis_after > events_in_redis_before);
 
     Ok(())

--- a/nexus-watcher/tests/event_processor/files/delete.rs
+++ b/nexus-watcher/tests/event_processor/files/delete.rs
@@ -33,7 +33,7 @@ async fn test_delete_pubkyapp_file() -> Result<()> {
     let blob_relative_url = PubkyAppBlob::create_path(&blob_id);
     let blob_absolute_url = blob_uri_builder(user_id.clone(), blob_id);
 
-    let (_, events_in_redis_before) = Event::get_events_from_redis(None, 1000).await.unwrap();
+    let (_, events_in_redis_before) = Event::get_events_from_redis(None, 100_000).await.unwrap();
 
     test.create_file_from_body(&user_kp, blob_relative_url.as_str(), blob.0.clone())
         .await?;
@@ -64,7 +64,7 @@ async fn test_delete_pubkyapp_file() -> Result<()> {
     let file_before_delete = files_before_delete[0].as_ref();
     assert!(file_before_delete.is_some());
 
-    let (_, events_in_redis_after) = Event::get_events_from_redis(None, 1000).await.unwrap();
+    let (_, events_in_redis_after) = Event::get_events_from_redis(None, 100_000).await.unwrap();
     assert!(events_in_redis_after > events_in_redis_before);
 
     test.cleanup_file(&user_kp, &file_path).await?;

--- a/nexus-watcher/tests/event_processor/posts/raw.rs
+++ b/nexus-watcher/tests/event_processor/posts/raw.rs
@@ -35,7 +35,7 @@ async fn test_homeserver_put_post_event() -> Result<()> {
         embed: None,
         attachments: None,
     };
-    let (_, events_in_redis_before) = Event::get_events_from_redis(None, 1000).await.unwrap();
+    let (_, events_in_redis_before) = Event::get_events_from_redis(None, 100_000).await.unwrap();
 
     let (post_id, post_path) = test.create_post(&user_kp, &post).await?;
 
@@ -53,7 +53,7 @@ async fn test_homeserver_put_post_event() -> Result<()> {
     assert!(post_details.indexed_at > 0);
 
     // CACHE_OP: Check if the event writes in the graph
-    let (_, events_in_redis_after) = Event::get_events_from_redis(None, 1000).await.unwrap();
+    let (_, events_in_redis_after) = Event::get_events_from_redis(None, 100_000).await.unwrap();
     assert!(events_in_redis_after > events_in_redis_before);
 
     //User:Details:user_id:post_id

--- a/nexus-watcher/tests/event_processor/tags/moderated.rs
+++ b/nexus-watcher/tests/event_processor/tags/moderated.rs
@@ -1,19 +1,21 @@
 use super::resource_utils::{compute_resource_id, find_resource_tag};
 use super::utils::find_post_tag;
 use crate::event_processor::utils::watcher::{HomeserverHashIdPath, WatcherTest};
-use anyhow::Result;
+use anyhow::{Error, Result};
 use chrono::Utc;
-use pubky::{recovery_file, Keypair, ResourcePath};
+use nexus_watcher::events::Moderation;
+use pubky::{Keypair, ResourcePath};
 use pubky_app_specs::traits::HashId;
-use pubky_app_specs::{post_uri_builder, tag_uri_builder, PubkyAppPost, PubkyAppTag, PubkyAppUser};
-use tokio::fs;
+use pubky_app_specs::{
+    post_uri_builder, tag_uri_builder, PubkyAppPost, PubkyAppTag, PubkyAppUser, PubkyId,
+};
+use std::sync::Arc;
 
 const MODERATION_LABEL: &str = "label_to_moderate";
 
 #[tokio_shared_rt::test(shared)]
 async fn test_moderation_deletes_pubky_app_tag() -> Result<()> {
-    let mut test = WatcherTest::setup().await?;
-    let moderator_kp = create_moderator(&mut test).await?;
+    let (mut test, moderator_kp) = setup_with_moderator().await?;
     let (_author_kp, author_id, post_id) = create_author_and_post(&mut test).await?;
     let (tagger_kp, tagger_id) = create_tagger(&mut test, "pubky-app").await?;
 
@@ -38,8 +40,7 @@ async fn test_moderation_deletes_pubky_app_tag() -> Result<()> {
 
 #[tokio_shared_rt::test(shared)]
 async fn test_moderation_deletes_universal_tag() -> Result<()> {
-    let mut test = WatcherTest::setup().await?;
-    let moderator_kp = create_moderator(&mut test).await?;
+    let (mut test, moderator_kp) = setup_with_moderator().await?;
     let (tagger_kp, tagger_id) = create_tagger(&mut test, "universal").await?;
 
     let target_uri = format!("https://example.com/moderate-universal/{tagger_id}");
@@ -71,8 +72,7 @@ async fn test_moderation_deletes_universal_tag() -> Result<()> {
 
 #[tokio_shared_rt::test(shared)]
 async fn test_moderation_deletes_app_specific_known_post_tag() -> Result<()> {
-    let mut test = WatcherTest::setup().await?;
-    let moderator_kp = create_moderator(&mut test).await?;
+    let (mut test, moderator_kp) = setup_with_moderator().await?;
     let (_author_kp, author_id, post_id) = create_author_and_post(&mut test).await?;
     let (tagger_kp, tagger_id) = create_tagger(&mut test, "known-post").await?;
 
@@ -99,8 +99,7 @@ async fn test_moderation_deletes_app_specific_known_post_tag() -> Result<()> {
 
 #[tokio_shared_rt::test(shared)]
 async fn test_moderation_keeps_same_label_universal_tag_from_same_user() -> Result<()> {
-    let mut test = WatcherTest::setup().await?;
-    let moderator_kp = create_moderator(&mut test).await?;
+    let (mut test, moderator_kp) = setup_with_moderator().await?;
     let (_author_kp, author_id, post_id) = create_author_and_post(&mut test).await?;
     let (tagger_kp, tagger_id) = create_tagger(&mut test, "same-user").await?;
 
@@ -136,8 +135,7 @@ async fn test_moderation_keeps_same_label_universal_tag_from_same_user() -> Resu
 
 #[tokio_shared_rt::test(shared)]
 async fn test_moderation_keeps_same_label_pubky_app_tag_from_different_user() -> Result<()> {
-    let mut test = WatcherTest::setup().await?;
-    let moderator_kp = create_moderator(&mut test).await?;
+    let (mut test, moderator_kp) = setup_with_moderator().await?;
     let (_author_kp, author_id, post_id) = create_author_and_post(&mut test).await?;
     let (pubky_tagger_kp, pubky_tagger_id) =
         create_tagger(&mut test, "different-user-pubky").await?;
@@ -180,13 +178,19 @@ async fn test_moderation_keeps_same_label_pubky_app_tag_from_different_user() ->
     Ok(())
 }
 
-async fn create_moderator(test: &mut WatcherTest) -> Result<Keypair> {
-    let moderator_recovery_file =
-        fs::read("./tests/event_processor/utils/moderator_key.pkarr").await?;
-    let moderator_kp = recovery_file::decrypt_recovery_file(&moderator_recovery_file, "password")?;
+async fn setup_with_moderator() -> Result<(WatcherTest, Keypair)> {
+    let moderator_kp = Keypair::random();
+    let moderator_id =
+        PubkyId::try_from(moderator_kp.public_key().to_z32().as_str()).map_err(Error::msg)?;
+    let moderation = Arc::new(Moderation {
+        id: moderator_id,
+        tags: vec![MODERATION_LABEL.to_string()],
+    });
+    let mut test = WatcherTest::setup_with_moderation(moderation).await?;
+
     let moderator = test_user("Mod:Moderator", "moderator");
     test.create_user(&moderator_kp, &moderator).await?;
-    Ok(moderator_kp)
+    Ok((test, moderator_kp))
 }
 
 async fn create_author_and_post(test: &mut WatcherTest) -> Result<(Keypair, String, String)> {

--- a/nexus-watcher/tests/event_processor/tags/post_put.rs
+++ b/nexus-watcher/tests/event_processor/tags/post_put.rs
@@ -54,7 +54,7 @@ async fn test_homeserver_put_tag_post() -> Result<()> {
     };
     let tag_path = tag.hs_path();
 
-    let (_, events_in_redis_before) = Event::get_events_from_redis(None, 1000).await.unwrap();
+    let (_, events_in_redis_before) = Event::get_events_from_redis(None, 100_000).await.unwrap();
     // Put tag
     test.put(&user_kp, &tag_path, tag).await?;
 
@@ -71,7 +71,7 @@ async fn test_homeserver_put_tag_post() -> Result<()> {
     assert_eq!(post_tag.taggers[0], tagger_user_id);
 
     // CACHE_OP: Check if the tag is correctly cached
-    let (_, events_in_redis_after) = Event::get_events_from_redis(None, 1000).await.unwrap();
+    let (_, events_in_redis_after) = Event::get_events_from_redis(None, 100_000).await.unwrap();
     assert!(events_in_redis_after > events_in_redis_before);
     let cache_post_tag = TagPost::get_from_index(
         &tagger_user_id,

--- a/nexus-watcher/tests/event_processor/tags/user_to_self_put.rs
+++ b/nexus-watcher/tests/event_processor/tags/user_to_self_put.rs
@@ -36,7 +36,7 @@ async fn test_homeserver_put_tag_user_self() -> Result<()> {
     };
 
     let tag_path = tag.hs_path();
-    let (_, events_in_redis_before) = Event::get_events_from_redis(None, 1000).await.unwrap();
+    let (_, events_in_redis_before) = Event::get_events_from_redis(None, 100_000).await.unwrap();
 
     // Put tag
     test.put(&user_kp, &tag_path, tag).await?;
@@ -53,7 +53,7 @@ async fn test_homeserver_put_tag_user_self() -> Result<()> {
     assert_eq!(user_tag.taggers[0], user_id);
 
     // CACHE_OP: Check if the tag is correctly cached
-    let (_, events_in_redis_after) = Event::get_events_from_redis(None, 1000).await.unwrap();
+    let (_, events_in_redis_after) = Event::get_events_from_redis(None, 100_000).await.unwrap();
     assert!(events_in_redis_after > events_in_redis_before);
     let cache_user_tag = TagUser::get_from_index(&user_id, None, None, None, None, None, false)
         .await

--- a/nexus-watcher/tests/event_processor/tags/user_to_user_del.rs
+++ b/nexus-watcher/tests/event_processor/tags/user_to_user_del.rs
@@ -47,7 +47,7 @@ async fn test_homeserver_del_tag_to_another_user() -> Result<()> {
     };
 
     let tag_path = tag.hs_path();
-    let (_, events_in_redis_before) = Event::get_events_from_redis(None, 1000).await.unwrap();
+    let (_, events_in_redis_before) = Event::get_events_from_redis(None, 100_000).await.unwrap();
 
     // Put tag
     test.put(&tagger_kp, &tag_path, tag).await?;
@@ -61,7 +61,7 @@ async fn test_homeserver_del_tag_to_another_user() -> Result<()> {
     assert!(user_tag.is_none());
 
     // CACHE_OP: Check if the tag is correctly updated in the cache
-    let (_, events_in_redis_after) = Event::get_events_from_redis(None, 1000).await.unwrap();
+    let (_, events_in_redis_after) = Event::get_events_from_redis(None, 100_000).await.unwrap();
     assert!(events_in_redis_after > events_in_redis_before);
     let cache_user_tag =
         TagUser::get_from_index(&tagged_user_id, None, None, None, None, None, false)

--- a/nexus-watcher/tests/event_processor/tags/user_to_user_put.rs
+++ b/nexus-watcher/tests/event_processor/tags/user_to_user_put.rs
@@ -45,7 +45,7 @@ async fn test_homeserver_put_tag_user_another() -> Result<()> {
     };
 
     let tag_path = tag.hs_path();
-    let (_, events_in_redis_before) = Event::get_events_from_redis(None, 1000).await.unwrap();
+    let (_, events_in_redis_before) = Event::get_events_from_redis(None, 100_000).await.unwrap();
 
     // PUT post tag
     test.put(&tagger_kp, &tag_path, tag).await?;
@@ -62,7 +62,7 @@ async fn test_homeserver_put_tag_user_another() -> Result<()> {
     assert_eq!(user_tag.taggers[0], tagger_user_id);
 
     // CACHE_OP: Check if the tag is correctly cached
-    let (_, events_in_redis_after) = Event::get_events_from_redis(None, 1000).await.unwrap();
+    let (_, events_in_redis_after) = Event::get_events_from_redis(None, 100_000).await.unwrap();
     assert!(events_in_redis_after > events_in_redis_before);
     let cache_user_tag =
         TagUser::get_from_index(&tagged_user_id, None, None, None, None, None, false)

--- a/nexus-watcher/tests/event_processor/users/moderated.rs
+++ b/nexus-watcher/tests/event_processor/users/moderated.rs
@@ -2,17 +2,27 @@
 
 use crate::event_processor::{
     users::utils::find_user_details,
-    utils::watcher::{HomeserverHashIdPath, HomeserverPath, WatcherTest},
+    utils::watcher::{HomeserverHashIdPath, WatcherTest},
 };
-use anyhow::Result;
+use anyhow::{Error, Result};
 use chrono::Utc;
+use nexus_watcher::events::Moderation;
 use pubky::{recovery_file, Keypair};
-use pubky_app_specs::{PubkyAppTag, PubkyAppUser};
+use pubky_app_specs::{PubkyAppTag, PubkyAppUser, PubkyId};
+use std::sync::Arc;
 use tokio::fs;
 
 #[tokio_shared_rt::test(shared)]
 async fn test_moderated_user_lifecycle() -> Result<()> {
-    let mut test = WatcherTest::setup().await?;
+    let mod_file = fs::read("./tests/event_processor/utils/moderator_key.pkarr").await?;
+    let mod_kp = recovery_file::decrypt_recovery_file(&mod_file, "password")?;
+    let moderator_id =
+        PubkyId::try_from(mod_kp.public_key().to_z32().as_str()).map_err(Error::msg)?;
+    let moderation = Arc::new(Moderation {
+        id: moderator_id,
+        tags: vec!["label_to_moderate".to_string()],
+    });
+    let mut test = WatcherTest::setup_with_moderation(moderation).await?;
 
     // 1. Create the target user
     let user_kp = Keypair::random();
@@ -29,11 +39,7 @@ async fn test_moderated_user_lifecycle() -> Result<()> {
     let details = find_user_details(&target_id).await?;
     assert_eq!(details.id.to_string(), target_id);
 
-    // 3. Load moderator key and create moderator
-    let mod_file = fs::read("./tests/event_processor/utils/moderator_key.pkarr")
-        .await
-        .unwrap();
-    let mod_kp = recovery_file::decrypt_recovery_file(&mod_file, "password").unwrap();
+    // 3. Create moderator
     let _moderator_id = test.create_user(&mod_kp, &target).await?;
 
     // 4. Tag the target user with the moderation label
@@ -57,8 +63,7 @@ async fn test_moderated_user_lifecycle() -> Result<()> {
         links: None,
         status: None,
     };
-    let profile_path = PubkyAppUser::hs_path();
-    test.put(&user_kp, &profile_path, new_profile).await?;
+    test.create_profile(&user_kp, &new_profile).await?;
 
     let details = find_user_details(&target_id).await?;
     assert_eq!(details.bio, Some("i am back, will behave".to_string()));

--- a/nexus-watcher/tests/event_processor/users/raw.rs
+++ b/nexus-watcher/tests/event_processor/users/raw.rs
@@ -32,7 +32,7 @@ async fn test_homeserver_user_put_event() -> Result<()> {
         name: "Watcher:UserEvent:User".to_string(),
         status: Some("Running Nexus Watcher".to_string()),
     };
-    let (_, events_in_redis_before) = Event::get_events_from_redis(None, 1000).await.unwrap();
+    let (_, events_in_redis_before) = Event::get_events_from_redis(None, 100_000).await.unwrap();
 
     let user_id = test.create_user(&user_kp, &user).await?;
 
@@ -61,7 +61,7 @@ async fn test_homeserver_user_put_event() -> Result<()> {
 
     // CACHE_OP: Check if the event writes in the graph
     // User:Counts:user_id
-    let (_, events_in_redis_after) = Event::get_events_from_redis(None, 1000).await.unwrap();
+    let (_, events_in_redis_after) = Event::get_events_from_redis(None, 100_000).await.unwrap();
     assert!(events_in_redis_after > events_in_redis_before);
 
     let user_counts = UserCounts::get_from_index(&user_id)

--- a/nexus-watcher/tests/event_processor/utils/watcher.rs
+++ b/nexus-watcher/tests/event_processor/utils/watcher.rs
@@ -2,16 +2,17 @@ use crate::event_processor::utils::default_moderation_tests;
 use anyhow::{anyhow, Error, Result};
 use base32::{encode, Alphabet};
 use chrono::Utc;
-use nexus_common::db::PubkyConnector;
+use nexus_common::db::{exec_single_row, queries, PubkyConnector};
 use nexus_common::get_files_dir_pathbuf;
 use nexus_common::models::event::{Event, EventProcessorError, ParseResult};
 use nexus_common::models::file::FileDetails;
 use nexus_common::models::homeserver::Homeserver;
 use nexus_common::models::traits::Collection;
+use nexus_common::models::user::UserDetails;
 use nexus_common::{StackConfig, StackManager};
 use nexus_watcher::events::retry::event::RetryEvent;
 use nexus_watcher::events::retry::{InitialBackoff, RedisRetryStore, RetryScheduler, RetryStore};
-use nexus_watcher::events::{DefaultEventHandler, EventHandler};
+use nexus_watcher::events::{DefaultEventHandler, EventHandler, Moderation};
 use nexus_watcher::service::HsEventProcessorRunner;
 use nexus_watcher::service::TEventProcessorRunner;
 use pubky::Keypair;
@@ -81,9 +82,9 @@ impl WatcherTest {
     fn create_test_event_processor_runner(
         default_homeserver: PubkyId,
         files_path: PathBuf,
+        moderation: Arc<Moderation>,
     ) -> HsEventProcessorRunner {
-        let event_handler: Arc<dyn EventHandler> =
-            Arc::new(DefaultEventHandler::new(default_moderation_tests()));
+        let event_handler: Arc<dyn EventHandler> = Arc::new(DefaultEventHandler::new(moderation));
 
         let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
 
@@ -120,6 +121,10 @@ impl WatcherTest {
     /// Returns an instance of `Self` containing the configuration, homeserver,
     /// event processor, and other test setup details, including the shutdown receiver.
     pub async fn setup() -> Result<Self> {
+        Self::setup_with_moderation(default_moderation_tests()).await
+    }
+
+    pub async fn setup_with_moderation(moderation: Arc<Moderation>) -> Result<Self> {
         if let Err(e) = StackManager::setup(&StackConfig::default()).await {
             return Err(Error::msg(format!("could not initialise the stack, {e:?}")));
         }
@@ -147,7 +152,7 @@ impl WatcherTest {
 
         // Initialize the test-scoped EventProcessorRunner; mirrors the standard processor behavior
         let event_processor_runner =
-            Self::create_test_event_processor_runner(homeserver_id.clone(), files_path);
+            Self::create_test_event_processor_runner(homeserver_id.clone(), files_path, moderation);
 
         Ok(Self {
             testnet,
@@ -248,10 +253,25 @@ impl WatcherTest {
         Ok(())
     }
 
+    async fn persist_user_homeserver(&self, user_id: &str) -> Result<()> {
+        let user_id = PubkyId::try_from(user_id).map_err(Error::msg)?;
+        let user = UserDetails::from_pubky(user_id.clone());
+
+        exec_single_row(queries::put::create_user(&user)?).await?;
+        exec_single_row(queries::put::set_user_homeserver(
+            &user_id,
+            &self.homeserver_id,
+        ))
+        .await?;
+
+        Ok(())
+    }
+
     pub async fn create_user(&mut self, user_kp: &Keypair, user: &PubkyAppUser) -> Result<String> {
         let user_id = user_kp.public_key().to_z32();
         // Register the key in the homeserver
         self.register_user(user_kp).await?;
+        self.persist_user_homeserver(&user_id).await?;
 
         // Write the user profile in the pubky.app repository
         let user_path = PubkyAppUser::hs_path();
@@ -269,6 +289,7 @@ impl WatcherTest {
         user: &PubkyAppUser,
     ) -> Result<String> {
         let user_id = user_kp.public_key().to_z32();
+        self.persist_user_homeserver(&user_id).await?;
 
         // Write the user profile in the pubky.app repository
         let user_path = PubkyAppUser::hs_path();

--- a/nexus-watcher/tests/service/hs_event_processor.rs
+++ b/nexus-watcher/tests/service/hs_event_processor.rs
@@ -1,11 +1,15 @@
 use crate::service::utils::common::create_mock_handler;
 use crate::service::utils::{new_in_memory_store, setup, TEST_USER_ID};
-use anyhow::Result;
+use anyhow::{Error, Result};
+use chrono::Utc;
+use nexus_common::db::{exec_single_row, queries};
 use nexus_common::models::event::EventProcessorError;
 use nexus_common::models::homeserver::Homeserver;
+use nexus_common::models::user::UserDetails;
 use nexus_watcher::events::retry::{InitialBackoff, RetryScheduler, RetryStore};
 use nexus_watcher::events::EventHandler;
 use nexus_watcher::service::HsEventProcessor;
+use pubky::Keypair;
 use pubky_app_specs::{post_uri_builder, PubkyId};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -39,6 +43,32 @@ fn build_processor(
     })
 }
 
+async fn persist_user(user_id: &str) -> Result<()> {
+    let user_id = PubkyId::try_from(user_id).map_err(Error::msg)?;
+    let user = UserDetails {
+        id: user_id,
+        name: "hs-event-processor-test-user".into(),
+        bio: None,
+        status: None,
+        links: None,
+        image: None,
+        indexed_at: Utc::now().timestamp_millis(),
+    };
+
+    exec_single_row(queries::put::create_user(&user)?).await?;
+    Ok(())
+}
+
+async fn persist_user_homeserver(user_id: &str, homeserver_id: &str) -> Result<()> {
+    persist_user(user_id).await?;
+    exec_single_row(queries::put::set_user_homeserver(user_id, homeserver_id)).await?;
+    Ok(())
+}
+
+fn random_user_id() -> String {
+    Keypair::random().public_key().to_z32()
+}
+
 // ============================================================================
 // Batch continues after a single event fails
 // A retryable application error on one event must not halt the batch — later
@@ -48,6 +78,7 @@ fn build_processor(
 #[tokio_shared_rt::test(shared)]
 async fn test_batch_continues_after_single_failure() -> Result<()> {
     setup().await?;
+    persist_user_homeserver(TEST_USER_ID, TEST_HS_ID).await?;
 
     let first_post_id = "failone";
     let second_post_id = "failtwo";
@@ -103,6 +134,7 @@ async fn test_batch_continues_after_single_failure() -> Result<()> {
 #[tokio_shared_rt::test(shared)]
 async fn test_retry_event_carries_origin_homeserver_id() -> Result<()> {
     setup().await?;
+    persist_user_homeserver(TEST_USER_ID, TEST_HS_ID).await?;
 
     let post_id = "originhs";
     let uri = post_uri_builder(TEST_USER_ID.to_string(), post_id.to_string());
@@ -143,6 +175,7 @@ async fn test_retry_event_carries_origin_homeserver_id() -> Result<()> {
 #[tokio_shared_rt::test(shared)]
 async fn test_batch_stops_on_infrastructure_error() -> Result<()> {
     setup().await?;
+    persist_user_homeserver(TEST_USER_ID, TEST_HS_ID).await?;
 
     let first_post_id = "infraone";
     let second_post_id = "infratwo";
@@ -191,6 +224,100 @@ async fn test_batch_stops_on_infrastructure_error() -> Result<()> {
     assert!(
         store.get(&second_uri).await?.is_none(),
         "Second event must not be queued — batch should have stopped at the first failure"
+    );
+
+    let _ = shutdown_tx.send(true);
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_event_without_hosted_by_is_queued_for_retry() -> Result<()> {
+    setup().await?;
+
+    let user_id = random_user_id();
+    persist_user(&user_id).await?;
+    let uri = post_uri_builder(user_id, "missinghs".to_string());
+
+    let store = new_in_memory_store();
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let handler = create_mock_handler(Ok(()), None);
+    let processor = build_processor(store.clone(), handler.clone(), shutdown_rx);
+
+    processor
+        .process_event_lines(vec![format!("PUT {uri}")])
+        .await?;
+
+    assert_eq!(
+        handler.get_handle_count(),
+        0,
+        "Event without HOSTED_BY must not be processed immediately"
+    );
+    assert!(
+        store.get(&uri).await?.is_some(),
+        "Event without HOSTED_BY must be queued for retry"
+    );
+
+    let _ = shutdown_tx.send(true);
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_event_hosted_by_different_homeserver_is_skipped() -> Result<()> {
+    setup().await?;
+
+    let user_id = random_user_id();
+    let other_hs_id = "8rsrmfrn1anbrzuxiffwy1174o58emf4qgbfk5h7s8a33r3bd8dy";
+    persist_user_homeserver(&user_id, other_hs_id).await?;
+    let uri = post_uri_builder(user_id, "otherhs".to_string());
+
+    let store = new_in_memory_store();
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let handler = create_mock_handler(Ok(()), None);
+    let processor = build_processor(store.clone(), handler.clone(), shutdown_rx);
+
+    processor
+        .process_event_lines(vec![format!("PUT {uri}")])
+        .await?;
+
+    assert_eq!(
+        handler.get_handle_count(),
+        0,
+        "Event hosted by a different homeserver must be skipped"
+    );
+    assert!(
+        store.get(&uri).await?.is_none(),
+        "Skipped event must not be queued for retry"
+    );
+
+    let _ = shutdown_tx.send(true);
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_event_hosted_by_default_homeserver_is_processed() -> Result<()> {
+    setup().await?;
+
+    let user_id = random_user_id();
+    persist_user_homeserver(&user_id, TEST_HS_ID).await?;
+    let uri = post_uri_builder(user_id, "defaulths".to_string());
+
+    let store = new_in_memory_store();
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let handler = create_mock_handler(Ok(()), None);
+    let processor = build_processor(store.clone(), handler.clone(), shutdown_rx);
+
+    processor
+        .process_event_lines(vec![format!("PUT {uri}")])
+        .await?;
+
+    assert_eq!(
+        handler.get_handle_count(),
+        1,
+        "Event hosted by the processor homeserver must be processed"
+    );
+    assert!(
+        store.get(&uri).await?.is_none(),
+        "Successfully processed event must not be queued for retry"
     );
 
     let _ = shutdown_tx.send(true);


### PR DESCRIPTION
This PR is a proposed alternative to #889.

Changes:
- in the default event processor `HsEventProcessor`:
  - Check each parsed event's user `HOSTED_BY` before processing
  - When `HOSTED_BY` is missing, enqueue those events for retry
  - When `HOSTED_BY` exists but points to a different HS, skip processing
- Add tests for above behavior
- Updated moderation tests, such that they use different random moderator IDs
  - Before, they were using the same moderator ID with different random HSs, so with the `HOSTED_BY` addition it looked as if the same moderator was hosted on multiple HSs at once
- Update user delete safety check `user_is_safe_to_delete`, so presence of `HOSTED_BY` does not prevent soft-deleting users
