### PR TITLE
fix: detect index existence

### DIFF
--- a/nexus-common/src/db/kv/index/search.rs
+++ b/nexus-common/src/db/kv/index/search.rs
@@ -32,7 +32,7 @@ pub(crate) async fn ft_create_json_text_index(
 
     match result {
         Ok(()) => Ok(()),
-        Err(e) if e.to_string().contains("Index already exists") => Ok(()),
+        Err(e) if e.to_string().contains("already exists") => Ok(()),
         Err(e) => Err(RedisError::CommandFailed(e.to_string().into())),
     }
 }

--- a/nexus-common/src/db/kv/index/search.rs
+++ b/nexus-common/src/db/kv/index/search.rs
@@ -3,7 +3,7 @@ use crate::db::kv::error::{RedisError, RedisResult};
 use tracing::warn;
 
 /// Creates a RediSearch JSON index with a single TEXT field.
-/// Idempotent: treats "Index already exists" as success so concurrent callers are safe.
+/// Idempotent: treats any error containing "already exists" as success so concurrent callers are safe.
 pub(crate) async fn ft_create_json_text_index(
     index_name: &str,
     prefix: &str,


### PR DESCRIPTION
Fixes string match in index existence check.

```
thread 'main' (504782) panicked at nexus-webapi/benches/setup.rs:16:47:
called `Result::unwrap()` on an `Err` value: CommandFailed("\"Index\": already exists")
```