### PR TITLE
fix(follows): paginate follower lists in Rust, stop past-the-end 404s

### DIFF
--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -592,36 +592,28 @@ pub fn user_counts(user_id: &str) -> Query {
     .param("user_id", user_id)
 }
 
-pub fn get_user_followers(user_id: &str, skip: Option<usize>, limit: Option<usize>) -> Query {
-    let mut query_string = String::from(
+// These queries aggregate into a single row, so SKIP/LIMIT cannot paginate the
+// collected list; callers slice in Rust instead.
+pub fn get_user_followers(user_id: &str) -> Query {
+    Query::new(
+        "get_user_followers",
         "MATCH (u:User {id: $user_id})
          OPTIONAL MATCH (u)<-[:FOLLOWS]-(follower:User)
          RETURN COUNT(u) > 0 AS user_exists,
                 COLLECT(follower.id) AS follower_ids",
-    );
-    if let Some(skip_value) = skip {
-        query_string.push_str(&format!(" SKIP {}", skip_value.min(MAX_QUERY_SKIP)));
-    }
-    if let Some(limit_value) = limit {
-        query_string.push_str(&format!(" LIMIT {}", limit_value.min(MAX_QUERY_LIMIT)));
-    }
-    Query::new("get_user_followers", &query_string).param("user_id", user_id)
+    )
+    .param("user_id", user_id)
 }
 
-pub fn get_user_following(user_id: &str, skip: Option<usize>, limit: Option<usize>) -> Query {
-    let mut query_string = String::from(
+pub fn get_user_following(user_id: &str) -> Query {
+    Query::new(
+        "get_user_following",
         "MATCH (u:User {id: $user_id})
          OPTIONAL MATCH (u)-[:FOLLOWS]->(following:User)
          RETURN COUNT(u) > 0 AS user_exists,
                 COLLECT(following.id) AS following_ids",
-    );
-    if let Some(skip_value) = skip {
-        query_string.push_str(&format!(" SKIP {}", skip_value.min(MAX_QUERY_SKIP)));
-    }
-    if let Some(limit_value) = limit {
-        query_string.push_str(&format!(" LIMIT {}", limit_value.min(MAX_QUERY_LIMIT)));
-    }
-    Query::new("get_user_following", &query_string).param("user_id", user_id)
+    )
+    .param("user_id", user_id)
 }
 
 fn stream_reach_to_graph_subquery(reach: &StreamReach) -> String {

--- a/nexus-common/src/db/kv/index/sets.rs
+++ b/nexus-common/src/db/kv/index/sets.rs
@@ -58,7 +58,9 @@ pub async fn put(
 ///
 /// # Returns
 ///
-/// Returns a vector of strings containing the retrieved elements.
+/// Returns `Ok(None)` if the key does not exist, and `Ok(Some(vec))` otherwise.
+/// The vector may be empty when the requested window is past the end of the set,
+/// so callers can tell a missing index apart from a past-the-end page.
 ///
 /// # Errors
 ///
@@ -107,10 +109,23 @@ pub async fn get_range(
         }
     }
 
-    if collected.is_empty() {
-        Ok(None)
-    } else {
+    if !collected.is_empty() {
+        return Ok(Some(collected));
+    }
+
+    // Redis deletes empty sets, so key-exists plus empty-window can only be a
+    // past-the-end page; report it as Some(vec![]) so callers do not treat it
+    // as a miss and refetch the whole list from the graph.
+    if skip == 0 {
+        // Nothing was skipped, so an empty scan already means the key is
+        // absent; the EXISTS round-trip is redundant.
+        return Ok(None);
+    }
+    let key_exists: bool = redis_conn.exists(&index_key).await?;
+    if key_exists {
         Ok(Some(collected))
+    } else {
+        Ok(None)
     }
 }
 

--- a/nexus-common/src/db/kv/traits.rs
+++ b/nexus-common/src/db/kv/traits.rs
@@ -356,7 +356,8 @@ pub trait RedisOps: Serialize + DeserializeOwned + Send + Sync {
     /// * `prefix` - An optional string representing the prefix for the Redis keys. If `Some(String)`, the prefix will be used
     /// # Returns
     ///
-    /// Returns a vector of deserialized elements if they exist, or an empty vector if no matching elements are found.
+    /// Returns `None` if the set does not exist, or `Some(vec)` with the requested window
+    /// otherwise. The vector may be empty when the window is past the end of the set.
     ///
     /// # Errors
     ///

--- a/nexus-common/src/models/follow/followers.rs
+++ b/nexus-common/src/models/follow/followers.rs
@@ -23,8 +23,8 @@ impl UserFollows for Followers {
         Self(vec)
     }
 
-    fn get_query(user_id: &str, skip: Option<usize>, limit: Option<usize>) -> Query {
-        queries::get::get_user_followers(user_id, skip, limit)
+    fn get_query(user_id: &str) -> Query {
+        queries::get::get_user_followers(user_id)
     }
 
     fn get_ids_field_name() -> &'static str {

--- a/nexus-common/src/models/follow/following.rs
+++ b/nexus-common/src/models/follow/following.rs
@@ -23,8 +23,8 @@ impl UserFollows for Following {
         Self(vec)
     }
 
-    fn get_query(user_id: &str, skip: Option<usize>, limit: Option<usize>) -> Query {
-        queries::get::get_user_following(user_id, skip, limit)
+    fn get_query(user_id: &str) -> Query {
+        queries::get::get_user_following(user_id)
     }
 
     fn get_ids_field_name() -> &'static str {

--- a/nexus-common/src/models/follow/traits.rs
+++ b/nexus-common/src/models/follow/traits.rs
@@ -25,22 +25,28 @@ pub trait UserFollows: Sized + RedisOps + AsRef<[String]> + Default {
         match Self::get_from_index(user_id, skip, limit).await? {
             Some(connections) => Ok(Some(Self::from_vec(connections))),
             None => {
-                let graph_response = Self::get_from_graph(user_id, skip, limit).await?;
-                if let Some(follows) = graph_response {
-                    follows.put_to_index(user_id).await?;
-                    return Ok(Some(follows));
+                // Index miss: cache the full list (check_in_index needs complete
+                // membership), then slice skip/limit in Rust.
+                let Some(follows) = Self::get_from_graph(user_id).await? else {
+                    // None is reserved for "user does not exist in the graph"
+                    return Ok(None);
+                };
+                follows.put_to_index(user_id).await?;
+
+                let mut connections = follows.as_ref().to_vec();
+                if let Some(skip) = skip {
+                    connections = connections.into_iter().skip(skip).collect();
                 }
-                Ok(None)
+                if let Some(limit) = limit {
+                    connections.truncate(limit);
+                }
+                Ok(Some(Self::from_vec(connections)))
             }
         }
     }
 
-    async fn get_from_graph(
-        user_id: &str,
-        skip: Option<usize>,
-        limit: Option<usize>,
-    ) -> GraphResult<Option<Self>> {
-        let query = Self::get_query(user_id, skip, limit);
+    async fn get_from_graph(user_id: &str) -> GraphResult<Option<Self>> {
+        let query = Self::get_query(user_id);
         let maybe_row = fetch_row_from_graph(query).await?;
 
         let Some(row) = maybe_row else {
@@ -75,7 +81,7 @@ pub trait UserFollows: Sized + RedisOps + AsRef<[String]> + Default {
     }
 
     async fn reindex(user_id: &str) -> ModelResult<()> {
-        match Self::get_from_graph(user_id, None, None).await? {
+        match Self::get_from_graph(user_id).await? {
             Some(follow) => follow.put_to_index(user_id).await?,
             None => tracing::error!(
                 "{}: Could not found user follow relationship in the graph",
@@ -94,7 +100,7 @@ pub trait UserFollows: Sized + RedisOps + AsRef<[String]> + Default {
         self.remove_from_index_set(&[user_id]).await
     }
 
-    fn get_query(user_id: &str, skip: Option<usize>, limit: Option<usize>) -> Query;
+    fn get_query(user_id: &str) -> Query;
 
     fn get_ids_field_name() -> &'static str;
 

--- a/nexus-webapi/benches/follows.rs
+++ b/nexus-webapi/benches/follows.rs
@@ -43,7 +43,7 @@ fn bench_get_followers_from_graph(c: &mut Criterion) {
         &user_id,
         |b, &id| {
             b.to_async(&rt).iter(|| async {
-                let followers = Followers::get_from_graph(id, None, None).await.unwrap();
+                let followers = Followers::get_from_graph(id).await.unwrap();
                 std::hint::black_box(followers);
             });
         },
@@ -87,7 +87,7 @@ fn bench_get_following_from_graph(c: &mut Criterion) {
         &user_id,
         |b, &id| {
             b.to_async(&rt).iter(|| async {
-                let following = Following::get_from_graph(id, None, None).await.unwrap();
+                let following = Following::get_from_graph(id).await.unwrap();
                 std::hint::black_box(following);
             });
         },

--- a/nexus-webapi/tests/user/reach.rs
+++ b/nexus-webapi/tests/user/reach.rs
@@ -1,6 +1,8 @@
-use crate::utils::{get_request, invalid_get_request};
+use crate::utils::{get_request, invalid_get_request, server::TestServiceServer};
 use anyhow::Result;
 use axum::http::StatusCode;
+use deadpool_redis::redis::AsyncCommands;
+use nexus_common::db::get_redis_conn;
 
 const NON_EXISTING_USER_ID: &str = "qca6wzjg4okp6g1hwr9g8hmx1po1jpoirjfau9ejsws1qz3t7iiy";
 
@@ -193,6 +195,111 @@ async fn test_follows_limit_cap() -> Result<()> {
 
     // limit=200 (at MAX) is accepted → 200
     get_request(&format!("/v0/user/{user_id}/followers?limit=200")).await?;
+
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_follows_skip_past_end() -> Result<()> {
+    // The fixture user has 10 followers and follows 15 users. Skipping past the
+    // end of either list must return 200 with an empty array, not 404.
+    let user_id = "4snwyct86m383rsduhw5xgcxpw7c63j3pq8x4ycqikxgik8y64ro";
+
+    let res = get_request(&format!("/v0/user/{user_id}/followers?skip=100")).await?;
+    assert!(res.is_array());
+    assert!(
+        res.as_array().unwrap().is_empty(),
+        "Expected empty followers page past the end"
+    );
+
+    let res = get_request(&format!("/v0/user/{user_id}/following?skip=100")).await?;
+    assert!(res.is_array());
+    assert!(
+        res.as_array().unwrap().is_empty(),
+        "Expected empty following page past the end"
+    );
+
+    // A nonexistent user still 404s, regardless of pagination
+    invalid_get_request(
+        &format!("/v0/user/{NON_EXISTING_USER_ID}/followers?skip=100"),
+        StatusCode::NOT_FOUND,
+    )
+    .await?;
+
+    invalid_get_request(
+        &format!("/v0/user/{NON_EXISTING_USER_ID}/following?skip=100"),
+        StatusCode::NOT_FOUND,
+    )
+    .await?;
+
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_follows_pagination_slicing() -> Result<()> {
+    // The fixture user has 10 followers and follows 15 users; skip/limit must
+    // slice the list instead of being ignored. CI seeds a warm
+    // cache, and the warm SSCAN path already slices, so each request below
+    // deletes the cached set first to force the cold graph-fetch path.
+    let user_id = "4snwyct86m383rsduhw5xgcxpw7c63j3pq8x4ycqikxgik8y64ro";
+
+    // Ensure the server is running, so the Redis pool is initialized
+    TestServiceServer::get_test_server().await;
+    let mut redis_conn = get_redis_conn().await?;
+    let followers_key = format!("Followers:{user_id}");
+    let following_key = format!("Following:{user_id}");
+
+    // Cold cache: limit smaller than the list returns exactly limit items
+    let _: () = redis_conn.del(&followers_key).await?;
+    let res = get_request(&format!("/v0/user/{user_id}/followers?limit=4")).await?;
+    assert_eq!(
+        res.as_array().unwrap().len(),
+        4,
+        "Expected followers limit to cap the page size on a cold cache"
+    );
+
+    // Cold cache: a mid-list skip returns 200 with the remainder instead of
+    // 404ing (the aggregated single-row query used to drop the row on SKIP)
+    let _: () = redis_conn.del(&followers_key).await?;
+    let res = get_request(&format!("/v0/user/{user_id}/followers?skip=8&limit=4")).await?;
+    assert_eq!(
+        res.as_array().unwrap().len(),
+        2,
+        "Expected a cold mid-list skip to return the remainder"
+    );
+
+    // The cold request above cached the full list, so the warm SSCAN path
+    // must serve a page of the same size
+    let res = get_request(&format!("/v0/user/{user_id}/followers?skip=8&limit=4")).await?;
+    assert_eq!(
+        res.as_array().unwrap().len(),
+        2,
+        "Expected the warm cache to serve the same page size as the cold path"
+    );
+
+    // Same checks for the following list
+    let _: () = redis_conn.del(&following_key).await?;
+    let res = get_request(&format!("/v0/user/{user_id}/following?limit=6")).await?;
+    assert_eq!(
+        res.as_array().unwrap().len(),
+        6,
+        "Expected following limit to cap the page size on a cold cache"
+    );
+
+    let _: () = redis_conn.del(&following_key).await?;
+    let res = get_request(&format!("/v0/user/{user_id}/following?skip=10&limit=10")).await?;
+    assert_eq!(
+        res.as_array().unwrap().len(),
+        5,
+        "Expected a cold mid-list skip to return the last following page"
+    );
+
+    let res = get_request(&format!("/v0/user/{user_id}/following?skip=10&limit=10")).await?;
+    assert_eq!(
+        res.as_array().unwrap().len(),
+        5,
+        "Expected the warm cache to serve the same page size as the cold path"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
`/user/{id}/followers` and `/user/{id}/following` build an aggregating `RETURN COUNT(u) > 0, COLLECT(...)` and then append `SKIP`/`LIMIT` to it. Aggregation yields exactly one row, so any `skip` that reached the graph dropped the row and 404'd an existing user, and `limit` was a no-op on a cold cache (full list returned and cached).

- `UserFollows::get_by_id` now fetches the full list on an index miss, caches it whole, and slices skip/limit in Rust. Pagination stays out of Cypher on purpose: the follow sets are complete-membership sets consumed by `check_in_index`, so caching a sliced page would corrupt follow checks.
- `sets::get_range` now distinguishes "key missing" from "page past the end" (`EXISTS`, only when skip > 0), so past-the-end pages answer `200 []` from Redis instead of refetching the whole list from the graph on every call.

Tests delete the cache keys to force the cold path; both fail on main and pass here.

Fixes #959

## Pre-submission Checklist

- [x] I manually reviewed the PR
- [x] I asked one or more LLMs to review the PR
- [x] I asked one or more LLMs to check if this PR can be simplified
- [x] If appropriate, I added tests for the changes in this PR
- [ ] If appropriate, I added performance benchmarks for the APIs added in this PR (n/a)
