### PR TITLE
feat: add author and tag field to post content index and search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3109,6 +3109,7 @@ dependencies = [
  "pubky-testnet",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/nexus-common/src/db/kv/index/search.rs
+++ b/nexus-common/src/db/kv/index/search.rs
@@ -15,18 +15,14 @@ fn ft_search_timeout_ms() -> usize {
     *FT_SEARCH_TIMEOUT.get().unwrap_or(&FT_SEARCH_TIMEOUT_MS)
 }
 
-/// Creates a RediSearch JSON index with a single TEXT field.
-/// Idempotent: treats any error containing "already exists" as success so concurrent callers are safe.
-pub(crate) async fn ft_create_json_text_index(
-    index_name: &str,
-    prefix: &str,
-    field_path: &str,
-    field_alias: &str,
-) -> RedisResult<()> {
+/// Creates the post content index: $.content TEXT + $.author TAG CASESENSITIVE + $.kind TAG CASESENSITIVE.
+/// NOOFFSETS/NOHL kept; NOFIELDS dropped to allow field-targeted queries.
+/// Idempotent: short-circuits on "already exists".
+pub(crate) async fn ft_create_post_content_index(prefix: &str) -> RedisResult<()> {
     let mut conn = get_redis_conn().await?;
 
     let result = deadpool_redis::redis::cmd("FT.CREATE")
-        .arg(index_name)
+        .arg("postContentIdx")
         .arg("ON")
         .arg("JSON")
         .arg("PREFIX")
@@ -34,12 +30,21 @@ pub(crate) async fn ft_create_json_text_index(
         .arg(prefix)
         .arg("NOOFFSETS")
         .arg("NOHL")
-        .arg("NOFIELDS")
         .arg("SCHEMA")
-        .arg(field_path)
+        .arg("$.content")
         .arg("AS")
-        .arg(field_alias)
+        .arg("content")
         .arg("TEXT")
+        .arg("$.author")
+        .arg("AS")
+        .arg("author")
+        .arg("TAG")
+        .arg("CASESENSITIVE")
+        .arg("$.kind")
+        .arg("AS")
+        .arg("kind")
+        .arg("TAG")
+        .arg("CASESENSITIVE")
         .query_async::<()>(&mut conn)
         .await;
 
@@ -50,24 +55,76 @@ pub(crate) async fn ft_create_json_text_index(
     }
 }
 
-/// Full-text search returning `(redis_key, score)` pairs ordered by relevance.
-/// Keys are returned as-is (including any Redis prefix); the caller strips the prefix.
-pub(crate) async fn ft_search_scored(
-    index_name: &str,
-    query: &str,
-    skip: usize,
-    limit: usize,
-) -> RedisResult<Vec<(String, f64)>> {
-    let sanitized = sanitize_query(query);
+/// Drops the post content index without deleting the underlying documents.
+/// Idempotent: swallows "Unknown index name" so repeated calls are safe.
+pub(crate) async fn drop_post_content_index() -> RedisResult<()> {
+    let mut conn = get_redis_conn().await?;
+
+    let result = deadpool_redis::redis::cmd("FT.DROPINDEX")
+        .arg("postContentIdx")
+        .query_async::<()>(&mut conn)
+        .await;
+
+    match result {
+        Ok(()) => Ok(()),
+        Err(e) if e.to_string().contains("Unknown index name") => Ok(()),
+        Err(e) => Err(RedisError::CommandFailed(e.to_string().into())),
+    }
+}
+
+/// Assembles the RediSearch query string from a content fragment, optional author
+/// filter, and optional kind filter.
+///
+/// * The **content** half runs through `sanitize_query` → `fuzzy_token` as before.
+/// * The **author** half is assembled raw as `@author:{<id>}` and must NOT pass
+///   through `sanitize_query` (which would turn `@` and `{` into spaces) or
+///   `fuzzy_token` (which would %-escape the author id).
+/// * The **kind** half is assembled raw as `@kind:{<kind>}` — the kind value is
+///   the serde-serialized enum variant (e.g. "short", "long").
+///
+/// Returns `None` when the content half is empty — author/kind filters alone
+/// must not degenerate into listing endpoints.
+fn build_ft_query(content: &str, author: Option<&str>, kind: Option<&str>) -> Option<String> {
+    let sanitized = sanitize_query(content);
     if sanitized.is_empty() {
-        return Ok(vec![]);
+        return None;
     }
 
-    let ft_query = sanitized
+    let fuzzy = sanitized
         .split_whitespace()
         .map(fuzzy_token)
         .collect::<Vec<_>>()
         .join(" ");
+
+    let mut parts = Vec::with_capacity(3);
+    if let Some(a) = author {
+        parts.push(format!("@author:{{{a}}}"));
+    }
+    if let Some(k) = kind {
+        parts.push(format!("@kind:{{{k}}}"));
+    }
+    parts.push(fuzzy);
+
+    Some(parts.join(" "))
+}
+
+/// Full-text search returning `(redis_key, score)` pairs ordered by relevance.
+/// Keys are returned as-is (including any Redis prefix); the caller strips the prefix.
+///
+/// When `author` is `Some`, results are scoped to posts by that author.
+/// When `kind` is `Some`, results are further filtered to that post kind.
+pub(crate) async fn ft_search_scored(
+    index_name: &str,
+    query: &str,
+    author: Option<&str>,
+    kind: Option<&str>,
+    skip: usize,
+    limit: usize,
+) -> RedisResult<Vec<(String, f64)>> {
+    let ft_query = match build_ft_query(query, author, kind) {
+        Some(q) => q,
+        None => return Ok(vec![]),
+    };
 
     let mut conn = get_redis_conn().await?;
 
@@ -166,7 +223,7 @@ fn parse_ft_search_response(raw: deadpool_redis::redis::Value) -> RedisResult<Ve
 
 #[cfg(test)]
 mod tests {
-    use super::sanitize_query;
+    use super::{build_ft_query, sanitize_query};
 
     #[test]
     fn punctuation_becomes_separator_not_glue() {
@@ -189,5 +246,85 @@ mod tests {
     #[test]
     fn only_punctuation_becomes_empty() {
         assert_eq!(sanitize_query("!!!"), "");
+    }
+
+    // -----------------------------------------------------------------------
+    // build_ft_query: brace escaping and sanitize-bypass correctness tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn author_none_produces_content_only() {
+        let q = build_ft_query("hello world", None, None);
+        // Two tokens ≥ 5 chars → fuzzy distance 1 → %hello% %world%
+        assert_eq!(q.as_deref(), Some("%hello% %world%"));
+    }
+
+    #[test]
+    fn author_some_appends_braced_tag_filter() {
+        let q = build_ft_query("hello", Some("user123"), None);
+        // @author:{user123} must use double-{{ }} to produce single braces.
+        // "hello" (5 chars) → %hello%
+        assert_eq!(q.as_deref(), Some("@author:{user123} %hello%"));
+    }
+
+    #[test]
+    fn author_only_empty_content_returns_none() {
+        // Scoped search with empty content → None, not an author listing.
+        // If this returned Some("@author:{alice}"), it would act as an
+        // unbounded author-listing endpoint rather than a search.
+        let q = build_ft_query("", Some("alice"), None);
+        assert!(q.is_none());
+    }
+
+    #[test]
+    fn author_only_all_punctuation_returns_none() {
+        // q=".." passes PostSearchQuery validation (2 chars, 1 term) but
+        // sanitize_query strips to empty. Must not become an author listing.
+        let q = build_ft_query("..", Some("alice"), None);
+        assert!(q.is_none());
+    }
+
+    #[test]
+    fn both_empty_returns_none() {
+        let q = build_ft_query("", None, None);
+        assert!(q.is_none());
+    }
+
+    #[test]
+    fn author_braces_are_not_sanitized() {
+        // CRITICAL: if the author clause ever routes through sanitize_query,
+        // "@author:{alice}" becomes "author alice" and the query degrades to garbage.
+        // This test asserts the braces survive intact.
+        let q = build_ft_query("test", Some("alice"), None);
+        assert!(
+            q.as_deref().map(|s| s.contains('@')).unwrap_or(false),
+            "author clause must contain @"
+        );
+        assert!(
+            q.as_deref().map(|s| s.contains('{')).unwrap_or(false),
+            "author clause must contain open brace"
+        );
+        assert!(
+            q.as_deref().map(|s| s.contains('}')).unwrap_or(false),
+            "author clause must contain close brace"
+        );
+    }
+
+    #[test]
+    fn kind_some_appends_braced_tag_filter() {
+        let q = build_ft_query("hello", None, Some("short"));
+        assert_eq!(q.as_deref(), Some("@kind:{short} %hello%"));
+    }
+
+    #[test]
+    fn author_and_kind_both_set() {
+        let q = build_ft_query("hello", Some("user123"), Some("long"));
+        assert_eq!(q.as_deref(), Some("@author:{user123} @kind:{long} %hello%"));
+    }
+
+    #[test]
+    fn kind_only_empty_content_returns_none() {
+        let q = build_ft_query("", None, Some("short"));
+        assert!(q.is_none());
     }
 }

--- a/nexus-common/src/db/kv/index/search.rs
+++ b/nexus-common/src/db/kv/index/search.rs
@@ -67,13 +67,14 @@ pub(crate) async fn drop_post_content_index() -> RedisResult<()> {
 
     match result {
         Ok(()) => Ok(()),
-        Err(e)
-            if e.to_string().contains("Unknown index name")
-                || e.to_string().contains("no such index") =>
-        {
-            Ok(())
+        Err(e) => {
+            let msg = e.to_string().to_lowercase();
+            if msg.contains("unknown index name") || msg.contains("no such index") {
+                Ok(())
+            } else {
+                Err(RedisError::CommandFailed(e.to_string().into()))
+            }
         }
-        Err(e) => Err(RedisError::CommandFailed(e.to_string().into())),
     }
 }
 

--- a/nexus-common/src/db/kv/index/search.rs
+++ b/nexus-common/src/db/kv/index/search.rs
@@ -108,13 +108,12 @@ fn build_ft_query(content: &str, author: Option<&str>, kind: Option<&str>) -> Op
     Some(parts.join(" "))
 }
 
-/// Full-text search returning `(redis_key, score)` pairs ordered by relevance.
+/// Full-text search on `postContentIdx` returning `(redis_key, score)` pairs ordered by relevance.
 /// Keys are returned as-is (including any Redis prefix); the caller strips the prefix.
 ///
 /// When `author` is `Some`, results are scoped to posts by that author.
 /// When `kind` is `Some`, results are further filtered to that post kind.
 pub(crate) async fn ft_search_scored(
-    index_name: &str,
     query: &str,
     author: Option<&str>,
     kind: Option<&str>,
@@ -129,7 +128,7 @@ pub(crate) async fn ft_search_scored(
     let mut conn = get_redis_conn().await?;
 
     let raw: deadpool_redis::redis::Value = deadpool_redis::redis::cmd("FT.SEARCH")
-        .arg(index_name)
+        .arg("postContentIdx")
         .arg(&ft_query)
         .arg("NOCONTENT")
         .arg("WITHSCORES")

--- a/nexus-common/src/db/kv/index/search.rs
+++ b/nexus-common/src/db/kv/index/search.rs
@@ -67,7 +67,12 @@ pub(crate) async fn drop_post_content_index() -> RedisResult<()> {
 
     match result {
         Ok(()) => Ok(()),
-        Err(e) if e.to_string().contains("Unknown index name") => Ok(()),
+        Err(e)
+            if e.to_string().contains("Unknown index name")
+                || e.to_string().contains("no such index") =>
+        {
+            Ok(())
+        }
         Err(e) => Err(RedisError::CommandFailed(e.to_string().into())),
     }
 }

--- a/nexus-common/src/models/post/mod.rs
+++ b/nexus-common/src/models/post/mod.rs
@@ -11,7 +11,7 @@ pub use bookmark::Bookmark;
 pub use counts::PostCounts;
 pub use details::PostDetails;
 pub use relationships::PostRelationships;
-pub use search::{create_post_content_index, PostsByContentSearch};
+pub use search::{create_post_content_index, drop_post_content_index, PostsByContentSearch};
 pub use stream::{
     PostKeyStream, PostStream, StreamSource, POST_PER_USER_KEY_PARTS,
     POST_REPLIES_PER_POST_KEY_PARTS, POST_REPLIES_PER_USER_KEY_PARTS, POST_TIMELINE_KEY_PARTS,

--- a/nexus-common/src/models/post/search.rs
+++ b/nexus-common/src/models/post/search.rs
@@ -150,12 +150,21 @@ impl PostsByTagSearch {
 
 const POST_CONTENT_INDEX: &str = "postContentIdx";
 
-/// Creates the RediSearch full-text index over PostDetails JSON documents.
+/// Creates the post content full-text index: $.content TEXT + $.author TAG CASESENSITIVE + $.kind TAG CASESENSITIVE.
+/// Includes NOOFFSETS/NOHL; NOFIELDS dropped to allow field-targeted queries.
 /// Idempotent: no-ops if the index already exists.
 pub async fn create_post_content_index() -> RedisResult<()> {
     let prefix = format!("{}:", PostDetails::prefix().await);
-    search::ft_create_json_text_index(POST_CONTENT_INDEX, &prefix, "$.content", "content").await?;
+    search::ft_create_post_content_index(&prefix).await?;
     info!("RediSearch index '{POST_CONTENT_INDEX}' created or already exists");
+    Ok(())
+}
+
+/// Drops the post content index without deleting underlying JSON documents.
+/// Idempotent: swallows "Unknown index name" errors.
+pub async fn drop_post_content_index() -> RedisResult<()> {
+    search::drop_post_content_index().await?;
+    info!("RediSearch index '{POST_CONTENT_INDEX}' dropped or already absent");
     Ok(())
 }
 
@@ -169,11 +178,14 @@ pub struct PostsByContentSearch {
 impl PostsByContentSearch {
     pub async fn search(
         query: &str,
+        author: Option<&str>,
+        kind: Option<&str>,
         skip: usize,
         limit: usize,
     ) -> RedisResult<Vec<PostsByContentSearch>> {
         let prefix = format!("{}:", PostDetails::prefix().await);
-        let pairs = search::ft_search_scored(POST_CONTENT_INDEX, query, skip, limit).await?;
+        let pairs =
+            search::ft_search_scored(POST_CONTENT_INDEX, query, author, kind, skip, limit).await?;
         Ok(pairs
             .into_iter()
             .filter_map(|(key, score)| {

--- a/nexus-common/src/models/post/search.rs
+++ b/nexus-common/src/models/post/search.rs
@@ -184,8 +184,7 @@ impl PostsByContentSearch {
         limit: usize,
     ) -> RedisResult<Vec<PostsByContentSearch>> {
         let prefix = format!("{}:", PostDetails::prefix().await);
-        let pairs =
-            search::ft_search_scored(POST_CONTENT_INDEX, query, author, kind, skip, limit).await?;
+        let pairs = search::ft_search_scored(query, author, kind, skip, limit).await?;
         Ok(pairs
             .into_iter()
             .filter_map(|(key, score)| {

--- a/nexus-webapi/Cargo.toml
+++ b/nexus-webapi/Cargo.toml
@@ -39,6 +39,7 @@ anyhow = { workspace = true }
 criterion = { version = "0.8", features = ["async_tokio"] }
 httpc-test = "0.1.10"
 pubky-testnet = { workspace = true }
+serde_urlencoded = "0.7"
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 tokio-shared-rt = { workspace = true }

--- a/nexus-webapi/benches/search.rs
+++ b/nexus-webapi/benches/search.rs
@@ -114,7 +114,9 @@ fn bench_post_content_search(c: &mut Criterion) {
             query,
             |b, &query| {
                 b.to_async(&rt).iter(|| async {
-                    let result = PostsByContentSearch::search(query, 0, 20).await.unwrap();
+                    let result = PostsByContentSearch::search(query, None, None, 0, 20)
+                        .await
+                        .unwrap();
                     std::hint::black_box(result);
                 });
             },

--- a/nexus-webapi/src/models/mod.rs
+++ b/nexus-webapi/src/models/mod.rs
@@ -28,7 +28,7 @@ pub use global_post_id::{GlobalPostId, GlobalPostIds};
 pub use info::ServerInfo;
 pub use post::{PostStreamDetailed, PostViewDetailed};
 pub use post_search_query::PostSearchQuery;
-pub use pubky_app_specs::PubkyId;
+pub use pubky_app_specs::{PubkyAppPostKind, PubkyId};
 pub use resource_id::ResourceId;
 pub use tag_label::TagLabel;
 pub use user_id_prefix::UserIdPrefix;

--- a/nexus-webapi/src/routes/v0/search/posts.rs
+++ b/nexus-webapi/src/routes/v0/search/posts.rs
@@ -1,4 +1,7 @@
-use crate::models::{BoundedLimit, BoundedPagination, BoundedSkip, PostSearchQuery, TagLabel};
+use crate::models::{
+    BoundedLimit, BoundedPagination, BoundedSkip, PostSearchQuery, PubkyAppPostKind, PubkyId,
+    TagLabel,
+};
 use crate::routes::v0::endpoints::{SEARCH_POSTS_BY_CONTENT_ROUTE, SEARCH_POSTS_BY_TAG_ROUTE};
 use crate::routes::{Path, Query};
 use crate::Result;
@@ -60,6 +63,8 @@ pub async fn search_posts_by_tag_handler(
 #[derive(Deserialize)]
 pub struct SearchPostsByContentQuery {
     pub q: PostSearchQuery,
+    pub author: Option<PubkyId>,
+    pub kind: Option<PubkyAppPostKind>,
     #[serde(flatten)]
     pub pagination: BoundedPagination<1000, 20, 100>,
 }
@@ -71,6 +76,8 @@ pub struct SearchPostsByContentQuery {
     tag = "Search",
     params(
         ("q" = PostSearchQuery, Query, description = "Search query (2–30 characters, up to 4 terms)"),
+        ("author" = Option<PubkyId>, Query, description = "Optional author Pubky ID to scope results"),
+        ("kind" = Option<PubkyAppPostKind>, Query, description = "Optional post kind to filter by: short, long, image, video, link, file, collection"),
         ("skip" = Option<BoundedSkip<1000>>, Query, description = "Skip N results (max 1000)"),
         ("limit" = Option<BoundedLimit<20, 100>>, Query, description = "Limit the number of results (1–100, default 20)")
     ),
@@ -87,17 +94,73 @@ pub async fn search_posts_by_content_handler(
     let limit = query.pagination.limit_value();
 
     debug!(
-        "GET {SEARCH_POSTS_BY_CONTENT_ROUTE} q:{}, skip:{skip}, limit:{limit}",
-        query.q
+        "GET {SEARCH_POSTS_BY_CONTENT_ROUTE} q:{}, author:{:?}, kind:{:?}, skip:{skip}, limit:{limit}",
+        query.q, query.author, query.kind
     );
 
-    let results = PostsByContentSearch::search(query.q.as_str(), skip, limit).await?;
+    let kind_str = query.kind.as_ref().map(|k| k.to_string());
+
+    let results = PostsByContentSearch::search(
+        query.q.as_str(),
+        query.author.as_deref(),
+        kind_str.as_deref(),
+        skip,
+        limit,
+    )
+    .await?;
     Ok(Json(results))
 }
 
 #[derive(OpenApi)]
 #[openapi(
     paths(search_posts_by_tag_handler, search_posts_by_content_handler),
-    components(schemas(PostsByTagSearch, PostsByContentSearch, PostSearchQuery))
+    components(schemas(
+        PostsByTagSearch,
+        PostsByContentSearch,
+        PostSearchQuery,
+        PubkyAppPostKind
+    ))
 )]
 pub struct SearchPostsApiDocs;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_query(
+        s: &str,
+    ) -> std::result::Result<SearchPostsByContentQuery, serde_urlencoded::de::Error> {
+        serde_urlencoded::from_str(s)
+    }
+
+    #[test]
+    fn author_missing_parses_unscoped() {
+        let q = parse_query("q=bitcoin").expect("valid query must parse");
+        assert!(q.author.is_none());
+        assert!(q.kind.is_none());
+    }
+
+    #[test]
+    fn author_invalid_format_rejected() {
+        assert!(parse_query("q=bitcoin&author=not-a-pubky").is_err());
+    }
+
+    #[test]
+    fn kind_missing_parses_unscoped() {
+        let q = parse_query("q=bitcoin").expect("valid query must parse");
+        assert!(q.kind.is_none());
+    }
+
+    #[test]
+    fn kind_valid_short_accepted() {
+        let q = parse_query("q=bitcoin&kind=short").expect("valid kind must parse");
+        assert_eq!(q.kind, Some(PubkyAppPostKind::Short));
+    }
+
+    #[test]
+    fn kind_unknown_parses_as_unknown() {
+        let q =
+            parse_query("q=bitcoin&kind=not-a-kind").expect("lenient kind parsing must not error");
+        assert_eq!(q.kind, Some(PubkyAppPostKind::Unknown));
+    }
+}

--- a/nexus-webapi/tests/post/search.rs
+++ b/nexus-webapi/tests/post/search.rs
@@ -266,6 +266,149 @@ async fn test_content_search_skip_over_max_rejected() -> Result<()> {
     Ok(())
 }
 
+// ── Content-search author-scoping tests ──────────────────────────────────────
+
+// detroit: authored "Open-source solutions build trusty" and "Open-source enables security auditing..."
+const DETROIT_USER: &str = "7w4hmktqa7gia5thmk7zki8px7ttwpwjtgaaaou4tbqx64re8d1o";
+
+#[tokio_shared_rt::test(shared)]
+async fn test_content_search_without_author_returns_multiple_authors() -> Result<()> {
+    // "open" matches all "Open-source …" posts authored by amsterdam, bogota, detroit, and cairo.
+    let url = format!("{SEARCH_POSTS_BY_CONTENT_ROUTE}?q=open&limit=100");
+    let body = get_request(&url).await?;
+    let results = body.as_array().expect("should be array");
+
+    let authors: std::collections::HashSet<&str> = results
+        .iter()
+        .filter_map(|r| r["post_key"].as_str()?.split(':').next())
+        .collect();
+
+    assert!(
+        authors.len() > 1,
+        "unscoped search for 'open' should return posts from more than one author, got: {:?}",
+        authors
+    );
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_content_search_with_author_scopes_to_that_author() -> Result<()> {
+    // Same query but scoped to DETROIT_USER — every result must belong to that author.
+    let url = format!("{SEARCH_POSTS_BY_CONTENT_ROUTE}?q=open&author={DETROIT_USER}&limit=100");
+    let body = get_request(&url).await?;
+    let results = body.as_array().expect("should be array");
+
+    assert!(
+        !results.is_empty(),
+        "author-scoped search for 'open' by detroit should return at least one result"
+    );
+    for r in results {
+        let post_key = r["post_key"].as_str().expect("post_key must be a string");
+        let author = post_key.split(':').next().unwrap_or("");
+        assert_eq!(
+            author, DETROIT_USER,
+            "post_key '{post_key}' does not belong to the expected author"
+        );
+    }
+    Ok(())
+}
+
+// ── Content-search kind-scoping tests ─────────────────────────────────────────
+
+// Seed data: searching "post" matches content across multiple kinds:
+//  long   → "Long post, article A–H"   (4ZCW1TGL5BKG1–8, authored by amsterdam)
+//  image  → "IMAGE post, SVG A–H"      (5YCW1TGL5BKG1–8, authored by amsterdam)
+//  video  → "VIDEO post, mkv A–H"      (MLOW1TGL5BKH1–8, authored by detroit/eixample)
+//  file   → "FILE post, pdf A–H"       (GJMW1TGL5BKG1–8, authored by bogota/cairo/eixample)
+//  link   → "LINK post, pubky A–H"     (SIJW1TGL5BKG1–9, authored by bogota/cairo/eixample)
+// Short posts and collection posts do NOT contain the word "post" in their content.
+
+#[tokio_shared_rt::test(shared)]
+async fn test_content_search_with_kind_scopes_to_that_kind() -> Result<()> {
+    // Search "post" scoped to kind=video — every result's post_id must match
+    // the video post prefix from the seed (MLOW1TGL5BKH*).
+    let url = format!("{SEARCH_POSTS_BY_CONTENT_ROUTE}?q=post&kind=video&limit=100");
+    let body = get_request(&url).await?;
+    let results = body.as_array().expect("should be array");
+
+    assert!(
+        !results.is_empty(),
+        "kind-scoped search for 'post' with kind=video should return at least one result"
+    );
+
+    // Verify every result is a video-kind post (MLOW prefix in seed data).
+    for r in results.iter() {
+        let post_key = r["post_key"].as_str().expect("post_key must be a string");
+        let post_id = post_key.split(':').nth(1).unwrap_or("");
+        assert!(
+            post_id.starts_with("MLOW"),
+            "post_key '{post_key}' does not look like a video-kind post (expected MLOW prefix)"
+        );
+    }
+
+    // Verify a known non-video post containing "post" is NOT in the results.
+    // GJMW1TGL5BKG1 is a file-kind post with content "FILE post, pdf A".
+    let contains_file_post = results.iter().any(|r| {
+        r["post_key"]
+            .as_str()
+            .is_some_and(|k| k.ends_with(":GJMW1TGL5BKG1"))
+    });
+    assert!(
+        !contains_file_post,
+        "kind=video should exclude file-kind post GJMW1TGL5BKG1 ('FILE post, pdf A')"
+    );
+
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_content_search_without_kind_returns_multiple_kinds() -> Result<()> {
+    // Same query without kind filter — should return posts from more than one kind.
+    // We infer kind from the post_id prefix in the seed data:
+    //  4ZCW = long, 5YCW = image, MLOW = video, GJMW = file, SIJW = link
+    let url = format!("{SEARCH_POSTS_BY_CONTENT_ROUTE}?q=post&limit=100");
+    let body = get_request(&url).await?;
+    let results = body.as_array().expect("should be array");
+
+    assert!(
+        !results.is_empty(),
+        "unscoped search for 'post' should return at least one result"
+    );
+
+    let mut kinds: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    for r in results.iter() {
+        let post_key = match r["post_key"].as_str() {
+            Some(pk) => pk,
+            None => continue,
+        };
+        let post_id = match post_key.split(':').nth(1) {
+            Some(pid) => pid,
+            None => continue,
+        };
+        let inferred_kind = if post_id.starts_with("4ZCW") {
+            "long"
+        } else if post_id.starts_with("5YCW") {
+            "image"
+        } else if post_id.starts_with("MLOW") {
+            "video"
+        } else if post_id.starts_with("GJMW") {
+            "file"
+        } else if post_id.starts_with("SIJW") {
+            "link"
+        } else {
+            continue;
+        };
+        kinds.insert(inferred_kind);
+    }
+
+    assert!(
+        kinds.len() > 1,
+        "unscoped search for 'post' should return posts from more than one kind, got: {:?}",
+        kinds
+    );
+    Ok(())
+}
+
 fn search_posts(posts: &[Value], post_order: Vec<&str>) {
     for (index, post) in posts.iter().enumerate() {
         let post_parts: Vec<&str> = post["post_key"].as_str().unwrap().split(':').collect();

--- a/nexus-webapi/tests/post/search.rs
+++ b/nexus-webapi/tests/post/search.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use axum::http::StatusCode;
+use nexus_common::models::post::PostDetails;
 use nexus_webapi::models::ErrorResponsePayload;
 use nexus_webapi::routes::v0::endpoints::{
     SEARCH_POSTS_BY_CONTENT_ROUTE, SEARCH_POSTS_BY_TAG_ROUTE,
@@ -340,12 +341,14 @@ async fn test_content_search_with_kind_scopes_to_that_kind() -> Result<()> {
         let (author, post_id) = post_key
             .split_once(':')
             .expect("post_key must be author:post_id");
-        let detail = get_request(&format!("/v0/post/{author}/{post_id}")).await?;
+        let details = PostDetails::get_by_id(author, post_id)
+            .await?
+            .unwrap_or_else(|| panic!("post '{post_key}' not found in index"));
         assert_eq!(
-            detail["details"]["kind"].as_str(),
-            Some("video"),
-            "post_key '{post_key}' was returned by kind=video filter but has kind={:?}",
-            detail["details"]["kind"]
+            details.kind.to_string(),
+            "video",
+            "post_key '{post_key}' was returned by kind=video filter but has kind={}",
+            details.kind,
         );
     }
 
@@ -374,9 +377,8 @@ async fn test_content_search_without_kind_returns_multiple_kinds() -> Result<()>
             Some(parts) => parts,
             None => continue,
         };
-        let detail = get_request(&format!("/v0/post/{author}/{post_id}")).await?;
-        if let Some(k) = detail["details"]["kind"].as_str() {
-            kinds.insert(k.to_string());
+        if let Some(details) = PostDetails::get_by_id(author, post_id).await? {
+            kinds.insert(details.kind.to_string());
         }
     }
 

--- a/nexus-webapi/tests/post/search.rs
+++ b/nexus-webapi/tests/post/search.rs
@@ -316,17 +316,15 @@ async fn test_content_search_with_author_scopes_to_that_author() -> Result<()> {
 // ── Content-search kind-scoping tests ─────────────────────────────────────────
 
 // Seed data: searching "post" matches content across multiple kinds:
-//  long   → "Long post, article A–H"   (4ZCW1TGL5BKG1–8, authored by amsterdam)
-//  image  → "IMAGE post, SVG A–H"      (5YCW1TGL5BKG1–8, authored by amsterdam)
-//  video  → "VIDEO post, mkv A–H"      (MLOW1TGL5BKH1–8, authored by detroit/eixample)
-//  file   → "FILE post, pdf A–H"       (GJMW1TGL5BKG1–8, authored by bogota/cairo/eixample)
-//  link   → "LINK post, pubky A–H"     (SIJW1TGL5BKG1–9, authored by bogota/cairo/eixample)
+//  long   → "Long post, article A–H"   (authored by amsterdam)
+//  image  → "IMAGE post, SVG A–H"      (authored by amsterdam)
+//  video  → "VIDEO post, mkv A–H"      (authored by detroit/eixample)
+//  file   → "FILE post, pdf A–H"       (authored by bogota/cairo/eixample)
+//  link   → "LINK post, pubky A–H"     (authored by bogota/cairo/eixample)
 // Short posts and collection posts do NOT contain the word "post" in their content.
 
 #[tokio_shared_rt::test(shared)]
 async fn test_content_search_with_kind_scopes_to_that_kind() -> Result<()> {
-    // Search "post" scoped to kind=video — every result's post_id must match
-    // the video post prefix from the seed (MLOW1TGL5BKH*).
     let url = format!("{SEARCH_POSTS_BY_CONTENT_ROUTE}?q=post&kind=video&limit=100");
     let body = get_request(&url).await?;
     let results = body.as_array().expect("should be array");
@@ -336,27 +334,20 @@ async fn test_content_search_with_kind_scopes_to_that_kind() -> Result<()> {
         "kind-scoped search for 'post' with kind=video should return at least one result"
     );
 
-    // Verify every result is a video-kind post (MLOW prefix in seed data).
+    // Verify every returned post actually has kind=video by looking up its details.
     for r in results.iter() {
         let post_key = r["post_key"].as_str().expect("post_key must be a string");
-        let post_id = post_key.split(':').nth(1).unwrap_or("");
-        assert!(
-            post_id.starts_with("MLOW"),
-            "post_key '{post_key}' does not look like a video-kind post (expected MLOW prefix)"
+        let (author, post_id) = post_key
+            .split_once(':')
+            .expect("post_key must be author:post_id");
+        let detail = get_request(&format!("/v0/post/{author}/{post_id}")).await?;
+        assert_eq!(
+            detail["details"]["kind"].as_str(),
+            Some("video"),
+            "post_key '{post_key}' was returned by kind=video filter but has kind={:?}",
+            detail["details"]["kind"]
         );
     }
-
-    // Verify a known non-video post containing "post" is NOT in the results.
-    // GJMW1TGL5BKG1 is a file-kind post with content "FILE post, pdf A".
-    let contains_file_post = results.iter().any(|r| {
-        r["post_key"]
-            .as_str()
-            .is_some_and(|k| k.ends_with(":GJMW1TGL5BKG1"))
-    });
-    assert!(
-        !contains_file_post,
-        "kind=video should exclude file-kind post GJMW1TGL5BKG1 ('FILE post, pdf A')"
-    );
 
     Ok(())
 }
@@ -364,8 +355,6 @@ async fn test_content_search_with_kind_scopes_to_that_kind() -> Result<()> {
 #[tokio_shared_rt::test(shared)]
 async fn test_content_search_without_kind_returns_multiple_kinds() -> Result<()> {
     // Same query without kind filter — should return posts from more than one kind.
-    // We infer kind from the post_id prefix in the seed data:
-    //  4ZCW = long, 5YCW = image, MLOW = video, GJMW = file, SIJW = link
     let url = format!("{SEARCH_POSTS_BY_CONTENT_ROUTE}?q=post&limit=100");
     let body = get_request(&url).await?;
     let results = body.as_array().expect("should be array");
@@ -375,30 +364,20 @@ async fn test_content_search_without_kind_returns_multiple_kinds() -> Result<()>
         "unscoped search for 'post' should return at least one result"
     );
 
-    let mut kinds: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    let mut kinds: std::collections::HashSet<String> = std::collections::HashSet::new();
     for r in results.iter() {
         let post_key = match r["post_key"].as_str() {
             Some(pk) => pk,
             None => continue,
         };
-        let post_id = match post_key.split(':').nth(1) {
-            Some(pid) => pid,
+        let (author, post_id) = match post_key.split_once(':') {
+            Some(parts) => parts,
             None => continue,
         };
-        let inferred_kind = if post_id.starts_with("4ZCW") {
-            "long"
-        } else if post_id.starts_with("5YCW") {
-            "image"
-        } else if post_id.starts_with("MLOW") {
-            "video"
-        } else if post_id.starts_with("GJMW") {
-            "file"
-        } else if post_id.starts_with("SIJW") {
-            "link"
-        } else {
-            continue;
-        };
-        kinds.insert(inferred_kind);
+        let detail = get_request(&format!("/v0/post/{author}/{post_id}")).await?;
+        if let Some(k) = detail["details"]["kind"].as_str() {
+            kinds.insert(k.to_string());
+        }
     }
 
     assert!(

--- a/nexusd/src/migrations/migrations_list/mod.rs
+++ b/nexusd/src/migrations/migrations_list/mod.rs
@@ -1,4 +1,5 @@
 // pub mod tag_counts_reset_1739459180;
+pub mod post_content_index_author_setup_1780531200;
 pub mod post_content_index_setup_1780444800;
 pub mod remove_muted_1771718400;
 pub mod resource_node_setup_1774000000;

--- a/nexusd/src/migrations/migrations_list/post_content_index_author_setup_1780531200.rs
+++ b/nexusd/src/migrations/migrations_list/post_content_index_author_setup_1780531200.rs
@@ -1,0 +1,59 @@
+/// Adds $.author TAG CASESENSITIVE + $.kind TAG CASESENSITIVE to the post content full-text index.
+///
+/// # Deployment expectation: stop → migrate → start
+///
+/// Between `drop_post_content_index` and `create_post_content_index` the
+/// index is absent, so global content search returns empty results. After
+/// FT.CREATE the PREFIX clause triggers a background scan that indexes all
+/// existing PostDetails JSON documents against the new schema — both `author`
+/// and `kind` fields are already present in every document, so no re-persistence
+/// is needed. For zero-downtime deployments, schedule this migration during a
+/// maintenance window or accept a brief gap where search is unavailable.
+use async_trait::async_trait;
+
+use crate::migrations::manager::Migration;
+use nexus_common::{
+    models::post::{create_post_content_index, drop_post_content_index},
+    types::DynError,
+};
+use tracing::info;
+
+pub struct PostContentIndexAuthorSetup1780531200;
+
+#[async_trait]
+impl Migration for PostContentIndexAuthorSetup1780531200 {
+    fn id(&self) -> &'static str {
+        "PostContentIndexAuthorSetup1780531200"
+    }
+
+    fn is_multi_staged(&self) -> bool {
+        false
+    }
+
+    async fn dual_write(_data: Box<dyn std::any::Any + Send + 'static>) -> Result<(), DynError> {
+        Ok(())
+    }
+
+    async fn backfill(&self) -> Result<(), DynError> {
+        // Drop existing index (idempotent — no-ops if already absent).
+        drop_post_content_index().await?;
+        info!("Dropped post content index for schema upgrade");
+
+        // Recreate with the new schema ($.content TEXT + $.author TAG + $.kind TAG).
+        // FT.CREATE with PREFIX triggers a background scan that indexes all existing
+        // PostDetails JSON documents against the new schema — both `author` and `kind`
+        // fields are already present in every document, so no re-persistence is needed.
+        create_post_content_index().await?;
+        info!("Recreated post content index with author and kind fields");
+
+        Ok(())
+    }
+
+    async fn cutover(&self) -> Result<(), DynError> {
+        Ok(())
+    }
+
+    async fn cleanup(&self) -> Result<(), DynError> {
+        Ok(())
+    }
+}

--- a/nexusd/src/migrations/migrations_list/post_content_index_setup_1780444800.rs
+++ b/nexusd/src/migrations/migrations_list/post_content_index_setup_1780444800.rs
@@ -1,9 +1,47 @@
 use async_trait::async_trait;
 
 use crate::migrations::manager::Migration;
-use nexus_common::{models::post::create_post_content_index, types::DynError};
+use nexus_common::{db::get_redis_conn, db::RedisOps, models::post::PostDetails, types::DynError};
+use tracing::info;
 
 pub struct PostContentIndexSetup1780444800;
+
+const POST_CONTENT_INDEX: &str = "postContentIdx";
+
+/// Creates the original v1 post content index: $.content TEXT only.
+/// Includes NOOFFSETS, NOHL, NOFIELDS optimisations.
+/// Idempotent: no-ops if the index already exists.
+async fn create_post_content_index_v1() -> Result<(), DynError> {
+    let prefix = format!("{}:", PostDetails::prefix().await);
+    let mut conn = get_redis_conn().await?;
+
+    let result = redis::cmd("FT.CREATE")
+        .arg(POST_CONTENT_INDEX)
+        .arg("ON")
+        .arg("JSON")
+        .arg("PREFIX")
+        .arg("1")
+        .arg(&prefix)
+        .arg("NOOFFSETS")
+        .arg("NOHL")
+        .arg("NOFIELDS")
+        .arg("SCHEMA")
+        .arg("$.content")
+        .arg("AS")
+        .arg("content")
+        .arg("TEXT")
+        .query_async::<()>(&mut conn)
+        .await;
+
+    match result {
+        Ok(()) => Ok(()),
+        Err(e) if e.to_string().contains("already exists") => {
+            info!("RediSearch index '{POST_CONTENT_INDEX}' already exists");
+            Ok(())
+        }
+        Err(e) => Err(e.into()),
+    }
+}
 
 #[async_trait]
 impl Migration for PostContentIndexSetup1780444800 {
@@ -20,7 +58,7 @@ impl Migration for PostContentIndexSetup1780444800 {
     }
 
     async fn backfill(&self) -> Result<(), DynError> {
-        create_post_content_index().await?;
+        create_post_content_index_v1().await?;
         Ok(())
     }
 

--- a/nexusd/src/migrations/mod.rs
+++ b/nexusd/src/migrations/mod.rs
@@ -9,6 +9,7 @@ mod utils;
 pub use builder::MigrationBuilder;
 pub use manager::MigrationManager;
 
+use crate::migrations::migrations_list::post_content_index_author_setup_1780531200::PostContentIndexAuthorSetup1780531200;
 use crate::migrations::migrations_list::post_content_index_setup_1780444800::PostContentIndexSetup1780444800;
 use crate::migrations::migrations_list::remove_muted_1771718400::RemoveMuted1771718400;
 use crate::migrations::migrations_list::resource_node_setup_1774000000::ResourceNodeSetup1774000000;
@@ -45,6 +46,7 @@ pub fn import_migrations(migration_manager: &mut MigrationManager) {
         Box::new(RemoveMuted1771718400),
         Box::new(ResourceNodeSetup1774000000),
         Box::new(PostContentIndexSetup1780444800),
+        Box::new(PostContentIndexAuthorSetup1780531200),
     ];
     for migration in migrations {
         migration_manager.register(migration);


### PR DESCRIPTION
## Author & kind filters for post content search

Adds optional `author` + `kind` params to `GET /v0/search/posts/by-content`,
scoping full-text results to a single author and/or post kind.

- `postContentIdx` gains `$.author` + `$.kind` as `TAG CASESENSITIVE`; the content
  match intersects with `@author:{}` / `@kind:{}`.
- `author`  validated `PubkyId` (400 on invalid); `kind` → `PubkyAppPostKind`,
  lenient (unknown → no match), consistent with the post-stream endpoint.
- Migration drops + recreates the index with the new schema.