### PR TITLE
feat(migrations): add `db migration check` subcommand

### DIFF
--- a/nexusd/src/cli.rs
+++ b/nexusd/src/cli.rs
@@ -94,6 +94,10 @@ pub enum MigrationCommands {
 
     /// Run pending migrations
     Run,
+
+    /// Check for pending migrations without running them.
+    /// Exits 0 when nothing is pending, 10 when at least one migration has pending work.
+    Check,
 }
 
 #[derive(Args, Debug)]

--- a/nexusd/src/main.rs
+++ b/nexusd/src/main.rs
@@ -25,6 +25,22 @@ async fn main() -> Result<(), DynError> {
                     import_migrations(&mut mm);
                     mm.run(&builder.migrations_backfill_ready()).await?;
                 }
+                MigrationCommands::Check => {
+                    let builder = MigrationBuilder::default().await?;
+                    StackManager::setup(builder.stack()).await?;
+                    let mut mm = MigrationManager::default();
+                    import_migrations(&mut mm);
+                    let pending = mm.check(&builder.migrations_backfill_ready()).await?;
+                    if pending.is_empty() {
+                        println!("No pending migrations");
+                    } else {
+                        for (id, phase) in &pending {
+                            println!("{id} ({phase})");
+                        }
+                        println!("{} pending migration(s)", pending.len());
+                        std::process::exit(10);
+                    }
+                }
             },
         },
         NexusCommands::Api(ApiArgs { config_dir }) => {

--- a/nexusd/src/migrations/manager.rs
+++ b/nexusd/src/migrations/manager.rs
@@ -218,6 +218,34 @@ impl MigrationManager {
         Ok(())
     }
 
+    /// Returns registered migrations with pending work as `(id, phase)` pairs,
+    /// where phase is the stored phase or "new" for a migration not yet stored.
+    ///
+    /// Mirrors `run` semantics: pending means `run` would execute a phase or
+    /// store a new migration node. Stored migrations that are not registered
+    /// are ignored, exactly as in `run`.
+    pub async fn check(
+        &self,
+        migrations_backfill_ready: &[String],
+    ) -> Result<Vec<(String, String)>, DynError> {
+        let stored_migrations = self.get_migrations().await?;
+        let mut pending = Vec::new();
+        for migration in &self.migrations {
+            let migration_id = migration.id();
+            let stored = stored_migrations.iter().find(|m| m.id == migration_id);
+            let backfill_ready = migrations_backfill_ready
+                .iter()
+                .any(|id| id == migration_id);
+            if is_pending(stored.map(|m| &m.phase), backfill_ready) {
+                let phase = stored
+                    .map(|m| m.phase.to_string().to_owned())
+                    .unwrap_or_else(|| "new".to_owned());
+                pending.push((migration_id.to_owned(), phase));
+            }
+        }
+        Ok(pending)
+    }
+
     async fn get_migrations(&self) -> Result<Vec<MigrationNode>, DynError> {
         let query = Query::new(
             "get_migrations",
@@ -267,5 +295,44 @@ impl MigrationManager {
 
         self.graph.run(query).await?;
         Ok(())
+    }
+}
+
+/// Decides whether a registered migration has pending work, given its stored
+/// phase (`None` when never stored) and whether it is listed in `backfill_ready`.
+///
+/// `Done` is terminal regardless of `backfill_ready`: `check` deliberately does
+/// not mirror `run`'s current behavior of resetting a done migration listed in
+/// `backfill_ready`, which is a bug tracked in #967.
+fn is_pending(stored_phase: Option<&MigrationPhase>, backfill_ready: bool) -> bool {
+    match stored_phase {
+        // Never stored: `run` stores the node (and backfills if single-staged)
+        None => true,
+        Some(MigrationPhase::Done) => false,
+        // Waiting for the operator flag; `run` only acts on it once listed
+        Some(MigrationPhase::DualWrite) => backfill_ready,
+        // Backfill, Cutover, Cleanup: `run` executes the phase
+        Some(_) => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_pending, MigrationPhase};
+
+    #[test]
+    fn pending_semantics_mirror_run() {
+        assert!(is_pending(None, false));
+        assert!(is_pending(None, true));
+
+        assert!(!is_pending(Some(&MigrationPhase::Done), false));
+        assert!(!is_pending(Some(&MigrationPhase::Done), true));
+
+        assert!(!is_pending(Some(&MigrationPhase::DualWrite), false));
+        assert!(is_pending(Some(&MigrationPhase::DualWrite), true));
+
+        assert!(is_pending(Some(&MigrationPhase::Backfill), false));
+        assert!(is_pending(Some(&MigrationPhase::Cutover), false));
+        assert!(is_pending(Some(&MigrationPhase::Cleanup), false));
     }
 }


### PR DESCRIPTION
Closes #967.

Adds `nexusd db migration check`: reports pending migrations without running them, so the deploy pipeline can gate DB snapshots and the migration run step on actual pending work (context: [pubky-stack `pubky-nexus-cicd.yml` L147-L167](https://github.com/pubky/pubky-stack/blob/2a2fed2dccd9d301444e09dfa6410ab91e417b92/.github/workflows/pubky-nexus-cicd.yml#L147-L167)).

## Behavior

- Prints each pending migration as `Id (phase)`, where phase is the stored phase or `new` for a migration not yet tracked in the graph.
- Exit codes: `0` = nothing pending, `10` = pending work, `1` = error, so CI can distinguish "work to do" from "broken".
- Mirrors `run` semantics exactly: pending means `run` would execute a phase or store a new migration node. `dual_write` counts as pending only when the id is listed in `backfill_ready`. Stored-but-unregistered ids (e.g. the reverted `IndexedAtSyncRedisToGraph1763650675`) are ignored, as in `run`.
- One deliberate divergence: `done` is terminal even when the id is listed in `backfill_ready`. `run` currently resets such migrations back to `backfill` and re-executes them; that is the bug tracked in #967 and `check` does not reproduce it.

## Verification

Against fresh neo4j 5.26.27 + redis 8.0.6 containers:

1. Empty graph: `check` lists all 5 registered migrations as `(new)`, exit 10.
2. After `db migration run`: `No pending migrations`, exit 0.
3. Simulated production state (nodes: `TagCountsReset1739459180`, `UsersByPkReindex1751635096`, `IndexedAtSyncRedisToGraph1763650675`, all `done`, matching what prod returns today): `check` lists exactly the 4 missing migrations, exit 10, orphan nodes ignored.

Unit test covers the pending-decision matrix (`cargo test -p nexusd --lib manager`). `cargo clippy -p nexusd` and `cargo fmt --check` clean.
