### PR TITLE
fix(counts): make user_counts O(1) per field, not O(tags x posts)

### DIFF
--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -501,40 +501,26 @@ pub fn user_counts(user_id: &str) -> Query {
         "user_counts",
         "
         MATCH (u:User {id: $user_id})
-        // tags that reference this user
-        OPTIONAL MATCH (u)<-[t:TAGGED]-(:User)
-        WITH u, COUNT(DISTINCT t.label) AS unique_tags,
-
-        // Count relationships to users
-        COUNT { (u)-[:FOLLOWS]->(:User) } AS following,
-        COUNT { (:User)-[:FOLLOWS]->(u) } AS followers,
-        COUNT { (u)-[:FOLLOWS]->(friend:User) WHERE (friend)-[:FOLLOWS]->(u) } AS friends,
-
-        // Count relationships to posts
-        COUNT { (u)-[:AUTHORED]->(:Post) } AS posts,
-        COUNT { (u)-[:AUTHORED]->(:Post)-[:REPLIED]->(:Post) } AS replies,
-        COUNT { (u)-[:AUTHORED]->(p:Post) WHERE p.kind = 'collection' } AS collections,
-        // A collection-follow is stored as a bookmark; keep it out of the count.
-        COUNT { (u)-[:BOOKMARKED]->(bp:Post) WHERE (bp.kind IS NULL OR bp.kind <> 'collection') } AS bookmarks,
-
-        // Count user and post tagging
-        COUNT { (u)-[:TAGGED]->(:User) } AS user_tags,
-        COUNT { (u)-[:TAGGED]->(:Post) } AS post_tags,
-        COUNT { (:User)-[:TAGGED]->(u) } AS tags
-
+        // Each field is an independent COUNT { } subquery off the single (u) row.
+        // Do NOT precede this with a row-multiplying OPTIONAL MATCH (e.g. over
+        // received tags): that makes every subquery a per-row grouping key, so the
+        // whole block runs once per received tag, i.e. O(received_tags x authored_posts)
+        // and hangs on heavy users. See issue #935.
         RETURN
             u IS NOT NULL AS exists,
             {
-                following: following,
-                followers: followers,
-                friends: friends,
-                posts: posts,
-                replies: replies,
-                collections: collections,
-                tagged: user_tags + post_tags,
-                tags: tags,
-                unique_tags: unique_tags,
-                bookmarks: bookmarks
+                following: COUNT { (u)-[:FOLLOWS]->(:User) },
+                followers: COUNT { (:User)-[:FOLLOWS]->(u) },
+                friends: COUNT { (u)-[:FOLLOWS]->(friend:User) WHERE (friend)-[:FOLLOWS]->(u) },
+                posts: COUNT { (u)-[:AUTHORED]->(:Post) },
+                replies: COUNT { (u)-[:AUTHORED]->(:Post)-[:REPLIED]->(:Post) },
+                collections: COUNT { (u)-[:AUTHORED]->(p:Post) WHERE p.kind = 'collection' },
+                // A collection-follow is stored as a bookmark; keep it out of the count.
+                bookmarks: COUNT { (u)-[:BOOKMARKED]->(bp:Post) WHERE (bp.kind IS NULL OR bp.kind <> 'collection') },
+                // tagged = tags this user assigned to users + to posts
+                tagged: COUNT { (u)-[:TAGGED]->(:User) } + COUNT { (u)-[:TAGGED]->(:Post) },
+                tags: COUNT { (:User)-[:TAGGED]->(u) },
+                unique_tags: COUNT { MATCH (u)<-[t:TAGGED]-(:User) RETURN DISTINCT t.label }
             } AS counts;
         ",
     )


### PR DESCRIPTION
## What
`user_counts` (`nexus-common/src/db/graph/queries/get.rs`) was O(received_tags x authored_posts) and hung on heavy users.

## Why
The query opened with `OPTIONAL MATCH (u)<-[t:TAGGED]-(:User)`, fanning out one row per received tag. The following `WITH` mixed `COUNT(DISTINCT t.label)` with the `COUNT { }` subqueries, so each subquery (including the full authored-posts scan) became a grouping key and re-ran once per received tag. `post_counts` already avoided this by collapsing tags to a single row first.

## Fix
Compute every field as an independent `COUNT { }` subquery off the single `(u)` row, with no leading row-multiplying `OPTIONAL MATCH`. The `RETURN` shape is unchanged, so `UserCounts::get_from_graph` parsing is untouched, and each field's semantics are preserved.

## Repro (authored posts fixed at 6k, varying received tags T)
| T | before | after |
|----|--------|-------|
| 0  | 3.7s   | 3.7s  |
| 2k | 29s    | 3.3s  |
| 4k | 53s    | 3.1s  |
| 8k | 128s   | 3.8s  |

Before scales linearly with received-tag count; after is flat. The ~3.7s floor is cypher-shell JVM startup, identical for both. Extrapolated to a real whale (20k tags, 100k posts) this is the 30+ minute hang from the issue.

## Test
Adds `users/counts_from_graph.rs`: builds one user with every counted relation type and asserts the full `get_from_graph` map, covering the tag-derived fields (`tags`, `unique_tags`, `tagged`) and `friends` that the existing suite did not assert via the graph path.

Fixes #935
