### PR TITLE
ref: extract serve_file_variant for static file handlers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3116,6 +3116,7 @@ dependencies = [
  "criterion",
  "deadpool-redis",
  "futures-util",
+ "http-body-util",
  "httpc-test",
  "nexus-common",
  "pubky",

--- a/nexus-common/src/models/user/mod.rs
+++ b/nexus-common/src/models/user/mod.rs
@@ -14,8 +14,8 @@ pub use influencers::Influencers;
 pub use relationship::Relationship;
 pub use search::{UserSearch, USER_NAME_KEY_PARTS};
 pub use stream::{
-    UserIdStream, UserStream, UserStreamInput, UserStreamSource, USER_INFLUENCERS_KEY_PARTS,
-    USER_MOSTFOLLOWED_KEY_PARTS,
+    UserIdStream, UserStream, UserStreamInput, UserStreamSource,
+    CACHE_USER_RECOMMENDED_KEY_PARTS, USER_INFLUENCERS_KEY_PARTS, USER_MOSTFOLLOWED_KEY_PARTS,
 };
 pub use tags::ProfileTag;
 pub use tags::UserTags;

--- a/nexus-common/src/models/user/mod.rs
+++ b/nexus-common/src/models/user/mod.rs
@@ -14,8 +14,8 @@ pub use influencers::Influencers;
 pub use relationship::Relationship;
 pub use search::{UserSearch, USER_NAME_KEY_PARTS};
 pub use stream::{
-    UserIdStream, UserStream, UserStreamInput, UserStreamSource,
-    CACHE_USER_RECOMMENDED_KEY_PARTS, USER_INFLUENCERS_KEY_PARTS, USER_MOSTFOLLOWED_KEY_PARTS,
+    UserIdStream, UserStream, UserStreamInput, UserStreamSource, CACHE_USER_RECOMMENDED_KEY_PARTS,
+    USER_INFLUENCERS_KEY_PARTS, USER_MOSTFOLLOWED_KEY_PARTS,
 };
 pub use tags::ProfileTag;
 pub use tags::UserTags;

--- a/nexus-webapi/Cargo.toml
+++ b/nexus-webapi/Cargo.toml
@@ -35,6 +35,7 @@ utoipa-swagger-ui = { version = "9.0.2", features = ["axum"] }
 [dev-dependencies]
 anyhow = { workspace = true }
 criterion = { version = "0.8", features = ["async_tokio"] }
+http-body-util = "0.1.3"
 httpc-test = "0.1.10"
 pubky-testnet = { workspace = true }
 tempfile = { workspace = true }
@@ -72,6 +73,11 @@ harness = false
 [[bench]]
 name = "search"
 harness = false
+
+[[bench]]
+name = "avatar"
+harness = false
+
 [[bench]]
 name = "events"
 harness = false

--- a/nexus-webapi/benches/avatar.rs
+++ b/nexus-webapi/benches/avatar.rs
@@ -156,7 +156,8 @@ fn bench_avatar_handler(c: &mut Criterion) {
     run_setup();
 
     let rt = Runtime::new().unwrap();
-    // Share one TempDir because PubkyServeDir pins the first files_path process-wide.
+    // Reuse one TempDir because PubkyServeDir stores the first files_path
+    // in a process-global OnceLock.
     let setup = rt.block_on(AvatarBenchSetup::new());
 
     c.bench_function("avatar_handler_warm", |b| {

--- a/nexus-webapi/benches/avatar.rs
+++ b/nexus-webapi/benches/avatar.rs
@@ -1,13 +1,10 @@
-use std::{
-    path::PathBuf,
-    sync::Arc,
-    time::Duration,
-};
+use std::{path::PathBuf, sync::Arc, time::Duration};
 
 use axum::{
     body::{Body, Bytes},
     extract::State,
     http::{Request, StatusCode},
+    response::Response,
 };
 use criterion::{criterion_group, criterion_main, Criterion};
 use http_body_util::BodyExt;
@@ -22,6 +19,7 @@ use nexus_webapi::{
 };
 use tempfile::TempDir;
 use tokio::{fs, runtime::Runtime};
+use tower_http::services::fs::ServeFileSystemResponseBody;
 
 mod setup;
 
@@ -31,8 +29,8 @@ const AVATAR_BLOB_NAME: &str = "avatar.png";
 const BLOB_PATH: &str = "tests/user/blobs";
 const USER_PUBKY: &str = "4snwyct86m383rsduhw5xgcxpw7c63j3pq8x4ycqikxgik8y64ro";
 const FILE_ID: &str = "003286NSMY490";
-const AVATAR_URI: &str =
-    "pubky://4snwyct86m383rsduhw5xgcxpw7c63j3pq8x4ycqikxgik8y64ro/pub/pubky.app/files/003286NSMY490";
+
+type AvatarResponse = Response<ServeFileSystemResponseBody>;
 
 struct AvatarBenchSetup {
     _temp_dir: TempDir,
@@ -42,6 +40,7 @@ struct AvatarBenchSetup {
 
 impl AvatarBenchSetup {
     async fn new() -> Self {
+        let user_id = PubkyId::try_from(USER_PUBKY).unwrap();
         let temp_dir = TempDir::new().unwrap();
         let files_path = temp_dir.path().to_path_buf();
         let image_dir = files_path.join(USER_PUBKY).join(FILE_ID);
@@ -50,29 +49,31 @@ impl AvatarBenchSetup {
         let source_path = PathBuf::from(BLOB_PATH).join(AVATAR_BLOB_NAME);
         let source_size = fs::copy(source_path, image_dir.join("main")).await.unwrap();
 
-        Self::seed_avatar_records(source_size).await;
+        Self::seed_avatar_records(&user_id, source_size).await;
 
         let setup = Self {
             _temp_dir: temp_dir,
             app_state: AppState {
                 files_path: Arc::new(files_path),
             },
-            user_id: PubkyId::try_from(USER_PUBKY).unwrap(),
+            user_id,
         };
 
-        setup.warm_small_variant().await;
+        let response = setup.call_avatar_handler().await.unwrap();
+        std::hint::black_box(consume_avatar_response(response).await);
         setup
     }
 
-    async fn seed_avatar_records(source_size: u64) {
-        let user_id = PubkyId::try_from(USER_PUBKY).unwrap();
+    async fn seed_avatar_records(user_id: &PubkyId, source_size: u64) {
+        let avatar_uri = format!("pubky://{USER_PUBKY}/pub/pubky.app/files/{FILE_ID}");
+
         let user = UserDetails {
             name: "Avatar Bench User".to_string(),
             bio: None,
-            id: user_id,
+            id: user_id.clone(),
             links: None,
             status: None,
-            image: Some(AVATAR_URI.to_string()),
+            image: Some(avatar_uri.clone()),
             indexed_at: 1_724_134_095_000,
         };
 
@@ -82,7 +83,7 @@ impl AvatarBenchSetup {
 
         let file = FileDetails {
             id: FILE_ID.to_string(),
-            uri: AVATAR_URI.to_string(),
+            uri: avatar_uri,
             owner_id: USER_PUBKY.to_string(),
             indexed_at: 1_724_134_095_000,
             created_at: 1_784_134_095_000,
@@ -103,29 +104,23 @@ impl AvatarBenchSetup {
             .unwrap();
     }
 
-    async fn warm_small_variant(&self) {
-        let response = self.call_avatar_handler().await.unwrap();
-        std::hint::black_box(consume_avatar_response(response).await);
-    }
-
-    async fn clear_small_variant(&self) {
-        let small_variant_path = self
-            .app_state
+    fn small_variant_path(&self) -> PathBuf {
+        self.app_state
             .files_path
             .join(USER_PUBKY)
             .join(FILE_ID)
-            .join("small");
+            .join("small")
+    }
 
-        if let Err(err) = fs::remove_file(small_variant_path).await {
+    async fn clear_small_variant(&self) {
+        if let Err(err) = fs::remove_file(self.small_variant_path()).await {
             if err.kind() != std::io::ErrorKind::NotFound {
                 panic!("failed to remove small avatar variant: {err}");
             }
         }
     }
 
-    async fn call_avatar_handler(&self) -> nexus_webapi::Result<
-        axum::response::Response<tower_http::services::fs::ServeFileSystemResponseBody>,
-    > {
+    async fn call_avatar_handler(&self) -> nexus_webapi::Result<AvatarResponse> {
         user_avatar_handler(
             Path(self.user_id.clone()),
             State(self.app_state.clone()),
@@ -133,18 +128,24 @@ impl AvatarBenchSetup {
         )
         .await
     }
+
+    async fn request_avatar(&self) {
+        let response = self.call_avatar_handler().await.unwrap();
+        std::hint::black_box(consume_avatar_response(response).await);
+    }
 }
 
-async fn consume_avatar_response(
-    response: axum::response::Response<tower_http::services::fs::ServeFileSystemResponseBody>,
-) -> (StatusCode, Bytes) {
+async fn consume_avatar_response(response: AvatarResponse) -> Bytes {
     let status = response.status();
     let bytes = response.into_body().collect().await.unwrap().to_bytes();
 
     assert_eq!(status, StatusCode::OK);
-    assert!(!bytes.is_empty(), "avatar response body should not be empty");
+    assert!(
+        !bytes.is_empty(),
+        "avatar response body should not be empty"
+    );
 
-    (status, bytes)
+    bytes
 }
 
 fn bench_avatar_handler(c: &mut Criterion) {
@@ -155,23 +156,19 @@ fn bench_avatar_handler(c: &mut Criterion) {
     run_setup();
 
     let rt = Runtime::new().unwrap();
-    // PubkyServeDir caches the first files_path in a process-wide OnceLock, so both
-    // measurements must share one temp directory while this function is running.
+    // Share one TempDir because PubkyServeDir pins the first files_path process-wide.
     let setup = rt.block_on(AvatarBenchSetup::new());
 
     c.bench_function("avatar_handler_warm", |b| {
         b.to_async(&rt).iter(|| async {
-            let response = setup.call_avatar_handler().await.unwrap();
-            std::hint::black_box(consume_avatar_response(response).await);
+            setup.request_avatar().await;
         });
     });
 
     c.bench_function("avatar_handler_cold", |b| {
         b.to_async(&rt).iter(|| async {
             setup.clear_small_variant().await;
-
-            let response = setup.call_avatar_handler().await.unwrap();
-            std::hint::black_box(consume_avatar_response(response).await);
+            setup.request_avatar().await;
         });
     });
 }

--- a/nexus-webapi/benches/avatar.rs
+++ b/nexus-webapi/benches/avatar.rs
@@ -1,0 +1,192 @@
+use std::{
+    path::PathBuf,
+    sync::Arc,
+    time::Duration,
+};
+
+use axum::{
+    body::{Body, Bytes},
+    extract::State,
+    http::{Request, StatusCode},
+};
+use criterion::{criterion_group, criterion_main, Criterion};
+use http_body_util::BodyExt;
+use nexus_common::models::{
+    file::{FileDetails, FileUrls},
+    traits::Collection,
+    user::UserDetails,
+};
+use nexus_webapi::{
+    models::PubkyId,
+    routes::{r#static::user_avatar_handler, AppState, Path},
+};
+use tempfile::TempDir;
+use tokio::{fs, runtime::Runtime};
+
+mod setup;
+
+use setup::run_setup;
+
+const AVATAR_BLOB_NAME: &str = "avatar.png";
+const BLOB_PATH: &str = "tests/user/blobs";
+const USER_PUBKY: &str = "4snwyct86m383rsduhw5xgcxpw7c63j3pq8x4ycqikxgik8y64ro";
+const FILE_ID: &str = "003286NSMY490";
+const AVATAR_URI: &str =
+    "pubky://4snwyct86m383rsduhw5xgcxpw7c63j3pq8x4ycqikxgik8y64ro/pub/pubky.app/files/003286NSMY490";
+
+struct AvatarBenchSetup {
+    _temp_dir: TempDir,
+    app_state: AppState,
+    user_id: PubkyId,
+}
+
+impl AvatarBenchSetup {
+    async fn new() -> Self {
+        let temp_dir = TempDir::new().unwrap();
+        let files_path = temp_dir.path().to_path_buf();
+        let image_dir = files_path.join(USER_PUBKY).join(FILE_ID);
+        fs::create_dir_all(&image_dir).await.unwrap();
+
+        let source_path = PathBuf::from(BLOB_PATH).join(AVATAR_BLOB_NAME);
+        let source_size = fs::copy(source_path, image_dir.join("main")).await.unwrap();
+
+        Self::seed_avatar_records(source_size).await;
+
+        let setup = Self {
+            _temp_dir: temp_dir,
+            app_state: AppState {
+                files_path: Arc::new(files_path),
+            },
+            user_id: PubkyId::try_from(USER_PUBKY).unwrap(),
+        };
+
+        setup.warm_small_variant().await;
+        setup
+    }
+
+    async fn seed_avatar_records(source_size: u64) {
+        let user_id = PubkyId::try_from(USER_PUBKY).unwrap();
+        let user = UserDetails {
+            name: "Avatar Bench User".to_string(),
+            bio: None,
+            id: user_id,
+            links: None,
+            status: None,
+            image: Some(AVATAR_URI.to_string()),
+            indexed_at: 1_724_134_095_000,
+        };
+
+        UserDetails::put_to_index(&[USER_PUBKY], vec![Some(user)])
+            .await
+            .unwrap();
+
+        let file = FileDetails {
+            id: FILE_ID.to_string(),
+            uri: AVATAR_URI.to_string(),
+            owner_id: USER_PUBKY.to_string(),
+            indexed_at: 1_724_134_095_000,
+            created_at: 1_784_134_095_000,
+            src: format!("pubky://{USER_PUBKY}/pub/pubky.app/blobs/{FILE_ID}"),
+            name: AVATAR_BLOB_NAME.to_string(),
+            size: source_size as i64,
+            content_type: "image/png".to_string(),
+            urls: FileUrls {
+                main: format!("{USER_PUBKY}/{FILE_ID}"),
+                feed: None,
+                small: None,
+            },
+            metadata: None,
+        };
+
+        FileDetails::put_to_index(&[&[USER_PUBKY, FILE_ID]], vec![Some(file)])
+            .await
+            .unwrap();
+    }
+
+    async fn warm_small_variant(&self) {
+        let response = self.call_avatar_handler().await.unwrap();
+        std::hint::black_box(consume_avatar_response(response).await);
+    }
+
+    async fn clear_small_variant(&self) {
+        let small_variant_path = self
+            .app_state
+            .files_path
+            .join(USER_PUBKY)
+            .join(FILE_ID)
+            .join("small");
+
+        if let Err(err) = fs::remove_file(small_variant_path).await {
+            if err.kind() != std::io::ErrorKind::NotFound {
+                panic!("failed to remove small avatar variant: {err}");
+            }
+        }
+    }
+
+    async fn call_avatar_handler(&self) -> nexus_webapi::Result<
+        axum::response::Response<tower_http::services::fs::ServeFileSystemResponseBody>,
+    > {
+        user_avatar_handler(
+            Path(self.user_id.clone()),
+            State(self.app_state.clone()),
+            Request::new(Body::empty()),
+        )
+        .await
+    }
+}
+
+async fn consume_avatar_response(
+    response: axum::response::Response<tower_http::services::fs::ServeFileSystemResponseBody>,
+) -> (StatusCode, Bytes) {
+    let status = response.status();
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+
+    assert_eq!(status, StatusCode::OK);
+    assert!(!bytes.is_empty(), "avatar response body should not be empty");
+
+    (status, bytes)
+}
+
+fn bench_avatar_handler(c: &mut Criterion) {
+    println!("******************************************************************************");
+    println!("Benchmarking avatar handler chain without an HTTP server.");
+    println!("******************************************************************************");
+
+    run_setup();
+
+    let rt = Runtime::new().unwrap();
+    // PubkyServeDir caches the first files_path in a process-wide OnceLock, so both
+    // measurements must share one temp directory while this function is running.
+    let setup = rt.block_on(AvatarBenchSetup::new());
+
+    c.bench_function("avatar_handler_warm", |b| {
+        b.to_async(&rt).iter(|| async {
+            let response = setup.call_avatar_handler().await.unwrap();
+            std::hint::black_box(consume_avatar_response(response).await);
+        });
+    });
+
+    c.bench_function("avatar_handler_cold", |b| {
+        b.to_async(&rt).iter(|| async {
+            setup.clear_small_variant().await;
+
+            let response = setup.call_avatar_handler().await.unwrap();
+            std::hint::black_box(consume_avatar_response(response).await);
+        });
+    });
+}
+
+fn configure_criterion() -> Criterion {
+    Criterion::default()
+        .measurement_time(Duration::new(5, 0))
+        .sample_size(100)
+        .warm_up_time(Duration::new(1, 0))
+}
+
+criterion_group! {
+    name = avatar;
+    config = configure_criterion();
+    targets = bench_avatar_handler
+}
+
+criterion_main!(avatar);

--- a/nexus-webapi/src/routes/static/avatar.rs
+++ b/nexus-webapi/src/routes/static/avatar.rs
@@ -1,15 +1,14 @@
 use std::path::PathBuf;
 
 use super::endpoints::USER_AVATAR_ROUTE;
+use super::serve_dir::serve_file_variant;
 use crate::models::PubkyId;
-use crate::routes::r#static::PubkyServeDir;
 use crate::routes::AppState;
 use crate::routes::Path;
 use crate::{Error, Result};
 use axum::extract::{Request, State};
 use axum::response::Response;
 use nexus_common::media::FileVariant;
-use nexus_common::models::file::Blob;
 use nexus_common::models::{file::FileDetails, traits::Collection, user::UserDetails};
 use tower_http::services::fs::ServeFileSystemResponseBody;
 use tracing::{debug, error};
@@ -38,73 +37,40 @@ pub async fn user_avatar_handler(
 
     let file_path: &PathBuf = &app_state.files_path;
 
-    // 1. Get user details
     let details = match UserDetails::get_by_id(&user_id).await? {
         None => return Err(Error::user_not_found(user_id)),
         Some(d) => d,
     };
 
-    // 2. Check if user has image. If not, 404
     let Some(image_uri) = details.image else {
         return Err(Error::FileNotFound {});
     };
 
-    // 3. Parse user_id + file_id from the "pubky://owner_id/file_id" style URI
     let (owner_id, file_id) =
         FileDetails::file_key_from_uri(&image_uri).ok_or(Error::InternalServerError {
             source: format!("Invalid file URI: {image_uri}").into(),
         })?;
 
-    // 4. Look up FileDetails in Redis/Neo4j using get_by_ids
     let file_list = FileDetails::get_by_ids(&[&[&owner_id, &file_id]]).await?;
 
-    // We expect only one result in file_list, a Vec<Option<FileDetails>>
     let Some(file_details) = file_list.into_iter().flatten().next() else {
         return Err(Error::FileNotFound {});
     };
 
-    // 5. ensure small variant is created
-    let small_variant_content_type =
-        Blob::get_by_id(&file_details, &FileVariant::Small, file_path.clone())
-            .await
-            .inspect_err(|_| {
-                error!(
+    serve_file_variant(
+        request,
+        &file_details,
+        &user_id,
+        &FileVariant::Small,
+        file_path.clone(),
+        None,
+    )
+    .await
+    .inspect_err(|_| {
+        error!(
             "Error while processing small variant for user: {user_id} avatar with file: {file_id}"
         )
-            })?;
-
-    // serve the file using ServeDir
-    // Create a new request with a modified path to serve the file using ServeDir
-    // 6. Build the url using small variant
-    let file_uri_path = format!(
-        "/{}/{}/{}", // /{owner_id}/{file_id}/{variant}
-        user_id,
-        file_details.id,
-        FileVariant::Small,
-    );
-
-    // 7. Serve the file. Then remove/replace any default Cache-Control header.
-    let mut response = PubkyServeDir::try_call(
-        request,
-        file_uri_path,
-        small_variant_content_type,
-        file_path.clone(),
-    )
-    .await?;
-
-    // Remove any default "cache-control" header
-    response.headers_mut().remove("cache-control");
-
-    // Insert a new Cache-Control header (e.g., 1 hour)
-    let cache_control_header = "public, max-age=3600"
-        .parse()
-        .inspect_err(|err| error!("Failed to parse Cache-Control header value: {}", err))?;
-
-    response
-        .headers_mut()
-        .insert("cache-control", cache_control_header);
-
-    Ok(response)
+    })
 }
 
 #[derive(OpenApi)]

--- a/nexus-webapi/src/routes/static/avatar.rs
+++ b/nexus-webapi/src/routes/static/avatar.rs
@@ -60,7 +60,6 @@ pub async fn user_avatar_handler(
     serve_file_variant(
         request,
         &file_details,
-        &owner_id,
         &FileVariant::Small,
         file_path.clone(),
         false,

--- a/nexus-webapi/src/routes/static/avatar.rs
+++ b/nexus-webapi/src/routes/static/avatar.rs
@@ -60,7 +60,7 @@ pub async fn user_avatar_handler(
     serve_file_variant(
         request,
         &file_details,
-        &user_id,
+        &owner_id,
         &FileVariant::Small,
         file_path.clone(),
         false,

--- a/nexus-webapi/src/routes/static/avatar.rs
+++ b/nexus-webapi/src/routes/static/avatar.rs
@@ -63,7 +63,7 @@ pub async fn user_avatar_handler(
         &user_id,
         &FileVariant::Small,
         file_path.clone(),
-        None,
+        false,
     )
     .await
     .inspect_err(|_| {

--- a/nexus-webapi/src/routes/static/files.rs
+++ b/nexus-webapi/src/routes/static/files.rs
@@ -12,15 +12,12 @@ use utoipa::OpenApi;
 use super::endpoints::STATIC_FILES_ROUTE;
 use super::serve_dir::serve_file_variant;
 use crate::models::{FileId, PubkyId};
-use crate::routes::Path;
 use crate::routes::AppState;
+use crate::routes::Path;
 use crate::{Error, Result};
 use nexus_common::{
     media::{FileVariant, VariantController},
-    models::{
-        file::FileDetails,
-        traits::Collection,
-    },
+    models::{file::FileDetails, traits::Collection},
 };
 
 #[derive(Deserialize)]
@@ -103,7 +100,7 @@ pub async fn static_files_handler(
         &owner_id,
         &variant,
         file_path.clone(),
-        params.dl.as_ref().map(|_| file.name.as_str()),
+        params.dl.is_some(),
     )
     .await
     .inspect_err(|_| {

--- a/nexus-webapi/src/routes/static/files.rs
+++ b/nexus-webapi/src/routes/static/files.rs
@@ -97,7 +97,6 @@ pub async fn static_files_handler(
     serve_file_variant(
         request,
         &file,
-        &owner_id,
         &variant,
         file_path.clone(),
         params.dl.is_some(),

--- a/nexus-webapi/src/routes/static/files.rs
+++ b/nexus-webapi/src/routes/static/files.rs
@@ -10,14 +10,15 @@ use tracing::{debug, error};
 use utoipa::OpenApi;
 
 use super::endpoints::STATIC_FILES_ROUTE;
+use super::serve_dir::serve_file_variant;
 use crate::models::{FileId, PubkyId};
 use crate::routes::Path;
-use crate::routes::{r#static::PubkyServeDir, AppState};
+use crate::routes::AppState;
 use crate::{Error, Result};
 use nexus_common::{
     media::{FileVariant, VariantController},
     models::{
-        file::{Blob, FileDetails},
+        file::FileDetails,
         traits::Collection,
     },
 };
@@ -96,46 +97,18 @@ pub async fn static_files_handler(
         )));
     }
 
-    let file_variant_content_type = Blob::get_by_id(&file, &variant, file_path.clone())
-        .await
-        .inspect_err(|_| {
-            error!("Error while processing file variant for variant: {variant} and file: {file_id}")
-        })?;
-
-    let request_uri = request.uri().clone();
-
-    let mut response = PubkyServeDir::try_call(
+    serve_file_variant(
         request,
-        request_uri.path().replace("static/files", ""),
-        file_variant_content_type,
+        &file,
+        &owner_id,
+        &variant,
         file_path.clone(),
+        params.dl.as_ref().map(|_| file.name.as_str()),
     )
-    .await?;
-
-    // Remove any default "cache-control" header (which may be set to no-cache)
-    response.headers_mut().remove("cache-control");
-
-    // Set a new Cache-Control header to cache the file for 3600 seconds (1 hour)
-    let cache_control_header = "public, max-age=3600"
-        .parse()
-        .inspect_err(|err| error!("Failed to parse Cache-Control header value: {}", err))?;
-
-    // Insert our newly parsed Cache-Control header.
-    response
-        .headers_mut()
-        .insert("cache-control", cache_control_header);
-
-    // if dl parameter is passed, set content-disposition header to attachment to force download
-    if params.dl.is_some() {
-        let content_disposition_header = format!("attachment; filename=\"{}\"", file.name)
-            .parse()
-            .inspect_err(|_| error!("Invalid content disposition header: {}", file.name))?;
-        response
-            .headers_mut()
-            .insert("content-disposition", content_disposition_header);
-    }
-
-    Ok(response)
+    .await
+    .inspect_err(|_| {
+        error!("Error while processing file variant for variant: {variant} and file: {file_id}")
+    })
 }
 
 #[derive(OpenApi)]

--- a/nexus-webapi/src/routes/static/mod.rs
+++ b/nexus-webapi/src/routes/static/mod.rs
@@ -4,6 +4,7 @@ use axum::{routing::get, Router};
 use endpoints::{LEGACY_STATIC_FILES_ROUTE, STATIC_FILES_ROUTE, USER_AVATAR_ROUTE};
 use utoipa::OpenApi;
 
+pub use avatar::user_avatar_handler;
 pub use serve_dir::PubkyServeDir;
 
 mod avatar;

--- a/nexus-webapi/src/routes/static/serve_dir.rs
+++ b/nexus-webapi/src/routes/static/serve_dir.rs
@@ -66,14 +66,13 @@ impl PubkyServeDir {
 pub async fn serve_file_variant(
     request: Request<Body>,
     file: &FileDetails,
-    owner_id: &str,
     variant: &FileVariant,
     files_path: PathBuf,
     download: bool,
 ) -> Result<Response<ServeFileSystemResponseBody>> {
     let content_type = Blob::get_by_id(file, variant, files_path.clone()).await?;
 
-    let disk_path = format!("/{owner_id}/{}/{variant}", file.id);
+    let disk_path = format!("/{}/{}/{variant}", file.owner_id, file.id);
 
     let mut response =
         PubkyServeDir::try_call(request, disk_path, content_type, files_path).await?;

--- a/nexus-webapi/src/routes/static/serve_dir.rs
+++ b/nexus-webapi/src/routes/static/serve_dir.rs
@@ -61,16 +61,15 @@ impl PubkyServeDir {
     }
 }
 
-/// Ensures a file variant exists on disk, serves it, and applies standard cache headers.
-///
-/// When `download_filename` is set, also adds a `Content-Disposition: attachment` header.
+/// Ensures a file variant exists, serves it, and applies cache headers.
+/// If `download` is true, sets `Content-Disposition: attachment`.
 pub async fn serve_file_variant(
     request: Request<Body>,
     file: &FileDetails,
     owner_id: &str,
     variant: &FileVariant,
     files_path: PathBuf,
-    download_filename: Option<&str>,
+    download: bool,
 ) -> Result<Response<ServeFileSystemResponseBody>> {
     let content_type = Blob::get_by_id(file, variant, files_path.clone()).await?;
 
@@ -89,7 +88,8 @@ pub async fn serve_file_variant(
         .headers_mut()
         .insert("cache-control", cache_control_header);
 
-    if let Some(filename) = download_filename {
+    if download {
+        let filename = &file.name;
         let content_disposition_header = format!("attachment; filename=\"{filename}\"")
             .parse()
             .inspect_err(|_| error!("Invalid content disposition header: {filename}"))?;

--- a/nexus-webapi/src/routes/static/serve_dir.rs
+++ b/nexus-webapi/src/routes/static/serve_dir.rs
@@ -7,10 +7,16 @@ use axum::{
     http::{Request, Uri},
     response::Response,
 };
+use nexus_common::{
+    media::FileVariant,
+    models::file::{Blob, FileDetails},
+};
 use tower_http::services::{fs::ServeFileSystemResponseBody, ServeDir};
 use tracing::error;
 
 static SERVE_DIR_INSTANCE: OnceLock<ServeDir> = OnceLock::new();
+
+const CACHE_CONTROL: &str = "public, max-age=3600";
 
 pub struct PubkyServeDir;
 
@@ -53,4 +59,44 @@ impl PubkyServeDir {
             .insert("content-type", content_type_header);
         Ok(response)
     }
+}
+
+/// Ensures a file variant exists on disk, serves it, and applies standard cache headers.
+///
+/// When `download_filename` is set, also adds a `Content-Disposition: attachment` header.
+pub async fn serve_file_variant(
+    request: Request<Body>,
+    file: &FileDetails,
+    owner_id: &str,
+    variant: &FileVariant,
+    files_path: PathBuf,
+    download_filename: Option<&str>,
+) -> Result<Response<ServeFileSystemResponseBody>> {
+    let content_type = Blob::get_by_id(file, variant, files_path.clone()).await?;
+
+    let disk_path = format!("/{owner_id}/{}/{variant}", file.id);
+
+    let mut response =
+        PubkyServeDir::try_call(request, disk_path, content_type, files_path).await?;
+
+    response.headers_mut().remove("cache-control");
+
+    let cache_control_header = CACHE_CONTROL
+        .parse()
+        .inspect_err(|err| error!("Failed to parse Cache-Control header value: {}", err))?;
+
+    response
+        .headers_mut()
+        .insert("cache-control", cache_control_header);
+
+    if let Some(filename) = download_filename {
+        let content_disposition_header = format!("attachment; filename=\"{filename}\"")
+            .parse()
+            .inspect_err(|_| error!("Invalid content disposition header: {filename}"))?;
+        response
+            .headers_mut()
+            .insert("content-disposition", content_disposition_header);
+    }
+
+    Ok(response)
 }

--- a/nexus-webapi/src/routes/static/serve_dir.rs
+++ b/nexus-webapi/src/routes/static/serve_dir.rs
@@ -4,7 +4,7 @@ use std::sync::OnceLock;
 use crate::Result;
 use axum::{
     body::Body,
-    http::{Request, Uri},
+    http::{header, HeaderValue, Request, Uri},
     response::Response,
 };
 use nexus_common::{
@@ -77,24 +77,18 @@ pub async fn serve_file_variant(
     let mut response =
         PubkyServeDir::try_call(request, disk_path, content_type, files_path).await?;
 
-    response.headers_mut().remove("cache-control");
-
-    let cache_control_header = CACHE_CONTROL
-        .parse()
-        .inspect_err(|err| error!("Failed to parse Cache-Control header value: {}", err))?;
-
-    response
-        .headers_mut()
-        .insert("cache-control", cache_control_header);
+    let headers = response.headers_mut();
+    headers.insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static(CACHE_CONTROL),
+    );
 
     if download {
         let filename = &file.name;
-        let content_disposition_header = format!("attachment; filename=\"{filename}\"")
+        let content_disposition = format!("attachment; filename=\"{filename}\"")
             .parse()
             .inspect_err(|_| error!("Invalid content disposition header: {filename}"))?;
-        response
-            .headers_mut()
-            .insert("content-disposition", content_disposition_header);
+        headers.insert(header::CONTENT_DISPOSITION, content_disposition);
     }
 
     Ok(response)

--- a/nexus-webapi/tests/user/avatar.rs
+++ b/nexus-webapi/tests/user/avatar.rs
@@ -1,9 +1,10 @@
-use std::path::PathBuf;
+use std::{io::ErrorKind, path::PathBuf};
 
 use crate::utils::host_url;
 use crate::utils::server::TestServiceServer;
 use anyhow::Result;
-use tokio::fs::{create_dir_all, read, write};
+use nexus_common::models::{traits::Collection, user::UserDetails};
+use tokio::fs::{create_dir_all, read, remove_dir_all, write};
 
 const AVATAR_BLOB_NAME: &str = "avatar.png";
 const BLOB_PATH: &str = "tests/user/blobs";
@@ -11,27 +12,67 @@ const BLOB_PATH: &str = "tests/user/blobs";
 // User "Aldert" in docker/test-graph/skunk.cypher has u.image set to
 // pubky://<USER_PUBKY>/pub/pubky.app/files/<FILE_ID>, and FILE_ID is
 // defined in docker/test-graph/mocks/files.cypher.
+//
+// USER_PUBKY/FILE_ID is intentionally shared across the avatar tests: the
+// handler resolves the file via FileDetails::get_by_ids, so it needs a real
+// FileDetails that exists in the graph rather than a synthetic on-disk-only file.
 const USER_PUBKY: &str = "4snwyct86m383rsduhw5xgcxpw7c63j3pq8x4ycqikxgik8y64ro";
 const FILE_ID: &str = "003286NSMY490";
+
+// User "Intruder" in docker/test-graph/skunk.cypher has no profile image.
+//
+// Used as the profile fixture for the cross-owner avatar case. The test mutates
+// only Intruder's `image` field and restores it, keeping the fixture footprint
+// smaller than creating a synthetic user visible to aggregate tests.
+const INTRUDER_PUBKY: &str = "4p1qa1ko7wuta4f1qm8io495cqsmefbgfp85wtnm9bj55gqbhjpo";
+
+async fn seed_avatar_main_variant(owner_id: &str, file_id: &str) -> Result<usize> {
+    let test_image_dir_path = TestServiceServer::get_test_server()
+        .await
+        .temp_dir
+        .path()
+        .join(owner_id)
+        .join(file_id);
+    let full_image_path = test_image_dir_path.join("main");
+
+    create_dir_all(&test_image_dir_path).await?;
+    let source_bytes = read(PathBuf::from(BLOB_PATH).join(AVATAR_BLOB_NAME)).await?;
+    let source_size = source_bytes.len();
+    write(&full_image_path, &source_bytes).await?;
+
+    Ok(source_size)
+}
+
+async fn remove_avatar_variants(owner_id: &str, file_id: &str) -> Result<()> {
+    let test_image_dir_path = TestServiceServer::get_test_server()
+        .await
+        .temp_dir
+        .path()
+        .join(owner_id)
+        .join(file_id);
+
+    match remove_dir_all(test_image_dir_path).await {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err.into()),
+    }
+}
+
+async fn set_user_image(user_id: &str, image: Option<String>) -> Result<()> {
+    let mut user = UserDetails::get_by_id(user_id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("user {user_id} not found in test graph"))?;
+    user.image = image;
+    user.put_to_graph().await?;
+    UserDetails::put_to_index(&[user_id], vec![Some(user)]).await?;
+    Ok(())
+}
 
 #[tokio_shared_rt::test(shared)]
 async fn test_user_avatar_endpoint() -> Result<()> {
     let client = httpc_test::new_client(host_url().await)?;
 
-    let test_image_dir_path = TestServiceServer::get_test_server()
-        .await
-        .temp_dir
-        .path()
-        .join(USER_PUBKY)
-        .join(FILE_ID);
-    let full_image_path = test_image_dir_path.join("main");
-
-    create_dir_all(&test_image_dir_path).await?;
-    // drop the source avatar into the static folder so the handler can
-    // lazily generate the small webp variant from it
-    let source_bytes = read(PathBuf::from(BLOB_PATH).join(AVATAR_BLOB_NAME)).await?;
-    let source_size = source_bytes.len();
-    write(&full_image_path, &source_bytes).await?;
+    let source_size = seed_avatar_main_variant(USER_PUBKY, FILE_ID).await?;
 
     let res = client
         .do_get(format!("/static/avatar/{USER_PUBKY}").as_str())
@@ -66,6 +107,63 @@ async fn test_user_avatar_endpoint() -> Result<()> {
         content_length, source_size,
         "Served size should differ from source — proves small webp variant was generated, not the original served back"
     );
+
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_user_avatar_serves_file_owned_by_another_user() -> Result<()> {
+    let client = httpc_test::new_client(host_url().await)?;
+
+    let original_intruder = UserDetails::get_by_id(INTRUDER_PUBKY)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("Intruder user not found in test graph"))?;
+    let original_image = original_intruder.image.clone();
+
+    let cross_owner_image = format!("pubky://{USER_PUBKY}/pub/pubky.app/files/{FILE_ID}");
+    set_user_image(INTRUDER_PUBKY, Some(cross_owner_image)).await?;
+
+    let test_result = async {
+        // A regression to using the profile user's path would look here and fail.
+        remove_avatar_variants(INTRUDER_PUBKY, FILE_ID).await?;
+
+        // The blob exists only under the file owner's path.
+        let source_size = seed_avatar_main_variant(USER_PUBKY, FILE_ID).await?;
+
+        let res = client
+            .do_get(format!("/static/avatar/{INTRUDER_PUBKY}").as_str())
+            .await?;
+
+        anyhow::ensure!(
+            res.status() == 200,
+            "Avatar should resolve the file owner's on-disk path, not the profile user's"
+        );
+
+        let content_type = res
+            .header("content-type")
+            .ok_or_else(|| anyhow::anyhow!("missing content-type header"))?
+            .parse::<String>()?;
+        anyhow::ensure!(
+            content_type == "image/webp",
+            "Avatar should be served as image/webp, got {content_type}"
+        );
+
+        let content_length = res
+            .header("content-length")
+            .ok_or_else(|| anyhow::anyhow!("missing content-length header"))?
+            .parse::<usize>()?;
+        anyhow::ensure!(
+            content_length != source_size,
+            "Served size should differ from source — proves the owned file was found and processed"
+        );
+
+        Ok::<(), anyhow::Error>(())
+    }
+    .await;
+
+    let restore_result = set_user_image(INTRUDER_PUBKY, original_image).await;
+    test_result?;
+    restore_result?;
 
     Ok(())
 }


### PR DESCRIPTION
Closes #331
## Summary
Extracts shared static file serving logic into `serve_file_variant` and completes the remaining polish from the avatar endpoint work in #322.
## Checklist status
| Item | Status |
|---|---|
| OpenAPI Axum handler (unified pattern) | Already was Done |
| Mock user + avatar file in repo | Already was Done |
| Integration test | Already was Done |
| Reuse #165 file-processing code | Done in that PR |
| `/avatar` benchmark | Done in that PR |
## Changes
- Add `serve_file_variant` helper in `serve_dir.rs` for variant generation, disk serving, and cache headers
- Refactor `avatar.rs` and `files.rs` to use the shared helper
- `files.rs` keeps variant validation and optional `?dl=` download header

# Pre-submission Checklist

- [x] I manually reviewed the PR
- [x] I asked one or more LLMs to review the PR
- [ ] I asked one or more LLMs to check if this PR can be simplified [^1]
- [ ] If appropriate, I added tests for the changes in this PR
- [x] If appropriate, I added performance benchmarks for the APIs added in this PR [^2]

[^1]: Sample prompt: "Can this be simplified? Can the code, comments, or logic introduced by these changes be simplfied, clarified or otherwise made more terse, concise and understandable, without affecting functionality?"
[^2]: `cargo bench -p nexus-webapi`
