### PR TITLE
fix(nexusd): scope db clear to a single Redis DB and gate it behind --yes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3105,6 +3105,7 @@ dependencies = [
  "futures-util",
  "httpc-test",
  "nexus-common",
+ "nexus-webapi",
  "opentelemetry 0.32.0",
  "pubky",
  "pubky-app-specs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3112,6 +3112,7 @@ dependencies = [
  "http-body-util",
  "httpc-test",
  "nexus-common",
+ "nexus-webapi",
  "opentelemetry 0.32.0",
  "pubky",
  "pubky-app-specs",

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ cargo run -p nexusd
 cargo run -p nexusd -- --config-dir="custom/config/folder"
 # There is also an option to run services individually
 # Useful to run a database clear command before start running the watcher
-# cargo run -p nexusd -- db clear
+# cargo run -p nexusd -- db clear --yes
 cargo run -p nexusd -- watcher
 cargo run -p nexusd -- api
 ```

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ cargo run -p nexusd
 cargo run -p nexusd -- --config-dir="custom/config/folder"
 # There is also an option to run services individually
 # Useful to run a database clear command before start running the watcher
-# cargo run -p nexusd -- db clear
+# cargo run -p nexusd -- db clear --yes
 cargo run -p nexusd -- watcher
 cargo run -p nexusd -- api
 ```

--- a/nexus-webapi/Cargo.toml
+++ b/nexus-webapi/Cargo.toml
@@ -8,6 +8,11 @@ repository = "https://github.com/pubky/pubky-nexus"
 license = "MIT"
 build = "build.rs"
 
+[features]
+# Dev and test tooling: MockDb helpers that wipe and reseed the databases.
+# Not part of the regular library surface, consumers must opt in.
+mock = []
+
 [dependencies]
 axum = "0.8.9"
 axum-server = { version = "0.8.0", features = ["tls-rustls-no-provider"] }
@@ -41,6 +46,9 @@ utoipa-swagger-ui = { version = "9.0.2", features = ["axum"] }
 anyhow = { workspace = true }
 criterion = { version = "0.8", features = ["async_tokio"] }
 httpc-test = "0.1.10"
+# Self dev-dependency so the crate's own tests and benches get the `mock`
+# feature without needing extra flags on `cargo test` or `cargo bench`.
+nexus-webapi = { path = ".", features = ["mock"] }
 pubky-testnet = { workspace = true }
 serde_urlencoded = "0.7"
 tempfile = { workspace = true }

--- a/nexus-webapi/Cargo.toml
+++ b/nexus-webapi/Cargo.toml
@@ -8,6 +8,11 @@ repository = "https://github.com/pubky/pubky-nexus"
 license = "MIT"
 build = "build.rs"
 
+[features]
+# Dev and test tooling: MockDb helpers that wipe and reseed the databases.
+# Not part of the regular library surface, consumers must opt in.
+mock = []
+
 [dependencies]
 axum = "0.8.9"
 axum-server = { version = "0.8.0", features = ["tls-rustls-no-provider"] }
@@ -43,6 +48,9 @@ criterion = { version = "0.8", features = ["async_tokio"] }
 http-body-util = "0.1.3"
 httpc-test = "0.1.10"
 nexus-common = { path = "../nexus-common", features = ["test-utils"] }
+# Self dev-dependency so the crate's own tests and benches get the `mock`
+# feature without needing extra flags on `cargo test` or `cargo bench`.
+nexus-webapi = { path = ".", features = ["mock"] }
 pubky-testnet = { workspace = true }
 serde_urlencoded = "0.7"
 tempfile = { workspace = true }

--- a/nexus-webapi/src/lib.rs
+++ b/nexus-webapi/src/lib.rs
@@ -47,6 +47,7 @@ pub mod api_context;
 mod builder;
 pub mod error;
 mod key_republisher;
+#[cfg(feature = "mock")]
 pub mod mock;
 pub mod models;
 pub mod routes;

--- a/nexus-webapi/src/mock.rs
+++ b/nexus-webapi/src/mock.rs
@@ -18,22 +18,24 @@ pub enum MockType {
 pub struct MockDb {}
 
 impl MockDb {
-    async fn init_stack() {
-        StackManager::setup(&StackConfig::default())
+    async fn init_stack(config: &StackConfig) {
+        StackManager::setup(config)
             .await
             .expect("Failed to initialize stack");
     }
 
-    pub async fn clear_database() {
-        Self::init_stack().await;
+    /// Clears the Redis and Neo4j databases described by `config`
+    pub async fn clear_database(config: &StackConfig) {
+        Self::init_stack(config).await;
 
         Self::drop_cache().await;
         Self::drop_graph().await;
         info!("Both ddbb cleared successfully");
     }
 
-    pub async fn run(mock_type: Option<MockType>) {
-        Self::init_stack().await;
+    /// Mocks the Redis and/or Neo4j databases described by `config`
+    pub async fn run(mock_type: Option<MockType>, config: &StackConfig) {
+        Self::init_stack(config).await;
 
         match mock_type {
             Some(MockType::Redis) => Self::sync_redis().await,

--- a/nexus-webapi/src/mock.rs
+++ b/nexus-webapi/src/mock.rs
@@ -1,6 +1,6 @@
 use clap::ValueEnum;
 use nexus_common::{
-    db::{get_neo4j_graph, get_redis_conn, graph::Query, reindex},
+    db::{get_neo4j_graph, graph::Query, kv::clear_redis, reindex},
     models::post::create_post_content_index,
     StackConfig, StackManager,
 };
@@ -59,15 +59,9 @@ impl MockDb {
 
     pub async fn drop_cache() {
         info!("Dropping Redis database...");
-        // Drop all keys in Redis
-        let mut redis_conn = get_redis_conn()
-            .await
-            .expect("Could not get the redis connection");
-
-        deadpool_redis::redis::cmd("FLUSHALL")
-            .exec_async(&mut redis_conn)
-            .await
-            .expect("Failed to flush Redis");
+        // FLUSHDB: drop all keys in the configured logical database only,
+        // other logical databases on the same Redis server are left untouched.
+        clear_redis().await.expect("Failed to flush Redis");
     }
 
     async fn sync_all() {

--- a/nexusd/Cargo.toml
+++ b/nexusd/Cargo.toml
@@ -13,7 +13,8 @@ dirs = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 futures = { workspace = true }
-nexus-webapi = { version = "0.4.1", path = "../nexus-webapi" }
+# `mock` is needed for the `nexusd db clear` and `nexusd db mock` subcommands.
+nexus-webapi = { version = "0.4.1", path = "../nexus-webapi", features = ["mock"] }
 nexus-common = { version = "0.4.1", path = "../nexus-common" }
 redis = { workspace = true, features = ["tokio-comp"] }
 nexus-watcher = { version = "0.4.1", path = "../nexus-watcher" }

--- a/nexusd/Cargo.toml
+++ b/nexusd/Cargo.toml
@@ -14,7 +14,8 @@ chrono = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 cron = { workspace = true }
 futures = { workspace = true }
-nexus-webapi = { version = "0.4.1", path = "../nexus-webapi" }
+# `mock` is needed for the `nexusd db clear` and `nexusd db mock` subcommands.
+nexus-webapi = { version = "0.4.1", path = "../nexus-webapi", features = ["mock"] }
 nexus-common = { version = "0.4.1", path = "../nexus-common" }
 opentelemetry = { workspace = true }
 redis = { workspace = true, features = ["tokio-comp"] }

--- a/nexusd/src/cli.rs
+++ b/nexusd/src/cli.rs
@@ -71,9 +71,8 @@ pub struct WatcherArgs {
 pub enum DbCommands {
     /// Clear the databases (destructive, requires --yes)
     Clear {
-        /// Confirm wiping the default-config Redis database (redis://localhost:6379)
-        /// and every node in the connected Neo4j graph. Note: `db clear` currently
-        /// ignores --config-dir.
+        /// Confirm wiping the Redis logical database (FLUSHDB) and every node
+        /// in the Neo4j graph configured via --config-dir.
         #[arg(long)]
         yes: bool,
     },
@@ -125,6 +124,26 @@ mod tests {
     #[test]
     fn db_clear_with_yes_parses_as_confirmed() {
         let cli = Cli::try_parse_from(["nexusd", "db", "clear", "--yes"]).expect("should parse");
+        match cli.command {
+            Some(NexusCommands::Db(DbCommands::Clear { yes })) => assert!(yes),
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    /// The top-level --config-dir must be available to db commands so they
+    /// operate on the configured stack rather than the default one.
+    #[test]
+    fn db_clear_keeps_top_level_config_dir() {
+        let cli = Cli::try_parse_from([
+            "nexusd",
+            "--config-dir",
+            "/custom/dir",
+            "db",
+            "clear",
+            "--yes",
+        ])
+        .expect("should parse");
+        assert_eq!(cli.config_dir, PathBuf::from("/custom/dir"));
         match cli.command {
             Some(NexusCommands::Db(DbCommands::Clear { yes })) => assert!(yes),
             other => panic!("unexpected command: {other:?}"),

--- a/nexusd/src/cli.rs
+++ b/nexusd/src/cli.rs
@@ -69,8 +69,14 @@ pub struct WatcherArgs {
 
 #[derive(Subcommand, Debug)]
 pub enum DbCommands {
-    /// Clear the databases
-    Clear,
+    /// Clear the databases (destructive, requires --yes)
+    Clear {
+        /// Confirm wiping the default-config Redis database (redis://localhost:6379)
+        /// and every node in the connected Neo4j graph. Note: `db clear` currently
+        /// ignores --config-dir.
+        #[arg(long)]
+        yes: bool,
+    },
 
     /// Mock the database (optional redis/graph). Usually for tests
     Mock(MockArgs),
@@ -101,4 +107,27 @@ pub struct MigrationNewArgs {
     /// The name of the new migration
     #[arg(required = true)]
     pub name: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn db_clear_without_yes_parses_as_unconfirmed() {
+        let cli = Cli::try_parse_from(["nexusd", "db", "clear"]).expect("should parse");
+        match cli.command {
+            Some(NexusCommands::Db(DbCommands::Clear { yes })) => assert!(!yes),
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn db_clear_with_yes_parses_as_confirmed() {
+        let cli = Cli::try_parse_from(["nexusd", "db", "clear", "--yes"]).expect("should parse");
+        match cli.command {
+            Some(NexusCommands::Db(DbCommands::Clear { yes })) => assert!(yes),
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
 }

--- a/nexusd/src/cli.rs
+++ b/nexusd/src/cli.rs
@@ -95,9 +95,8 @@ pub struct JobRunArgs {
 pub enum DbCommands {
     /// Clear the databases (destructive, requires --yes)
     Clear {
-        /// Confirm wiping the default-config Redis database (redis://localhost:6379)
-        /// and every node in the connected Neo4j graph. Note: `db clear` currently
-        /// ignores --config-dir.
+        /// Confirm wiping the Redis logical database (FLUSHDB) and every node
+        /// in the Neo4j graph configured via --config-dir.
         #[arg(long)]
         yes: bool,
     },
@@ -153,6 +152,26 @@ mod tests {
     #[test]
     fn db_clear_with_yes_parses_as_confirmed() {
         let cli = Cli::try_parse_from(["nexusd", "db", "clear", "--yes"]).expect("should parse");
+        match cli.command {
+            Some(NexusCommands::Db(DbCommands::Clear { yes })) => assert!(yes),
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    /// The top-level --config-dir must be available to db commands so they
+    /// operate on the configured stack rather than the default one.
+    #[test]
+    fn db_clear_keeps_top_level_config_dir() {
+        let cli = Cli::try_parse_from([
+            "nexusd",
+            "--config-dir",
+            "/custom/dir",
+            "db",
+            "clear",
+            "--yes",
+        ])
+        .expect("should parse");
+        assert_eq!(cli.config_dir, PathBuf::from("/custom/dir"));
         match cli.command {
             Some(NexusCommands::Db(DbCommands::Clear { yes })) => assert!(yes),
             other => panic!("unexpected command: {other:?}"),

--- a/nexusd/src/cli.rs
+++ b/nexusd/src/cli.rs
@@ -93,8 +93,14 @@ pub struct JobRunArgs {
 
 #[derive(Subcommand, Debug)]
 pub enum DbCommands {
-    /// Clear the databases
-    Clear,
+    /// Clear the databases (destructive, requires --yes)
+    Clear {
+        /// Confirm wiping the default-config Redis database (redis://localhost:6379)
+        /// and every node in the connected Neo4j graph. Note: `db clear` currently
+        /// ignores --config-dir.
+        #[arg(long)]
+        yes: bool,
+    },
 
     /// Mock the database (optional redis/graph). Usually for tests
     Mock(MockArgs),
@@ -129,4 +135,27 @@ pub struct MigrationNewArgs {
     /// The name of the new migration
     #[arg(required = true)]
     pub name: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn db_clear_without_yes_parses_as_unconfirmed() {
+        let cli = Cli::try_parse_from(["nexusd", "db", "clear"]).expect("should parse");
+        match cli.command {
+            Some(NexusCommands::Db(DbCommands::Clear { yes })) => assert!(!yes),
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn db_clear_with_yes_parses_as_confirmed() {
+        let cli = Cli::try_parse_from(["nexusd", "db", "clear", "--yes"]).expect("should parse");
+        match cli.command {
+            Some(NexusCommands::Db(DbCommands::Clear { yes })) => assert!(yes),
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
 }

--- a/nexusd/src/main.rs
+++ b/nexusd/src/main.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use nexus_common::types::DynError;
-use nexus_common::StackManager;
+use nexus_common::{DaemonConfig, StackManager};
 use nexus_watcher::service::NexusWatcher;
 use nexus_webapi::mock::MockDb;
 use nexus_webapi::NexusApi;
@@ -11,21 +11,26 @@ use nexusd::DaemonLauncher;
 #[tokio::main]
 async fn main() -> Result<(), DynError> {
     let cli = Cli::parse();
+    let config_dir = cli.config_dir.clone();
     let command = Cli::receive_command(cli);
     match command {
         NexusCommands::Db(db_command) => match db_command {
             DbCommands::Clear { yes } => {
                 if !yes {
                     eprintln!(
-                        "db clear is destructive: it wipes the default-config Redis database (redis://localhost:6379, FLUSHDB) and deletes every node in the connected Neo4j graph."
+                        "db clear is destructive: it wipes the Redis logical database (FLUSHDB) and deletes every node in the Neo4j graph configured in {}.",
+                        config_dir.display()
                     );
-                    eprintln!("Note: db clear currently ignores --config-dir.");
                     eprintln!("Re-run with --yes to proceed.");
                     std::process::exit(1);
                 }
-                MockDb::clear_database().await
+                let config = DaemonConfig::read_or_create_config_file(config_dir).await?;
+                MockDb::clear_database(&config.stack).await
             }
-            DbCommands::Mock(args) => MockDb::run(args.mock_type).await,
+            DbCommands::Mock(args) => {
+                let config = DaemonConfig::read_or_create_config_file(config_dir).await?;
+                MockDb::run(args.mock_type, &config.stack).await
+            }
             DbCommands::Migration(migration_command) => match migration_command {
                 MigrationCommands::New(args) => MigrationManager::new_migration(args.name).await?,
                 MigrationCommands::Run => {

--- a/nexusd/src/main.rs
+++ b/nexusd/src/main.rs
@@ -14,7 +14,17 @@ async fn main() -> Result<(), DynError> {
     let command = Cli::receive_command(cli);
     match command {
         NexusCommands::Db(db_command) => match db_command {
-            DbCommands::Clear => MockDb::clear_database().await,
+            DbCommands::Clear { yes } => {
+                if !yes {
+                    eprintln!(
+                        "db clear is destructive: it wipes the default-config Redis database (redis://localhost:6379, FLUSHDB) and deletes every node in the connected Neo4j graph."
+                    );
+                    eprintln!("Note: db clear currently ignores --config-dir.");
+                    eprintln!("Re-run with --yes to proceed.");
+                    std::process::exit(1);
+                }
+                MockDb::clear_database().await
+            }
             DbCommands::Mock(args) => MockDb::run(args.mock_type).await,
             DbCommands::Migration(migration_command) => match migration_command {
                 MigrationCommands::New(args) => MigrationManager::new_migration(args.name).await?,

--- a/nexusd/src/main.rs
+++ b/nexusd/src/main.rs
@@ -32,7 +32,17 @@ async fn main() -> Result<(), DynError> {
 
     match command {
         NexusCommands::Db(db_command) => match db_command {
-            DbCommands::Clear => MockDb::clear_database().await,
+            DbCommands::Clear { yes } => {
+                if !yes {
+                    eprintln!(
+                        "db clear is destructive: it wipes the default-config Redis database (redis://localhost:6379, FLUSHDB) and deletes every node in the connected Neo4j graph."
+                    );
+                    eprintln!("Note: db clear currently ignores --config-dir.");
+                    eprintln!("Re-run with --yes to proceed.");
+                    std::process::exit(1);
+                }
+                MockDb::clear_database().await
+            }
             DbCommands::Mock(args) => MockDb::run(args.mock_type).await,
             DbCommands::Migration(migration_command) => match migration_command {
                 MigrationCommands::New(args) => MigrationManager::new_migration(args.name).await?,

--- a/nexusd/src/main.rs
+++ b/nexusd/src/main.rs
@@ -27,6 +27,7 @@ fn job_registry(trust_rank: &TrustRankConfig, lock_ttl_secs: u64) -> JobRegistry
 #[tokio::main]
 async fn main() -> Result<(), DynError> {
     let cli = Cli::parse();
+    let config_dir = cli.config_dir.clone();
     let command = Cli::receive_command(cli);
     let lock_ttl_secs = nexusd::jobs::LOCK_TTL_SECS;
 
@@ -35,15 +36,19 @@ async fn main() -> Result<(), DynError> {
             DbCommands::Clear { yes } => {
                 if !yes {
                     eprintln!(
-                        "db clear is destructive: it wipes the default-config Redis database (redis://localhost:6379, FLUSHDB) and deletes every node in the connected Neo4j graph."
+                        "db clear is destructive: it wipes the Redis logical database (FLUSHDB) and deletes every node in the Neo4j graph configured in {}.",
+                        config_dir.display()
                     );
-                    eprintln!("Note: db clear currently ignores --config-dir.");
                     eprintln!("Re-run with --yes to proceed.");
                     std::process::exit(1);
                 }
-                MockDb::clear_database().await
+                let config = DaemonConfig::read_or_create_config_file(config_dir).await?;
+                MockDb::clear_database(&config.stack).await
             }
-            DbCommands::Mock(args) => MockDb::run(args.mock_type).await,
+            DbCommands::Mock(args) => {
+                let config = DaemonConfig::read_or_create_config_file(config_dir).await?;
+                MockDb::run(args.mock_type, &config.stack).await
+            }
             DbCommands::Migration(migration_command) => match migration_command {
                 MigrationCommands::New(args) => MigrationManager::new_migration(args.name).await?,
                 MigrationCommands::Run => {


### PR DESCRIPTION
`nexusd db clear` ran Redis `FLUSHALL` (every key in every logical DB on the server) plus a full graph wipe, with no confirmation, and the `MockDb` tooling that implements it shipped unconditionally in the release library.

- `drop_cache` now uses the existing `clear_redis()` (FLUSHDB, one logical DB).
- `db clear` requires `--yes`; without it, it prints what would be wiped and exits 1.
- `db clear` and `db mock` now load the configuration from `--config-dir` (same loader as `run`) and act on the configured stack, instead of silently targeting the default one.
- `pub mod mock` is behind a new `mock` cargo feature. nexusd opts in (keeps its db subcommands); nexus-webapi's own tests/benches get it via a self dev-dependency, so plain `cargo test` still works; library consumers no longer compile it.

Release note: gating a previously public module is a breaking change vs the published 0.4.1, so publishing needs a version bump; left to the release process.

Fixes #964

## Pre-submission Checklist

- [x] I manually reviewed the PR
- [x] I asked one or more LLMs to review the PR
- [x] I asked one or more LLMs to check if this PR can be simplified
- [x] If appropriate, I added tests for the changes in this PR
- [ ] If appropriate, I added performance benchmarks for the APIs added in this PR (n/a)

