### PR TITLE
fix: bound `FilesByIdsBody.uris` to 1..=100 using `FileUris` newtype

### DIFF
--- a/nexus-webapi/src/models/file_id.rs
+++ b/nexus-webapi/src/models/file_id.rs
@@ -131,9 +131,7 @@ mod tests {
     // --- FileUris tests ---
 
     fn make_uris(count: usize) -> String {
-        let items: Vec<String> = (0..count)
-            .map(|i| format!("uri_{}", i))
-            .collect();
+        let items: Vec<String> = (0..count).map(|i| format!("uri_{}", i)).collect();
         serde_json::to_string(&items).unwrap()
     }
 

--- a/nexus-webapi/src/models/file_id.rs
+++ b/nexus-webapi/src/models/file_id.rs
@@ -7,6 +7,8 @@ use serde::de;
 use serde::Deserialize;
 use utoipa::ToSchema;
 
+use super::bounded_vec;
+
 /// 13-character Crockford Base32-encoded file ID.
 #[derive(Debug, ToSchema)]
 #[schema(value_type = String, example = "00000039YD9DP")]
@@ -51,6 +53,24 @@ impl TryFrom<String> for FileId {
     fn try_from(s: String) -> Result<Self, Self::Error> {
         Self::validate_id(&s)?;
         Ok(FileId(s))
+    }
+}
+
+/// JSON array of file URI strings (min=1, max=100).
+#[derive(Debug, ToSchema)]
+pub struct FileUris(pub Vec<String>);
+
+impl Deref for FileUris {
+    type Target = Vec<String>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for FileUris {
+    fn deserialize<D: serde::de::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        bounded_vec::deserialize_json_array::<String, D, 1, 100>(d).map(Self)
     }
 }
 
@@ -106,5 +126,50 @@ mod tests {
     fn test_validate_id_with_space() {
         let result = FileId::try_from("ABCDEFG HIJKL".to_string());
         assert!(result.is_err());
+    }
+
+    // --- FileUris tests ---
+
+    fn make_uris(count: usize) -> String {
+        let items: Vec<String> = (0..count)
+            .map(|i| format!("uri_{}", i))
+            .collect();
+        serde_json::to_string(&items).unwrap()
+    }
+
+    #[test]
+    fn test_file_uris_rejects_empty_array() {
+        let result: Result<FileUris, _> = serde_json::from_str("[]");
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("At least 1 item(s) required"));
+    }
+
+    #[test]
+    fn test_file_uris_accepts_one_uri() {
+        let result: Result<FileUris, _> = serde_json::from_str(r#"["single_uri"]"#);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().0.len(), 1);
+    }
+
+    #[test]
+    fn test_file_uris_accepts_100_uris() {
+        let json = make_uris(100);
+        let result: Result<FileUris, _> = serde_json::from_str(&json);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().0.len(), 100);
+    }
+
+    #[test]
+    fn test_file_uris_rejects_101_uris() {
+        let json = make_uris(101);
+        let result: Result<FileUris, _> = serde_json::from_str(&json);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Maximum 100 items allowed"));
     }
 }

--- a/nexus-webapi/src/models/mod.rs
+++ b/nexus-webapi/src/models/mod.rs
@@ -20,7 +20,7 @@ use serde::Deserialize;
 use utoipa::ToSchema;
 
 pub use error_response::ErrorResponsePayload;
-pub use file_id::FileId;
+pub use file_id::{FileId, FileUris};
 pub use global_post_id::{GlobalPostId, GlobalPostIds};
 pub use info::ServerInfo;
 pub use post::{PostStreamDetailed, PostViewDetailed};

--- a/nexus-webapi/src/routes/v0/file/list.rs
+++ b/nexus-webapi/src/routes/v0/file/list.rs
@@ -1,3 +1,4 @@
+use crate::models::FileUris;
 use crate::routes::v0::endpoints::FILE_LIST_ROUTE;
 use crate::routes::Json as RequestJson;
 use crate::Result;
@@ -10,7 +11,7 @@ use utoipa::{OpenApi, ToSchema};
 
 #[derive(Deserialize, ToSchema)]
 pub struct FilesByIdsBody {
-    uris: Vec<String>,
+    uris: FileUris,
 }
 
 #[utoipa::path(


### PR DESCRIPTION
Wrap uris in `FileUris(Vec<String>)` with `bounded_vec deserialization` enforcing 1..=100 items at the wire boundary. 

Tests added for empty, 1, 100, and 101 URI counts.