### PR TITLE
fix: keybased processor enforces events fetch cap

### DIFF
--- a/nexus-watcher/src/events/fetch.rs
+++ b/nexus-watcher/src/events/fetch.rs
@@ -1,6 +1,29 @@
+use std::sync::LazyLock;
+
 use futures::StreamExt;
+use opentelemetry::metrics::Counter;
+use opentelemetry::{global, KeyValue};
 
 use crate::EventProcessorError;
+
+/// OpenTelemetry meter name for all watcher metrics.
+const METER_NAME: &str = "nexus.watcher";
+
+/// Counter for events permanently rejected for exceeding a fetch size limit.
+///
+/// Shared by every event-fetch path (`/events` polling and per-user
+/// `/events-stream` consumption) so size rejections are reported uniformly.
+static REJECTED: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    global::meter(METER_NAME)
+        .u64_counter("watcher.fetch.rejected")
+        .with_description("Event fetches rejected for exceeding a size limit")
+        .build()
+});
+
+/// Records a single fetch rejected for exceeding a size limit.
+pub(crate) fn record_fetch_size_rejected() {
+    REJECTED.add(1, &[KeyValue::new("reason", "size_exceeded")]);
+}
 
 /// Max bytes to read from an error response body.
 pub(crate) const MAX_ERROR_BODY: usize = 4 * 1024;

--- a/nexus-watcher/src/events/mod.rs
+++ b/nexus-watcher/src/events/mod.rs
@@ -16,8 +16,8 @@ mod moderation;
 pub mod retry;
 
 pub(crate) use fetch::{
-    fetch_capped, format_error_body, read_stream_capped, MAX_ERROR_BODY, MAX_EVENTS_BODY,
-    MAX_RESOURCE_SIZE,
+    fetch_capped, format_error_body, read_stream_capped, record_fetch_size_rejected,
+    MAX_ERROR_BODY, MAX_EVENTS_BODY, MAX_RESOURCE_SIZE,
 };
 pub use moderation::Moderation;
 

--- a/nexus-watcher/src/service/indexer/homeserver.rs
+++ b/nexus-watcher/src/service/indexer/homeserver.rs
@@ -1,30 +1,19 @@
 use super::TEventProcessor;
 use crate::errors::EventProcessorError;
 use crate::events::retry::RetryScheduler;
-use crate::events::{read_stream_capped, Event, EventHandler, MAX_EVENTS_BODY};
+use crate::events::{
+    read_stream_capped, record_fetch_size_rejected, Event, EventHandler, MAX_EVENTS_BODY,
+};
 use nexus_common::db::{fetch_row_from_graph, queries, GraphResult, PubkyConnector};
 use nexus_common::models::homeserver::Homeserver;
-use opentelemetry::metrics::Counter;
-use opentelemetry::{global, KeyValue};
 use pubky::Method;
 use pubky_app_specs::PubkyId;
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
 use tokio::sync::watch::Receiver;
 use tokio::sync::Mutex;
 use tracing::{debug, error, info, warn};
-
-/// OpenTelemetry meter name for all watcher metrics.
-const METER_NAME: &str = "nexus.watcher";
-
-/// Counter for events permanently rejected for exceeding a fetch size limit.
-static REJECTED: LazyLock<Counter<u64>> = LazyLock::new(|| {
-    global::meter(METER_NAME)
-        .u64_counter("watcher.fetch.rejected")
-        .with_description("Event fetches rejected for exceeding a size limit")
-        .build()
-});
 
 /// A user's `HOSTED_BY` mapping, classified relative to a processor's HS.
 ///
@@ -208,7 +197,7 @@ impl HsEventProcessor {
                 .await
                 .map_err(|e| EventProcessorError::client_error(e.to_string()))?;
             if exceeded {
-                REJECTED.add(1, &[KeyValue::new("reason", "size_exceeded")]);
+                record_fetch_size_rejected();
 
                 return Err(EventProcessorError::FetchSizeExceeded(
                     buf.len() as u64,

--- a/nexus-watcher/src/service/indexer/key_based.rs
+++ b/nexus-watcher/src/service/indexer/key_based.rs
@@ -12,11 +12,25 @@ use tracing::{debug, error, info, warn};
 
 use super::TEventProcessor;
 use crate::events::retry::RetryScheduler;
-use crate::events::EventHandler;
+use crate::events::{record_fetch_size_rejected, EventHandler, MAX_EVENTS_BODY};
 use crate::service::runner::UserNotFoundBackoff;
 use crate::service::user_hs_resolver;
 
 const FETCH_EVENTS_429_BACKOFF_SECS: [u64; 3] = [1, 2, 3];
+
+/// Adds `event`'s URI size to `total`, rejecting once the running total exceeds
+/// the `MAX_EVENTS_BODY` cap `HsEventProcessor::poll_events` applies to `/events`.
+fn checked_add_event_size(total: usize, event: &StreamEvent) -> Result<usize, EventProcessorError> {
+    let next = total.saturating_add(event.resource.to_pubky_url().len());
+    if next > MAX_EVENTS_BODY {
+        record_fetch_size_rejected();
+        return Err(EventProcessorError::FetchSizeExceeded(
+            next as u64,
+            MAX_EVENTS_BODY as u64,
+        ));
+    }
+    Ok(next)
+}
 
 #[async_trait::async_trait]
 pub trait KeyBasedEventSource: Send + Sync + 'static {
@@ -53,9 +67,14 @@ impl KeyBasedEventSource for PubkyKeyBasedEventSource {
             .await
             .inspect_err(|e| error!("Failed to subscribe to event stream: {e:?}"))?;
 
+        // Bound the bytes loaded into memory: `limit` caps the event count but not
+        // their size, so reject once the cumulative URI size exceeds the cap.
         let mut events = Vec::new();
+        let mut consumed_bytes = 0usize;
         while let Some(result) = stream.next().await {
-            events.push(result?);
+            let event = result?;
+            consumed_bytes = checked_add_event_size(consumed_bytes, &event)?;
+            events.push(event);
         }
 
         Ok(events)
@@ -350,5 +369,57 @@ impl KeyBasedEventProcessor {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pubky::{EventType, Keypair, PubkyResource};
+
+    /// Builds an event whose URI is at least `uri_len` bytes long.
+    fn event_with_uri_len(uri_len: usize) -> StreamEvent {
+        let owner = Keypair::random().public_key();
+        let path = format!("/pub/{}", "a".repeat(uri_len));
+        StreamEvent {
+            event_type: EventType::Delete,
+            resource: PubkyResource::new(owner, path).expect("valid resource path"),
+            cursor: EventCursor::new(1),
+        }
+    }
+
+    #[test]
+    fn accumulates_uri_sizes() {
+        let event = event_with_uri_len(100);
+        let per_event = event.resource.to_pubky_url().len();
+
+        let after_first = checked_add_event_size(0, &event).unwrap();
+        assert_eq!(after_first, per_event);
+        assert_eq!(
+            checked_add_event_size(after_first, &event).unwrap(),
+            per_event * 2
+        );
+    }
+
+    #[test]
+    fn accepts_exactly_at_cap() {
+        let event = event_with_uri_len(100);
+        let start = MAX_EVENTS_BODY - event.resource.to_pubky_url().len();
+        assert_eq!(
+            checked_add_event_size(start, &event).unwrap(),
+            MAX_EVENTS_BODY
+        );
+    }
+
+    #[test]
+    fn rejects_over_cap() {
+        let event = event_with_uri_len(100);
+        match checked_add_event_size(MAX_EVENTS_BODY, &event) {
+            Err(EventProcessorError::FetchSizeExceeded(consumed, limit)) => {
+                assert!(consumed > MAX_EVENTS_BODY as u64);
+                assert_eq!(limit, MAX_EVENTS_BODY as u64);
+            }
+            other => panic!("expected FetchSizeExceeded, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
This PR enforces a cap on the data received from a keybased-HS's `/events-stream` endpoint , similar to https://github.com/pubky/pubky-nexus/pull/926 .

Since we only have access to the parsed events, and the only variable field in a parsed event is its URI, the logic checks that the cumulaative URI bytesizes do not exceed a limit.

---
# Pre-submission Checklist

- [x] I manually reviewed the PR
- [x] I asked one or more LLMs to review the PR
- [x] I asked one or more LLMs to check if this PR can be simplified [^1]
- [x] If appropriate, I added tests for the changes in this PR
- [ ] If appropriate, I added performance benchmarks for the APIs added in this PR [^2]

[^1]: Sample prompt: "Can this be simplified? Can the code, comments, or logic introduced by these changes be simplfied, clarified or otherwise made more terse, concise and understandable, without affecting functionality?"
[^2]: `cargo bench -p nexus-webapi`
