### PR TITLE
Add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/pubky/pubky-nexus)
 ![Integration Tests](https://github.com/pubky/pubky-nexus/actions/workflows/test.yml/badge.svg?branch=main)
 
 # Pubky Nexus


### PR DESCRIPTION
This PR adds a badge to our README, which is a link to https://deepwiki.com/pubky/pubky-nexus

This has two benefits:
- gives us quick link to the DeepWiki page for Nexus (where anyone can ask AI questions about our repo)
- DeepWiki will regularly re-index our repo if we have the badge in our README