### PR TITLE
fix(moderation): route moderated post deletion through the safe-to-delete gate

### DIFF
--- a/nexus-watcher/src/events/mod.rs
+++ b/nexus-watcher/src/events/mod.rs
@@ -138,7 +138,7 @@ pub async fn handle_put_event(
         (PubkyAppObject::Tag(tag), Resource::Tag(tag_id)) => {
             if moderation.should_delete(&tag, user_id.clone()) {
                 moderation
-                    .apply_moderation(tag, event.files_path.clone())
+                    .apply_moderation(tag, event.files_path.clone(), &ingestor)
                     .await?
             } else {
                 // Route universal tag events (non-pubky.app apps) to sync_put_resource

--- a/nexus-watcher/src/events/mod.rs
+++ b/nexus-watcher/src/events/mod.rs
@@ -147,7 +147,9 @@ pub async fn handle_put_event(
         }
         (PubkyAppObject::Tag(tag), Resource::Tag(tag_id)) => {
             if moderation.should_delete(&tag, &user_id) {
-                moderation.apply_moderation(tag, files_path).await?
+                moderation
+                    .apply_moderation(tag, files_path, &ingestor)
+                    .await?
             } else {
                 // Route universal tag events (non-pubky.app apps) to sync_put_resource
                 // which handles Resource nodes for InternalUnknown/InternalUnknown URIs.

--- a/nexus-watcher/src/events/moderation.rs
+++ b/nexus-watcher/src/events/moderation.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use crate::errors::EventProcessorError;
 use crate::events::handlers;
+use nexus_common::models::user::UserIngestor;
 use nexus_common::WatcherConfig;
 use pubky_app_specs::{ParsedUri, PubkyAppTag, PubkyId, Resource};
 use tracing::info;
@@ -30,15 +31,17 @@ impl Moderation {
         tagger_id == self.id && self.tags.contains(&tag.label)
     }
 
-    /// Apply moderation by deleting the tagged resource.
+    /// Apply moderation to the tagged resource.
     ///
-    /// Parses the embedded URI in the moderator tag and deletes the corresponding
-    /// resource (post, tag, user, or file).
+    /// Parses the embedded URI in the moderator tag and removes the corresponding
+    /// resource (tag, user, or file). Posts are hard-deleted when edge-free or
+    /// tombstoned when engagement edges remain.
     #[tracing::instrument(name = "moderation.apply", skip_all)]
     pub async fn apply_moderation(
         &self,
         moderator_tag: PubkyAppTag,
         files_path: PathBuf,
+        ingestor: &UserIngestor,
     ) -> Result<(), EventProcessorError> {
         let lahel = moderator_tag.label;
         let moderated_uri = &moderator_tag.uri;
@@ -57,7 +60,9 @@ impl Moderation {
         match parsed_uri.resource {
             Resource::Post(post_id) => {
                 info!("Moderation tag '{lahel}' detected. Deleting post {user_id}:{post_id}");
-                handlers::post::sync_del(user_id, post_id).await
+                // Same gate as user-issued DEL events: hard-delete when edge-free, tombstone
+                // when any engagement edge remains (tags, bookmarks, replies, reposts, mentions).
+                handlers::post::del(user_id, post_id, ingestor).await
             }
             Resource::Tag(tag_id) => {
                 info!("Moderation tag '{lahel}' detected. Deleting tag {user_id}:{tag_id}");

--- a/nexus-watcher/src/events/moderation.rs
+++ b/nexus-watcher/src/events/moderation.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use crate::errors::EventProcessorError;
 use crate::events::handlers;
+use nexus_common::models::user::UserIngestor;
 use nexus_common::WatcherConfig;
 use pubky_app_specs::{ParsedUri, PubkyAppTag, PubkyId, Resource};
 use tracing::info;
@@ -30,15 +31,17 @@ impl Moderation {
         tagger_id == &self.id && self.tags.contains(&tag.label)
     }
 
-    /// Apply moderation by deleting the tagged resource.
+    /// Apply moderation to the tagged resource.
     ///
-    /// Parses the embedded URI in the moderator tag and deletes the corresponding
-    /// resource (post, tag, user, or file).
+    /// Parses the embedded URI in the moderator tag and removes the corresponding
+    /// resource (tag, user, or file). Posts are hard-deleted when edge-free or
+    /// tombstoned when engagement edges remain.
     #[tracing::instrument(name = "moderation.apply", skip_all)]
     pub async fn apply_moderation(
         &self,
         moderator_tag: PubkyAppTag,
         files_path: &Path,
+        ingestor: &UserIngestor,
     ) -> Result<(), EventProcessorError> {
         let lahel = moderator_tag.label;
         let moderated_uri = &moderator_tag.uri;
@@ -57,7 +60,9 @@ impl Moderation {
         match parsed_uri.resource {
             Resource::Post(post_id) => {
                 info!("Moderation tag '{lahel}' detected. Deleting post {user_id}:{post_id}");
-                handlers::post::sync_del(user_id, post_id).await
+                // Same gate as user-issued DEL events: hard-delete when edge-free, tombstone
+                // when any engagement edge remains (tags, bookmarks, replies, reposts, mentions).
+                handlers::post::del(user_id, post_id, ingestor).await
             }
             Resource::Tag(tag_id) => {
                 info!("Moderation tag '{lahel}' detected. Deleting tag {user_id}:{tag_id}");

--- a/nexus-watcher/tests/event_processor/posts/moderated.rs
+++ b/nexus-watcher/tests/event_processor/posts/moderated.rs
@@ -1,14 +1,19 @@
 use crate::event_processor::{
-    posts::utils::find_post_details,
+    posts::utils::{find_post_details, short_post, test_user},
+    tags::utils::check_member_post_tag_global_timeline,
+    users::utils::find_user_counts,
     utils::watcher::{HomeserverHashIdPath, WatcherTest},
 };
 use anyhow::Result;
 use chrono::Utc;
+use nexus_common::models::post::PostCounts;
 use pubky::{recovery_file, Keypair};
 use pubky_app_specs::{
     post_uri_builder, PubkyAppPost, PubkyAppPostKind, PubkyAppTag, PubkyAppUser,
 };
 use tokio::fs;
+
+const MODERATION_LABEL: &str = "label_to_moderate";
 
 #[tokio_shared_rt::test(shared)]
 async fn test_moderated_post_lifecycle() -> Result<()> {
@@ -62,4 +67,157 @@ async fn test_moderated_post_lifecycle() -> Result<()> {
     assert!(post_details.is_err());
 
     Ok(())
+}
+
+/// Moderating a post that still has a tag from another user must tombstone the
+/// post (content becomes "[DELETED]") instead of DETACH DELETEing the node,
+/// so the tagger's counts and the tag timeline index stay consistent.
+#[tokio_shared_rt::test(shared)]
+async fn test_moderated_post_with_tag_is_tombstoned() -> Result<()> {
+    let mut test = WatcherTest::setup(None).await?;
+
+    // Author signup and post creation
+    let author_kp = Keypair::random();
+    let author = test_user("Watcher:PostModerateTagged:Author", "author");
+    let author_id = test.create_user(&author_kp, &author).await?;
+
+    let post = short_post("Watcher:PostModerateTagged:Post");
+    let (post_id, _post_path) = test.create_post(&author_kp, &post).await?;
+
+    // A second user tags the post
+    let tagger_kp = Keypair::random();
+    let tagger = test_user("Watcher:PostModerateTagged:Tagger", "tagger");
+    let tagger_id = test.create_user(&tagger_kp, &tagger).await?;
+
+    let label = "mod_tagged_post";
+    let tag = PubkyAppTag {
+        uri: post_uri_builder(author_id.clone(), post_id.clone()),
+        label: label.to_string(),
+        created_at: Utc::now().timestamp_millis(),
+    };
+    let tag_path = tag.hs_path();
+    test.put(&tagger_kp, &tag_path, tag).await?;
+
+    // Sanity: the tag is indexed before moderation
+    let post_key: [&str; 2] = [&author_id, &post_id];
+    assert_eq!(
+        find_user_counts(&tagger_id).await.tagged,
+        1,
+        "tagger's tagged count should be 1 before moderation"
+    );
+    assert!(
+        check_member_post_tag_global_timeline(&post_key, label)
+            .await?
+            .is_some(),
+        "tag timeline entry should exist before moderation"
+    );
+
+    // Moderator flags the post
+    let moderator_kp = create_moderator(&mut test).await?;
+    moderate_post(&mut test, &moderator_kp, &author_id, &post_id).await?;
+
+    // The post node survives as a tombstone with its content replaced
+    let post_details = find_post_details(&author_id, &post_id)
+        .await
+        .expect("moderated post with edges should still exist as a tombstone");
+    assert_eq!(
+        post_details.content, "[DELETED]",
+        "moderated post content should exactly be [DELETED]"
+    );
+
+    // The tagger's state stays intact: counts and tag timeline are untouched
+    assert_eq!(
+        find_user_counts(&tagger_id).await.tagged,
+        1,
+        "tagger's tagged count should stay intact after moderation"
+    );
+    assert!(
+        check_member_post_tag_global_timeline(&post_key, label)
+            .await?
+            .is_some(),
+        "tag timeline entry should stay intact after moderation"
+    );
+
+    // End-to-end kill shot: the tagger deletes their tag on the tombstoned post.
+    // Because the TAGGED edge survived moderation, the DEL event runs the normal
+    // cleanup path. With a DETACH DELETE (the old behavior) the edge is gone,
+    // tag::del hits its idempotent no-op and the state below stays orphaned.
+    test.del(&tagger_kp, &tag_path).await?;
+
+    assert_eq!(
+        find_user_counts(&tagger_id).await.tagged,
+        0,
+        "tagger's tagged count should drop to 0 once they delete their tag"
+    );
+    assert!(
+        check_member_post_tag_global_timeline(&post_key, label)
+            .await?
+            .is_none(),
+        "tag timeline entry should be gone once the tagger deletes their tag"
+    );
+
+    Ok(())
+}
+
+/// Moderating a post without any edges must still fully delete it from both
+/// the graph and the Redis indexes, exactly as before the tombstone gating.
+#[tokio_shared_rt::test(shared)]
+async fn test_moderated_bare_post_is_hard_deleted() -> Result<()> {
+    let mut test = WatcherTest::setup(None).await?;
+
+    // Author signup and post creation
+    let author_kp = Keypair::random();
+    let author = test_user("Watcher:PostModerateBare:Author", "author");
+    let author_id = test.create_user(&author_kp, &author).await?;
+
+    let post = short_post("Watcher:PostModerateBare:Post");
+    let (post_id, _post_path) = test.create_post(&author_kp, &post).await?;
+
+    // Sanity: the post exists before moderation
+    assert!(find_post_details(&author_id, &post_id).await.is_ok());
+
+    // Moderator flags the post
+    let moderator_kp = create_moderator(&mut test).await?;
+    moderate_post(&mut test, &moderator_kp, &author_id, &post_id).await?;
+
+    // The edge-free post is hard-deleted from the graph, not tombstoned
+    assert!(
+        find_post_details(&author_id, &post_id).await.is_err(),
+        "bare moderated post should be fully deleted from the graph"
+    );
+
+    // The cached counts are gone as well
+    let post_counts = PostCounts::get_from_index(&author_id, &post_id)
+        .await
+        .unwrap();
+    assert!(
+        post_counts.is_none(),
+        "bare moderated post counts should be deleted from the index"
+    );
+
+    Ok(())
+}
+
+async fn create_moderator(test: &mut WatcherTest) -> Result<Keypair> {
+    let moderator_recovery_file =
+        fs::read("./tests/event_processor/utils/moderator_key.pkarr").await?;
+    let moderator_kp = recovery_file::decrypt_recovery_file(&moderator_recovery_file, "password")?;
+    let moderator = test_user("Watcher:PostModerate:Moderator", "moderator");
+    test.create_user(&moderator_kp, &moderator).await?;
+    Ok(moderator_kp)
+}
+
+async fn moderate_post(
+    test: &mut WatcherTest,
+    moderator_kp: &Keypair,
+    author_id: &str,
+    post_id: &str,
+) -> Result<()> {
+    let tag = PubkyAppTag {
+        uri: post_uri_builder(author_id.to_string(), post_id.to_string()),
+        label: MODERATION_LABEL.to_string(),
+        created_at: Utc::now().timestamp_millis(),
+    };
+    let tag_path = tag.hs_path();
+    test.put(moderator_kp, &tag_path, tag).await
 }

--- a/nexus-watcher/tests/event_processor/posts/moderated.rs
+++ b/nexus-watcher/tests/event_processor/posts/moderated.rs
@@ -1,14 +1,19 @@
 use crate::event_processor::{
-    posts::utils::find_post_details,
+    posts::utils::{find_post_details, short_post, test_user},
+    tags::utils::check_member_post_tag_global_timeline,
+    users::utils::find_user_counts,
     utils::watcher::{HomeserverHashIdPath, WatcherTest},
 };
 use anyhow::Result;
 use chrono::Utc;
+use nexus_common::models::post::PostCounts;
 use pubky::{recovery_file, Keypair};
 use pubky_app_specs::{
     post_uri_builder, PubkyAppPost, PubkyAppPostKind, PubkyAppTag, PubkyAppUser,
 };
 use tokio::fs;
+
+const MODERATION_LABEL: &str = "label_to_moderate";
 
 #[tokio_shared_rt::test(shared)]
 async fn test_moderated_post_lifecycle() -> Result<()> {
@@ -63,4 +68,157 @@ async fn test_moderated_post_lifecycle() -> Result<()> {
     assert!(post_details.is_err());
 
     Ok(())
+}
+
+/// Moderating a post that still has a tag from another user must tombstone the
+/// post (content becomes "[DELETED]") instead of DETACH DELETEing the node,
+/// so the tagger's counts and the tag timeline index stay consistent.
+#[tokio_shared_rt::test(shared)]
+async fn test_moderated_post_with_tag_is_tombstoned() -> Result<()> {
+    let mut test = WatcherTest::setup(None).await?;
+
+    // Author signup and post creation
+    let author_kp = Keypair::random();
+    let author = test_user("Watcher:PostModerateTagged:Author", "author");
+    let author_id = test.create_user(&author_kp, &author).await?;
+
+    let post = short_post("Watcher:PostModerateTagged:Post");
+    let (post_id, _post_path) = test.create_post(&author_kp, &post).await?;
+
+    // A second user tags the post
+    let tagger_kp = Keypair::random();
+    let tagger = test_user("Watcher:PostModerateTagged:Tagger", "tagger");
+    let tagger_id = test.create_user(&tagger_kp, &tagger).await?;
+
+    let label = "mod_tagged_post";
+    let tag = PubkyAppTag {
+        uri: post_uri_builder(author_id.clone(), post_id.clone()),
+        label: label.to_string(),
+        created_at: Utc::now().timestamp_millis(),
+    };
+    let tag_path = tag.hs_path();
+    test.put(&tagger_kp, &tag_path, tag).await?;
+
+    // Sanity: the tag is indexed before moderation
+    let post_key: [&str; 2] = [&author_id, &post_id];
+    assert_eq!(
+        find_user_counts(&tagger_id).await.tagged,
+        1,
+        "tagger's tagged count should be 1 before moderation"
+    );
+    assert!(
+        check_member_post_tag_global_timeline(&post_key, label)
+            .await?
+            .is_some(),
+        "tag timeline entry should exist before moderation"
+    );
+
+    // Moderator flags the post
+    let moderator_kp = create_moderator(&mut test).await?;
+    moderate_post(&mut test, &moderator_kp, &author_id, &post_id).await?;
+
+    // The post node survives as a tombstone with its content replaced
+    let post_details = find_post_details(&author_id, &post_id)
+        .await
+        .expect("moderated post with edges should still exist as a tombstone");
+    assert_eq!(
+        post_details.content, "[DELETED]",
+        "moderated post content should exactly be [DELETED]"
+    );
+
+    // The tagger's state stays intact: counts and tag timeline are untouched
+    assert_eq!(
+        find_user_counts(&tagger_id).await.tagged,
+        1,
+        "tagger's tagged count should stay intact after moderation"
+    );
+    assert!(
+        check_member_post_tag_global_timeline(&post_key, label)
+            .await?
+            .is_some(),
+        "tag timeline entry should stay intact after moderation"
+    );
+
+    // End-to-end kill shot: the tagger deletes their tag on the tombstoned post.
+    // Because the TAGGED edge survived moderation, the DEL event runs the normal
+    // cleanup path. With a DETACH DELETE (the old behavior) the edge is gone,
+    // tag::del hits its idempotent no-op and the state below stays orphaned.
+    test.del(&tagger_kp, &tag_path).await?;
+
+    assert_eq!(
+        find_user_counts(&tagger_id).await.tagged,
+        0,
+        "tagger's tagged count should drop to 0 once they delete their tag"
+    );
+    assert!(
+        check_member_post_tag_global_timeline(&post_key, label)
+            .await?
+            .is_none(),
+        "tag timeline entry should be gone once the tagger deletes their tag"
+    );
+
+    Ok(())
+}
+
+/// Moderating a post without any edges must still fully delete it from both
+/// the graph and the Redis indexes, exactly as before the tombstone gating.
+#[tokio_shared_rt::test(shared)]
+async fn test_moderated_bare_post_is_hard_deleted() -> Result<()> {
+    let mut test = WatcherTest::setup(None).await?;
+
+    // Author signup and post creation
+    let author_kp = Keypair::random();
+    let author = test_user("Watcher:PostModerateBare:Author", "author");
+    let author_id = test.create_user(&author_kp, &author).await?;
+
+    let post = short_post("Watcher:PostModerateBare:Post");
+    let (post_id, _post_path) = test.create_post(&author_kp, &post).await?;
+
+    // Sanity: the post exists before moderation
+    assert!(find_post_details(&author_id, &post_id).await.is_ok());
+
+    // Moderator flags the post
+    let moderator_kp = create_moderator(&mut test).await?;
+    moderate_post(&mut test, &moderator_kp, &author_id, &post_id).await?;
+
+    // The edge-free post is hard-deleted from the graph, not tombstoned
+    assert!(
+        find_post_details(&author_id, &post_id).await.is_err(),
+        "bare moderated post should be fully deleted from the graph"
+    );
+
+    // The cached counts are gone as well
+    let post_counts = PostCounts::get_from_index(&author_id, &post_id)
+        .await
+        .unwrap();
+    assert!(
+        post_counts.is_none(),
+        "bare moderated post counts should be deleted from the index"
+    );
+
+    Ok(())
+}
+
+async fn create_moderator(test: &mut WatcherTest) -> Result<Keypair> {
+    let moderator_recovery_file =
+        fs::read("./tests/event_processor/utils/moderator_key.pkarr").await?;
+    let moderator_kp = recovery_file::decrypt_recovery_file(&moderator_recovery_file, "password")?;
+    let moderator = test_user("Watcher:PostModerate:Moderator", "moderator");
+    test.create_user(&moderator_kp, &moderator).await?;
+    Ok(moderator_kp)
+}
+
+async fn moderate_post(
+    test: &mut WatcherTest,
+    moderator_kp: &Keypair,
+    author_id: &str,
+    post_id: &str,
+) -> Result<()> {
+    let tag = PubkyAppTag {
+        uri: post_uri_builder(author_id.to_string(), post_id.to_string()),
+        label: MODERATION_LABEL.to_string(),
+        created_at: Utc::now().timestamp_millis(),
+    };
+    let tag_path = tag.hs_path();
+    test.put(moderator_kp, &tag_path, tag).await
 }


### PR DESCRIPTION
Moderation deleted posts by calling `sync_del` directly, skipping the `post_is_safe_to_delete` gate every other resource type goes through. A moderated post that still had tags, bookmarks or replies was DETACH DELETEd, leaving tagger/bookmarker counts and tag timelines permanently orphaned, and destroying the edges means the users' own later tag/bookmark DELs hit the "edge already gone" no-op, so it never self-heals.

Fix: route `Resource::Post` through `post::del`, threading the `UserIngestor` the tombstone path needs. Behavior change: a moderated post with engagement is now tombstoned (`[DELETED]`) like a user-deleted one instead of vanishing with corrupted indexes; edge-free posts are hard-deleted as before.

The new test tombstones a tagged post, then has the tagger delete their tag and asserts the cleanup actually lands (red on main at four points).

Fixes #961

## Pre-submission Checklist

- [x] I manually reviewed the PR
- [x] I asked one or more LLMs to review the PR
- [x] I asked one or more LLMs to check if this PR can be simplified
- [x] If appropriate, I added tests for the changes in this PR
- [ ] If appropriate, I added performance benchmarks for the APIs added in this PR (n/a)
