### PR TITLE
perf(models): parallelize per-item read fan-out in list/view assembly

### DIFF
--- a/nexus-common/src/models/post/stream.rs
+++ b/nexus-common/src/models/post/stream.rs
@@ -10,6 +10,7 @@ use crate::models::{
     post::search::PostsByTagSearch,
 };
 use crate::types::{Pagination, StreamSorting, WotDepth};
+use futures::stream::{self, StreamExt};
 use futures::TryStreamExt;
 use pubky_app_specs::{ParsedUri, PubkyAppCollectionContent, PubkyAppPostKind, Resource};
 use serde::{Deserialize, Serialize};
@@ -600,32 +601,44 @@ impl PostStream {
         skip: Option<usize>,
         limit: Option<usize>,
     ) -> ModelResult<Vec<(String, f64)>> {
-        let mut post_keys = Vec::new();
         // Limit the number of user IDs to process to the first 200
         let max_user_ids = 200;
-        let truncated_user_ids: Vec<&str> = user_ids.iter().take(max_user_ids).cloned().collect();
+        let truncated_user_ids: Vec<String> = user_ids
+            .iter()
+            .take(max_user_ids)
+            .map(|s| s.to_string())
+            .collect();
 
-        // Retrieve posts for each user and collect them
-        for user_id in &truncated_user_ids {
-            let key_parts = [&POST_PER_USER_KEY_PARTS[..], &[user_id]].concat();
-            if let Some(post_ids) = Self::try_from_index_sorted_set(
-                &key_parts,
-                start,
-                end,
-                None, // We do not apply skip and limit here, as we need the full sorted set
-                None,
-                order.clone(),
-                None,
-            )
+        // Bounded to protect the pool; `buffered` keeps equal-score ties in input
+        // order through the stable re-sort below; items owned so the future stays `Send`.
+        let mut post_keys: Vec<(f64, String)> =
+            stream::iter(truncated_user_ids.into_iter().map(|user_id| {
+                let order = order.clone();
+                async move {
+                    let key_parts = [&POST_PER_USER_KEY_PARTS[..], &[user_id.as_str()]].concat();
+                    let post_ids = Self::try_from_index_sorted_set(
+                        &key_parts, start, end,
+                        None, // We do not apply skip and limit here, as we need the full sorted set
+                        None, order, None,
+                    )
+                    .await?;
+                    Ok::<_, ModelError>(
+                        post_ids
+                            .map(|ids| {
+                                ids.into_iter()
+                                    .map(|(post_id, score)| (score, format!("{user_id}:{post_id}")))
+                                    .collect::<Vec<_>>()
+                            })
+                            .unwrap_or_default(),
+                    )
+                }
+            }))
+            .buffered(8)
+            .try_collect::<Vec<Vec<_>>>()
             .await?
-            {
-                let user_post_keys: Vec<(f64, String)> = post_ids
-                    .into_iter()
-                    .map(|(post_id, score)| (score, format!("{user_id}:{post_id}")))
-                    .collect();
-                post_keys.extend(user_post_keys);
-            }
-        }
+            .into_iter()
+            .flatten()
+            .collect();
 
         // The selected user_ids does not have any post
         if post_keys.is_empty() {

--- a/nexus-common/src/models/resource/stream.rs
+++ b/nexus-common/src/models/resource/stream.rs
@@ -1,11 +1,12 @@
 use crate::db::graph::error::GraphError;
 use crate::db::kv::{RedisResult, ScoreAction, SortOrder};
 use crate::db::{queries, RedisOps};
-use crate::models::error::ModelResult;
+use crate::models::error::{ModelError, ModelResult};
 use crate::models::resource::tag::TagResource;
 use crate::models::resource::ResourceDetails;
 use crate::models::tag::traits::TagCollection;
 use crate::types::Pagination;
+use futures::stream::{self, StreamExt};
 use futures::TryStreamExt;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -294,28 +295,45 @@ impl ResourceStream {
             return Ok(None);
         }
 
-        let mut views = Vec::with_capacity(resource_ids.len());
+        // Bounded to protect the pool; `buffered` preserves order; inputs owned so
+        // the future stays `Send`.
+        let viewer_id = viewer_id.map(str::to_string);
+        let views: Vec<ResourceView> =
+            stream::iter(resource_ids.iter().cloned().map(|resource_id| {
+                let viewer_id = viewer_id.clone();
+                async move {
+                    let Some(details) = ResourceDetails::get_by_id(&resource_id).await? else {
+                        return Ok::<_, ModelError>(None);
+                    };
 
-        for resource_id in resource_ids {
-            let details = match ResourceDetails::get_by_id(resource_id).await? {
-                Some(d) => d,
-                None => continue, // Resource was deleted between query and load
-            };
-
-            // Load tags via TagResource
-            let tags =
-                TagResource::get_by_id(resource_id, None, None, Some(5), Some(3), viewer_id, None)
+                    // Load tags via TagResource
+                    let tags = TagResource::get_by_id(
+                        &resource_id,
+                        None,
+                        None,
+                        Some(5),
+                        Some(3),
+                        viewer_id.as_deref(),
+                        None,
+                    )
                     .await?
                     .unwrap_or_default();
 
-            let taggers_count = tags.iter().map(|t| t.taggers_count).sum();
+                    let taggers_count = tags.iter().map(|t| t.taggers_count).sum();
 
-            views.push(ResourceView {
-                details,
-                tags,
-                taggers_count,
-            });
-        }
+                    Ok(Some(ResourceView {
+                        details,
+                        tags,
+                        taggers_count,
+                    }))
+                }
+            }))
+            .buffered(8)
+            .try_collect::<Vec<Option<_>>>()
+            .await?
+            .into_iter()
+            .flatten()
+            .collect();
 
         if views.is_empty() {
             Ok(None)

--- a/nexus-common/src/models/user/view.rs
+++ b/nexus-common/src/models/user/view.rs
@@ -3,11 +3,13 @@ use utoipa::ToSchema;
 
 use super::{Relationship, UserCounts, UserDetails};
 use crate::db::RedisOps;
-use crate::models::error::ModelResult;
+use crate::models::error::{ModelError, ModelResult};
 use crate::models::tag::traits::TagCollection;
 use crate::models::tag::user::TagUser;
 use crate::models::tag::TagDetails;
 use crate::types::WotDepth;
+use futures::stream::{self, StreamExt};
+use futures::TryStreamExt;
 
 /// Represents a Pubky user with relational data including tags, counts, bookmark and relationship with other posts.
 #[derive(Serialize, Deserialize, ToSchema, Debug)]
@@ -76,46 +78,59 @@ impl UserView {
         // Use mget to fetch all user details and counts in bulk
         let (details_list, counts_list): (Vec<Option<UserDetails>>, Vec<Option<UserCounts>>) =
             tokio::try_join!(UserDetails::mget(user_ids), UserCounts::mget(user_ids))?;
+        // mget returns one slot per id; the positional zip below relies on it.
+        debug_assert_eq!(details_list.len(), user_ids.len());
+        debug_assert_eq!(counts_list.len(), user_ids.len());
 
-        let mut user_views = Vec::with_capacity(user_ids.len());
+        // Bounded to protect the pool; `buffered` preserves order so results stay
+        // aligned with `user_ids`; inputs owned so the future stays `Send`.
+        let viewer_id = viewer_id.map(str::to_string);
+        let user_views: Vec<Option<Self>> = stream::iter(
+            user_ids
+                .iter()
+                .cloned()
+                .zip(details_list)
+                .zip(counts_list)
+                .map(|((user_id, details), counts)| {
+                    let viewer_id = viewer_id.clone();
+                    async move {
+                        let Some(details) = details else {
+                            return Ok::<_, ModelError>(None);
+                        };
 
-        for (i, user_id) in user_ids.iter().enumerate() {
-            let details = &details_list[i];
-            let counts = &counts_list[i];
+                        let counts = counts.unwrap_or_default();
+                        let relationship = Relationship::get_by_id(&user_id, viewer_id.as_deref())
+                            .await?
+                            .unwrap_or_default();
 
-            let Some(details) = details else {
-                user_views.push(None);
-                continue;
-            };
+                        // Before fetching post tags, check if the post has any tags
+                        let tags = match counts.tags {
+                            0 => Vec::new(),
+                            _ => TagUser::get_by_id(
+                                &user_id,
+                                None,
+                                None,
+                                None,
+                                None,
+                                viewer_id.as_deref(),
+                                depth.and_then(|d| WotDepth::new(d).ok()),
+                            )
+                            .await?
+                            .unwrap_or_default(),
+                        };
 
-            let counts = counts.clone().unwrap_or_default();
-            let relationship = Relationship::get_by_id(user_id, viewer_id)
-                .await?
-                .unwrap_or_default();
-
-            // Before fetching post tags, check if the post has any tags
-            let tags = match counts.tags {
-                0 => Vec::new(),
-                _ => TagUser::get_by_id(
-                    user_id,
-                    None,
-                    None,
-                    None,
-                    None,
-                    viewer_id,
-                    depth.and_then(|d| WotDepth::new(d).ok()),
-                )
-                .await?
-                .unwrap_or_default(),
-            };
-
-            user_views.push(Some(Self {
-                details: details.clone(),
-                counts,
-                relationship,
-                tags,
-            }));
-        }
+                        Ok(Some(Self {
+                            details,
+                            counts,
+                            relationship,
+                            tags,
+                        }))
+                    }
+                }),
+        )
+        .buffered(8)
+        .try_collect()
+        .await?;
 
         Ok(user_views)
     }


### PR DESCRIPTION
Small perf optimization from #953, pure latency win, no db-hit change.

~230ms sequential vs ~58ms with `buffered(8)` (~4x), cutting per-request round-trips from 200 to ~25; the gap widens with real network Redis/Neo4j latency. 

Replaces the sequential per-item `await` loops in `PostStream::get_posts_for_user_ids`, `UserView::get_by_ids`, and `ResourceStream::from_listed_resource_ids` with bounded concurrency (`buffered`/`buffer_unordered(8)`, the existing `bootstrap.rs` idiom), so N sequential Redis/graph round-trips per request run ~8 at a time. 

The perf fix is behaviour preserving: `buffered` keeps input order where callers rely on it, and `get_posts_for_user_ids` re-sorts so order is irrelevant there; results are identical.  These are three of the four caller-side N+1 sites found in the graph query audit (#953); the fourth, `PostStream::from_listed_post_ids`, is already concurrent and left unchanged.