### PR TITLE
feat: ingest Collection item authors

### DIFF
--- a/nexus-watcher/src/events/handlers/post.rs
+++ b/nexus-watcher/src/events/handlers/post.rs
@@ -9,7 +9,8 @@ use nexus_common::models::post::{
 };
 use nexus_common::models::user::{UserCounts, UserIngestor};
 use pubky_app_specs::{
-    post_uri_builder, ParsedUri, PubkyAppPost, PubkyAppPostKind, PubkyId, Resource,
+    post_uri_builder, ParsedUri, PubkyAppCollectionContent, PubkyAppPost, PubkyAppPostKind,
+    PubkyId, Resource,
 };
 use tracing::{debug, Instrument};
 
@@ -80,7 +81,14 @@ pub async fn sync_put(
                 if existing_details.is_different_than(&post_details)
                     || was_collection != is_collection
                 {
-                    sync_edit(post, author_id.clone(), post_id.clone(), post_details).await?;
+                    sync_edit(
+                        &post,
+                        author_id.clone(),
+                        post_id.clone(),
+                        post_details,
+                        ingestor,
+                    )
+                    .await?;
                 }
                 match (was_collection, is_collection) {
                     (false, true) => UserCounts::increment(&author_id, "collections", None).await?,
@@ -119,6 +127,8 @@ pub async fn sync_put(
             tracing::warn!("Failed to ingest user {mentioned_user_id}: {e}");
         }
     }
+
+    ingest_collection_item_authors(&post, ingestor).await;
 
     // SAVE TO INDEX - PHASE 1, update post counts
     let indexing_results = nexus_common::traced_join!(
@@ -321,16 +331,20 @@ async fn recover_post_index_state(
 }
 
 async fn sync_edit(
-    post: PubkyAppPost,
+    post: &PubkyAppPost,
     author_id: PubkyId,
     post_id: String,
     post_details: PostDetails,
+    ingestor: &UserIngestor,
 ) -> Result<(), EventProcessorError> {
     // Construct the URI of the post that changed
     let changed_uri = post_uri_builder(author_id.to_string(), post_id.clone());
 
     // Update content of PostDetails!
     post_details.put_to_index(&author_id, None, true).await?;
+
+    // Re-run on edits; `maybe_ingest_user` is a no-op for already-known users.
+    ingest_collection_item_authors(post, ingestor).await;
 
     // Notifications
     // Determine the change type
@@ -344,12 +358,12 @@ async fn sync_edit(
     Notification::changed_post(&author_id, &post_id, &changed_uri, &change_type).await?;
 
     // Handle "A reply to your post was edited/deleted"
-    if let Some(parent) = post.parent {
+    if let Some(parent) = &post.parent {
         let parsed_parent =
             ParsedUri::try_from(parent.as_str()).map_err(EventProcessorError::generic)?;
         Notification::post_children_changed(
             &author_id,
-            &parent,
+            parent,
             &parsed_parent.user_id,
             &changed_uri,
             PostChangedSource::Reply,
@@ -430,6 +444,32 @@ async fn merge_mention_edges(
         }
     }
     Ok(())
+}
+
+/// Best-effort ingestion of the user of every URI in a Collection's
+/// `items` envelope. No-op for non-Collection posts; failures (malformed URI,
+/// blacklisted HS) are logged and skipped so the Collection is still indexed.
+async fn ingest_collection_item_authors(post: &PubkyAppPost, ingestor: &UserIngestor) {
+    if post.kind != PubkyAppPostKind::Collection {
+        return;
+    }
+    let Ok(envelope) = serde_json::from_str::<PubkyAppCollectionContent>(&post.content) else {
+        tracing::warn!("Collection user ingestion: unparseable content envelope, skipping");
+        return;
+    };
+
+    for item_uri in &envelope.items {
+        match ParsedUri::try_from(item_uri.as_str()) {
+            Ok(parsed) => {
+                if let Err(e) = ingestor.maybe_ingest_user(&parsed.user_id).await {
+                    tracing::warn!("Failed to ingest collection item author {item_uri}: {e}");
+                }
+            }
+            Err(e) => {
+                tracing::warn!("Collection user ingestion: skipping malformed item {item_uri}: {e}")
+            }
+        }
+    }
 }
 
 #[tracing::instrument(name = "post.del", skip_all, fields(user_id = %author_id, post_id = %post_id))]

--- a/nexus-watcher/tests/user_ingestion/ingest_user_from_post_events.rs
+++ b/nexus-watcher/tests/user_ingestion/ingest_user_from_post_events.rs
@@ -4,8 +4,8 @@ use anyhow::Result;
 use nexus_common::models::user::UserDetails;
 use pubky::Keypair;
 use pubky_app_specs::{
-    post_uri_builder, traits::TimestampId, PubkyAppPost, PubkyAppPostEmbed, PubkyAppPostKind,
-    PubkyAppUser,
+    post_uri_builder, traits::TimestampId, PubkyAppCollectionContent, PubkyAppPost,
+    PubkyAppPostEmbed, PubkyAppPostKind, PubkyAppUser,
 };
 
 #[tokio_shared_rt::test(shared)]
@@ -157,6 +157,82 @@ async fn test_post_and_mention_users_on_unknown_homeserver() -> Result<()> {
 
     test.cleanup_user(&post_author_kp).await?;
     test.cleanup_post(&post_author_kp, &post_path).await?;
+
+    Ok(())
+}
+
+/// A Collection post curates an ordered list of canonical post URIs. Each item
+/// URI's host pubky-id identifies a user whose homeserver may not be known to
+/// Nexus yet. When the Collection is indexed, Nexus must best-effort ingest the
+/// author of every curated item (mirroring how mentions ingest tagged users).
+#[tokio_shared_rt::test(shared)]
+async fn test_collection_ingests_each_item_author() -> Result<()> {
+    let mut test = WatcherTest::setup(None).await?;
+
+    // Two external authors on their own HSs, each with one post that will be curated by the Collection.
+    let item1_hs_pk = create_external_test_homeserver(&mut test).await?;
+    let item2_hs_pk = create_external_test_homeserver(&mut test).await?;
+
+    let item1_kp = Keypair::random();
+    let item1_id = item1_kp.public_key().to_z32();
+    let item2_kp = Keypair::random();
+    let item2_id = item2_kp.public_key().to_z32();
+
+    test.register_user_in_hs(&item1_kp, &item1_hs_pk).await?;
+    test.register_user_in_hs(&item2_kp, &item2_hs_pk).await?;
+
+    let item1_post = PubkyAppPost {
+        content: "Watcher:CollectionIngest:Item1".to_string(),
+        kind: PubkyAppPostKind::Short,
+        parent: None,
+        embed: None,
+        attachments: None,
+    };
+    let item1_post_id = item1_post.create_id();
+    let item1_uri = post_uri_builder(item1_id.clone(), item1_post_id.clone());
+
+    let item2_post = PubkyAppPost {
+        content: "Watcher:CollectionIngest:Item2".to_string(),
+        kind: PubkyAppPostKind::Short,
+        parent: None,
+        embed: None,
+        attachments: None,
+    };
+    let item2_post_id = item2_post.create_id();
+    let item2_uri = post_uri_builder(item2_id.clone(), item2_post_id.clone());
+
+    // The Collection author is a regular (Nexus-known) user.
+    let curator = PubkyAppUser {
+        bio: Some("test_collection_ingests_each_item_author".to_string()),
+        image: None,
+        links: None,
+        name: "Watcher:CollectionIngest:Curator".to_string(),
+        status: None,
+    };
+    let curator_kp = Keypair::random();
+    let _curator_id = test.create_user(&curator_kp, &curator).await?;
+
+    let envelope = PubkyAppCollectionContent {
+        name: "Curated".to_string(),
+        description: None,
+        items: vec![item1_uri.clone(), item2_uri.clone()],
+        cover_image: None,
+    };
+    let collection = PubkyAppPost {
+        content: serde_json::to_string(&envelope).unwrap(),
+        kind: PubkyAppPostKind::Collection,
+        parent: None,
+        embed: None,
+        attachments: None,
+    };
+    let (_col_id, col_path) = test.create_post(&curator_kp, &collection).await?;
+
+    // Both item authors must have been ingested
+    assert_user_ingested(&item1_id, &item1_hs_pk).await;
+    assert_user_ingested(&item2_id, &item2_hs_pk).await;
+
+    test.cleanup_user(&curator_kp).await?;
+    test.cleanup_post(&curator_kp, &col_path).await?;
 
     Ok(())
 }


### PR DESCRIPTION
This PR extends Collection indexing with the automatic ingestion of the authors of collection items.

Currently, collections only allow items of type `Post`, but the ingestion logic is kept as generic as possible, which should automatically catch new `ParsedUri` types when the collection item validation logic is expanded.

---

### Pre-submission Checklist

- [x] I manually reviewed the PR
- [x] I asked one or more LLMs to review the PR
- [x] I asked one or more LLMs to check if this PR can be simplified [^1]
- [x] If appropriate, I added tests for the changes in this PR
- [ ] If appropriate, I added performance benchmarks for the APIs added in this PR [^2]

[^1]: Sample prompt: "Can this be simplified? Can the code, comments, or logic introduced by these changes be simplfied, clarified or otherwise made more terse, concise and understandable, without affecting functionality?"
[^2]: `cargo bench -p nexus-webapi`
