### PR TITLE
fix(tags): gate resource tag del decrements behind tagger set membership

### DIFF
--- a/nexus-watcher/src/events/handlers/tag.rs
+++ b/nexus-watcher/src/events/handlers/tag.rs
@@ -147,6 +147,10 @@ async fn put_sync_resource(
                 ),
                 // Add tagger to Resource's label tagger set
                 TagResource::add_tagger_to_index(resource_id, None, &tagger_id, tag_label),
+                // Add tagger to the app-scoped tagger set. The TAGGED edge is
+                // keyed {label, app}, so this records one member per created
+                // edge; tag::del uses it as the retry gate for the decrements
+                TagResource::add_tagger_to_index(resource_id, Some(app), &tagger_id, tag_label),
                 // Add to global tag search index
                 TagSearch::put_to_index(tag_label_slice),
                 // ResourceStream sorted set maintenance
@@ -187,6 +191,7 @@ async fn put_sync_resource(
             indexing_results.8?;
             indexing_results.9?;
             indexing_results.10?;
+            indexing_results.11?;
 
             Ok(())
         }
@@ -476,10 +481,24 @@ pub async fn del(tag_uri: &str) -> Result<(), EventProcessorError> {
             .await?;
         }
         (None, None, None, Some(res_id)) => {
-            let tagger_in_index =
-                TagResource::check_set_member(&[&res_id, &label], arg_user_id.as_ref())
-                    .await?
-                    .1;
+            // The put path runs its increments once per created TAGGED edge,
+            // and resource edges are keyed {label, app}: the same user tagging
+            // the same resource and label from two apps increments every count
+            // twice. The retry gate must therefore be app-scoped as well; the
+            // app-agnostic taggers set holds the member only once and would
+            // wrongly skip the decrements of the second app's delete
+            let tagger_in_index = match app.as_deref() {
+                Some(a) => {
+                    TagResource::check_set_member(&[&res_id, a, &label], arg_user_id.as_ref())
+                        .await?
+                        .1
+                }
+                None => {
+                    TagResource::check_set_member(&[&res_id, &label], arg_user_id.as_ref())
+                        .await?
+                        .1
+                }
+            };
             del_sync_resource(
                 arg_user_id.clone(),
                 &res_id,
@@ -697,7 +716,9 @@ async fn del_sync_post(
 /// Orphaned Resource node cleanup is handled by the delete_tag Cypher query.
 /// Timeline entries are only removed when taggers count reaches zero.
 /// Non-idempotent decrements are guarded by `tagger_in_index` so a retried
-/// event does not double-decrement the taggers counts.
+/// event does not double-decrement the taggers counts. The gate comes from
+/// the app-scoped tagger set, which the put path fills once per created
+/// TAGGED edge (keyed {label, app}), matching the per-edge increments.
 async fn del_sync_resource(
     tagger_id: PubkyId,
     resource_id: &str,
@@ -725,6 +746,13 @@ async fn del_sync_resource(
             TagResource(vec![tagger_id.to_string()])
                 .del_from_index(resource_id, None, tag_label)
                 .await?;
+            // Idempotent: Delete the tagger from the app-scoped tagger set
+            // that gates the decrements above (SREM)
+            if let Some(a) = app {
+                TagResource(vec![tagger_id.to_string()])
+                    .del_from_index(resource_id, Some(a), tag_label)
+                    .await?;
+            }
             Ok::<(), EventProcessorError>(())
         },
         // Guarded: Decrement global taggers count

--- a/nexus-watcher/src/events/handlers/tag.rs
+++ b/nexus-watcher/src/events/handlers/tag.rs
@@ -476,7 +476,18 @@ pub async fn del(tag_uri: &str) -> Result<(), EventProcessorError> {
             .await?;
         }
         (None, None, None, Some(res_id)) => {
-            del_sync_resource(arg_user_id.clone(), &res_id, &label, app.as_deref()).await?;
+            let tagger_in_index =
+                TagResource::check_set_member(&[&res_id, &label], arg_user_id.as_ref())
+                    .await?
+                    .1;
+            del_sync_resource(
+                arg_user_id.clone(),
+                &res_id,
+                &label,
+                app.as_deref(),
+                tagger_in_index,
+            )
+            .await?;
         }
         _ => {
             debug!("DEL-Tag: Unexpected combination of tag details");
@@ -685,46 +696,82 @@ async fn del_sync_post(
 /// Cleans up Redis indexes when a Resource tag is deleted.
 /// Orphaned Resource node cleanup is handled by the delete_tag Cypher query.
 /// Timeline entries are only removed when taggers count reaches zero.
+/// Non-idempotent decrements are guarded by `tagger_in_index` so a retried
+/// event does not double-decrement the taggers counts.
 async fn del_sync_resource(
     tagger_id: PubkyId,
     resource_id: &str,
     tag_label: &str,
     app: Option<&str>,
+    tagger_in_index: bool,
 ) -> Result<(), EventProcessorError> {
     // Step 1: Decrement scores and remove tagger from sets
     let score_results = tokio::join!(
-        TagResource::update_index_score(resource_id, None, tag_label, ScoreAction::Decrement(1.0)),
+        // Guarded: Decrement label score in the resource
         async {
+            if tagger_in_index {
+                TagResource::update_index_score(
+                    resource_id,
+                    None,
+                    tag_label,
+                    ScoreAction::Decrement(1.0),
+                )
+                .await?;
+            }
+            Ok::<(), EventProcessorError>(())
+        },
+        async {
+            // Idempotent: Delete the tagger from the tag list (SREM)
             TagResource(vec![tagger_id.to_string()])
                 .del_from_index(resource_id, None, tag_label)
                 .await?;
             Ok::<(), EventProcessorError>(())
         },
-        ResourceStream::update_global_taggers_count(resource_id, ScoreAction::Decrement(1.0)),
-        ResourceStream::update_tag_taggers_count(
-            tag_label,
-            resource_id,
-            ScoreAction::Decrement(1.0),
-        ),
+        // Guarded: Decrement global taggers count
         async {
-            if let Some(a) = app {
-                let (r1, r2) = tokio::join!(
-                    ResourceStream::update_app_taggers_count(
-                        a,
-                        resource_id,
-                        ScoreAction::Decrement(1.0),
-                    ),
-                    ResourceStream::update_app_tag_taggers_count(
-                        a,
-                        tag_label,
-                        resource_id,
-                        ScoreAction::Decrement(1.0),
-                    ),
-                );
-                r1?;
-                r2?;
+            if tagger_in_index {
+                ResourceStream::update_global_taggers_count(
+                    resource_id,
+                    ScoreAction::Decrement(1.0),
+                )
+                .await?;
             }
-            Ok::<(), nexus_common::db::kv::RedisError>(())
+            Ok::<(), EventProcessorError>(())
+        },
+        // Guarded: Decrement tag taggers count
+        async {
+            if tagger_in_index {
+                ResourceStream::update_tag_taggers_count(
+                    tag_label,
+                    resource_id,
+                    ScoreAction::Decrement(1.0),
+                )
+                .await?;
+            }
+            Ok::<(), EventProcessorError>(())
+        },
+        // Guarded: Decrement app and app-tag taggers counts
+        async {
+            if tagger_in_index {
+                if let Some(a) = app {
+                    let (r1, r2) = tokio::join!(
+                        ResourceStream::update_app_taggers_count(
+                            a,
+                            resource_id,
+                            ScoreAction::Decrement(1.0),
+                        ),
+                        ResourceStream::update_app_tag_taggers_count(
+                            a,
+                            tag_label,
+                            resource_id,
+                            ScoreAction::Decrement(1.0),
+                        ),
+                    );
+                    r1?;
+                    r2?;
+                }
+            }
+            Ok::<(), EventProcessorError>(())
         }
     );
 

--- a/nexus-watcher/tests/event_processor/tags/mod.rs
+++ b/nexus-watcher/tests/event_processor/tags/mod.rs
@@ -10,6 +10,7 @@ mod post_notification;
 mod post_put;
 mod resource_dedup;
 mod resource_del;
+mod resource_del_retry;
 mod resource_internal_known;
 mod resource_put;
 mod resource_utils;

--- a/nexus-watcher/tests/event_processor/tags/resource_del_retry.rs
+++ b/nexus-watcher/tests/event_processor/tags/resource_del_retry.rs
@@ -16,9 +16,9 @@ use pubky_app_specs::{PubkyAppTag, PubkyAppUser};
 
 /// Simulate a retry of a resource tag del after a partial failure where the
 /// Redis cleanup succeeded but the graph deletion failed. On retry, the
-/// taggers counts must NOT be decremented again (guarded by the tagger set
-/// membership check), so a still-tagged resource must keep count 1 and stay
-/// in the resource timelines.
+/// taggers counts must NOT be decremented again (guarded by the app-scoped
+/// tagger set membership check), so a still-tagged resource must keep count 1
+/// and stay in the resource timelines.
 #[tokio_shared_rt::test(shared)]
 async fn test_resource_tag_del_retry_no_double_decrement() -> Result<()> {
     let mut test = WatcherTest::setup(None).await?;
@@ -75,10 +75,13 @@ async fn test_resource_tag_del_retry_no_double_decrement() -> Result<()> {
     assert_eq!(global_count, Some(2));
 
     // Simulate partial completion of a previous del attempt for user1's tag:
-    // the Redis cleanup (SREM + all decrements) completed, but the graph
+    // the Redis cleanup (SREMs + all decrements) completed, but the graph
     // deletion failed, so the TAGGED edge is still present
     TagResource(vec![user1_id.clone()])
         .del_from_index(&resource_id, None, label)
+        .await?;
+    TagResource(vec![user1_id.clone()])
+        .del_from_index(&resource_id, Some(app), label)
         .await?;
     TagResource::update_index_score(&resource_id, None, label, ScoreAction::Decrement(1.0)).await?;
     ResourceStream::update_global_taggers_count(&resource_id, ScoreAction::Decrement(1.0)).await?;
@@ -163,6 +166,177 @@ async fn test_resource_tag_del_retry_no_double_decrement() -> Result<()> {
     test.del(&user2_kp, &path2).await?;
     test.cleanup_user(&user1_kp).await?;
     test.cleanup_user(&user2_kp).await?;
+
+    Ok(())
+}
+
+/// The same user tags the same external URI with the same label from TWO
+/// different app namespaces, creating two app-scoped TAGGED edges whose put
+/// events each incremented all five taggers counts. The retry gate must be
+/// app-scoped: a retry of the first app's delete must not double-decrement,
+/// and the second app's delete must still run its decrements so that every
+/// count reaches zero and the resource is evicted from all timelines.
+#[tokio_shared_rt::test(shared)]
+async fn test_resource_tag_del_multi_app_full_cleanup() -> Result<()> {
+    let mut test = WatcherTest::setup(None).await?;
+
+    let target_uri = "https://example.com/multi-app-del-test";
+    let label = "multi-app-res-label";
+    let app1 = "mapky";
+    let app2 = "eventky";
+    let resource_id = compute_resource_id(target_uri);
+
+    let user_kp = Keypair::random();
+    let user = PubkyAppUser {
+        bio: Some("resource_del_multi_app_user".to_string()),
+        image: None,
+        links: None,
+        name: "Watcher:ResourceDelMultiApp:User".to_string(),
+        status: None,
+    };
+    let user_id = test.create_user(&user_kp, &user).await?;
+
+    // Tag the URI from app1
+    let tag1 = PubkyAppTag {
+        uri: target_uri.to_string(),
+        label: label.to_string(),
+        created_at: Utc::now().timestamp_millis(),
+    };
+    let tag1_id = tag1.create_id();
+    let path1: ResourcePath = format!("/pub/{app1}/tags/{tag1_id}").parse()?;
+    test.put(&user_kp, &path1, &tag1).await?;
+
+    // Tag the same URI with the same label from app2
+    let tag2 = PubkyAppTag {
+        uri: target_uri.to_string(),
+        label: label.to_string(),
+        created_at: Utc::now().timestamp_millis() + 1,
+    };
+    let tag2_id = tag2.create_id();
+    let path2: ResourcePath = format!("/pub/{app2}/tags/{tag2_id}").parse()?;
+    test.put(&user_kp, &path2, &tag2).await?;
+
+    // Two app-scoped TAGGED edges; the per-edge increments ran twice for the
+    // app-agnostic counts and once for each app-scoped count
+    assert_eq!(count_resource_tags(&resource_id).await?, 2);
+    for (count_key_parts, expected) in [
+        (vec!["Resources", "Global", "TaggersCount"], 2),
+        (vec!["Resources", "Tag", label, "TaggersCount"], 2),
+        (vec!["Resources", "App", app1, "TaggersCount"], 1),
+        (
+            vec!["Resources", "App", app1, "Tag", label, "TaggersCount"],
+            1,
+        ),
+        (vec!["Resources", "App", app2, "TaggersCount"], 1),
+        (
+            vec!["Resources", "App", app2, "Tag", label, "TaggersCount"],
+            1,
+        ),
+    ] {
+        let count = check_resource_in_sorted_set(&count_key_parts, &resource_id).await?;
+        assert_eq!(
+            count,
+            Some(expected),
+            "Taggers count {count_key_parts:?} after both puts"
+        );
+    }
+
+    // Simulate partial completion of a del attempt for the app1 tag: the
+    // Redis cleanup (SREMs + all decrements) completed, but the graph
+    // deletion failed, so the app1 TAGGED edge is still present
+    TagResource(vec![user_id.clone()])
+        .del_from_index(&resource_id, None, label)
+        .await?;
+    TagResource(vec![user_id.clone()])
+        .del_from_index(&resource_id, Some(app1), label)
+        .await?;
+    TagResource::update_index_score(&resource_id, None, label, ScoreAction::Decrement(1.0)).await?;
+    ResourceStream::update_global_taggers_count(&resource_id, ScoreAction::Decrement(1.0)).await?;
+    ResourceStream::update_tag_taggers_count(label, &resource_id, ScoreAction::Decrement(1.0))
+        .await?;
+    ResourceStream::update_app_taggers_count(app1, &resource_id, ScoreAction::Decrement(1.0))
+        .await?;
+    ResourceStream::update_app_tag_taggers_count(
+        app1,
+        label,
+        &resource_id,
+        ScoreAction::Decrement(1.0),
+    )
+    .await?;
+
+    // Retry the app1 delete: it must not decrement anything again, only
+    // finish the pending graph deletion
+    let tag1_uri = format!("pubky://{user_id}/pub/{app1}/tags/{tag1_id}");
+    handlers::tag::del(&tag1_uri).await?;
+
+    // Only the app2 TAGGED edge remains, and the retry did not
+    // double-decrement the app-agnostic counts
+    assert_eq!(count_resource_tags(&resource_id).await?, 1);
+    for count_key_parts in [
+        vec!["Resources", "Global", "TaggersCount"],
+        vec!["Resources", "Tag", label, "TaggersCount"],
+        vec!["Resources", "App", app2, "TaggersCount"],
+        vec!["Resources", "App", app2, "Tag", label, "TaggersCount"],
+    ] {
+        let count = check_resource_in_sorted_set(&count_key_parts, &resource_id).await?;
+        assert_eq!(
+            count,
+            Some(1),
+            "Taggers count {count_key_parts:?} must be 1 after the app1 retry"
+        );
+    }
+    for timeline_key_parts in [
+        vec!["Resources", "Global", "Timeline"],
+        vec!["Resources", "Tag", label, "Timeline"],
+        vec!["Resources", "App", app2, "Timeline"],
+        vec!["Resources", "App", app2, "Tag", label, "Timeline"],
+    ] {
+        let member = check_resource_in_sorted_set(&timeline_key_parts, &resource_id).await?;
+        assert!(
+            member.is_some(),
+            "Resource must remain in timeline {timeline_key_parts:?} after the app1 retry"
+        );
+    }
+
+    // Delete the app2 tag: its app-scoped tagger set still holds the member,
+    // so all five decrements must run and zero out every count
+    test.del(&user_kp, &path2).await?;
+
+    assert_eq!(count_resource_tags(&resource_id).await?, 0);
+    for count_key_parts in [
+        vec!["Resources", "Global", "TaggersCount"],
+        vec!["Resources", "Tag", label, "TaggersCount"],
+        vec!["Resources", "App", app1, "TaggersCount"],
+        vec!["Resources", "App", app1, "Tag", label, "TaggersCount"],
+        vec!["Resources", "App", app2, "TaggersCount"],
+        vec!["Resources", "App", app2, "Tag", label, "TaggersCount"],
+    ] {
+        let count = check_resource_in_sorted_set(&count_key_parts, &resource_id).await?;
+        assert_eq!(
+            count.unwrap_or(0),
+            0,
+            "Taggers count {count_key_parts:?} must be 0 after both deletes"
+        );
+    }
+    for timeline_key_parts in [
+        vec!["Resources", "Global", "Timeline"],
+        vec!["Resources", "Tag", label, "Timeline"],
+        vec!["Resources", "App", app1, "Timeline"],
+        vec!["Resources", "App", app1, "Tag", label, "Timeline"],
+        vec!["Resources", "App", app2, "Timeline"],
+        vec!["Resources", "App", app2, "Tag", label, "Timeline"],
+    ] {
+        let member = check_resource_in_sorted_set(&timeline_key_parts, &resource_id).await?;
+        assert!(
+            member.is_none(),
+            "Resource must be evicted from timeline {timeline_key_parts:?} after both deletes"
+        );
+    }
+
+    // Cleanup: the app1 homeserver file still exists (its graph edge is
+    // already gone, so the DEL event is an idempotent no-op)
+    test.del(&user_kp, &path1).await?;
+    test.cleanup_user(&user_kp).await?;
 
     Ok(())
 }

--- a/nexus-watcher/tests/event_processor/tags/resource_del_retry.rs
+++ b/nexus-watcher/tests/event_processor/tags/resource_del_retry.rs
@@ -1,0 +1,168 @@
+use super::resource_utils::{
+    check_resource_in_sorted_set, compute_resource_id, count_resource_tags,
+};
+use crate::event_processor::utils::watcher::WatcherTest;
+use anyhow::Result;
+use chrono::Utc;
+use nexus_common::db::kv::ScoreAction;
+use nexus_common::models::resource::stream::ResourceStream;
+use nexus_common::models::resource::tag::TagResource;
+use nexus_common::models::tag::traits::{TagCollection, TaggersCollection};
+use nexus_watcher::events::handlers;
+use pubky::Keypair;
+use pubky::ResourcePath;
+use pubky_app_specs::traits::HashId;
+use pubky_app_specs::{PubkyAppTag, PubkyAppUser};
+
+/// Simulate a retry of a resource tag del after a partial failure where the
+/// Redis cleanup succeeded but the graph deletion failed. On retry, the
+/// taggers counts must NOT be decremented again (guarded by the tagger set
+/// membership check), so a still-tagged resource must keep count 1 and stay
+/// in the resource timelines.
+#[tokio_shared_rt::test(shared)]
+async fn test_resource_tag_del_retry_no_double_decrement() -> Result<()> {
+    let mut test = WatcherTest::setup(None).await?;
+
+    let target_uri = "https://example.com/del-retry-test";
+    let label = "retry-res-label";
+    let app = "mapky";
+    let resource_id = compute_resource_id(target_uri);
+
+    // Two users tag the same external URI with the same label from the same app
+    let user1_kp = Keypair::random();
+    let user1 = PubkyAppUser {
+        bio: Some("resource_del_retry_user_1".to_string()),
+        image: None,
+        links: None,
+        name: "Watcher:ResourceDelRetry:User1".to_string(),
+        status: None,
+    };
+    let user1_id = test.create_user(&user1_kp, &user1).await?;
+
+    let tag1 = PubkyAppTag {
+        uri: target_uri.to_string(),
+        label: label.to_string(),
+        created_at: Utc::now().timestamp_millis(),
+    };
+    let tag1_id = tag1.create_id();
+    let path1: ResourcePath = format!("/pub/{app}/tags/{tag1_id}").parse()?;
+    test.put(&user1_kp, &path1, &tag1).await?;
+
+    let user2_kp = Keypair::random();
+    let user2 = PubkyAppUser {
+        bio: Some("resource_del_retry_user_2".to_string()),
+        image: None,
+        links: None,
+        name: "Watcher:ResourceDelRetry:User2".to_string(),
+        status: None,
+    };
+    let _user2_id = test.create_user(&user2_kp, &user2).await?;
+
+    let tag2 = PubkyAppTag {
+        uri: target_uri.to_string(),
+        label: label.to_string(),
+        created_at: Utc::now().timestamp_millis(),
+    };
+    let tag2_id = tag2.create_id();
+    let path2: ResourcePath = format!("/pub/{app}/tags/{tag2_id}").parse()?;
+    test.put(&user2_kp, &path2, &tag2).await?;
+
+    // Verify initial state: 2 TAGGED edges, taggers counts at 2
+    assert_eq!(count_resource_tags(&resource_id).await?, 2);
+    let global_count =
+        check_resource_in_sorted_set(&["Resources", "Global", "TaggersCount"], &resource_id)
+            .await?;
+    assert_eq!(global_count, Some(2));
+
+    // Simulate partial completion of a previous del attempt for user1's tag:
+    // the Redis cleanup (SREM + all decrements) completed, but the graph
+    // deletion failed, so the TAGGED edge is still present
+    TagResource(vec![user1_id.clone()])
+        .del_from_index(&resource_id, None, label)
+        .await?;
+    TagResource::update_index_score(&resource_id, None, label, ScoreAction::Decrement(1.0)).await?;
+    ResourceStream::update_global_taggers_count(&resource_id, ScoreAction::Decrement(1.0)).await?;
+    ResourceStream::update_tag_taggers_count(label, &resource_id, ScoreAction::Decrement(1.0))
+        .await?;
+    ResourceStream::update_app_taggers_count(app, &resource_id, ScoreAction::Decrement(1.0))
+        .await?;
+    ResourceStream::update_app_tag_taggers_count(
+        app,
+        label,
+        &resource_id,
+        ScoreAction::Decrement(1.0),
+    )
+    .await?;
+
+    // Verify simulated state: graph still has both edges, counts already at 1
+    assert_eq!(count_resource_tags(&resource_id).await?, 2);
+    let global_count =
+        check_resource_in_sorted_set(&["Resources", "Global", "TaggersCount"], &resource_id)
+            .await?;
+    assert_eq!(global_count, Some(1));
+
+    // Retry: re-run the same delete event by calling the del handler directly.
+    // It must delete the graph edge without decrementing the counts again
+    let tag_uri = format!("pubky://{user1_id}/pub/{app}/tags/{tag1_id}");
+    handlers::tag::del(&tag_uri).await?;
+
+    // Only user2's TAGGED edge should remain in the graph
+    assert_eq!(count_resource_tags(&resource_id).await?, 1);
+
+    // Taggers count must be 1 (not 0): the retry must not double-decrement
+    let cache_tags = <TagResource as TagCollection>::get_from_index(
+        &resource_id,
+        None,
+        None,
+        None,
+        None,
+        None,
+        false,
+    )
+    .await?;
+    let details = cache_tags.expect("TagResource cache should still exist");
+    assert_eq!(details.len(), 1, "Should still have 1 label");
+    assert_eq!(details[0].label, label);
+    assert_eq!(
+        details[0].taggers_count, 1,
+        "Taggers count must be 1 after retry, not double-decremented to 0"
+    );
+
+    // All taggers counts must be 1 (not 0)
+    for count_key_parts in [
+        vec!["Resources", "Global", "TaggersCount"],
+        vec!["Resources", "Tag", label, "TaggersCount"],
+        vec!["Resources", "App", app, "TaggersCount"],
+        vec!["Resources", "App", app, "Tag", label, "TaggersCount"],
+    ] {
+        let count = check_resource_in_sorted_set(&count_key_parts, &resource_id).await?;
+        assert_eq!(
+            count,
+            Some(1),
+            "Taggers count {count_key_parts:?} must be 1 after retry"
+        );
+    }
+
+    // The still-tagged resource must NOT be evicted from the timelines
+    for timeline_key_parts in [
+        vec!["Resources", "Global", "Timeline"],
+        vec!["Resources", "Tag", label, "Timeline"],
+        vec!["Resources", "App", app, "Timeline"],
+        vec!["Resources", "App", app, "Tag", label, "Timeline"],
+    ] {
+        let member = check_resource_in_sorted_set(&timeline_key_parts, &resource_id).await?;
+        assert!(
+            member.is_some(),
+            "Resource must remain in timeline {timeline_key_parts:?} after retry"
+        );
+    }
+
+    // Cleanup: user1's homeserver file still exists (graph edge already gone,
+    // the DEL event is an idempotent no-op), then really delete user2's tag
+    test.del(&user1_kp, &path1).await?;
+    test.del(&user2_kp, &path2).await?;
+    test.cleanup_user(&user1_kp).await?;
+    test.cleanup_user(&user2_kp).await?;
+
+    Ok(())
+}


### PR DESCRIPTION
The user and post branches of `tag::del` compute a `tagger_in_index` gate so retried deletes skip the non-idempotent decrements. The resource branch didn't: a retry re-applied five unfloored ZINCRBY decrements, and `remove_timeline_if_empty` then evicted still-tagged resources from the global/tag/app/app-tag timelines once the double-decremented score hit zero.

Fix: compute the gate via `TagResource::check_set_member` and guard the five decrements in `del_sync_resource`, mirroring the sibling branches exactly. The SREM and the timeline cleanup stay unconditional (idempotent).

The new retry test fails on main (count double-decremented to 0, resource evicted) and passes here.

Fixes #962

## Pre-submission Checklist

- [x] I manually reviewed the PR
- [x] I asked one or more LLMs to review the PR
- [x] I asked one or more LLMs to check if this PR can be simplified
- [x] If appropriate, I added tests for the changes in this PR
- [ ] If appropriate, I added performance benchmarks for the APIs added in this PR (n/a)
