### PR TITLE
perf(graph): query performance audit fixes (#953)

### DIFF
--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -239,11 +239,13 @@ pub fn global_tags_by_post_engagement() -> Query {
         WITH post, COUNT(tag) AS tags_count, tag.label AS label, author.id + ':' + post.id AS key
         WITH DISTINCT key, label, post, tags_count
         WHERE tags_count > 0
-        OPTIONAL MATCH (post)<-[reply:REPLIED]-()
-        OPTIONAL MATCH (post)<-[repost:REPOSTED]-()
-        OPTIONAL MATCH (post)-[mention:MENTIONED]->()
-        OPTIONAL MATCH (post)<-[tagged:TAGGED]-()
-        WITH COUNT(DISTINCT tagged) AS taggers, COUNT(DISTINCT reply) AS replies_count, COUNT(DISTINCT repost) AS reposts_count, COUNT(DISTINCT mention) AS mention_count, key, label
+        // Each engagement count is its own COUNT{} subquery, so they don't
+        // multiply into a cartesian product per post.
+        WITH key, label,
+             COUNT { (post)<-[:TAGGED]-() } AS taggers,
+             COUNT { (post)<-[:REPLIED]-() } AS replies_count,
+             COUNT { (post)<-[:REPOSTED]-() } AS reposts_count,
+             COUNT { (post)-[:MENTIONED]->() } AS mention_count
         WITH label, COLLECT([toFloat(taggers + replies_count + reposts_count + mention_count), key ]) AS sorted_set
         RETURN label, sorted_set
         order by label

--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -829,17 +829,24 @@ pub fn get_global_influencers(skip: usize, limit: usize, timeframe: &Timeframe) 
         WHERE user.name <> '[DELETED]'
         WITH DISTINCT user
 
-        OPTIONAL MATCH (others:User)-[follow:FOLLOWS]->(user)
-        WHERE follow.indexed_at >= $from AND follow.indexed_at < $to
-
-        OPTIONAL MATCH (user)-[tag:TAGGED]->(tagged:Post)
-        WHERE tag.indexed_at >= $from AND tag.indexed_at < $to
-
-        OPTIONAL MATCH (user)-[authored:AUTHORED]->(post:Post)
-        WHERE authored.indexed_at >= $from AND authored.indexed_at < $to
-
-        WITH user, COUNT(DISTINCT follow) AS followers_count, COUNT(DISTINCT tag) AS tags_count,
-             COUNT(DISTINCT post) AS posts_count
+        // Each count is a scoped CALL(user){} subquery so it stays per-user
+        // instead of multiplying into a cartesian product. Mirrors
+        // get_influencers_by_reach.
+        CALL (user) {
+            MATCH (others:User)-[follow:FOLLOWS]->(user)
+            WHERE follow.indexed_at >= $from AND follow.indexed_at < $to
+            RETURN count(DISTINCT follow) AS followers_count
+        }
+        CALL (user) {
+            MATCH (user)-[tag:TAGGED]->(:Post)
+            WHERE tag.indexed_at >= $from AND tag.indexed_at < $to
+            RETURN count(DISTINCT tag) AS tags_count
+        }
+        CALL (user) {
+            MATCH (user)-[authored:AUTHORED]->(post:Post)
+            WHERE authored.indexed_at >= $from AND authored.indexed_at < $to
+            RETURN count(DISTINCT post) AS posts_count
+        }
         WITH {
             id: user.id,
             score: (tags_count + posts_count) * sqrt(followers_count)

--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -1192,12 +1192,10 @@ pub fn user_is_safe_to_delete(user_id: &str) -> Query {
         "user_is_safe_to_delete",
         "
         MATCH (u:User {id: $user_id})
-        // Ensures all relationships to the user (u) are checked, counting as 0 if none exist
-        OPTIONAL MATCH (u)-[r]-()
-        // Checks if the user has any relationships
-        WITH u, NOT (COUNT(r) = 0) AS flag
-        RETURN flag
-        ",
+        // EXISTS stops at the first relationship, so this is O(1) on high-degree
+        // users rather than scanning every edge.
+        RETURN EXISTS { (u)-[]-() } AS flag
+",
     )
     .param("user_id", user_id)
 }
@@ -1214,23 +1212,23 @@ pub fn post_is_safe_to_delete(author_id: &str, post_id: &str) -> Query {
         "post_is_safe_to_delete",
         "
         MATCH (u:User {id: $author_id})-[:AUTHORED]->(p:Post {id: $post_id})
-        // Ensures all relationships to the post (p) are checked, counting as 0 if none exist
-        OPTIONAL MATCH (p)-[r]-()
-        WHERE NOT (
-            // Allowed relationships:
-            // 1. Incoming AUTHORED relationship from the specified user
-            (type(r) = 'AUTHORED' AND startNode(r).id = $author_id AND endNode(r) = p)
-            OR
-            // 2. Outgoing REPOSTED relationship to another post
-            (type(r) = 'REPOSTED' AND startNode(r) = p)
-            OR
-            // 3. Outgoing REPLIED relationship to another post
-            (type(r) = 'REPLIED' AND startNode(r) = p)
-        )
-        // Checks if any disallowed relationships exist for the post
-        WITH p, NOT (COUNT(r) = 0) AS flag
-        RETURN flag
-        ",
+        // EXISTS stops at the first disallowed relationship, so this is O(1) on
+        // high-degree posts rather than scanning every edge.
+        RETURN EXISTS {
+            MATCH (p)-[r]-()
+            WHERE NOT (
+                // Allowed relationships:
+                // 1. Incoming AUTHORED relationship from the specified user
+                (type(r) = 'AUTHORED' AND startNode(r).id = $author_id AND endNode(r) = p)
+                OR
+                // 2. Outgoing REPOSTED relationship to another post
+                (type(r) = 'REPOSTED' AND startNode(r) = p)
+                OR
+                // 3. Outgoing REPLIED relationship to another post
+                (type(r) = 'REPLIED' AND startNode(r) = p)
+            )
+        } AS flag
+",
     )
     .param("author_id", author_id)
     .param("post_id", post_id)

--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -21,7 +21,11 @@ pub fn get_post_by_id(author_id: &str, post_id: &str) -> Query {
     Query::new(
         "get_post_by_id",
         "
-            MATCH (u:User {id: $author_id})-[:AUTHORED]->(p:Post {id: $post_id})
+            // The WITH barrier is load-bearing: without it the planner anchors on the
+            // author and expands all their posts instead of seeking the post by id.
+            MATCH (p:Post {id: $post_id})
+            WITH p
+            MATCH (u:User {id: $author_id}) WHERE (u)-[:AUTHORED]->(p)
             OPTIONAL MATCH (p)-[replied:REPLIED]->(parent_post:Post)<-[:AUTHORED]-(author:User)
             WITH u, p, parent_post, author
             RETURN {
@@ -47,7 +51,10 @@ pub fn post_counts(author_id: &str, post_id: &str) -> Query {
     Query::new(
         "post_counts",
         "
-        MATCH (u:User {id: $author_id})-[:AUTHORED]->(p:Post {id: $post_id})
+        // Anchor on the post's unique id: matching via the author would make the
+        // planner expand every post they wrote.
+        MATCH (p:Post {id: $post_id})
+        WHERE EXISTS { (:User {id: $author_id})-[:AUTHORED]->(p) }
         WITH p
         OPTIONAL MATCH (p)<-[t:TAGGED]-()
         WITH p, COUNT (t) AS tags_count, COUNT(DISTINCT t.label) AS unique_tags_count
@@ -168,7 +175,9 @@ pub fn get_tag_target(user_id: &str, tag_id: &str, app: Option<&str>) -> Query {
 pub fn get_post_tags(author_id: &str, post_id: &str) -> Query {
     Query::new(
         "get_post_tags",
-        "MATCH (tagger:User)-[t:TAGGED]->(p:Post {id: $post_id})<-[:AUTHORED]-(author:User {id: $author_id})
+        "MATCH (p:Post {id: $post_id})
+         WHERE EXISTS { (:User {id: $author_id})-[:AUTHORED]->(p) }
+         MATCH (tagger:User)-[t:TAGGED]->(p)
          RETURN tagger.id AS tagger_id, t.id AS tag_id",
     )
     .param("author_id", author_id)
@@ -178,7 +187,8 @@ pub fn get_post_tags(author_id: &str, post_id: &str) -> Query {
 pub fn post_relationships(author_id: &str, post_id: &str) -> Query {
     Query::new(
         "post_relationships",
-        "MATCH (u:User {id: $author_id})-[:AUTHORED]->(p:Post {id: $post_id})
+        "MATCH (p:Post {id: $post_id})
+        WHERE EXISTS { (:User {id: $author_id})-[:AUTHORED]->(p) }
         OPTIONAL MATCH (p)-[:REPLIED]->(replied_post:Post)<-[:AUTHORED]-(replied_author:User)
         OPTIONAL MATCH (p)-[:REPOSTED]->(reposted_post:Post)<-[:AUTHORED]-(reposted_author:User)
         OPTIONAL MATCH (p)-[:MENTIONED]->(mentioned_user:User)
@@ -258,7 +268,11 @@ pub fn post_tags(user_id: &str, post_id: &str) -> Query {
     Query::new(
         "post_tags",
         "
-        MATCH (u:User {id: $user_id})-[:AUTHORED]->(p:Post {id: $post_id})
+        // Anchor on the post's unique id: matching via the author would make the
+        // planner expand every post they wrote.
+        MATCH (p:Post {id: $post_id})
+        WITH p
+        MATCH (u:User {id: $user_id}) WHERE (u)-[:AUTHORED]->(p)
         CALL {
             WITH p
             MATCH (tagger:User)-[tag:TAGGED]->(p)

--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -1033,21 +1033,14 @@ pub fn post_stream(
             format!("ORDER BY p.indexed_at {order_dir}, p.id {order_dir}"),
         ),
         StreamSorting::TotalEngagement => {
-            // TODO: These optional matches could potentially be combined/collected to improve performance
+            // Each engagement count is its own COUNT{} subquery, so they don't
+            // multiply into a cartesian product per post.
             cypher.push_str(
                 "
-                // Count tags
-                OPTIONAL MATCH (p)<-[tag:TAGGED]-(:User)
-                // Count replies
-                OPTIONAL MATCH (p)<-[reply:REPLIED]-(:Post)
-                // Count reposts
-                OPTIONAL MATCH (p)<-[repost:REPOSTED]-(:Post)
-
                 WITH p, author,
-                    COUNT(DISTINCT tag) AS tags_count,
-                    COUNT(DISTINCT reply) AS replies_count,
-                    COUNT(DISTINCT repost) AS reposts_count,
-                    (COUNT(DISTINCT tag) + COUNT(DISTINCT reply) + COUNT(DISTINCT repost)) AS total_engagement
+                    COUNT { (p)<-[:TAGGED]-(:User) }
+                    + COUNT { (p)<-[:REPLIED]-(:Post) }
+                    + COUNT { (p)<-[:REPOSTED]-(:Post) } AS total_engagement
                 ",
             );
 

--- a/nexus-common/src/db/graph/setup.rs
+++ b/nexus-common/src/db/graph/setup.rs
@@ -27,16 +27,13 @@ async fn setup_graph_inner() -> GraphResult<()> {
         "CREATE CONSTRAINT uniqueResourceId IF NOT EXISTS FOR (r:Resource) REQUIRE r.id IS UNIQUE",
     ];
 
-    // Create indexes
+    // User.id / Post.id / File.(owner_id,id) / Homeserver.id need no CREATE INDEX:
+    // the UNIQUE constraints above already create a backing index for them.
     let indexes = [
-        "CREATE INDEX userIdIndex IF NOT EXISTS FOR (u:User) ON (u.id)",
-        "CREATE INDEX postIdIndex IF NOT EXISTS FOR (p:Post) ON (p.id)",
         "CREATE INDEX postTimestampIndex IF NOT EXISTS FOR (p:Post) ON (p.indexed_at)",
         "CREATE INDEX postKindIndex IF NOT EXISTS FOR (p:Post) ON (p.kind)",
         "CREATE INDEX taggedLabelIndex IF NOT EXISTS FOR ()-[r:TAGGED]-() ON (r.label)",
         "CREATE INDEX taggedTimestampIndex IF NOT EXISTS FOR ()-[r:TAGGED]-() ON (r.indexed_at)",
-        "CREATE INDEX fileIdIndex IF NOT EXISTS FOR (f:File) ON (f.owner_id, f.id)",
-        "CREATE INDEX homeserverIdIndex IF NOT EXISTS FOR (hs:Homeserver) ON (hs.id)",
         "CREATE INDEX resourceSchemeIndex IF NOT EXISTS FOR (r:Resource) ON (r.scheme)",
         "CREATE INDEX taggedAppIndex IF NOT EXISTS FOR ()-[r:TAGGED]-() ON (r.app)",
     ];


### PR DESCRIPTION
Performance fixes from the graph query audit (#953). Six independent, behavior-preserving query optimizations, **one commit each** for per-fix review.

| fix | what | db hits (before → after) |
|---|---|---|
| F1 | `global_tags_by_post_engagement`: 4 `OPTIONAL MATCH` (cartesian) → `COUNT{}` per post | 154M → 28k (M=1; was timing out at scale) |
| F2 | `get_global_influencers`: 3 `OPTIONAL MATCH` → `CALL(user){}` per count (mirrors `get_influencers_by_reach`) | 1.9M → 60k (M=3) |
| F7 | `post_stream` TotalEngagement: 3 `OPTIONAL MATCH` → `COUNT{}` | 6.96M → 8.9k (M=3) |
| F8 | per-post queries (×5): seek `Post` by its unique id + verify author, instead of expanding all the author's posts | e.g. `get_post_by_id` 1217 → 19 (M=3) |
| F9 | `user_/post_is_safe_to_delete`: `EXISTS{}` instead of counting every relationship | 2,707 → 3 |
| IDX-1 | drop 4 dead no-op `CREATE INDEX` (the UNIQUE constraints already index those schemas) | n/a |

**Pure performance, no behavior change.** Each rewrite was diffed old-vs-new on a synthetic graph and shown **result-identical**, including edge cases (author mismatch, post-not-found, zero-relationship/clean nodes, each allowed-relationship branch for F9). The cartesian / per-post plans simply stop multiplying work. Numbers are at the audit's synthetic scale; the wins grow with data.

**Validation:** no new Cypher surface, `COUNT{}` and scoped `CALL(var){}` already ship on `main` (`user_counts`, `get_influencers_by_reach`); CI runs the watcher/webapi integration suites over these paths against the pinned `neo4j:5.26.27`.

Harness + methodology: #952. Findings: #953.
