### PR TITLE
`HsEventProcessor`: validate HS mapping with graceful fallback

### DIFF
--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -431,12 +431,13 @@ pub fn get_users_needing_hs_resolution(ttl_ms: u64) -> Query {
     .param("ttl_ms", ttl_ms as i64)
 }
 
-/// Retrieves the homeserver ID a user is currently hosted on, if any.
+/// Retrieves the homeserver ID a user is currently hosted on, if any, along with
+/// whether that `HOSTED_BY` mapping is marked `stale`.
 pub fn get_user_homeserver(user_id: &str) -> Query {
     Query::new(
         "get_user_homeserver",
-        "MATCH (u:User {id: $user_id})-[:HOSTED_BY]->(hs:Homeserver)
-         RETURN hs.id AS homeserver_id",
+        "MATCH (u:User {id: $user_id})-[r:HOSTED_BY]->(hs:Homeserver)
+         RETURN hs.id AS homeserver_id, coalesce(r.stale, false) AS stale",
     )
     .param("user_id", user_id.to_string())
 }

--- a/nexus-watcher/src/service/indexer/homeserver.rs
+++ b/nexus-watcher/src/service/indexer/homeserver.rs
@@ -6,9 +6,11 @@ use nexus_common::models::event::{Event, EventProcessorError};
 use nexus_common::models::homeserver::Homeserver;
 use pubky::Method;
 use pubky_app_specs::PubkyId;
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::watch::Receiver;
+use tokio::sync::Mutex;
 use tracing::{debug, error, info, warn};
 
 /// A user's `HOSTED_BY` binding, classified relative to a processor's homeserver.
@@ -16,7 +18,8 @@ use tracing::{debug, error, info, warn};
 /// The `stale` flag is only carried where it is meaningful: a stale mapping means
 /// the user's published homeserver has diverged from the stored one (see
 /// [`set_user_homeserver_stale`](nexus_common::db::queries::put::set_user_homeserver_stale)).
-enum HsBinding {
+#[derive(Clone)]
+pub enum HsBinding {
     /// The user has no `HOSTED_BY` edge yet.
     Unbound,
     /// The user is bound to this processor's homeserver.
@@ -37,6 +40,10 @@ pub struct HsEventProcessor {
     pub shutdown_rx: Receiver<bool>,
     /// Scheduler used to enqueue failed events onto the retry queue
     pub retry_scheduler: Arc<RetryScheduler>,
+
+    /// Per-run cache of users' `HOSTED_BY` mappings. For a given user's events in
+    /// the events list, only the 1st one results in a graph lookup, the rest read from this cache.
+    pub hs_mapping_cache: Mutex<HashMap<String, HsBinding>>,
 }
 
 #[async_trait::async_trait]
@@ -74,7 +81,7 @@ impl TEventProcessor for HsEventProcessor {
     async fn should_process_event(&self, event: &Event) -> bool {
         let user_id = event.parsed_uri.user_id();
 
-        match self.user_hs_binding(user_id).await {
+        match self.user_hs_mapping(user_id).await {
             // No mapping yet (graceful fallback) or actively bound here: process.
             Ok(HsBinding::Unbound) | Ok(HsBinding::Current { stale: false }) => true,
 
@@ -132,25 +139,33 @@ impl TEventProcessor for HsEventProcessor {
 }
 
 impl HsEventProcessor {
-    /// Resolves a user's `HOSTED_BY` binding relative to this processor's HS.
-    ///
-    /// Performs a single graph lookup and classifies the result, attaching the
-    /// `stale` flag where it is meaningful (see [`HsBinding`]).
-    async fn user_hs_binding(&self, user_id: &PubkyId) -> GraphResult<HsBinding> {
-        let query = queries::get::get_user_homeserver(user_id.as_ref());
+    /// Resolves and caches a user's `HOSTED_BY` binding relative to this processor's HS
+    async fn user_hs_mapping(&self, user_id: &PubkyId) -> GraphResult<HsBinding> {
+        if let Some(binding) = self.hs_mapping_cache.lock().await.get(user_id.as_ref()) {
+            return Ok(binding.clone());
+        }
 
-        let Some(row) = fetch_row_from_graph(query).await? else {
-            return Ok(HsBinding::Unbound);
+        let query = queries::get::get_user_homeserver(user_id.as_ref());
+        let mapping = match fetch_row_from_graph(query).await? {
+            None => HsBinding::Unbound,
+            Some(row) => {
+                let hs_id: String = row.get("homeserver_id")?;
+                let stale: bool = row.get("stale")?;
+
+                if hs_id.as_str() == self.homeserver.id.as_ref() {
+                    HsBinding::Current { stale }
+                } else {
+                    HsBinding::Other { hs_id }
+                }
+            }
         };
 
-        let hs_id: String = row.get("homeserver_id")?;
-        let stale: bool = row.get("stale")?;
+        self.hs_mapping_cache
+            .lock()
+            .await
+            .insert(user_id.as_ref().to_string(), mapping.clone());
 
-        Ok(if hs_id.as_str() == self.homeserver.id.as_ref() {
-            HsBinding::Current { stale }
-        } else {
-            HsBinding::Other { hs_id }
-        })
+        Ok(mapping)
     }
 
     /// Polls new events from the homeserver.

--- a/nexus-watcher/src/service/indexer/homeserver.rs
+++ b/nexus-watcher/src/service/indexer/homeserver.rs
@@ -79,29 +79,26 @@ impl TEventProcessor for HsEventProcessor {
     /// - A stale edge to this homeserver (the user's published homeserver has
     ///   diverged): log a warning and skip until the resolver realigns it.
     /// - An edge to a different homeserver: log a warning and skip.
-    ///
-    /// A lookup failure fails open (the event is processed), so a transient
-    /// graph error never silently drops legitimate events.
-    async fn should_process_event(&self, event: &Event) -> bool {
+    async fn should_process_event(&self, event: &Event) -> Result<bool, EventProcessorError> {
         let user_id = event.parsed_uri.user_id();
 
-        match self.user_hs_mapping(user_id).await {
+        match self.user_hs_mapping(user_id).await? {
             // No mapping yet (graceful fallback) or actively bound here: process.
-            Ok(HsMapping::Unbound | HsMapping::Current { stale: false }) => true,
+            HsMapping::Unbound | HsMapping::Current { stale: false } => Ok(true),
 
             // Bound here but the mapping is stale: skip until the resolver realigns it.
-            Ok(HsMapping::Current { stale: true }) => {
+            HsMapping::Current { stale: true } => {
                 warn!(
                     event.uri = %event.uri,
                     user_id = %user_id,
                     processor_homeserver = %self.homeserver.id,
                     "User's homeserver mapping is stale; skipping event"
                 );
-                false
+                Ok(false)
             }
 
             // Bound to a different homeserver: skip.
-            Ok(HsMapping::Other { hs_id }) => {
+            HsMapping::Other { hs_id } => {
                 warn!(
                     event.uri = %event.uri,
                     user_id = %user_id,
@@ -109,17 +106,7 @@ impl TEventProcessor for HsEventProcessor {
                     user_homeserver = %hs_id,
                     "User is hosted on a different homeserver; skipping event"
                 );
-                false
-            }
-
-            // Lookup failed: fail open so transient graph errors don't drop events.
-            Err(e) => {
-                warn!(
-                    event.uri = %event.uri,
-                    user_id = %user_id,
-                    "Failed to resolve user's homeserver; processing event anyway: {e}"
-                );
-                true
+                Ok(false)
             }
         }
     }

--- a/nexus-watcher/src/service/indexer/homeserver.rs
+++ b/nexus-watcher/src/service/indexer/homeserver.rs
@@ -43,6 +43,10 @@ pub struct HsEventProcessor {
 
     /// Per-run cache of users' `HOSTED_BY` mappings. For a given user's events in
     /// the events list, only the 1st one results in a graph lookup, the rest read from this cache.
+    ///
+    /// Entries are deliberately never refreshed within a run: once a user's mapping
+    /// is resolved, the same decision is reused for the rest of the batch even if the
+    /// resolver realigns the underlying edge mid-run. The cache is dropped when the run ends.
     pub hs_mapping_cache: Mutex<HashMap<String, HsMapping>>,
 }
 

--- a/nexus-watcher/src/service/indexer/homeserver.rs
+++ b/nexus-watcher/src/service/indexer/homeserver.rs
@@ -1,10 +1,11 @@
 use super::TEventProcessor;
 use crate::events::retry::RetryScheduler;
 use crate::events::EventHandler;
-use nexus_common::db::PubkyConnector;
-use nexus_common::models::event::EventProcessorError;
+use nexus_common::db::{fetch_key_from_graph, queries, GraphResult, PubkyConnector};
+use nexus_common::models::event::{Event, EventProcessorError};
 use nexus_common::models::homeserver::Homeserver;
 use pubky::Method;
+use pubky_app_specs::PubkyId;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::watch::Receiver;
@@ -46,6 +47,40 @@ impl TEventProcessor for HsEventProcessor {
         Some(self.homeserver.id.as_ref())
     }
 
+    /// Skips events from users that are bound to a *different* homeserver.
+    ///
+    /// Before an event is processed we inspect the user's `HOSTED_BY` edge:
+    /// - No edge, or the edge points at this processor's homeserver: process.
+    /// - The edge points at a different homeserver: log a warning and skip.
+    ///
+    /// A lookup failure fails open (the event is processed), so a transient
+    /// graph error never silently drops legitimate events.
+    async fn should_process_event(&self, event: &Event) -> bool {
+        let user_id = event.parsed_uri.user_id();
+
+        match self.user_bound_to_other_homeserver(user_id).await {
+            Ok(Some(other_hs_id)) => {
+                warn!(
+                    event.uri = %event.uri,
+                    user_id = %user_id,
+                    processor_homeserver = %self.homeserver.id,
+                    user_homeserver = %other_hs_id,
+                    "User is hosted on a different homeserver; skipping event"
+                );
+                false
+            }
+            Ok(None) => true,
+            Err(e) => {
+                warn!(
+                    event.uri = %event.uri,
+                    user_id = %user_id,
+                    "Failed to resolve user's homeserver; processing event anyway: {e}"
+                );
+                true
+            }
+        }
+    }
+
     async fn run_internal(self: Arc<Self>) -> Result<(), EventProcessorError> {
         let maybe_event_lines = self
             .poll_events()
@@ -65,6 +100,22 @@ impl TEventProcessor for HsEventProcessor {
 }
 
 impl HsEventProcessor {
+    /// Returns the homeserver a user is bound to via `HOSTED_BY`, but only when
+    /// it differs from this processor's homeserver.
+    ///
+    /// Returns `Ok(None)` when the user has no `HOSTED_BY` edge or the edge
+    /// points at this processor's homeserver, and `Ok(Some(hs_id))` when the
+    /// edge points at a different homeserver.
+    async fn user_bound_to_other_homeserver(
+        &self,
+        user_id: &PubkyId,
+    ) -> GraphResult<Option<String>> {
+        let query = queries::get::get_user_homeserver(user_id.as_ref());
+        let maybe_hs_id: Option<String> = fetch_key_from_graph(query, "homeserver_id").await?;
+
+        Ok(maybe_hs_id.filter(|hs_id| hs_id.as_str() != self.homeserver.id.as_ref()))
+    }
+
     /// Polls new events from the homeserver.
     ///
     /// It sends a GET request to the homeserver's events endpoint

--- a/nexus-watcher/src/service/indexer/homeserver.rs
+++ b/nexus-watcher/src/service/indexer/homeserver.rs
@@ -87,7 +87,7 @@ impl TEventProcessor for HsEventProcessor {
 
         match self.user_hs_mapping(user_id).await {
             // No mapping yet (graceful fallback) or actively bound here: process.
-            Ok(HsMapping::Unbound) | Ok(HsMapping::Current { stale: false }) => true,
+            Ok(HsMapping::Unbound | HsMapping::Current { stale: false }) => true,
 
             // Bound here but the mapping is stale: skip until the resolver realigns it.
             Ok(HsMapping::Current { stale: true }) => {

--- a/nexus-watcher/src/service/indexer/homeserver.rs
+++ b/nexus-watcher/src/service/indexer/homeserver.rs
@@ -1,7 +1,7 @@
 use super::TEventProcessor;
 use crate::events::retry::RetryScheduler;
 use crate::events::EventHandler;
-use nexus_common::db::{fetch_key_from_graph, queries, GraphResult, PubkyConnector};
+use nexus_common::db::{fetch_row_from_graph, queries, GraphResult, PubkyConnector};
 use nexus_common::models::event::{Event, EventProcessorError};
 use nexus_common::models::homeserver::Homeserver;
 use pubky::Method;
@@ -10,6 +10,20 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::watch::Receiver;
 use tracing::{debug, error, info, warn};
+
+/// A user's `HOSTED_BY` binding, classified relative to a processor's homeserver.
+///
+/// The `stale` flag is only carried where it is meaningful: a stale mapping means
+/// the user's published homeserver has diverged from the stored one (see
+/// [`set_user_homeserver_stale`](nexus_common::db::queries::put::set_user_homeserver_stale)).
+enum HsBinding {
+    /// The user has no `HOSTED_BY` edge yet.
+    Unbound,
+    /// The user is bound to this processor's homeserver.
+    Current { stale: bool },
+    /// The user is bound to a different homeserver.
+    Other { hs_id: String },
+}
 
 /// Event processor for the default homeserver
 pub struct HsEventProcessor {
@@ -47,29 +61,47 @@ impl TEventProcessor for HsEventProcessor {
         Some(self.homeserver.id.as_ref())
     }
 
-    /// Skips events from users that are bound to a *different* homeserver.
+    /// Skips events from users that are not actively bound to this homeserver.
     ///
     /// Before an event is processed we inspect the user's `HOSTED_BY` edge:
-    /// - No edge, or the edge points at this processor's homeserver: process.
-    /// - The edge points at a different homeserver: log a warning and skip.
+    /// - No edge, or a non-stale edge to this processor's homeserver: process.
+    /// - A stale edge to this homeserver (the user's published homeserver has
+    ///   diverged): log a warning and skip until the resolver realigns it.
+    /// - An edge to a different homeserver: log a warning and skip.
     ///
     /// A lookup failure fails open (the event is processed), so a transient
     /// graph error never silently drops legitimate events.
     async fn should_process_event(&self, event: &Event) -> bool {
         let user_id = event.parsed_uri.user_id();
 
-        match self.user_bound_to_other_homeserver(user_id).await {
-            Ok(Some(other_hs_id)) => {
+        match self.user_hs_binding(user_id).await {
+            // No mapping yet (graceful fallback) or actively bound here: process.
+            Ok(HsBinding::Unbound) | Ok(HsBinding::Current { stale: false }) => true,
+
+            // Bound here but the mapping is stale: skip until the resolver realigns it.
+            Ok(HsBinding::Current { stale: true }) => {
                 warn!(
                     event.uri = %event.uri,
                     user_id = %user_id,
                     processor_homeserver = %self.homeserver.id,
-                    user_homeserver = %other_hs_id,
+                    "User's homeserver mapping is stale; skipping event"
+                );
+                false
+            }
+
+            // Bound to a different homeserver: skip.
+            Ok(HsBinding::Other { hs_id }) => {
+                warn!(
+                    event.uri = %event.uri,
+                    user_id = %user_id,
+                    processor_homeserver = %self.homeserver.id,
+                    user_homeserver = %hs_id,
                     "User is hosted on a different homeserver; skipping event"
                 );
                 false
             }
-            Ok(None) => true,
+
+            // Lookup failed: fail open so transient graph errors don't drop events.
             Err(e) => {
                 warn!(
                     event.uri = %event.uri,
@@ -100,20 +132,25 @@ impl TEventProcessor for HsEventProcessor {
 }
 
 impl HsEventProcessor {
-    /// Returns the homeserver a user is bound to via `HOSTED_BY`, but only when
-    /// it differs from this processor's homeserver.
+    /// Resolves a user's `HOSTED_BY` binding relative to this processor's HS.
     ///
-    /// Returns `Ok(None)` when the user has no `HOSTED_BY` edge or the edge
-    /// points at this processor's homeserver, and `Ok(Some(hs_id))` when the
-    /// edge points at a different homeserver.
-    async fn user_bound_to_other_homeserver(
-        &self,
-        user_id: &PubkyId,
-    ) -> GraphResult<Option<String>> {
+    /// Performs a single graph lookup and classifies the result, attaching the
+    /// `stale` flag where it is meaningful (see [`HsBinding`]).
+    async fn user_hs_binding(&self, user_id: &PubkyId) -> GraphResult<HsBinding> {
         let query = queries::get::get_user_homeserver(user_id.as_ref());
-        let maybe_hs_id: Option<String> = fetch_key_from_graph(query, "homeserver_id").await?;
 
-        Ok(maybe_hs_id.filter(|hs_id| hs_id.as_str() != self.homeserver.id.as_ref()))
+        let Some(row) = fetch_row_from_graph(query).await? else {
+            return Ok(HsBinding::Unbound);
+        };
+
+        let hs_id: String = row.get("homeserver_id")?;
+        let stale: bool = row.get("stale")?;
+
+        Ok(if hs_id.as_str() == self.homeserver.id.as_ref() {
+            HsBinding::Current { stale }
+        } else {
+            HsBinding::Other { hs_id }
+        })
     }
 
     /// Polls new events from the homeserver.

--- a/nexus-watcher/src/service/indexer/homeserver.rs
+++ b/nexus-watcher/src/service/indexer/homeserver.rs
@@ -13,18 +13,18 @@ use tokio::sync::watch::Receiver;
 use tokio::sync::Mutex;
 use tracing::{debug, error, info, warn};
 
-/// A user's `HOSTED_BY` binding, classified relative to a processor's homeserver.
+/// A user's `HOSTED_BY` mapping, classified relative to a processor's HS.
 ///
 /// The `stale` flag is only carried where it is meaningful: a stale mapping means
-/// the user's published homeserver has diverged from the stored one (see
+/// the user's published HS has diverged from the stored one (see
 /// [`set_user_homeserver_stale`](nexus_common::db::queries::put::set_user_homeserver_stale)).
 #[derive(Clone)]
-pub enum HsBinding {
+pub enum HsMapping {
     /// The user has no `HOSTED_BY` edge yet.
     Unbound,
-    /// The user is bound to this processor's homeserver.
+    /// The user is mapped to this processor's HS.
     Current { stale: bool },
-    /// The user is bound to a different homeserver.
+    /// The user is mapped to a different HS.
     Other { hs_id: String },
 }
 
@@ -43,7 +43,7 @@ pub struct HsEventProcessor {
 
     /// Per-run cache of users' `HOSTED_BY` mappings. For a given user's events in
     /// the events list, only the 1st one results in a graph lookup, the rest read from this cache.
-    pub hs_mapping_cache: Mutex<HashMap<String, HsBinding>>,
+    pub hs_mapping_cache: Mutex<HashMap<String, HsMapping>>,
 }
 
 #[async_trait::async_trait]
@@ -83,10 +83,10 @@ impl TEventProcessor for HsEventProcessor {
 
         match self.user_hs_mapping(user_id).await {
             // No mapping yet (graceful fallback) or actively bound here: process.
-            Ok(HsBinding::Unbound) | Ok(HsBinding::Current { stale: false }) => true,
+            Ok(HsMapping::Unbound) | Ok(HsMapping::Current { stale: false }) => true,
 
             // Bound here but the mapping is stale: skip until the resolver realigns it.
-            Ok(HsBinding::Current { stale: true }) => {
+            Ok(HsMapping::Current { stale: true }) => {
                 warn!(
                     event.uri = %event.uri,
                     user_id = %user_id,
@@ -97,7 +97,7 @@ impl TEventProcessor for HsEventProcessor {
             }
 
             // Bound to a different homeserver: skip.
-            Ok(HsBinding::Other { hs_id }) => {
+            Ok(HsMapping::Other { hs_id }) => {
                 warn!(
                     event.uri = %event.uri,
                     user_id = %user_id,
@@ -139,23 +139,23 @@ impl TEventProcessor for HsEventProcessor {
 }
 
 impl HsEventProcessor {
-    /// Resolves and caches a user's `HOSTED_BY` binding relative to this processor's HS
-    async fn user_hs_mapping(&self, user_id: &PubkyId) -> GraphResult<HsBinding> {
-        if let Some(binding) = self.hs_mapping_cache.lock().await.get(user_id.as_ref()) {
-            return Ok(binding.clone());
+    /// Resolves and caches a user's `HOSTED_BY` mapping relative to this processor's HS
+    async fn user_hs_mapping(&self, user_id: &PubkyId) -> GraphResult<HsMapping> {
+        if let Some(hs_mapping) = self.hs_mapping_cache.lock().await.get(user_id.as_ref()) {
+            return Ok(hs_mapping.clone());
         }
 
         let query = queries::get::get_user_homeserver(user_id.as_ref());
         let mapping = match fetch_row_from_graph(query).await? {
-            None => HsBinding::Unbound,
+            None => HsMapping::Unbound,
             Some(row) => {
                 let hs_id: String = row.get("homeserver_id")?;
                 let stale: bool = row.get("stale")?;
 
                 if hs_id.as_str() == self.homeserver.id.as_ref() {
-                    HsBinding::Current { stale }
+                    HsMapping::Current { stale }
                 } else {
-                    HsBinding::Other { hs_id }
+                    HsMapping::Other { hs_id }
                 }
             }
         };

--- a/nexus-watcher/src/service/indexer/mod.rs
+++ b/nexus-watcher/src/service/indexer/mod.rs
@@ -189,6 +189,16 @@ pub trait TEventProcessor: Send + Sync + 'static {
         }
     }
 
+    /// Decides whether the given event should be processed by this processor.
+    ///
+    /// Called at the start of [`Self::handle_event`], before the event is handed
+    /// to the event handler. The default always processes the event;
+    /// [`HsEventProcessor`](crate::service::indexer::HsEventProcessor) overrides
+    /// this to skip events from users bound to a different homeserver.
+    async fn should_process_event(&self, _event: &Event) -> bool {
+        true
+    }
+
     /// Processes an event and delegates to [`Self::handle_error`] on failure.
     #[tracing::instrument(
         name = "event.process",
@@ -205,6 +215,10 @@ pub trait TEventProcessor: Send + Sync + 'static {
         )
     )]
     async fn handle_event(&self, event: &Event) -> Result<(), EventProcessorError> {
+        if !self.should_process_event(event).await {
+            return Ok(());
+        }
+
         let span = tracing::Span::current();
         if let Err(e) = self.event_handler().handle(event).await {
             span.record("otel.status_code", "ERROR");

--- a/nexus-watcher/src/service/indexer/mod.rs
+++ b/nexus-watcher/src/service/indexer/mod.rs
@@ -215,11 +215,13 @@ pub trait TEventProcessor: Send + Sync + 'static {
         )
     )]
     async fn handle_event(&self, event: &Event) -> Result<(), EventProcessorError> {
+        let span = tracing::Span::current();
+
         if !self.should_process_event(event).await {
+            span.record("otel.status_code", "OK");
             return Ok(());
         }
 
-        let span = tracing::Span::current();
         if let Err(e) = self.event_handler().handle(event).await {
             span.record("otel.status_code", "ERROR");
             span.record("otel.status_message", tracing::field::display(&e));

--- a/nexus-watcher/src/service/indexer/mod.rs
+++ b/nexus-watcher/src/service/indexer/mod.rs
@@ -195,8 +195,8 @@ pub trait TEventProcessor: Send + Sync + 'static {
     /// to the event handler. The default always processes the event;
     /// [`HsEventProcessor`](crate::service::indexer::HsEventProcessor) overrides
     /// this to skip events from users bound to a different homeserver.
-    async fn should_process_event(&self, _event: &Event) -> bool {
-        true
+    async fn should_process_event(&self, _event: &Event) -> Result<bool, EventProcessorError> {
+        Ok(true)
     }
 
     /// Processes an event and delegates to [`Self::handle_error`] on failure.
@@ -217,9 +217,18 @@ pub trait TEventProcessor: Send + Sync + 'static {
     async fn handle_event(&self, event: &Event) -> Result<(), EventProcessorError> {
         let span = tracing::Span::current();
 
-        if !self.should_process_event(event).await {
-            span.record("otel.status_code", "OK");
-            return Ok(());
+        match self.should_process_event(event).await {
+            Ok(true) => {}
+            Ok(false) => {
+                span.record("otel.status_code", "UNSET");
+                span.record("otel.status_message", "SKIPPED");
+                return Ok(());
+            }
+            Err(e) => {
+                span.record("otel.status_code", "ERROR");
+                span.record("otel.status_message", tracing::field::display(&e));
+                return self.handle_error(event, e).await;
+            }
         }
 
         if let Err(e) = self.event_handler().handle(event).await {

--- a/nexus-watcher/src/service/runner/homeserver.rs
+++ b/nexus-watcher/src/service/runner/homeserver.rs
@@ -60,6 +60,7 @@ impl TEventProcessorRunner for HsEventProcessorRunner {
             event_handler: self.event_handler.clone(),
             shutdown_rx: self.shutdown_rx.clone(),
             retry_scheduler: self.retry_scheduler.clone(),
+            hs_mapping_cache: Default::default(),
         }))
     }
 

--- a/nexus-watcher/tests/service/hs_event_processor.rs
+++ b/nexus-watcher/tests/service/hs_event_processor.rs
@@ -68,6 +68,7 @@ fn build_processor(
         event_handler,
         shutdown_rx,
         retry_scheduler,
+        hs_mapping_cache: Default::default(),
     })
 }
 
@@ -303,6 +304,50 @@ async fn test_processes_event_when_user_has_no_homeserver_edge() -> Result<()> {
         handler.get_handle_count(),
         1,
         "Event from a user without a HOSTED_BY edge must be processed"
+    );
+
+    let _ = shutdown_tx.send(true);
+    Ok(())
+}
+
+// ============================================================================
+// HOSTED_BY guard: the mapping is cached for the processor's lifetime
+// The first event resolves the user's mapping and caches it; later events reuse
+// the cached decision even if the underlying graph state changes afterwards.
+// ============================================================================
+
+#[tokio_shared_rt::test(shared)]
+async fn test_user_homeserver_mapping_is_cached_across_events() -> Result<()> {
+    setup().await?;
+
+    // User starts with no HOSTED_BY edge, so the first event is processed and the
+    // resulting "unbound" mapping is cached.
+    let user_id = random_user_id();
+    let first_uri = post_uri_builder(user_id.clone(), "cacheone".to_string());
+    let second_uri = post_uri_builder(user_id.clone(), "cachetwo".to_string());
+
+    let store = new_in_memory_store();
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let handler = create_mock_handler(Ok(()), None);
+    let processor = build_processor(store.clone(), handler.clone(), shutdown_rx);
+
+    processor
+        .process_event_lines(vec![format!("PUT {first_uri}")])
+        .await?;
+
+    // Map the user to a *different* homeserver. A fresh lookup would now skip,
+    // but the cached "unbound" mapping must keep this user's events flowing.
+    let other_hs_id = PubkyId::from(Keypair::random().public_key()).to_string();
+    create_user_hosted_on(&user_id, Some(&other_hs_id)).await;
+
+    processor
+        .process_event_lines(vec![format!("PUT {second_uri}")])
+        .await?;
+
+    assert_eq!(
+        handler.get_handle_count(),
+        2,
+        "Second event must reuse the cached mapping and still be processed despite the new HOSTED_BY edge"
     );
 
     let _ = shutdown_tx.send(true);

--- a/nexus-watcher/tests/service/hs_event_processor.rs
+++ b/nexus-watcher/tests/service/hs_event_processor.rs
@@ -1,17 +1,49 @@
 use crate::service::utils::common::create_mock_handler;
-use crate::service::utils::{new_in_memory_store, setup, TEST_USER_ID};
+use crate::service::utils::{new_in_memory_store, setup};
 use anyhow::Result;
+use chrono::Utc;
+use nexus_common::db::{exec_single_row, queries};
 use nexus_common::models::event::EventProcessorError;
 use nexus_common::models::homeserver::Homeserver;
+use nexus_common::models::user::UserDetails;
 use nexus_watcher::events::retry::{InitialBackoff, RetryScheduler, RetryStore};
 use nexus_watcher::events::EventHandler;
 use nexus_watcher::service::HsEventProcessor;
+use pubky::Keypair;
 use pubky_app_specs::{post_uri_builder, PubkyId};
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::watch;
 
 const TEST_HS_ID: &str = "1hb71xx9km3f4pw5izsy1gn19ff1uuuqonw4mcygzobwkryujoiy";
+
+/// Returns a fresh random user id (z32 public key) that has no graph state yet.
+fn random_user_id() -> String {
+    Keypair::random().public_key().to_z32()
+}
+
+/// Creates a `User` node and, when `hs_id` is `Some`, links it to that homeserver
+/// via `HOSTED_BY` (the `Homeserver` node is merged if missing).
+async fn create_user_hosted_on(user_id: &str, hs_id: Option<&str>) {
+    let user = UserDetails {
+        id: PubkyId::try_from(user_id).expect("Valid user Pubky ID"),
+        name: "test-user".to_string(),
+        bio: None,
+        status: None,
+        links: None,
+        image: None,
+        indexed_at: Utc::now().timestamp_millis(),
+    };
+    exec_single_row(queries::put::create_user(&user).expect("create_user query"))
+        .await
+        .expect("create user node");
+
+    if let Some(hs_id) = hs_id {
+        exec_single_row(queries::put::set_user_homeserver(user_id, hs_id))
+            .await
+            .expect("link user to homeserver");
+    }
+}
 
 /// Assemble an [`HsEventProcessor`] for tests. Tests bypass `poll_events` by
 /// calling `process_event_lines` directly with constructed event lines.
@@ -49,10 +81,12 @@ fn build_processor(
 async fn test_batch_continues_after_single_failure() -> Result<()> {
     setup().await?;
 
+    // Fresh user with no HOSTED_BY edge, so the guard processes its events.
+    let user_id = random_user_id();
     let first_post_id = "failone";
     let second_post_id = "failtwo";
-    let first_uri = post_uri_builder(TEST_USER_ID.to_string(), first_post_id.to_string());
-    let second_uri = post_uri_builder(TEST_USER_ID.to_string(), second_post_id.to_string());
+    let first_uri = post_uri_builder(user_id.clone(), first_post_id.to_string());
+    let second_uri = post_uri_builder(user_id, second_post_id.to_string());
 
     let lines = vec![format!("PUT {first_uri}"), format!("PUT {second_uri}")];
 
@@ -104,8 +138,9 @@ async fn test_batch_continues_after_single_failure() -> Result<()> {
 async fn test_retry_event_carries_origin_homeserver_id() -> Result<()> {
     setup().await?;
 
+    // Fresh user with no HOSTED_BY edge, so the guard processes its events.
     let post_id = "originhs";
-    let uri = post_uri_builder(TEST_USER_ID.to_string(), post_id.to_string());
+    let uri = post_uri_builder(random_user_id(), post_id.to_string());
 
     let store = new_in_memory_store();
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
@@ -135,6 +170,108 @@ async fn test_retry_event_carries_origin_homeserver_id() -> Result<()> {
 }
 
 // ============================================================================
+// HOSTED_BY guard: skip events from users bound to a different homeserver
+// When the event's user has a HOSTED_BY edge pointing at a homeserver other
+// than this processor's, the event must be skipped without reaching the handler.
+// ============================================================================
+
+#[tokio_shared_rt::test(shared)]
+async fn test_skips_event_when_user_hosted_on_different_homeserver() -> Result<()> {
+    setup().await?;
+
+    // User is bound to a homeserver that is NOT this processor's homeserver.
+    let user_id = random_user_id();
+    let other_hs_id = PubkyId::from(Keypair::random().public_key()).to_string();
+    create_user_hosted_on(&user_id, Some(&other_hs_id)).await;
+
+    let uri = post_uri_builder(user_id.clone(), "skipme".to_string());
+
+    let store = new_in_memory_store();
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let handler = create_mock_handler(Ok(()), None);
+    let processor = build_processor(store.clone(), handler.clone(), shutdown_rx);
+
+    processor
+        .process_event_lines(vec![format!("PUT {uri}")])
+        .await?;
+
+    assert_eq!(
+        handler.get_handle_count(),
+        0,
+        "Event from a user hosted on a different homeserver must be skipped"
+    );
+
+    let _ = shutdown_tx.send(true);
+    Ok(())
+}
+
+// ============================================================================
+// HOSTED_BY guard: process events from users bound to this homeserver
+// ============================================================================
+
+#[tokio_shared_rt::test(shared)]
+async fn test_processes_event_when_user_hosted_on_same_homeserver() -> Result<()> {
+    setup().await?;
+
+    // User is bound to this processor's homeserver.
+    let user_id = random_user_id();
+    create_user_hosted_on(&user_id, Some(TEST_HS_ID)).await;
+
+    let uri = post_uri_builder(user_id.clone(), "keepme".to_string());
+
+    let store = new_in_memory_store();
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let handler = create_mock_handler(Ok(()), None);
+    let processor = build_processor(store.clone(), handler.clone(), shutdown_rx);
+
+    processor
+        .process_event_lines(vec![format!("PUT {uri}")])
+        .await?;
+
+    assert_eq!(
+        handler.get_handle_count(),
+        1,
+        "Event from a user hosted on this homeserver must be processed"
+    );
+
+    let _ = shutdown_tx.send(true);
+    Ok(())
+}
+
+// ============================================================================
+// HOSTED_BY guard: process events from users with no HOSTED_BY edge
+// A missing edge is the common case (e.g. before the resolver has run) and must
+// not block processing.
+// ============================================================================
+
+#[tokio_shared_rt::test(shared)]
+async fn test_processes_event_when_user_has_no_homeserver_edge() -> Result<()> {
+    setup().await?;
+
+    // Fresh user id with no graph state: no User node, no HOSTED_BY edge.
+    let user_id = random_user_id();
+    let uri = post_uri_builder(user_id, "noedge".to_string());
+
+    let store = new_in_memory_store();
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let handler = create_mock_handler(Ok(()), None);
+    let processor = build_processor(store.clone(), handler.clone(), shutdown_rx);
+
+    processor
+        .process_event_lines(vec![format!("PUT {uri}")])
+        .await?;
+
+    assert_eq!(
+        handler.get_handle_count(),
+        1,
+        "Event from a user without a HOSTED_BY edge must be processed"
+    );
+
+    let _ = shutdown_tx.send(true);
+    Ok(())
+}
+
+// ============================================================================
 // Infrastructure error stops the batch
 // Errors that should not be retried right now propagate out of `handle_error`,
 // short-circuiting the loop so the cursor is not advanced past unprocessed events.
@@ -144,10 +281,12 @@ async fn test_retry_event_carries_origin_homeserver_id() -> Result<()> {
 async fn test_batch_stops_on_infrastructure_error() -> Result<()> {
     setup().await?;
 
+    // Fresh user with no HOSTED_BY edge, so the guard processes its events.
+    let user_id = random_user_id();
     let first_post_id = "infraone";
     let second_post_id = "infratwo";
-    let first_uri = post_uri_builder(TEST_USER_ID.to_string(), first_post_id.to_string());
-    let second_uri = post_uri_builder(TEST_USER_ID.to_string(), second_post_id.to_string());
+    let first_uri = post_uri_builder(user_id.clone(), first_post_id.to_string());
+    let second_uri = post_uri_builder(user_id, second_post_id.to_string());
 
     let lines = vec![format!("PUT {first_uri}"), format!("PUT {second_uri}")];
 

--- a/nexus-watcher/tests/service/hs_event_processor.rs
+++ b/nexus-watcher/tests/service/hs_event_processor.rs
@@ -239,6 +239,44 @@ async fn test_processes_event_when_user_hosted_on_same_homeserver() -> Result<()
 }
 
 // ============================================================================
+// HOSTED_BY guard: skip events when the mapping to this homeserver is stale
+// A stale edge means the user's published homeserver has diverged, so events
+// must be paused until the resolver realigns the mapping.
+// ============================================================================
+
+#[tokio_shared_rt::test(shared)]
+async fn test_skips_event_when_user_mapping_to_this_homeserver_is_stale() -> Result<()> {
+    setup().await?;
+
+    // User is bound to this processor's homeserver, but the mapping is stale.
+    let user_id = random_user_id();
+    create_user_hosted_on(&user_id, Some(TEST_HS_ID)).await;
+    exec_single_row(queries::put::set_user_homeserver_stale(&user_id, true))
+        .await
+        .expect("mark user homeserver mapping stale");
+
+    let uri = post_uri_builder(user_id.clone(), "staleme".to_string());
+
+    let store = new_in_memory_store();
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let handler = create_mock_handler(Ok(()), None);
+    let processor = build_processor(store.clone(), handler.clone(), shutdown_rx);
+
+    processor
+        .process_event_lines(vec![format!("PUT {uri}")])
+        .await?;
+
+    assert_eq!(
+        handler.get_handle_count(),
+        0,
+        "Event from a user with a stale mapping to this homeserver must be skipped"
+    );
+
+    let _ = shutdown_tx.send(true);
+    Ok(())
+}
+
+// ============================================================================
 // HOSTED_BY guard: process events from users with no HOSTED_BY edge
 // A missing edge is the common case (e.g. before the resolver has run) and must
 // not block processing.


### PR DESCRIPTION
This PR is a proposed alternative to #889.

Changes:
- in the default event processor `HsEventProcessor`:
  - Check each parsed event's user `HOSTED_BY` before processing
  - When `HOSTED_BY` exists but points to a different HS, skip processing
  - When `HOSTED_BY` is missing, or is pointing to the current HS, continue processing event (graceful fallback)
- Add tests for above behavior

This is relevant for two time periods:
- first, when DX will be introduced, between the time of startup and until all existing users have their PKDNS records resolved: all existing users will belong to the default HS, but have no `HOSTED_BY` edge yet.
- second, between the time when a new user registers on the default HS and when `UserHsResolverRunner` resolves its PKDNS record: new user(s) map to the default HS and generate events there, but we have not populated their `HOSTED_BY` edge yet.

In both these cases:
- validation treats `HOSTED_BY` as a strong signal: if it points to a different HS, it means the user very recently changed HSs => skip processing
- in the absence of `HOSTED_BY`, validation gracefully falls back on other available signals: the presence of this user's events in the `/events` lines indicates this user points to the default HS => process such events