### PR TITLE
fix(counts): add collections field and exclude collection-follows from bookmarks

### DIFF
--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -474,7 +474,9 @@ pub fn user_counts(user_id: &str) -> Query {
         // Count relationships to posts
         COUNT { (u)-[:AUTHORED]->(:Post) } AS posts,
         COUNT { (u)-[:AUTHORED]->(:Post)-[:REPLIED]->(:Post) } AS replies,
-        COUNT { (u)-[:BOOKMARKED]->(:Post) } AS bookmarks,
+        COUNT { (u)-[:AUTHORED]->(p:Post) WHERE p.kind = 'collection' } AS collections,
+        // A collection-follow is stored as a bookmark; keep it out of the count.
+        COUNT { (u)-[:BOOKMARKED]->(bp:Post) WHERE (bp.kind IS NULL OR bp.kind <> 'collection') } AS bookmarks,
 
         // Count user and post tagging
         COUNT { (u)-[:TAGGED]->(:User) } AS user_tags,
@@ -489,6 +491,7 @@ pub fn user_counts(user_id: &str) -> Query {
                 friends: friends,
                 posts: posts,
                 replies: replies,
+                collections: collections,
                 tagged: user_tags + post_tags,
                 tags: tags,
                 unique_tags: unique_tags,

--- a/nexus-common/src/models/user/counts.rs
+++ b/nexus-common/src/models/user/counts.rs
@@ -18,6 +18,9 @@ pub struct UserCounts {
     pub unique_tags: u32,
     pub posts: u32,
     pub replies: u32,
+    // Defaulted so counts cached before this field existed still deserialize.
+    #[serde(default)]
+    pub collections: u32,
     pub following: u32,
     pub followers: u32,
     pub friends: u32,

--- a/nexus-watcher/src/events/handlers/bookmark.rs
+++ b/nexus-watcher/src/events/handlers/bookmark.rs
@@ -5,6 +5,7 @@ use nexus_common::models::user::UserCounts;
 use pubky_app_specs::{ParsedUri, PubkyAppBookmark, PubkyId, Resource};
 use tracing::debug;
 
+use super::utils::post_is_collection;
 use crate::events::EventProcessorError;
 
 #[tracing::instrument(name = "bookmark.put", skip_all, fields(user_id = %user_id, bookmark_id = %id))]
@@ -27,6 +28,11 @@ pub async fn sync_put(
         }
     };
 
+    // Decide collection-follow BEFORE any write: if this lookup failed after the
+    // graph/index write, the retry would see `existed = true` and skip the
+    // increment forever, leaving a real bookmark uncounted.
+    let target_is_collection = post_is_collection(&author_id, &post_id).await?;
+
     // Save new bookmark relationship to the graph, only if the bookmarked user exists
     let indexed_at = Utc::now().timestamp_millis();
     let existed =
@@ -46,7 +52,8 @@ pub async fn sync_put(
         .put_to_index(&author_id, &post_id, &user_id)
         .await?;
 
-    if !existed {
+    // A collection-follow is stored as a bookmark; don't count it.
+    if !existed && !target_is_collection {
         UserCounts::increment(&user_id, "bookmarks", None).await?;
     }
     Ok(())
@@ -71,10 +78,16 @@ pub async fn sync_del(user_id: PubkyId, bookmark_id: String) -> Result<(), Event
         .await?
         .is_some();
 
+    // Decide collection-follow BEFORE the cleanup: if this lookup failed after
+    // `del_from_index`, the retry would see `existed_in_index = false` and skip
+    // the decrement forever, leaving a real bookmark counted.
+    let target_is_collection = post_is_collection(&author_id, &post_id).await?;
+
     // 3. Redis cleanup (idempotent)
     Bookmark::del_from_index(&user_id, &post_id, &author_id).await?;
 
-    if existed_in_index {
+    // Mirror the PUT gate: collection-follows never incremented `bookmarks`.
+    if existed_in_index && !target_is_collection {
         UserCounts::decrement(&user_id, "bookmarks", None).await?;
     }
 

--- a/nexus-watcher/src/events/handlers/post.rs
+++ b/nexus-watcher/src/events/handlers/post.rs
@@ -15,7 +15,7 @@ use pubky_app_specs::{
 };
 use tracing::{debug, Instrument};
 
-use super::utils::post_relationships_is_reply;
+use super::utils::{post_is_collection, post_relationships_is_reply};
 
 #[tracing::instrument(name = "post.put", skip_all, fields(user_id = %author_id, post_id = %post_id))]
 pub async fn sync_put(
@@ -28,6 +28,7 @@ pub async fn sync_put(
     let post_details = PostDetails::from_homeserver(post.clone(), &author_id, &post_id);
     // We avoid indexing replies into global feed sorted sets
     let is_reply = post.parent.is_some();
+    let is_collection = post.kind == PubkyAppPostKind::Collection;
     // PRE-INDEX operation, identify the post relationship
     let mut post_relationships = PostRelationships::from_homeserver(&post);
 
@@ -66,8 +67,21 @@ pub async fn sync_put(
         // If the post existed, let's confirm this is an edit. Is the content different?
         match PostDetails::get_from_index(&author_id, &post_id).await? {
             Some(existing_details) => {
-                if existing_details.is_different_than(&post_details) {
-                    sync_edit(post, author_id, post_id, post_details).await?;
+                let was_collection = existing_details.kind == PubkyAppPostKind::Collection;
+                // Persist the new PostDetails (incl. kind) BEFORE moving the
+                // `collections` counter. If the counter moved first and a later
+                // step failed, a retry would re-read the old kind, see the same
+                // transition, and move the counter twice. Writing the kind first
+                // means a retry sees the new kind and the transition is gone.
+                if existing_details.is_different_than(&post_details)
+                    || was_collection != is_collection
+                {
+                    sync_edit(post, author_id.clone(), post_id.clone(), post_details).await?;
+                }
+                match (was_collection, is_collection) {
+                    (false, true) => UserCounts::increment(&author_id, "collections", None).await?,
+                    (true, false) => UserCounts::decrement(&author_id, "collections", None).await?,
+                    _ => {}
                 }
             }
             None => {
@@ -119,8 +133,11 @@ pub async fn sync_put(
         // Update user counts with the new post
         UserCounts::increment(&author_id, "posts", None),
         async {
+            // reply XOR collection (collections forbid `parent`); never both.
             if is_reply {
                 UserCounts::increment(&author_id, "replies", None).await?;
+            } else if is_collection {
+                UserCounts::increment(&author_id, "collections", None).await?;
             };
             Ok::<(), EventProcessorError>(())
         }
@@ -460,6 +477,11 @@ pub async fn sync_del(author_id: PubkyId, post_id: String) -> Result<(), EventPr
         PostRelationships::get_from_index(&author_id, &post_id).await?;
     let post_in_index = post_relationships_from_index.is_some();
 
+    // Recover the kind BEFORE removing the gate below. PostDetails is still present
+    // (graph-delete runs last). Doing this after the gate deletion would let a
+    // failed lookup strand the decrements on retry (gate gone, post_in_index false).
+    let is_collection = post_in_index && post_is_collection(&author_id, &post_id).await?;
+
     // 2. Atomically commit the cleanup decision: remove the gate as the very
     //    first mutation. Subsequent retries will observe `post_in_index = false`
     //    and skip non-idempotent ops (counters, scores, notifications).
@@ -495,8 +517,11 @@ pub async fn sync_del(author_id: PubkyId, post_id: String) -> Result<(), EventPr
             Ok::<(), EventProcessorError>(())
         },
         async {
+            // reply XOR collection; never both fire.
             if post_in_index && is_reply {
                 UserCounts::decrement(&author_id, "replies", None).await?;
+            } else if is_collection {
+                UserCounts::decrement(&author_id, "collections", None).await?;
             };
             Ok::<(), EventProcessorError>(())
         }

--- a/nexus-watcher/src/events/handlers/utils.rs
+++ b/nexus-watcher/src/events/handlers/utils.rs
@@ -1,5 +1,6 @@
 use nexus_common::models::event::EventProcessorError;
-use nexus_common::models::post::PostRelationships;
+use nexus_common::models::post::{PostDetails, PostRelationships};
+use pubky_app_specs::PubkyAppPostKind;
 
 /// Checks if a post is a reply based on its relationships.
 /// # Arguments
@@ -15,4 +16,16 @@ pub async fn post_relationships_is_reply(
         // If the post does not exist, it is treated as a reply to avoid incorrect assumptions
         None => Ok(true),
     }
+}
+
+/// Whether a post is a Collection. A missing/unknown target defaults to `false`
+/// (a normal post) so the increment and decrement paths stay symmetric.
+pub async fn post_is_collection(
+    author_id: &str,
+    post_id: &str,
+) -> Result<bool, EventProcessorError> {
+    Ok(matches!(
+        PostDetails::get_by_id(author_id, post_id).await?,
+        Some(details) if details.kind == PubkyAppPostKind::Collection
+    ))
 }

--- a/nexus-watcher/tests/event_processor/posts/collection_counts.rs
+++ b/nexus-watcher/tests/event_processor/posts/collection_counts.rs
@@ -1,0 +1,257 @@
+use crate::event_processor::users::utils::find_user_counts;
+use crate::event_processor::utils::watcher::{HomeserverHashIdPath, WatcherTest};
+use anyhow::Result;
+use nexus_common::models::post::PostDetails;
+use nexus_common::models::user::UserCounts;
+use pubky::Keypair;
+use pubky_app_specs::{
+    post_uri_builder, PubkyAppBookmark, PubkyAppPost, PubkyAppPostKind, PubkyAppUser,
+};
+
+/// Collection posts require a JSON envelope (`name` + `items`) in `content`.
+fn collection_post(name: &str) -> PubkyAppPost {
+    let content = serde_json::json!({ "name": name, "items": [] }).to_string();
+    PubkyAppPost {
+        content,
+        kind: PubkyAppPostKind::Collection,
+        parent: None,
+        embed: None,
+        attachments: None,
+    }
+}
+
+fn short_post(content: &str) -> PubkyAppPost {
+    PubkyAppPost {
+        content: content.to_string(),
+        kind: PubkyAppPostKind::Short,
+        parent: None,
+        embed: None,
+        attachments: None,
+    }
+}
+
+/// Bookmarks `owner_id`'s post (a real bookmark, or "following" a collection).
+async fn bookmark_post(
+    test: &mut WatcherTest,
+    user_kp: &Keypair,
+    owner_id: &str,
+    post_id: &str,
+) -> Result<()> {
+    let bookmark = PubkyAppBookmark {
+        uri: post_uri_builder(owner_id.to_string(), post_id.to_string()),
+        created_at: chrono::Utc::now().timestamp_millis(),
+    };
+    let bookmark_path = bookmark.hs_path();
+    test.put(user_kp, &bookmark_path, bookmark).await?;
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_collection_post_increments_collections_not_replies() -> Result<()> {
+    let mut test = WatcherTest::setup().await?;
+
+    let user_kp = Keypair::random();
+    let user = PubkyAppUser {
+        bio: None,
+        image: None,
+        links: None,
+        name: "Watcher:CollectionCounts:Put".to_string(),
+        status: None,
+    };
+    let user_id = test.create_user(&user_kp, &user).await?;
+
+    let (_short_id, short_path) = test.create_post(&user_kp, &short_post("plain")).await?;
+    let (_col_id, col_path) = test
+        .create_post(&user_kp, &collection_post("My Collection"))
+        .await?;
+
+    let counts = find_user_counts(&user_id).await;
+    assert_eq!(
+        counts.posts, 2,
+        "posts is the grand total incl. the collection"
+    );
+    assert_eq!(counts.collections, 1, "the collection is counted once");
+    assert_eq!(counts.replies, 0, "a collection is not a reply");
+
+    // Graph backfill must match the live counters.
+    let graph_counts = UserCounts::get_from_graph(&user_id)
+        .await?
+        .expect("user counts present in graph");
+    assert_eq!(graph_counts.posts, 2);
+    assert_eq!(graph_counts.collections, 1);
+    assert_eq!(graph_counts.replies, 0);
+
+    test.cleanup_post(&user_kp, &short_path).await?;
+    test.cleanup_post(&user_kp, &col_path).await?;
+    test.cleanup_user(&user_kp).await?;
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_delete_collection_decrements_collections() -> Result<()> {
+    let mut test = WatcherTest::setup().await?;
+
+    let user_kp = Keypair::random();
+    let user = PubkyAppUser {
+        bio: None,
+        image: None,
+        links: None,
+        name: "Watcher:CollectionCounts:Del".to_string(),
+        status: None,
+    };
+    let user_id = test.create_user(&user_kp, &user).await?;
+
+    let (_col_id, col_path) = test
+        .create_post(&user_kp, &collection_post("Doomed"))
+        .await?;
+
+    let before = find_user_counts(&user_id).await;
+    assert_eq!(before.collections, 1);
+    assert_eq!(before.posts, 1);
+
+    test.cleanup_post(&user_kp, &col_path).await?;
+
+    let after = find_user_counts(&user_id).await;
+    assert_eq!(after.collections, 0, "collections decremented on delete");
+    assert_eq!(after.posts, 0);
+
+    test.cleanup_user(&user_kp).await?;
+    Ok(())
+}
+
+/// Editing a post across the collection boundary moves `collections`; the graph
+/// kind is overwritten on every PUT, so otherwise the live counter drifts from
+/// the Cypher backfill until the next reindex.
+#[tokio_shared_rt::test(shared)]
+async fn test_editing_post_kind_moves_collections_counter() -> Result<()> {
+    let mut test = WatcherTest::setup().await?;
+
+    let user_kp = Keypair::random();
+    let user = PubkyAppUser {
+        bio: None,
+        image: None,
+        links: None,
+        name: "Watcher:CollectionCounts:Edit".to_string(),
+        status: None,
+    };
+    let user_id = test.create_user(&user_kp, &user).await?;
+
+    let (_id, path) = test.create_post(&user_kp, &short_post("draft")).await?;
+    assert_eq!(find_user_counts(&user_id).await.collections, 0);
+
+    // Short -> Collection.
+    test.put(&user_kp, &path, &collection_post("Now curated"))
+        .await?;
+    assert_eq!(
+        find_user_counts(&user_id).await.collections,
+        1,
+        "edit into a collection increments collections"
+    );
+
+    // Collection -> Short.
+    test.put(&user_kp, &path, &short_post("never mind")).await?;
+    assert_eq!(
+        find_user_counts(&user_id).await.collections,
+        0,
+        "edit out of a collection decrements collections"
+    );
+
+    // Graph backfill agrees with the final live state.
+    let graph = UserCounts::get_from_graph(&user_id)
+        .await?
+        .expect("user counts present in graph");
+    assert_eq!(graph.collections, 0);
+
+    test.cleanup_user(&user_kp).await?;
+    Ok(())
+}
+
+/// Deleting a collection that still has relationships soft-deletes it (rewrites
+/// it as a `[DELETED]` Short via the edit path). The author's `collections` must
+/// drop by exactly one, and the kind transition must persist.
+#[tokio_shared_rt::test(shared)]
+async fn test_soft_deleting_a_bookmarked_collection_decrements_collections_once() -> Result<()> {
+    let mut test = WatcherTest::setup().await?;
+
+    let author_kp = Keypair::random();
+    let author = PubkyAppUser {
+        bio: None,
+        image: None,
+        links: None,
+        name: "Watcher:CollectionCounts:SoftDelAuthor".to_string(),
+        status: None,
+    };
+    let author_id = test.create_user(&author_kp, &author).await?;
+    let (col_id, col_path) = test
+        .create_post(&author_kp, &collection_post("Curated"))
+        .await?;
+    assert_eq!(find_user_counts(&author_id).await.collections, 1);
+
+    // A follower bookmarks it, so deleting the collection soft-deletes (keeps the
+    // node) instead of hard-deleting.
+    let follower_kp = Keypair::random();
+    let follower = PubkyAppUser {
+        bio: None,
+        image: None,
+        links: None,
+        name: "Watcher:CollectionCounts:Follower".to_string(),
+        status: None,
+    };
+    let _follower_id = test.create_user(&follower_kp, &follower).await?;
+    bookmark_post(&mut test, &follower_kp, &author_id, &col_id).await?;
+
+    test.cleanup_post(&author_kp, &col_path).await?;
+
+    assert_eq!(
+        find_user_counts(&author_id).await.collections,
+        0,
+        "soft-deleting the collection decrements collections exactly once"
+    );
+    // The post survives as a soft-deleted Short placeholder.
+    let details = PostDetails::get_by_id(&author_id, &col_id)
+        .await?
+        .expect("soft-deleted placeholder still present");
+    assert_eq!(details.kind, PubkyAppPostKind::Short);
+    assert_eq!(details.content, "[DELETED]");
+
+    test.cleanup_user(&author_kp).await?;
+    test.cleanup_user(&follower_kp).await?;
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_bookmarking_a_collection_is_excluded_from_bookmarks() -> Result<()> {
+    let mut test = WatcherTest::setup().await?;
+
+    let user_kp = Keypair::random();
+    let user = PubkyAppUser {
+        bio: None,
+        image: None,
+        links: None,
+        name: "Watcher:CollectionCounts:Bookmark".to_string(),
+        status: None,
+    };
+    let user_id = test.create_user(&user_kp, &user).await?;
+
+    let (short_id, _short_path) = test.create_post(&user_kp, &short_post("plain")).await?;
+    let (col_id, _col_path) = test
+        .create_post(&user_kp, &collection_post("Followed"))
+        .await?;
+
+    bookmark_post(&mut test, &user_kp, &user_id, &short_id).await?; // real bookmark: counts
+    bookmark_post(&mut test, &user_kp, &user_id, &col_id).await?; // collection-follow: excluded
+
+    let counts = find_user_counts(&user_id).await;
+    assert_eq!(
+        counts.bookmarks, 1,
+        "only the real post bookmark counts, not the collection-follow"
+    );
+
+    let graph_counts = UserCounts::get_from_graph(&user_id)
+        .await?
+        .expect("user counts present in graph");
+    assert_eq!(graph_counts.bookmarks, 1);
+
+    test.cleanup_user(&user_kp).await?;
+    Ok(())
+}

--- a/nexus-watcher/tests/event_processor/posts/mod.rs
+++ b/nexus-watcher/tests/event_processor/posts/mod.rs
@@ -1,4 +1,5 @@
 mod attachments;
+mod collection_counts;
 mod del_reply_notification;
 mod del_reply_parent_notification;
 mod forwards_compat;

--- a/nexus-webapi/tests/user/views.rs
+++ b/nexus-webapi/tests/user/views.rs
@@ -125,10 +125,35 @@ async fn test_get_counts() -> Result<()> {
     assert_eq!(res["friends"], 6);
     assert!(res["bookmarks"].is_number());
     assert_eq!(res["bookmarks"], 14);
+    assert!(res["collections"].is_number());
+    assert_eq!(res["collections"], 0, "user authored no collections");
 
     // Test non-existing user
     let user_id = "bad_user_id";
     invalid_get_request(&format!("/v0/user/{user_id}/counts"), StatusCode::NOT_FOUND).await?;
+
+    Ok(())
+}
+
+/// Counts derived from the seed in `docker/test-graph/mocks/posts.cypher`.
+#[tokio_shared_rt::test(shared)]
+async fn test_user_counts_collections_and_bookmark_exclusion() -> Result<()> {
+    let bogota = "ep441mndnsjeesenwz78r9paepm6e4kqm4ggiyy9uzpoe43eu9ny";
+    let res = get_request(&format!("/v0/user/{bogota}/counts")).await?;
+    assert_eq!(res["collections"], 4, "Bogota authored 4 collections");
+
+    let cairo = "f5tcy5gtgzshipr6pag6cn9uski3s8tjare7wd3n7enmyokgjk1o";
+    let res = get_request(&format!("/v0/user/{cairo}/counts")).await?;
+    assert_eq!(res["collections"], 1, "Cairo authored 1 collection");
+
+    // Eixample bookmarks one normal post and one collection.
+    let eixample = "8attbeo9ftu5nztqkcfw3gydksehr7jbspgfi64u4h8eo5e7dbiy";
+    let res = get_request(&format!("/v0/user/{eixample}/counts")).await?;
+    assert_eq!(
+        res["bookmarks"], 1,
+        "collection-follow excluded from bookmarks"
+    );
+    assert_eq!(res["collections"], 0, "Eixample authored no collections");
 
     Ok(())
 }


### PR DESCRIPTION
fixes #930

### Known limitation: counts keyed on a target's mutable kind

`collections` counts a user's authored posts by kind, and `bookmarks` excludes bookmarks whose target is a collection. Both the live counters and the Cypher backfill read the target's current kind, so a bookmarked post that crosses the collection boundary can make the live `bookmarks` counter drift from the graph.

A post's kind can change two ways: an edit (the client does not expose this), and soft-delete, which rewrites a still-referenced deleted post as a `[DELETED]` post with kind `Short`. So deleting a followed (bookmarked) collection flips its kind to `Short`. The follow was suppressed from `bookmarks` at PUT, but the later un-follow is evaluated against the now-`Short` kind, so it can decrement a value that was never incremented. The counter is floored at 0 (no negative value, no failed read), so the worst case is a bounded undercount for that user. Other users' counters are likewise not repaired when a post they bookmarked changes kind (that would require scanning every bookmarker on each edit).

There is no automatic reindex, so this does not self-heal; a manual reindex recomputes the counts from the graph. The author's own `collections` counter is kept correct live across both edit and delete. This is a property of any live counter keyed on a target's mutable state, not specific to collections.

Accepted and documented rather than fixed: the trigger is narrow and the impact is a bounded, non-crashing undercount that a reindex corrects.
