### PR TITLE
fix(retry): guard retry-store removals and reschedules with a per-entry nonce

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3072,6 +3072,7 @@ dependencies = [
  "base32",
  "bytes",
  "chrono",
+ "deadpool-redis",
  "futures",
  "http",
  "nexus-common",

--- a/nexus-watcher/Cargo.toml
+++ b/nexus-watcher/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT"
 async-trait = { workspace = true }
 bytes = "1"
 chrono = { workspace = true }
+deadpool-redis = { workspace = true }
 futures = { workspace = true }
 nexus-common = { path = "../nexus-common" }
 opentelemetry = { workspace = true }

--- a/nexus-watcher/src/events/retry/event.rs
+++ b/nexus-watcher/src/events/retry/event.rs
@@ -1,9 +1,11 @@
 use crate::events::{Event, EventType};
 use async_trait::async_trait;
-use nexus_common::db::kv::{RedisResult, SortOrder};
+use chrono::Utc;
+use deadpool_redis::redis::Script;
+use nexus_common::db::kv::{RedisError, RedisResult, SortOrder};
 use serde::{Deserialize, Serialize};
 
-use nexus_common::db::RedisOps;
+use nexus_common::db::{get_redis_conn, RedisOps};
 
 use crate::events::EventProcessorError;
 
@@ -53,6 +55,19 @@ pub struct RetryEvent {
     pub next_retry_at: i64,
     /// Homeserver that served the event
     pub origin_homeserver_id: String,
+    /// Identity of this logical enqueue, used by the compare-and-act store ops.
+    ///
+    /// Retry entries are keyed by hash(URI) only, so a newer event for the same
+    /// URI overwrites the stored entry while the retry processor may still hold
+    /// the previous one in memory. Conditional removals and reschedules compare
+    /// this nonce so a stale in-flight retry cannot clobber the newer entry.
+    ///
+    /// A reschedule keeps the nonce (same logical event); only a fresh enqueue
+    /// mints a new one. `#[serde(default)]` lets entries stored before this
+    /// field existed deserialize as nonce 0, which the conditional ops also
+    /// treat as the "field missing in stored JSON" case.
+    #[serde(default)]
+    pub nonce: i64,
 }
 
 #[async_trait]
@@ -61,6 +76,27 @@ impl RedisOps for RetryEvent {
         String::from(RETRY_MANAGER_PREFIX)
     }
 }
+
+/// Shared Lua preamble for the compare-and-act scripts
+/// ([`RetryEvent::remove_from_index_if_nonce`] and
+/// [`RetryEvent::put_to_index_if_nonce`]): loads the stored entry's nonce from
+/// the JSON state at `KEYS[1]` and returns 0 (no-op) unless it equals
+/// `ARGV[1]`; each script appends its own action suffix.
+///
+/// Nonces are compared as raw strings: they are i64 nanosecond timestamps that
+/// would lose precision as Lua doubles. `JSON.GET key $.nonce` returns a JSON
+/// array of matches, e.g. `[123]`; an entry stored before the nonce field
+/// existed yields `[]` and is treated as nonce 0, matching `#[serde(default)]`
+/// on the Rust side.
+const NONCE_GUARD_LUA: &str = r#"
+            local stored = redis.call('JSON.GET', KEYS[1], '$.nonce')
+            if not stored then
+                return 0
+            end
+            local nonce = string.match(stored, '^%[(%-?%d+)%]$') or '0'
+            if nonce ~= ARGV[1] then
+                return 0
+            end"#;
 
 impl RetryEvent {
     /// Creates a new RetryEvent from the source event
@@ -71,7 +107,34 @@ impl RetryEvent {
             event_uri: event.uri.clone(),
             next_retry_at,
             origin_homeserver_id: origin_homeserver_id.into(),
+            nonce: Self::fresh_nonce(),
         }
+    }
+
+    /// Nonce for a freshly enqueued event: the current wall-clock time in
+    /// nanoseconds, falling back to milliseconds if nanoseconds do not fit in
+    /// an i64 (dates past the year 2262).
+    fn fresh_nonce() -> i64 {
+        let now = Utc::now();
+        now.timestamp_nanos_opt()
+            .unwrap_or_else(|| now.timestamp_millis())
+    }
+
+    /// Full Redis key of the JSON state entry for `index_key`, matching the
+    /// layout used by [`Self::put_to_index`] (RedisOps prefix + key parts
+    /// joined with ':').
+    fn state_json_key(index_key: &IndexKey) -> String {
+        format!(
+            "{RETRY_MANAGER_PREFIX}:{}:{}",
+            RETRY_MANAGER_STATE_INDEX[0],
+            index_key.as_str()
+        )
+    }
+
+    /// Full Redis key of the events sorted set, matching the layout used by
+    /// [`Self::put_to_index`].
+    fn events_sorted_set_key() -> String {
+        format!("{RETRY_MANAGER_PREFIX}:{}", RETRY_MANAGER_EVENTS_INDEX[0])
     }
 
     /// Stores an event in both a sorted set and a JSON index in Redis.
@@ -145,6 +208,75 @@ impl RetryEvent {
         Self::remove_from_index_multiple_json(&[index.as_slice()]).await
     }
 
+    /// Atomically removes the event for `index_key` only if the stored entry's
+    /// nonce equals `expected_nonce`. Returns whether the removal happened.
+    ///
+    /// The compare and the mutation run in a single Lua script so a concurrent
+    /// enqueue for the same URI (which overwrites the entry with a fresh nonce)
+    /// cannot be deleted by a stale in-flight retry. Nonce-comparison rules
+    /// live in [`NONCE_GUARD_LUA`].
+    #[tracing::instrument(name = "retry.index.remove_if", skip_all)]
+    pub async fn remove_from_index_if_nonce(
+        index_key: &IndexKey,
+        expected_nonce: i64,
+    ) -> RedisResult<bool> {
+        let script = Script::new(&format!(
+            r#"{NONCE_GUARD_LUA}
+            redis.call('JSON.DEL', KEYS[1])
+            redis.call('ZREM', KEYS[2], ARGV[2])
+            return 1
+        "#
+        ));
+
+        let mut redis_conn = get_redis_conn().await?;
+        let removed: i64 = script
+            .key(Self::state_json_key(index_key))
+            .key(Self::events_sorted_set_key())
+            .arg(expected_nonce.to_string())
+            .arg(index_key.as_str())
+            .invoke_async(&mut redis_conn)
+            .await
+            .map_err(RedisError::from)?;
+        Ok(removed == 1)
+    }
+
+    /// Atomically replaces the event for `index_key` only if the stored entry's
+    /// nonce equals `expected_nonce`. Returns whether the write happened.
+    ///
+    /// Same key layout and nonce-comparison rules ([`NONCE_GUARD_LUA`]) as
+    /// [`Self::remove_from_index_if_nonce`]; on a match it performs the same
+    /// JSON.SET + ZADD as [`Self::put_to_index`].
+    #[tracing::instrument(name = "retry.index.put_if", skip_all)]
+    pub async fn put_to_index_if_nonce(
+        &self,
+        index_key: &IndexKey,
+        expected_nonce: i64,
+    ) -> RedisResult<bool> {
+        let payload = serde_json::to_string(self)
+            .map_err(|e| RedisError::SerializationFailed(Box::new(e)))?;
+
+        let script = Script::new(&format!(
+            r#"{NONCE_GUARD_LUA}
+            redis.call('JSON.SET', KEYS[1], '$', ARGV[2])
+            redis.call('ZADD', KEYS[2], ARGV[3], ARGV[4])
+            return 1
+        "#
+        ));
+
+        let mut redis_conn = get_redis_conn().await?;
+        let updated: i64 = script
+            .key(Self::state_json_key(index_key))
+            .key(Self::events_sorted_set_key())
+            .arg(expected_nonce.to_string())
+            .arg(payload)
+            .arg(self.next_retry_at)
+            .arg(index_key.as_str())
+            .invoke_async(&mut redis_conn)
+            .await
+            .map_err(RedisError::from)?;
+        Ok(updated == 1)
+    }
+
     /// Removes multiple sorted-set index entries without touching JSON state.
     ///
     /// Used for tombstone cleanup in the retry store: the JSON state is already
@@ -202,5 +334,19 @@ mod tests {
         let key = IndexKey::for_uri(uri);
         assert_eq!(key.as_str().len(), 32);
         assert_eq!(key, IndexKey::for_uri(uri));
+    }
+
+    #[test]
+    fn nonce_defaults_to_zero_for_entries_stored_before_the_field_existed() {
+        // JSON shape of a RetryEvent enqueued before the nonce field was added.
+        let json = r#"{
+            "retry_count": 3,
+            "event_type": "Put",
+            "event_uri": "pubky://abc123/pub/pubky.app/posts/xyz789",
+            "next_retry_at": 1234567890,
+            "origin_homeserver_id": "hs_id"
+        }"#;
+        let event: RetryEvent = serde_json::from_str(json).expect("pre-nonce JSON must parse");
+        assert_eq!(event.nonce, 0);
     }
 }

--- a/nexus-watcher/src/events/retry/event.rs
+++ b/nexus-watcher/src/events/retry/event.rs
@@ -4,6 +4,7 @@ use chrono::Utc;
 use deadpool_redis::redis::Script;
 use nexus_common::db::kv::{RedisError, RedisResult, SortOrder};
 use serde::{Deserialize, Serialize};
+use std::sync::LazyLock;
 
 use nexus_common::db::{get_redis_conn, RedisOps};
 
@@ -98,6 +99,30 @@ const NONCE_GUARD_LUA: &str = r#"
                 return 0
             end"#;
 
+/// Script for [`RetryEvent::remove_from_index_if_nonce`]. Static so the source
+/// string and its SHA1 are computed once, not on every call.
+static REMOVE_IF_NONCE_SCRIPT: LazyLock<Script> = LazyLock::new(|| {
+    Script::new(&format!(
+        r#"{NONCE_GUARD_LUA}
+            redis.call('JSON.DEL', KEYS[1])
+            redis.call('ZREM', KEYS[2], ARGV[2])
+            return 1
+        "#
+    ))
+});
+
+/// Script for [`RetryEvent::put_to_index_if_nonce`]. Static so the source
+/// string and its SHA1 are computed once, not on every call.
+static PUT_IF_NONCE_SCRIPT: LazyLock<Script> = LazyLock::new(|| {
+    Script::new(&format!(
+        r#"{NONCE_GUARD_LUA}
+            redis.call('JSON.SET', KEYS[1], '$', ARGV[2])
+            redis.call('ZADD', KEYS[2], ARGV[3], ARGV[4])
+            return 1
+        "#
+    ))
+});
+
 impl RetryEvent {
     /// Creates a new RetryEvent from the source event
     pub fn new(event: &Event, next_retry_at: i64, origin_homeserver_id: impl Into<String>) -> Self {
@@ -121,8 +146,8 @@ impl RetryEvent {
     }
 
     /// Full Redis key of the JSON state entry for `index_key`, matching the
-    /// layout used by [`Self::put_to_index`] (RedisOps prefix + key parts
-    /// joined with ':').
+    /// layout used by the RedisOps helpers (prefix + key parts joined with
+    /// ':').
     fn state_json_key(index_key: &IndexKey) -> String {
         format!(
             "{RETRY_MANAGER_PREFIX}:{}:{}",
@@ -132,27 +157,46 @@ impl RetryEvent {
     }
 
     /// Full Redis key of the events sorted set, matching the layout used by
-    /// [`Self::put_to_index`].
+    /// the RedisOps helpers.
     fn events_sorted_set_key() -> String {
         format!("{RETRY_MANAGER_PREFIX}:{}", RETRY_MANAGER_EVENTS_INDEX[0])
     }
 
     /// Stores an event in both a sorted set and a JSON index in Redis.
     /// The sorted set uses next_retry_at as the score for efficient retrieval of ready events.
+    ///
+    /// Both keys are written in a single MULTI/EXEC transaction. Writing them
+    /// with two separate commands would open a race with the conditional ops:
+    /// a stale [`Self::remove_from_index_if_nonce`] could interleave between
+    /// them, match the old JSON nonce, and delete the sorted-set member this
+    /// enqueue just wrote, leaving JSON state that [`Self::fetch_ready`] never
+    /// returns.
     #[tracing::instrument(name = "retry.index.write", skip_all)]
     pub async fn put_to_index(&self, index_key: &IndexKey) -> RedisResult<()> {
-        // Add to sorted set with next_retry_at as score
-        Self::put_index_sorted_set(
-            &RETRY_MANAGER_EVENTS_INDEX,
-            &[(self.next_retry_at as f64, index_key.as_str())],
-            Some(RETRY_MANAGER_PREFIX),
-            None,
-        )
-        .await?;
+        let payload = serde_json::to_string(self)
+            .map_err(|e| RedisError::SerializationFailed(Box::new(e)))?;
 
-        // Store full RetryEvent struct in JSON
-        let index = &[RETRY_MANAGER_STATE_INDEX[0], index_key.as_str()];
-        self.put_index_json(index, None, None).await
+        let mut pipe = deadpool_redis::redis::pipe();
+        pipe.atomic()
+            // Store full RetryEvent struct in JSON
+            .cmd("JSON.SET")
+            .arg(Self::state_json_key(index_key))
+            .arg("$")
+            .arg(payload)
+            .ignore()
+            // Add to sorted set with next_retry_at as score
+            .cmd("ZADD")
+            .arg(Self::events_sorted_set_key())
+            .arg(self.next_retry_at)
+            .arg(index_key.as_str())
+            .ignore();
+
+        let mut redis_conn = get_redis_conn().await?;
+        let _: () = pipe
+            .query_async(&mut redis_conn)
+            .await
+            .map_err(RedisError::from)?;
+        Ok(())
     }
 
     /// Checks if a specific event exists in the Redis sorted set.
@@ -193,6 +237,12 @@ impl RetryEvent {
     }
 
     /// Removes an event from the retry queue (both sorted set and JSON state)
+    ///
+    /// NOTE: the two removals are not atomic, so a concurrent enqueue for the
+    /// same URI can interleave between them and lose its entry. This is the
+    /// last remaining non-atomic writer of the key pair; the processor only
+    /// removes fetched events via [`Self::remove_from_index_if_nonce`], and
+    /// this baseline primitive currently has no production callers.
     #[tracing::instrument(name = "retry.index.remove", skip_all)]
     pub async fn remove_from_index(index_key: &IndexKey) -> RedisResult<()> {
         // Remove from sorted set
@@ -220,16 +270,8 @@ impl RetryEvent {
         index_key: &IndexKey,
         expected_nonce: i64,
     ) -> RedisResult<bool> {
-        let script = Script::new(&format!(
-            r#"{NONCE_GUARD_LUA}
-            redis.call('JSON.DEL', KEYS[1])
-            redis.call('ZREM', KEYS[2], ARGV[2])
-            return 1
-        "#
-        ));
-
         let mut redis_conn = get_redis_conn().await?;
-        let removed: i64 = script
+        let removed: i64 = REMOVE_IF_NONCE_SCRIPT
             .key(Self::state_json_key(index_key))
             .key(Self::events_sorted_set_key())
             .arg(expected_nonce.to_string())
@@ -255,16 +297,8 @@ impl RetryEvent {
         let payload = serde_json::to_string(self)
             .map_err(|e| RedisError::SerializationFailed(Box::new(e)))?;
 
-        let script = Script::new(&format!(
-            r#"{NONCE_GUARD_LUA}
-            redis.call('JSON.SET', KEYS[1], '$', ARGV[2])
-            redis.call('ZADD', KEYS[2], ARGV[3], ARGV[4])
-            return 1
-        "#
-        ));
-
         let mut redis_conn = get_redis_conn().await?;
-        let updated: i64 = script
+        let updated: i64 = PUT_IF_NONCE_SCRIPT
             .key(Self::state_json_key(index_key))
             .key(Self::events_sorted_set_key())
             .arg(expected_nonce.to_string())

--- a/nexus-watcher/src/events/retry/processor.rs
+++ b/nexus-watcher/src/events/retry/processor.rs
@@ -106,17 +106,22 @@ impl RetryProcessor {
         // Event format is "METHOD URI" (e.g., "PUT pubky://...")
         let event_line = format!("{} {}", retry_event.event_type, retry_event.event_uri);
 
-        // Parse the event from the line - if corrupted, remove and continue
+        // Parse the event from the line - if corrupted, remove and continue.
+        // The fetched RetryEvent deserialized fine (only the reconstructed event
+        // line failed to parse), so its nonce is trustworthy and the cleanup can
+        // be conditional too: a newer entry for the same URI must survive.
         let event = match Event::parse_event(&event_line, self.files_path().clone()) {
             Ok(ParseResult::Parsed(event)) => event,
             Ok(ParseResult::Skipped) | Err(_) => {
                 warn!("Corrupted retry entry for key {index_key}, removing: '{event_line}'");
-                self.store.remove(index_key).await?;
+                self.remove_if_current(index_key, retry_event.nonce, &retry_event.event_uri)
+                    .await?;
                 return Ok(());
             }
             Ok(ParseResult::UnrecognizedUri { reason, .. }) => {
                 warn!("Unrecognized URI in retry entry for key {index_key}, removing: {reason}");
-                self.store.remove(index_key).await?;
+                self.remove_if_current(index_key, retry_event.nonce, &retry_event.event_uri)
+                    .await?;
                 return Ok(());
             }
         };
@@ -136,16 +141,22 @@ impl RetryProcessor {
             warn!("Retry event handling failed: {e}");
         });
 
+        // Removals and reschedules below are conditional on the nonce of the event
+        // we fetched: a live processor may have overwritten the hash(URI)-keyed
+        // entry with a newer event (fresh nonce) while this retry was in flight,
+        // and that newer entry must not be removed or clobbered.
         match event_handle_res {
             Ok(()) => {
                 // Success - event was processed, remove from retry queue
                 debug!("Retry successful for event: {ev_uri}");
-                self.store.remove(index_key).await?;
+                self.remove_if_current(index_key, retry_event.nonce, ev_uri)
+                    .await?;
             }
             Err(e) if !RetryScheduler::should_enqueue_related_event(&e) => {
                 // Not worth retrying (ParseFailed, etc.) - dead-letter immediately
                 warn!("Event {ev_uri} threw an error not worth retrying, dead-lettering: {e}");
-                self.store.remove(index_key).await?;
+                self.remove_if_current(index_key, retry_event.nonce, ev_uri)
+                    .await?;
             }
             Err(e) if e.should_not_retry_now() => {
                 // Errors we should not retry right now (e.g. Neo4j/Redis failures) must NOT count
@@ -156,7 +167,8 @@ impl RetryProcessor {
             }
             Err(e) if ev_retry_count >= self.max_retries_for(&e) => {
                 warn!("Event {ev_uri} exceeded max retries ({ev_retry_count}), dead-lettering");
-                self.store.remove(index_key).await?;
+                self.remove_if_current(index_key, retry_event.nonce, ev_uri)
+                    .await?;
             }
             Err(e) => {
                 // Schedule retry with backoff (increments retry_count)
@@ -164,6 +176,21 @@ impl RetryProcessor {
             }
         }
 
+        Ok(())
+    }
+
+    /// Remove the entry for `index_key` only if it still carries `nonce`, i.e.
+    /// it is still the event this processor fetched. Logs at debug when the
+    /// entry was superseded by a newer event enqueued for the same URI.
+    async fn remove_if_current(
+        &self,
+        index_key: &IndexKey,
+        nonce: i64,
+        uri: &str,
+    ) -> Result<(), EventProcessorError> {
+        if !self.store.remove_if(index_key, nonce).await? {
+            debug!("Retry entry superseded by a newer event for this URI, leaving it: {uri}");
+        }
         Ok(())
     }
 
@@ -216,7 +243,16 @@ impl RetryProcessor {
         updated_event.retry_count = new_retry_count;
         updated_event.next_retry_at = next_retry_at;
 
-        self.store.put(&updated_event).await?;
+        // The clone keeps the nonce: a reschedule updates the same logical event.
+        // The conditional put refuses to act if a newer event (fresh nonce) has
+        // replaced the entry for this URI while the retry was in flight.
+        if !self.store.put_if(&updated_event, retry_event.nonce).await? {
+            debug!(
+                "Retry entry superseded by a newer event for this URI, leaving it: {}",
+                retry_event.event_uri
+            );
+            return Ok(());
+        }
 
         let retry_time =
             DateTime::<Utc>::from_timestamp_millis(next_retry_at).unwrap_or_else(Utc::now);
@@ -236,4 +272,94 @@ fn calculate_backoff(retry_count: u32, initial: u64, max: u64) -> u64 {
         .and_then(|p| initial.checked_mul(p))
         .unwrap_or(max);
     min(exponential, max)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::events::retry::store::InMemoryRetryStore;
+    use crate::events::EventType;
+    use tokio::sync::watch;
+
+    /// Valid post URI (z32 user id + pubky.app post path) so
+    /// `Event::parse_event` yields `ParseResult::Parsed` without any stack.
+    const URI: &str =
+        "pubky://uo7jgkykft4885n8cruizwy6khw71mnu5pq3ay9i8pw1ymcn85ko/pub/pubky.app/posts/clobberpst";
+
+    /// Handler that simulates a live event processor enqueuing a NEW retry
+    /// event (fresh nonce) for the same URI while the fetched retry is still
+    /// in flight, i.e. after fetch_ready but before the success-path removal.
+    struct EnqueueNewerEventHandler {
+        store: Arc<dyn RetryStore>,
+        newer: RetryEvent,
+    }
+
+    #[async_trait::async_trait]
+    impl EventHandler for EnqueueNewerEventHandler {
+        async fn handle(&self, _event: &Event) -> Result<(), EventProcessorError> {
+            self.store.put(&self.newer).await?;
+            Ok(())
+        }
+    }
+
+    /// The #963 clobber scenario end-to-end through the processor: the
+    /// success-path removal of a fetched event must not delete the newer
+    /// entry that replaced it mid-flight.
+    #[tokio::test]
+    async fn success_path_removal_does_not_clobber_event_enqueued_mid_flight() {
+        let store: Arc<dyn RetryStore> = Arc::new(InMemoryRetryStore::new());
+        let index_key = IndexKey::for_uri(URI);
+        let now = Utc::now().timestamp_millis();
+
+        // E1: a PUT already in the queue, ready for retry; the processor
+        // fetches and handles it.
+        let e1 = RetryEvent {
+            retry_count: 0,
+            event_type: EventType::Put,
+            event_uri: URI.to_string(),
+            next_retry_at: now - 1_000,
+            origin_homeserver_id: "test_hs".to_string(),
+            nonce: 100,
+        };
+        store.put(&e1).await.unwrap();
+
+        // E2: a DEL for the same URI, enqueued by the handler mid-flight with
+        // a fresh nonce. Scheduled in the future so the processor's next
+        // fetch_ready pass leaves it alone.
+        let e2 = RetryEvent {
+            event_type: EventType::Del,
+            next_retry_at: now + 60_000,
+            nonce: 200,
+            ..e1.clone()
+        };
+
+        let (_shutdown_tx, shutdown_rx) = watch::channel(false);
+        let processor = Arc::new(RetryProcessor {
+            files_path: PathBuf::from("/tmp/test"),
+            event_handler: Arc::new(EnqueueNewerEventHandler {
+                store: store.clone(),
+                newer: e2,
+            }),
+            shutdown_rx,
+            config: EventRetryConfig::default(),
+            store: store.clone(),
+        });
+
+        processor
+            .run_internal()
+            .await
+            .expect("processing must succeed");
+
+        // E1's handle() returned Ok(()), so the processor took the success
+        // path; its conditional removal must have been a no-op and E2 (the
+        // newer entry) must survive.
+        let stored = store
+            .get(&index_key)
+            .await
+            .unwrap()
+            .expect("newer entry must survive the stale success-path removal");
+        assert_eq!(stored.nonce, 200, "stored entry must be E2, not E1");
+        assert_eq!(stored.event_type, EventType::Del);
+        assert_eq!(stored.next_retry_at, now + 60_000);
+    }
 }

--- a/nexus-watcher/src/events/retry/processor.rs
+++ b/nexus-watcher/src/events/retry/processor.rs
@@ -181,7 +181,8 @@ impl RetryProcessor {
 
     /// Remove the entry for `index_key` only if it still carries `nonce`, i.e.
     /// it is still the event this processor fetched. Logs at debug when the
-    /// entry was superseded by a newer event enqueued for the same URI.
+    /// entry was superseded by a newer event enqueued for the same URI or was
+    /// already removed.
     async fn remove_if_current(
         &self,
         index_key: &IndexKey,
@@ -189,7 +190,9 @@ impl RetryProcessor {
         uri: &str,
     ) -> Result<(), EventProcessorError> {
         if !self.store.remove_if(index_key, nonce).await? {
-            debug!("Retry entry superseded by a newer event for this URI, leaving it: {uri}");
+            debug!(
+                "Retry entry superseded by a newer event or already removed for this URI, skipping: {uri}"
+            );
         }
         Ok(())
     }
@@ -248,7 +251,7 @@ impl RetryProcessor {
         // replaced the entry for this URI while the retry was in flight.
         if !self.store.put_if(&updated_event, retry_event.nonce).await? {
             debug!(
-                "Retry entry superseded by a newer event for this URI, leaving it: {}",
+                "Retry entry superseded by a newer event or already removed for this URI, skipping: {}",
                 retry_event.event_uri
             );
             return Ok(());
@@ -302,7 +305,7 @@ mod tests {
         }
     }
 
-    /// The #963 clobber scenario end-to-end through the processor: the
+    /// Lost-update clobber scenario end-to-end through the processor: the
     /// success-path removal of a fetched event must not delete the newer
     /// entry that replaced it mid-flight.
     #[tokio::test]

--- a/nexus-watcher/src/events/retry/scheduler.rs
+++ b/nexus-watcher/src/events/retry/scheduler.rs
@@ -114,8 +114,11 @@ impl RetryScheduler {
         let next_retry_at = Utc::now().timestamp_millis() + initial_backoff_ms;
         let retry_event = RetryEvent::new(event, next_retry_at, origin_homeserver_id);
 
-        // New EventRetries for the same URI will reset the retry_count
-        // The HS state changed since the earlier event, so we disregard previous retry attempts
+        // New EventRetries for the same URI intentionally overwrite the stored entry
+        // and reset retry_count: the HS state changed since the earlier event, so we
+        // disregard previous retry attempts. The fresh nonce minted in RetryEvent::new
+        // also turns any in-flight retry of the overwritten event into a no-op on its
+        // conditional remove/reschedule, so it cannot clobber this newer entry.
         self.store.put(&retry_event).await?;
         warn!("Queued event for retry ({}): {}", reason, event.uri);
         Ok(())

--- a/nexus-watcher/src/events/retry/store.rs
+++ b/nexus-watcher/src/events/retry/store.rs
@@ -13,6 +13,12 @@ use super::{IndexKey, RetryEvent};
 /// Abstracts persistence so the processor can run against Redis in production and
 /// against a per-test in-memory store under `cargo test`, keeping parallel tests
 /// from stomping on each other's queue state.
+///
+/// Multi-replica ABA bound: reschedules keep the entry's nonce (they update the
+/// same logical event), so with multiple concurrent `RetryProcessor` replicas a
+/// stale reschedule can regress `retry_count` of the same logical event, but it
+/// can never resurrect a removed entry nor clobber a different event, because
+/// fresh enqueues always mint new nonces.
 #[async_trait]
 pub trait RetryStore: Send + Sync {
     /// Insert or replace `event`, keyed by `IndexKey::for_uri(&event.event_uri)`.
@@ -22,7 +28,38 @@ pub trait RetryStore: Send + Sync {
     async fn get(&self, index_key: &IndexKey) -> Result<Option<RetryEvent>, EventProcessorError>;
 
     /// Remove `index_key` from the store. No-op if absent.
+    ///
+    /// Unconditional baseline primitive. The processor currently drives every
+    /// removal of a fetched event through [`Self::remove_if`], including the
+    /// corrupted-entry cleanup: the fetched entry deserialized fine, so its
+    /// nonce is trustworthy even when the reconstructed event line fails to
+    /// parse. Reach for this only when there is no fetched entry to compare
+    /// against.
     async fn remove(&self, index_key: &IndexKey) -> Result<(), EventProcessorError>;
+
+    /// Remove `index_key` only if the stored entry's nonce equals
+    /// `expected_nonce`. The compare and the removal are atomic.
+    ///
+    /// Returns `true` when the entry was removed, `false` when nothing was done
+    /// because the entry is absent or carries a different nonce, i.e. it was
+    /// superseded by a newer event enqueued for the same URI.
+    async fn remove_if(
+        &self,
+        index_key: &IndexKey,
+        expected_nonce: i64,
+    ) -> Result<bool, EventProcessorError>;
+
+    /// Insert or replace the entry keyed by `IndexKey::for_uri(&event.event_uri)`
+    /// only if the currently stored entry's nonce equals `expected_nonce`. The
+    /// compare and the write are atomic.
+    ///
+    /// Returns `true` when the write happened, `false` when nothing was done
+    /// because the entry is absent or carries a different nonce.
+    async fn put_if(
+        &self,
+        event: &RetryEvent,
+        expected_nonce: i64,
+    ) -> Result<bool, EventProcessorError>;
 
     /// Return all events with `next_retry_at <= now`, ordered ascending by
     /// `next_retry_at`, capped at `limit` if provided.
@@ -68,6 +105,25 @@ impl RetryStore for RedisRetryStore {
     async fn remove(&self, index_key: &IndexKey) -> Result<(), EventProcessorError> {
         RetryEvent::remove_from_index(index_key).await?;
         Ok(())
+    }
+
+    async fn remove_if(
+        &self,
+        index_key: &IndexKey,
+        expected_nonce: i64,
+    ) -> Result<bool, EventProcessorError> {
+        Ok(RetryEvent::remove_from_index_if_nonce(index_key, expected_nonce).await?)
+    }
+
+    async fn put_if(
+        &self,
+        event: &RetryEvent,
+        expected_nonce: i64,
+    ) -> Result<bool, EventProcessorError> {
+        let index_key = IndexKey::for_uri(&event.event_uri);
+        Ok(event
+            .put_to_index_if_nonce(&index_key, expected_nonce)
+            .await?)
     }
 
     async fn fetch_ready(
@@ -142,6 +198,37 @@ impl RetryStore for InMemoryRetryStore {
         Ok(())
     }
 
+    async fn remove_if(
+        &self,
+        index_key: &IndexKey,
+        expected_nonce: i64,
+    ) -> Result<bool, EventProcessorError> {
+        let mut guard = self.inner.lock().await;
+        match guard.get(index_key) {
+            Some(stored) if stored.nonce == expected_nonce => {
+                guard.remove(index_key);
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    async fn put_if(
+        &self,
+        event: &RetryEvent,
+        expected_nonce: i64,
+    ) -> Result<bool, EventProcessorError> {
+        let index_key = IndexKey::for_uri(&event.event_uri);
+        let mut guard = self.inner.lock().await;
+        match guard.get(&index_key) {
+            Some(stored) if stored.nonce == expected_nonce => {
+                guard.insert(index_key, event.clone());
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
     async fn fetch_ready(
         &self,
         now: i64,
@@ -165,5 +252,130 @@ impl RetryStore for InMemoryRetryStore {
             ready.truncate(limit);
         }
         Ok(ready)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::events::EventType;
+
+    const URI: &str = "pubky://test_user/pub/pubky.app/posts/0000000001";
+
+    fn retry_event(event_type: EventType, nonce: i64) -> RetryEvent {
+        RetryEvent {
+            retry_count: 0,
+            event_type,
+            event_uri: URI.to_string(),
+            next_retry_at: 0,
+            origin_homeserver_id: "test_hs".to_string(),
+            nonce,
+        }
+    }
+
+    #[tokio::test]
+    async fn remove_if_with_stale_nonce_leaves_newer_entry() {
+        let store = InMemoryRetryStore::new();
+        let key = IndexKey::for_uri(URI);
+
+        store.put(&retry_event(EventType::Put, 1)).await.unwrap();
+        // A newer event for the same URI overwrites the entry.
+        store.put(&retry_event(EventType::Del, 2)).await.unwrap();
+
+        // Conditional removal keyed on the old nonce must be a no-op.
+        assert!(!store.remove_if(&key, 1).await.unwrap());
+        let stored = store.get(&key).await.unwrap().expect("entry must survive");
+        assert_eq!(stored.nonce, 2);
+    }
+
+    #[tokio::test]
+    async fn put_if_with_stale_nonce_does_not_clobber() {
+        let store = InMemoryRetryStore::new();
+        let key = IndexKey::for_uri(URI);
+
+        store.put(&retry_event(EventType::Del, 2)).await.unwrap();
+
+        // A reschedule of the older (nonce 1) event must not overwrite.
+        let mut rescheduled = retry_event(EventType::Put, 1);
+        rescheduled.retry_count = 5;
+        rescheduled.next_retry_at = 999;
+        assert!(!store.put_if(&rescheduled, 1).await.unwrap());
+
+        let stored = store.get(&key).await.unwrap().expect("entry must survive");
+        assert_eq!(stored.nonce, 2);
+        assert_eq!(stored.retry_count, 0);
+        assert_eq!(stored.event_type, EventType::Del);
+    }
+
+    #[tokio::test]
+    async fn remove_if_with_matching_nonce_removes_and_returns_true() {
+        let store = InMemoryRetryStore::new();
+        let key = IndexKey::for_uri(URI);
+
+        store.put(&retry_event(EventType::Put, 7)).await.unwrap();
+        assert!(store.remove_if(&key, 7).await.unwrap());
+        assert!(store.get(&key).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn put_if_with_matching_nonce_writes_and_returns_true() {
+        let store = InMemoryRetryStore::new();
+        let key = IndexKey::for_uri(URI);
+
+        store.put(&retry_event(EventType::Put, 7)).await.unwrap();
+
+        let mut rescheduled = retry_event(EventType::Put, 7);
+        rescheduled.retry_count = 1;
+        rescheduled.next_retry_at = 42;
+        assert!(store.put_if(&rescheduled, 7).await.unwrap());
+
+        let stored = store.get(&key).await.unwrap().expect("entry must exist");
+        assert_eq!(stored.retry_count, 1);
+        assert_eq!(stored.next_retry_at, 42);
+        assert_eq!(stored.nonce, 7);
+    }
+
+    #[tokio::test]
+    async fn conditional_ops_on_absent_entry_are_noops() {
+        let store = InMemoryRetryStore::new();
+        let key = IndexKey::for_uri(URI);
+
+        assert!(!store.remove_if(&key, 0).await.unwrap());
+        assert!(!store
+            .put_if(&retry_event(EventType::Put, 1), 1)
+            .await
+            .unwrap());
+        assert!(store.get(&key).await.unwrap().is_none());
+    }
+
+    /// The #963 clobber scenario at store level: the retry processor holds a
+    /// fetched PUT (E1) while a live processor enqueues a DEL (E2) for the same
+    /// URI, overwriting the hash(URI)-keyed entry. E1's success-path removal
+    /// must not delete E2, which must remain fetchable.
+    #[tokio::test]
+    async fn stale_removal_does_not_lose_newer_event_end_to_end() {
+        let store = InMemoryRetryStore::new();
+        let key = IndexKey::for_uri(URI);
+
+        // E1 = PUT enqueued, then snapshotted by the retry processor.
+        let e1 = retry_event(EventType::Put, 100);
+        store.put(&e1).await.unwrap();
+
+        // E2 = DEL for the same URI fails transiently on a live processor and
+        // is enqueued with a fresh nonce, overwriting E1's slot.
+        let e2 = retry_event(EventType::Del, 200);
+        store.put(&e2).await.unwrap();
+
+        // E1's retry succeeds; its conditional removal must be a no-op.
+        assert!(!store.remove_if(&key, e1.nonce).await.unwrap());
+
+        // E2 is still there and still returned by fetch_ready.
+        let ready = store.fetch_ready(i64::MAX, None).await.unwrap();
+        let (_, fetched) = ready
+            .iter()
+            .find(|(k, _)| k == &key)
+            .expect("E2 must still be fetchable");
+        assert_eq!(fetched.nonce, 200);
+        assert_eq!(fetched.event_type, EventType::Del);
     }
 }

--- a/nexus-watcher/src/events/retry/store.rs
+++ b/nexus-watcher/src/events/retry/store.rs
@@ -348,7 +348,7 @@ mod tests {
         assert!(store.get(&key).await.unwrap().is_none());
     }
 
-    /// The #963 clobber scenario at store level: the retry processor holds a
+    /// Lost-update clobber scenario at store level: the retry processor holds a
     /// fetched PUT (E1) while a live processor enqueues a DEL (E2) for the same
     /// URI, overwriting the hash(URI)-keyed entry. E1's success-path removal
     /// must not delete E2, which must remain fetchable.

--- a/nexus-watcher/tests/service/retry_processor.rs
+++ b/nexus-watcher/tests/service/retry_processor.rs
@@ -742,7 +742,7 @@ async fn test_stale_sorted_set_entry_cleaned_up() -> Result<()> {
 
 // ============================================================================
 // Nonce guard survives an overwrite (Redis-backed)
-// Regression test for #963: retry entries are keyed by hash(URI) only, so a
+// Regression test: retry entries are keyed by hash(URI) only, so a
 // newer event enqueued for the same URI overwrites the entry while the retry
 // processor may still hold the old one in memory. The stale event's
 // conditional remove/reschedule (Lua compare-and-act) must be a no-op and the

--- a/nexus-watcher/tests/service/retry_processor.rs
+++ b/nexus-watcher/tests/service/retry_processor.rs
@@ -53,6 +53,7 @@ fn create_test_retry_event(
         event_uri,
         next_retry_at,
         origin_homeserver_id: TEST_HOMESERVER_ID.to_string(),
+        nonce: 0,
     }
 }
 
@@ -740,6 +741,94 @@ async fn test_stale_sorted_set_entry_cleaned_up() -> Result<()> {
 }
 
 // ============================================================================
+// Nonce guard survives an overwrite (Redis-backed)
+// Regression test for #963: retry entries are keyed by hash(URI) only, so a
+// newer event enqueued for the same URI overwrites the entry while the retry
+// processor may still hold the old one in memory. The stale event's
+// conditional remove/reschedule (Lua compare-and-act) must be a no-op and the
+// newer entry must remain fetchable. Exercises RedisRetryStore directly since
+// the atomicity lives in the Redis Lua script.
+// ============================================================================
+
+#[tokio_shared_rt::test(shared)]
+async fn test_redis_stale_conditional_ops_do_not_clobber_newer_entry() -> Result<()> {
+    setup().await?;
+
+    let post_id = "noncegrd01";
+    let resource_key = create_index_key(post_id);
+    let store = RedisRetryStore::new();
+
+    let now = Utc::now().timestamp_millis();
+
+    // E1: a PUT enqueued and then snapshotted by the retry processor.
+    let mut e1 = create_test_retry_event(post_id, EventType::Put, 0, now - 1000);
+    e1.nonce = 100;
+    store.put(&e1).await?;
+
+    // E2: a live processor transiently fails a DEL for the same URI and
+    // enqueues it, overwriting the hash(URI) slot with a fresh nonce.
+    let mut e2 = create_test_retry_event(post_id, EventType::Del, 0, now - 500);
+    e2.nonce = 200;
+    store.put(&e2).await?;
+
+    // E1's retry succeeds; its conditional removal must not act.
+    assert!(
+        !store.remove_if(&resource_key, e1.nonce).await?,
+        "remove_if with a stale nonce must be a no-op"
+    );
+
+    // A stale reschedule of E1 must not clobber E2 either.
+    let mut rescheduled_e1 = e1.clone();
+    rescheduled_e1.retry_count = 1;
+    rescheduled_e1.next_retry_at = now + 60_000;
+    assert!(
+        !store.put_if(&rescheduled_e1, e1.nonce).await?,
+        "put_if with a stale nonce must be a no-op"
+    );
+
+    // E2 survives untouched and is still fetchable.
+    let stored = store
+        .get(&resource_key)
+        .await?
+        .expect("newer entry must survive stale conditional ops");
+    assert_eq!(stored.nonce, 200, "stored entry must still be E2");
+    assert_eq!(stored.event_type, EventType::Del);
+    assert_eq!(stored.retry_count, 0);
+    let ready = store.fetch_ready(now, None).await?;
+    assert!(
+        ready
+            .iter()
+            .any(|(key, event)| key == &resource_key && event.nonce == 200),
+        "newer entry must still be returned by fetch_ready"
+    );
+
+    // Matching nonce acts: reschedule E2, then remove it (also cleans up).
+    let mut rescheduled_e2 = stored.clone();
+    rescheduled_e2.retry_count = 1;
+    assert!(
+        store.put_if(&rescheduled_e2, 200).await?,
+        "put_if with the matching nonce must act"
+    );
+    assert!(
+        store.remove_if(&resource_key, 200).await?,
+        "remove_if with the matching nonce must act"
+    );
+    assert!(
+        store.get(&resource_key).await?.is_none(),
+        "entry must be gone after matching-nonce removal"
+    );
+    // The Lua script's ZREM must also drop the sorted-set member; a key/member
+    // mismatch inside the script would leave a stale index entry behind while
+    // the JSON state is gone.
+    assert!(
+        !RetryEvent::check_index_key(&resource_key).await?,
+        "sorted-set member must be gone after matching-nonce removal"
+    );
+
+    Ok(())
+}
+
+// ============================================================================
 // Shutdown interrupts batch
 // Shutdown signal set mid-batch stops processing remaining events and returns Ok(())
 // ============================================================================
@@ -763,6 +852,7 @@ async fn test_shutdown_interrupts_batch() -> Result<()> {
             event_uri,
             next_retry_at: now - 1000,
             origin_homeserver_id: TEST_HOMESERVER_ID.to_string(),
+            nonce: 0,
         };
         store.put(&retry_event).await?;
     }
@@ -837,6 +927,7 @@ async fn test_infrastructure_error_stops_batch() -> Result<()> {
             event_uri,
             next_retry_at: now - 1000,
             origin_homeserver_id: TEST_HOMESERVER_ID.to_string(),
+            nonce: 0,
         };
         store.put(&retry_event).await?;
     }


### PR DESCRIPTION
Retry entries are keyed by hash(URI) only, and the RetryProcessor's success removal and reschedule were blind writes. So while a stale retry is in flight, a live processor can enqueue a newer event for the same URI (fresh failure, cursor already advanced), and the stale retry then deletes or overwrites it. Concrete loss: a transiently failed DEL enqueued behind an in-flight PUT retry is gone for good, the homeserver never resends it.

Fix: `RetryEvent` gets a `nonce` (serde default 0 keeps existing queue entries valid) and the store gets atomic `remove_if`/`put_if` (Lua on Redis, compare inside the mutex in-memory). Every store mutation the processor derives from a fetched event is now conditional on that event's nonce; a superseded entry is left alone. The scheduler's overwrite-on-enqueue stays intentional, its fresh nonce is what neutralizes stale in-flight retries.

Covered by store-level unit tests, an end-to-end clobber test through the processor, and a Redis-backed service test for the Lua path.

Fixes #963

## Pre-submission Checklist

- [x] I manually reviewed the PR
- [x] I asked one or more LLMs to review the PR
- [x] I asked one or more LLMs to check if this PR can be simplified
- [x] If appropriate, I added tests for the changes in this PR
- [ ] If appropriate, I added performance benchmarks for the APIs added in this PR (n/a)
