### PR TITLE
chore: use 'RetryManager' prefix and remove legacy `RetryManager` keys from Redis

### DIFF
--- a/nexus-watcher/src/events/retry/event.rs
+++ b/nexus-watcher/src/events/retry/event.rs
@@ -7,9 +7,7 @@ use nexus_common::db::RedisOps;
 
 use crate::events::EventProcessorError;
 
-// v2: RetryEvent schema changed incompatibly; bumped prefix so old keys under
-// "RetryManager:*" stay orphaned rather than failing to deserialize.
-pub const RETRY_MANAGER_PREFIX: &str = "RetryManagerV2";
+pub const RETRY_MANAGER_PREFIX: &str = "RetryManager";
 pub const RETRY_MANAGER_EVENTS_INDEX: [&str; 1] = ["events"];
 pub const RETRY_MANAGER_STATE_INDEX: [&str; 1] = ["state"];
 

--- a/nexusd/src/migrations/migrations_list/mod.rs
+++ b/nexusd/src/migrations/migrations_list/mod.rs
@@ -1,4 +1,5 @@
 // pub mod tag_counts_reset_1739459180;
 pub mod remove_muted_1771718400;
+pub mod remove_retry_manager_1781173800;
 pub mod resource_node_setup_1774000000;
 pub mod users_by_pk_reindex_1751635096;

--- a/nexusd/src/migrations/migrations_list/remove_retry_manager_1781173800.rs
+++ b/nexusd/src/migrations/migrations_list/remove_retry_manager_1781173800.rs
@@ -1,0 +1,46 @@
+use async_trait::async_trait;
+
+use crate::migrations::{manager::Migration, utils::delete_keys_by_pattern};
+use nexus_common::types::DynError;
+use tracing::info;
+
+/// Removes all `RetryManager:*` keys from Redis.
+///
+/// This migration cleans up the legacy `RetryManager` index on prod. The old data
+/// cannot be migrated (schema mismatch), so all entries are dropped to free the
+/// prefix for safe reuse without deserialization issues.
+pub struct RemoveRetryManager1781173800;
+
+#[async_trait]
+impl Migration for RemoveRetryManager1781173800 {
+    fn id(&self) -> &'static str {
+        "RemoveRetryManager1781173800"
+    }
+
+    fn is_multi_staged(&self) -> bool {
+        false
+    }
+
+    async fn dual_write(_data: Box<dyn std::any::Any + Send + 'static>) -> Result<(), DynError> {
+        Ok(())
+    }
+
+    async fn backfill(&self) -> Result<(), DynError> {
+        // Remove all RetryManager:* keys from Redis (sorted set + state JSON entries)
+        let deleted = delete_keys_by_pattern("RetryManager:*", 100).await?;
+        info!(
+            "RemoveRetryManager migration: deleted {} RetryManager keys from Redis",
+            deleted
+        );
+
+        Ok(())
+    }
+
+    async fn cutover(&self) -> Result<(), DynError> {
+        Ok(())
+    }
+
+    async fn cleanup(&self) -> Result<(), DynError> {
+        Ok(())
+    }
+}

--- a/nexusd/src/migrations/mod.rs
+++ b/nexusd/src/migrations/mod.rs
@@ -10,6 +10,7 @@ pub use builder::MigrationBuilder;
 pub use manager::MigrationManager;
 
 use crate::migrations::migrations_list::remove_muted_1771718400::RemoveMuted1771718400;
+use crate::migrations::migrations_list::remove_retry_manager_1781173800::RemoveRetryManager1781173800;
 use crate::migrations::migrations_list::resource_node_setup_1774000000::ResourceNodeSetup1774000000;
 use crate::migrations::migrations_list::users_by_pk_reindex_1751635096::UsersByPkReindex1751635096;
 /// Registers migrations with the `MigrationManager`
@@ -43,6 +44,7 @@ pub fn import_migrations(migration_manager: &mut MigrationManager) {
         Box::new(UsersByPkReindex1751635096),
         Box::new(RemoveMuted1771718400),
         Box::new(ResourceNodeSetup1774000000),
+        Box::new(RemoveRetryManager1781173800),
     ];
     for migration in migrations {
         migration_manager.register(migration);


### PR DESCRIPTION
Changes `RetryManagerV2` to `RetryManager` redis key prefix.
Cleans up the `RetryManager` index on prod where old data cannot be migrated due to schema mismatch. Drops all `RetryManager:*` entries (sorted set + state JSON) to free the prefix for safe reuse.