### PR TITLE
fix: only read limit events from `/events-stream`

### DIFF
--- a/nexus-watcher/src/service/indexer/key_based.rs
+++ b/nexus-watcher/src/service/indexer/key_based.rs
@@ -53,8 +53,18 @@ impl KeyBasedEventSource for PubkyKeyBasedEventSource {
             .await
             .inspect_err(|e| error!("Failed to subscribe to event stream: {e:?}"))?;
 
-        let mut events = Vec::new();
+        // The HS is asked for at most `limit` events, but a misbehaving one could return more
+        let limit = limit as usize;
+        let mut events = Vec::with_capacity(limit);
         while let Some(result) = stream.next().await {
+            // Read at most `limit` events. If the stream still has more, log an error and drop the rest.
+            if events.len() >= limit {
+                error!(
+                    "Event stream for user {user_pk} on HS {hs_pk} returned more than the \
+                     requested limit of {limit} events; ignoring the excess"
+                );
+                break;
+            }
             events.push(result?);
         }
 


### PR DESCRIPTION
This is an alternative implementation of #941.

It enforces the `limit` when reading from `/events-stream`, which prevents malicious external HSs from serving large amounts of data, which would then be read, loaded, parsed and processed by Nexus.

---
# Pre-submission Checklist

- [x] I manually reviewed the PR
- [x] I asked one or more LLMs to review the PR
- [x] I asked one or more LLMs to check if this PR can be simplified [^1]
- [ ] If appropriate, I added tests for the changes in this PR
- [ ] If appropriate, I added performance benchmarks for the APIs added in this PR [^2]

[^1]: Sample prompt: "Can this be simplified? Can the code, comments, or logic introduced by these changes be simplfied, clarified or otherwise made more terse, concise and understandable, without affecting functionality?"
[^2]: `cargo bench -p nexus-webapi`
