### PR TITLE
fix: dropping large graph

### DIFF
--- a/nexus-webapi/src/mock.rs
+++ b/nexus-webapi/src/mock.rs
@@ -46,8 +46,11 @@ impl MockDb {
         info!("Dropping Graph database...");
         let graph = get_neo4j_graph().expect("Failed to get Neo4j graph connection");
 
-        // drop and run the queries again
-        let drop_all_query = Query::new("drop_graph", "MATCH (n) DETACH DELETE n;");
+        // Batch deletion avoids blowing Neo4j's transaction memory limit on large graphs.
+        let drop_all_query = Query::new(
+            "drop_graph",
+            "CALL { MATCH (n) WITH n LIMIT 10000 DETACH DELETE n } IN TRANSACTIONS OF 10000 ROWS;",
+        );
         graph
             .run(drop_all_query)
             .await

--- a/nexus-webapi/src/mock.rs
+++ b/nexus-webapi/src/mock.rs
@@ -46,10 +46,10 @@ impl MockDb {
         info!("Dropping Graph database...");
         let graph = get_neo4j_graph().expect("Failed to get Neo4j graph connection");
 
-        // Batch deletion avoids blowing Neo4j's transaction memory limit on large graphs.
+        // MATCH must be outside the subquery so IN TRANSACTIONS batches on the rows it feeds in.
         let drop_all_query = Query::new(
             "drop_graph",
-            "CALL { MATCH (n) WITH n LIMIT 10000 DETACH DELETE n } IN TRANSACTIONS OF 10000 ROWS;",
+            "MATCH (n) CALL { WITH n DETACH DELETE n } IN TRANSACTIONS OF 10000 ROWS;",
         );
         graph
             .run(drop_all_query)


### PR DESCRIPTION
Dropping large graphs will fail due to transaction limit. This change splits deletion into smaller txns. 

```
  thread 'main' (116158) panicked at nexus-webapi/src/mock.rs:54:14:                                                                                                                                                                                                                                                                                                                    
  Could not drop graph nodes.: Neo4j(Neo4jError { kind: Transient, code: "Neo.TransientError.General.MemoryPoolOutOfMemoryError", message: "The allocation of an extra 2.0 MiB would use more than the limit 1.4 GiB. Currently using 1.4 GiB. dbms.memory.transaction.total.max threshold reached" })                                                                                  
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace   
```