### PR TITLE
Simplify `PubkyClientError` structure, conversion from `pubky::Error`

### DIFF
--- a/nexus-common/src/db/connectors/pubky.rs
+++ b/nexus-common/src/db/connectors/pubky.rs
@@ -1,5 +1,5 @@
+use pubky::errors::{AuthError, BuildError, PkarrError, RequestError};
 use pubky::{Pubky, PubkyHttpClient, StatusCode};
-use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::OnceCell;
@@ -9,7 +9,7 @@ static PUBKY_SINGLETON: OnceCell<Arc<Pubky>> = OnceCell::const_new();
 
 pub type PubkyClientResult<T> = std::result::Result<T, PubkyClientError>;
 
-#[derive(Debug, Error, Clone, Serialize, Deserialize)]
+#[derive(Debug, Error)]
 pub enum PubkyClientError {
     #[error("PubkyClient not initialized")]
     NotInitialized,
@@ -26,56 +26,39 @@ pub enum PubkyClientError {
     #[error("Request failed: {message}")]
     RequestFailed { message: String },
 
-    #[error("Pkarr failed: {message}")]
-    PkarrFailed { message: String },
+    #[error("Pkarr failed: {0}")]
+    PkarrFailed(#[from] PkarrError),
 
-    #[error("Authentication failed: {message}")]
-    AuthenticationFailed { message: String },
+    #[error("Authentication failed: {0}")]
+    AuthenticationFailed(#[from] AuthError),
 
-    #[error("Build failed: {message}")]
-    BuildFailed { message: String },
+    #[error("Build failed: {0}")]
+    BuildFailed(#[from] BuildError),
 
-    #[error("Parse failed: {message}")]
-    ParseFailed { message: String },
+    #[error("Parse failed: {0}")]
+    ParseFailed(#[from] url::ParseError),
 }
 
 impl From<pubky::Error> for PubkyClientError {
     fn from(err: pubky::Error) -> Self {
         match err {
-            pubky::Error::Request(req_err) => match req_err {
-                pubky::errors::RequestError::Server { status, message } => {
-                    if status == StatusCode::NOT_FOUND {
-                        Self::NotFound404 { message }
-                    } else if status == StatusCode::TOO_MANY_REQUESTS {
-                        Self::TooManyRequests429 { message }
-                    } else if status.is_server_error() {
-                        Self::ServerError5xx { message }
-                    } else {
-                        Self::RequestFailed { message }
-                    }
-                }
-                pubky::errors::RequestError::Transport(err) => Self::RequestFailed {
-                    message: err.to_string(),
-                },
-                pubky::errors::RequestError::Validation { message } => {
-                    Self::RequestFailed { message }
-                }
-                pubky::errors::RequestError::DecodeJson { message } => {
-                    Self::RequestFailed { message }
-                }
+            pubky::Error::Request(RequestError::Server { status, message }) => match status {
+                StatusCode::NOT_FOUND => Self::NotFound404 { message },
+                StatusCode::TOO_MANY_REQUESTS => Self::TooManyRequests429 { message },
+                s if s.is_server_error() => Self::ServerError5xx { message },
+                _ => Self::RequestFailed { message },
             },
-            pubky::Error::Pkarr(pkarr_err) => Self::PkarrFailed {
-                message: pkarr_err.to_string(),
+            pubky::Error::Request(RequestError::Transport(e)) => Self::RequestFailed {
+                message: e.to_string(),
             },
-            pubky::Error::Authentication(auth_err) => Self::AuthenticationFailed {
-                message: auth_err.to_string(),
-            },
-            pubky::Error::Build(build_err) => Self::BuildFailed {
-                message: build_err.to_string(),
-            },
-            pubky::Error::Parse(parse_err) => Self::ParseFailed {
-                message: parse_err.to_string(),
-            },
+            pubky::Error::Request(
+                RequestError::Validation { message } | RequestError::DecodeJson { message },
+            ) => Self::RequestFailed { message },
+
+            pubky::Error::Pkarr(e) => e.into(),
+            pubky::Error::Authentication(e) => e.into(),
+            pubky::Error::Build(e) => e.into(),
+            pubky::Error::Parse(e) => e.into(),
         }
     }
 }

--- a/nexus-common/src/models/event/errors.rs
+++ b/nexus-common/src/models/event/errors.rs
@@ -1,12 +1,12 @@
 use std::fmt::Display;
+use std::sync::Arc;
 
-use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::db::{kv::RedisError, GraphError, PubkyClientError};
 use crate::models::error::ModelError;
 
-#[derive(Error, Debug, Clone, Serialize, Deserialize)]
+#[derive(Error, Debug, Clone)]
 pub enum EventProcessorError {
     /// Failed to execute query in the graph database
     #[error("GraphQueryFailed (should_not_retry_now: {0}): {1}")]
@@ -43,7 +43,7 @@ pub enum EventProcessorError {
 
     /// The Pubky client could not resolve the pubky
     #[error("PubkyClientError: {0}")]
-    PubkyClientError(#[from] PubkyClientError),
+    PubkyClientError(Arc<PubkyClientError>),
 
     /// A homeserver's /events-stream keeps returning 429 Too Many Requests
     /// even after all internal backoff retries were exhausted.
@@ -86,9 +86,15 @@ impl From<ModelError> for EventProcessorError {
     }
 }
 
+impl From<PubkyClientError> for EventProcessorError {
+    fn from(e: PubkyClientError) -> Self {
+        EventProcessorError::PubkyClientError(Arc::new(e))
+    }
+}
+
 impl From<pubky::Error> for EventProcessorError {
     fn from(e: pubky::Error) -> Self {
-        EventProcessorError::PubkyClientError(PubkyClientError::from(e))
+        PubkyClientError::from(e).into()
     }
 }
 
@@ -118,11 +124,11 @@ impl EventProcessorError {
     }
 
     pub fn client_error(message: String) -> Self {
-        Self::PubkyClientError(PubkyClientError::RequestFailed { message })
+        PubkyClientError::RequestFailed { message }.into()
     }
 
     pub fn client_error_404(message: String) -> Self {
-        Self::PubkyClientError(PubkyClientError::NotFound404 { message })
+        PubkyClientError::NotFound404 { message }.into()
     }
 
     pub fn static_save_failed(source: impl Display) -> Self {
@@ -154,14 +160,14 @@ impl EventProcessorError {
     pub fn is_not_found(&self) -> bool {
         matches!(
             self,
-            Self::PubkyClientError(PubkyClientError::NotFound404 { .. })
+            Self::PubkyClientError(e) if matches!(e.as_ref(), PubkyClientError::NotFound404 { .. })
         )
     }
 
     pub fn is_too_many_requests(&self) -> bool {
         matches!(
             self,
-            Self::PubkyClientError(PubkyClientError::TooManyRequests429 { .. })
+            Self::PubkyClientError(e) if matches!(e.as_ref(), PubkyClientError::TooManyRequests429 { .. })
         )
     }
 

--- a/nexus-watcher/src/events/retry/scheduler.rs
+++ b/nexus-watcher/src/events/retry/scheduler.rs
@@ -50,17 +50,17 @@ impl RetryScheduler {
     /// When in doubt we enqueue (bounded by `max_retries`) rather than drop data.
     pub fn should_enqueue_related_event(error: &EventProcessorError) -> bool {
         match error {
-            EventProcessorError::PubkyClientError(err) => match err {
+            EventProcessorError::PubkyClientError(err) => match err.as_ref() {
                 PubkyClientError::NotInitialized
                 | PubkyClientError::TooManyRequests429 { .. }
                 | PubkyClientError::ServerError5xx { .. }
                 | PubkyClientError::RequestFailed { .. }
-                | PubkyClientError::PkarrFailed { .. } => true,
+                | PubkyClientError::PkarrFailed(..) => true,
 
                 PubkyClientError::NotFound404 { .. }
-                | PubkyClientError::AuthenticationFailed { .. }
-                | PubkyClientError::BuildFailed { .. }
-                | PubkyClientError::ParseFailed { .. } => false,
+                | PubkyClientError::AuthenticationFailed(..)
+                | PubkyClientError::BuildFailed(..)
+                | PubkyClientError::ParseFailed(..) => false,
             },
 
             EventProcessorError::InvalidEventLine(_)

--- a/nexus-watcher/tests/service/key_based_event_processor.rs
+++ b/nexus-watcher/tests/service/key_based_event_processor.rs
@@ -642,15 +642,17 @@ fn stream_event(cursor: u64, user_id: &str, path: &str) -> Result<StreamEvent, D
 }
 
 fn too_many_requests_error() -> EventProcessorError {
-    EventProcessorError::PubkyClientError(PubkyClientError::TooManyRequests429 {
+    PubkyClientError::TooManyRequests429 {
         message: "rate limited".into(),
-    })
+    }
+    .into()
 }
 
 fn user_not_found_error() -> EventProcessorError {
-    EventProcessorError::PubkyClientError(PubkyClientError::NotFound404 {
+    PubkyClientError::NotFound404 {
         message: "user not found".into(),
-    })
+    }
+    .into()
 }
 
 fn processor(

--- a/nexus-watcher/tests/service/retry_processor.rs
+++ b/nexus-watcher/tests/service/retry_processor.rs
@@ -404,9 +404,7 @@ async fn test_retry_404_removes_from_queue() -> Result<()> {
         store.clone(),
         create_test_config(10, 50, 60, 3600, 60, 3600),
         create_mock_handler(
-            Err(EventProcessorError::PubkyClientError(
-                nexus_common::db::PubkyClientError::NotFound404 { message: event_uri },
-            )),
+            Err(nexus_common::db::PubkyClientError::NotFound404 { message: event_uri }.into()),
             Some(post_id),
         ),
         shutdown_rx,


### PR DESCRIPTION
This PR simplifies the 3-level-deep nested `From<pubky::Error> for PubkyClientError` conversion, which was hard to understand and reason about.

Part of the reason that nesting was necessary was because `PubkyClientErrorr` derived `Clone, Serialize, Deserialize`, which are never really needed. So this PR removes those traits too. Neither `PubkyClientErrorr`, nor its parent `EventProcessorError` (which internally uses it) need to serialize/deserialize their content, so removing those traits doesn't affect any callers.

The `PubkyClientError` enum values are now slightly inconsistent:
- some are `ErrorType { message: String }` 
- some are `ErrorType(#[from] AnotherErrorType)`

IMO that's a minor inconvenience, more than justified by the clearer conversion logic in `From<pubky::Error> for PubkyClientError`.