### PR TITLE
fix: build key-based event processor without Redis homeserver lookup

### DIFF
--- a/nexus-watcher/src/service/indexer/key_based.rs
+++ b/nexus-watcher/src/service/indexer/key_based.rs
@@ -4,9 +4,10 @@ use crate::errors::EventProcessorError;
 use crate::events::Event;
 use futures::StreamExt;
 use nexus_common::db::PubkyConnector;
-use nexus_common::models::homeserver::{Homeserver, HsBlacklist};
+use nexus_common::models::homeserver::HsBlacklist;
 use nexus_common::models::user::UserHsCursor;
 use pubky::{Event as StreamEvent, EventCursor, PublicKey};
+use pubky_app_specs::PubkyId;
 use tokio::sync::watch::Receiver;
 use tracing::{debug, error, info, warn};
 
@@ -65,7 +66,7 @@ impl KeyBasedEventSource for PubkyKeyBasedEventSource {
 /// Event processor for non-default HSs, where the user-specific `/events-stream` endpoint is used
 pub struct KeyBasedEventProcessor {
     /// The HS endpoint this processor fetches events from
-    pub homeserver: Homeserver,
+    pub homeserver_id: PubkyId,
 
     /// Max events the homeserver will send before closing the stream.
     /// Bounds execution time per user, preventing timeout and starvation.
@@ -98,7 +99,7 @@ impl TEventProcessor for KeyBasedEventProcessor {
     }
 
     fn instance_name(&self) -> String {
-        format!("KeyBasedEventProcessor with HS ID: {}", self.homeserver.id)
+        format!("KeyBasedEventProcessor with HS ID: {}", self.homeserver_id)
     }
 
     fn retry_scheduler(&self) -> Option<&Arc<RetryScheduler>> {
@@ -106,11 +107,11 @@ impl TEventProcessor for KeyBasedEventProcessor {
     }
 
     fn homeserver_id(&self) -> Option<&str> {
-        Some(self.homeserver.id.as_ref())
+        Some(self.homeserver_id.as_ref())
     }
 
     async fn run_internal(self: Arc<Self>) -> Result<(), EventProcessorError> {
-        let hs_id = self.homeserver.id.to_string();
+        let hs_id = self.homeserver_id.to_string();
 
         // Blacklisted HSs must never be indexed. The runner already excludes
         // them from `pre_run`, so reaching here is unexpected.
@@ -119,7 +120,7 @@ impl TEventProcessor for KeyBasedEventProcessor {
             return Err(EventProcessorError::HsBlacklisted { hs_id });
         }
 
-        let hs_pk = self.homeserver.id.to_public_key();
+        let hs_pk = self.homeserver_id.to_public_key();
 
         let users = self
             .resolve_users_with_cursors(&hs_id)

--- a/nexus-watcher/src/service/runner/key_based.rs
+++ b/nexus-watcher/src/service/runner/key_based.rs
@@ -89,12 +89,9 @@ impl TEventProcessorRunner for KeyBasedEventProcessorRunner {
 
     async fn build(&self, hs_id: &str) -> Result<Arc<dyn TEventProcessor>, DynError> {
         let homeserver_id = PubkyId::try_from(hs_id)?;
-        let homeserver = Homeserver::get_by_id(homeserver_id)
-            .await?
-            .ok_or("Homeserver not found")?;
 
         Ok(Arc::new(KeyBasedEventProcessor {
-            homeserver,
+            homeserver: Homeserver::new(homeserver_id),
             limit: self.limit,
             files_path: self.files_path.clone(),
             event_handler: self.event_handler.clone(),

--- a/nexus-watcher/src/service/runner/key_based.rs
+++ b/nexus-watcher/src/service/runner/key_based.rs
@@ -91,7 +91,7 @@ impl TEventProcessorRunner for KeyBasedEventProcessorRunner {
         let homeserver_id = PubkyId::try_from(hs_id)?;
 
         Ok(Arc::new(KeyBasedEventProcessor {
-            homeserver: Homeserver::new(homeserver_id),
+            homeserver_id,
             limit: self.limit,
             files_path: self.files_path.clone(),
             event_handler: self.event_handler.clone(),

--- a/nexus-watcher/tests/service/key_based_event_processor.rs
+++ b/nexus-watcher/tests/service/key_based_event_processor.rs
@@ -773,7 +773,7 @@ fn processor_with_options(
     hs_blacklist: HsBlacklist,
 ) -> Arc<KeyBasedEventProcessor> {
     Arc::new(KeyBasedEventProcessor {
-        homeserver,
+        homeserver_id: homeserver.id,
         limit,
         files_path: PathBuf::from("/tmp/nexus-watcher-test"),
         event_handler: handler,


### PR DESCRIPTION
# Pre-submission Checklist

- [ ] I manually reviewed the PR
- [ ] I asked one or more LLMs to review the PR
- [ ] I asked one or more LLMs to check if this PR can be simplified [^1]
- [ ] If appropriate, I added tests for the changes in this PR
- [ ] If appropriate, I added performance benchmarks for the APIs added in this PR [^2]

[^1]: Sample prompt: "Can this be simplified? Can the code, comments, or logic introduced by these changes be simplfied, clarified or otherwise made more terse, concise and understandable, without affecting functionality?"
[^2]: `cargo bench -p nexus-webapi`
