### PR TITLE
perf:  Add FTS query limits and bound RediSearch query time

### DIFF
--- a/nexus-common/default.config.toml
+++ b/nexus-common/default.config.toml
@@ -49,6 +49,8 @@ name = "nexusd"
 
 [stack.db]
 redis = "redis://127.0.0.1:6379"
+# Maximum time (ms) RediSearch spends on a single FT.SEARCH before returning partial results
+#ft_search_timeout_ms = 50
 
 [stack.db.neo4j]
 uri = "bolt://localhost:7687"

--- a/nexus-common/src/db/config/mod.rs
+++ b/nexus-common/src/db/config/mod.rs
@@ -6,10 +6,21 @@ pub use neo4j::Neo4JConfig;
 
 pub const REDIS_URI: &str = "redis://localhost:6379";
 
+/// Caps FT.SEARCH execution time well below RediSearch's 500ms default; ON_TIMEOUT RETURN yields partial results.
+pub const FT_SEARCH_TIMEOUT_MS: usize = 50;
+
+fn default_ft_search_timeout_ms() -> usize {
+    FT_SEARCH_TIMEOUT_MS
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct DatabaseConfig {
     pub redis: String,
     pub neo4j: Neo4JConfig,
+
+    /// Maximum time (ms) RediSearch spends on a single FT.SEARCH before returning partial results.
+    #[serde(default = "default_ft_search_timeout_ms")]
+    pub ft_search_timeout_ms: usize,
 }
 
 impl Default for DatabaseConfig {
@@ -17,6 +28,7 @@ impl Default for DatabaseConfig {
         Self {
             redis: String::from(REDIS_URI),
             neo4j: Neo4JConfig::default(),
+            ft_search_timeout_ms: default_ft_search_timeout_ms(),
         }
     }
 }

--- a/nexus-common/src/db/kv/index/search.rs
+++ b/nexus-common/src/db/kv/index/search.rs
@@ -1,6 +1,19 @@
+use crate::db::config::FT_SEARCH_TIMEOUT_MS;
 use crate::db::get_redis_conn;
 use crate::db::kv::error::{RedisError, RedisResult};
+use std::sync::OnceLock;
 use tracing::warn;
+
+static FT_SEARCH_TIMEOUT: OnceLock<usize> = OnceLock::new();
+
+/// Sets the configured FT.SEARCH timeout (ms). Called once during stack setup.
+pub(crate) fn set_ft_search_timeout_ms(ms: usize) {
+    let _ = FT_SEARCH_TIMEOUT.set(ms);
+}
+
+fn ft_search_timeout_ms() -> usize {
+    *FT_SEARCH_TIMEOUT.get().unwrap_or(&FT_SEARCH_TIMEOUT_MS)
+}
 
 /// Creates a RediSearch JSON index with a single TEXT field.
 /// Idempotent: treats any error containing "already exists" as success so concurrent callers are safe.
@@ -66,6 +79,8 @@ pub(crate) async fn ft_search_scored(
         .arg("LIMIT")
         .arg(skip)
         .arg(limit)
+        .arg("TIMEOUT")
+        .arg(ft_search_timeout_ms())
         .query_async(&mut conn)
         .await
         .map_err(|e| RedisError::CommandFailed(e.to_string().into()))?;

--- a/nexus-common/src/stack.rs
+++ b/nexus-common/src/stack.rs
@@ -1,3 +1,4 @@
+use crate::db::kv::search::set_ft_search_timeout_ms;
 use crate::db::{Neo4jConnector, RedisConnector};
 use crate::types::DynError;
 use crate::{Level, StackConfig};
@@ -36,6 +37,7 @@ impl StackManager {
 
                 RedisConnector::init(&config.db.redis).await?;
                 Neo4jConnector::init(&config.db.neo4j).await?;
+                set_ft_search_timeout_ms(config.db.ft_search_timeout_ms);
                 Ok::<_, DynError>(config.clone())
             })
             .await?;

--- a/nexus-webapi/benches/search.rs
+++ b/nexus-webapi/benches/search.rs
@@ -1,6 +1,10 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use nexus_common::{
-    models::{post::search::PostsByTagSearch, tag::search::TagSearch, user::UserSearch},
+    models::{
+        post::search::{PostsByContentSearch, PostsByTagSearch},
+        tag::search::TagSearch,
+        user::UserSearch,
+    },
     types::Pagination,
 };
 use setup::run_setup;
@@ -86,6 +90,28 @@ fn bench_post_tag_search_by_timeline(c: &mut Criterion) {
     );
 }
 
+fn bench_post_content_search(c: &mut Criterion) {
+    println!("******************************************************************************");
+    println!("Benchmarking post content search.");
+    println!("******************************************************************************");
+
+    run_setup();
+
+    let query = "free";
+    let rt = Runtime::new().unwrap();
+
+    c.bench_with_input(
+        BenchmarkId::new("post_content_search", query),
+        &query,
+        |b, &query| {
+            b.to_async(&rt).iter(|| async {
+                let result = PostsByContentSearch::search(query, 0, 20).await.unwrap();
+                std::hint::black_box(result);
+            });
+        },
+    );
+}
+
 fn configure_criterion() -> Criterion {
     Criterion::default()
         .measurement_time(Duration::new(5, 0))
@@ -98,7 +124,8 @@ criterion_group! {
     config = configure_criterion();
     targets =   bench_user_search,
                 bench_tag_search,
-                bench_post_tag_search_by_timeline
+                bench_post_tag_search_by_timeline,
+                bench_post_content_search
 }
 
 criterion_main!(benches);

--- a/nexus-webapi/benches/search.rs
+++ b/nexus-webapi/benches/search.rs
@@ -92,24 +92,34 @@ fn bench_post_tag_search_by_timeline(c: &mut Criterion) {
 
 fn bench_post_content_search(c: &mut Criterion) {
     println!("******************************************************************************");
-    println!("Benchmarking post content search.");
+    println!("Benchmarking post content search");
     println!("******************************************************************************");
 
     run_setup();
 
-    let query = "free";
     let rt = Runtime::new().unwrap();
 
-    c.bench_with_input(
-        BenchmarkId::new("post_content_search", query),
-        &query,
-        |b, &query| {
-            b.to_async(&rt).iter(|| async {
-                let result = PostsByContentSearch::search(query, 0, 20).await.unwrap();
-                std::hint::black_box(result);
-            });
-        },
-    );
+    // Each covers a different fuzzy-distance tier in fuzzy_token()
+    let queries = &[
+        ("api", "api"),                   // <=3 chars: exact match, 1 hit
+        ("privacy", "privacy"),           // <=8 chars: 1-fuzzy, 4 hits
+        ("transparency", "transparency"), // >8 chars: 2-fuzzy, 2 hits
+        ("open_source", "open source"),   // multi-token AND, 6 hits
+        ("free", "free"),                 // no match, empty-result path
+    ];
+
+    for (id, query) in queries {
+        c.bench_with_input(
+            BenchmarkId::new("post_content_search", id),
+            query,
+            |b, &query| {
+                b.to_async(&rt).iter(|| async {
+                    let result = PostsByContentSearch::search(query, 0, 20).await.unwrap();
+                    std::hint::black_box(result);
+                });
+            },
+        );
+    }
 }
 
 fn configure_criterion() -> Criterion {

--- a/nexus-webapi/benches/setup.rs
+++ b/nexus-webapi/benches/setup.rs
@@ -1,4 +1,4 @@
-use nexus_common::{Level, StackConfig, StackManager};
+use nexus_common::{models::post::create_post_content_index, Level, StackConfig, StackManager};
 use std::sync::Once;
 use tokio::runtime::Runtime;
 
@@ -13,6 +13,8 @@ pub fn run_setup() {
                 ..Default::default()
             };
             let _ = StackManager::setup(&config).await;
+            // index is create through migration script, we call it explicitly here
+            create_post_content_index().await.unwrap();
         });
     });
 }

--- a/nexus-webapi/src/models/post_search_query.rs
+++ b/nexus-webapi/src/models/post_search_query.rs
@@ -8,8 +8,9 @@ use utoipa::ToSchema;
 
 pub const MIN_POST_SEARCH_QUERY_LEN: usize = 2;
 pub const MAX_POST_SEARCH_QUERY_LEN: usize = 30;
+pub const MAX_POST_SEARCH_QUERY_TERMS: usize = 4;
 
-/// Post content search query (2–30 characters).
+/// Post content search query (2–30 characters, up to 4 terms).
 #[derive(Debug, ToSchema)]
 #[schema(value_type = String, example = "bitcoin")]
 pub struct PostSearchQuery(pub String);
@@ -44,6 +45,12 @@ impl PostSearchQuery {
         if len > MAX_POST_SEARCH_QUERY_LEN {
             return Err(Error::invalid_input(&format!(
                 "Search query exceeds maximum length of {MAX_POST_SEARCH_QUERY_LEN} characters"
+            )));
+        }
+        let terms = q.split_whitespace().count();
+        if terms > MAX_POST_SEARCH_QUERY_TERMS {
+            return Err(Error::invalid_input(&format!(
+                "Search query exceeds maximum of {MAX_POST_SEARCH_QUERY_TERMS} terms"
             )));
         }
         Ok(())
@@ -102,5 +109,15 @@ mod tests {
     fn accepts_normal_query() {
         let q = PostSearchQuery::try_from("bitcoin price".to_string()).unwrap();
         assert_eq!(q.0, "bitcoin price");
+    }
+
+    #[test]
+    fn accepts_max_terms() {
+        assert!(PostSearchQuery::try_from("a b c d".to_string()).is_ok());
+    }
+
+    #[test]
+    fn rejects_over_max_terms() {
+        assert!(PostSearchQuery::try_from("a b c d e".to_string()).is_err());
     }
 }

--- a/nexus-webapi/src/models/post_search_query.rs
+++ b/nexus-webapi/src/models/post_search_query.rs
@@ -7,9 +7,9 @@ use serde::Deserialize;
 use utoipa::ToSchema;
 
 pub const MIN_POST_SEARCH_QUERY_LEN: usize = 2;
-pub const MAX_POST_SEARCH_QUERY_LEN: usize = 200;
+pub const MAX_POST_SEARCH_QUERY_LEN: usize = 30;
 
-/// Post content search query (2–200 characters).
+/// Post content search query (2–30 characters).
 #[derive(Debug, ToSchema)]
 #[schema(value_type = String, example = "bitcoin")]
 pub struct PostSearchQuery(pub String);
@@ -90,12 +90,12 @@ mod tests {
 
     #[test]
     fn rejects_over_limit() {
-        assert!(PostSearchQuery::try_from("a".repeat(201)).is_err());
+        assert!(PostSearchQuery::try_from("a".repeat(31)).is_err());
     }
 
     #[test]
     fn accepts_max_length() {
-        assert!(PostSearchQuery::try_from("a".repeat(200)).is_ok());
+        assert!(PostSearchQuery::try_from("a".repeat(30)).is_ok());
     }
 
     #[test]

--- a/nexus-webapi/src/routes/v0/search/posts.rs
+++ b/nexus-webapi/src/routes/v0/search/posts.rs
@@ -73,7 +73,7 @@ pub struct SearchPostsByContentQuery {
     description = "Full-text search over post content",
     tag = "Search",
     params(
-        ("q" = PostSearchQuery, Query, description = "Search query (2–30 characters)"),
+        ("q" = PostSearchQuery, Query, description = "Search query (2–30 characters, up to 4 terms)"),
         ("skip" = Option<SearchSkip<1000>>, Query, description = "Skip N results (max 1000)"),
         ("limit" = Option<SearchLimit<100>>, Query, description = "Limit the number of results")
     ),

--- a/nexus-webapi/src/routes/v0/search/posts.rs
+++ b/nexus-webapi/src/routes/v0/search/posts.rs
@@ -73,7 +73,7 @@ pub struct SearchPostsByContentQuery {
     description = "Full-text search over post content",
     tag = "Search",
     params(
-        ("q" = PostSearchQuery, Query, description = "Search query (2–200 characters)"),
+        ("q" = PostSearchQuery, Query, description = "Search query (2–30 characters)"),
         ("skip" = Option<SearchSkip<1000>>, Query, description = "Skip N results (max 1000)"),
         ("limit" = Option<SearchLimit<100>>, Query, description = "Limit the number of results")
     ),


### PR DESCRIPTION
  Summary
  - Add full-text search benchmarks for post content search (`nexus-webapi/benches/search.rs`)
  - Cap post search queries at 4 terms (`MAX_POST_SEARCH_QUERY_TERMS`) in addition to the changed 2–30 character limit
  - Add a configurable `ft_search_timeout_ms` (default 50ms) so `FT.SEARCH` should not take longer that and will return partial results/error out depending on `ON_TIMEOUT` config value.

