### PR TITLE
fix(influencers): write AllTime graph fallback into the live sorted set

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,14 @@
+# Minimal nextest configuration.
+#
+# test_global_influencers_alltime_cache_recovery deletes and reseeds the shared
+# Sorted:Users:Influencers Redis sorted set. nextest runs each test in its own
+# process, in parallel, against one shared Redis, so that test must never
+# interleave with the sibling tests that assert the exact member order of the
+# same sorted set. Put all three in a test group limited to one concurrent test.
+
+[test-groups]
+influencers-sorted-set = { max-threads = 1 }
+
+[[profile.default.overrides]]
+filter = 'test(=stream::user::influencers::test_global_influencers) | test(=stream::user::influencers::test_global_influencers_skip_limit) | test(=stream::user::influencers::test_global_influencers_alltime_cache_recovery)'
+test-group = 'influencers-sorted-set'

--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -843,8 +843,11 @@ pub fn get_global_influencers(skip: usize, limit: usize, timeframe: &Timeframe) 
             RETURN count(DISTINCT tag) AS tags_count
         }
         CALL (user) {
-            MATCH (user)-[authored:AUTHORED]->(post:Post)
-            WHERE authored.indexed_at >= $from AND authored.indexed_at < $to
+            // Filter on the Post node's indexed_at, like get_influencers_by_reach does.
+            // The AUTHORED edge carries no indexed_at property (create_post never sets
+            // one), so filtering on the edge would always yield posts_count = 0.
+            MATCH (user)-[:AUTHORED]->(post:Post)
+            WHERE post.indexed_at >= $from AND post.indexed_at < $to
             RETURN count(DISTINCT post) AS posts_count
         }
         WITH {

--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -822,50 +822,58 @@ pub fn get_influencers_by_reach(
 
 pub fn get_global_influencers(skip: usize, limit: usize, timeframe: &Timeframe) -> Query {
     let (from, to) = timeframe.to_timestamp_range();
-    Query::new(
-        "get_global_influencers",
+    // AllTime seeds the live influencers set, whose incremental scores count
+    // tags the user assigned to posts AND to users, so the seed must match
+    // that definition. Windowed timeframes keep their post-tags-only scoring;
+    // they only feed their own per-timeframe cache.
+    let tag_targets = match timeframe {
+        Timeframe::AllTime => ":Post|User",
+        _ => ":Post",
+    };
+    let query_string = format!(
         "
         MATCH (user:User)
         WHERE user.name <> '[DELETED]'
         WITH DISTINCT user
 
-        // Each count is a scoped CALL(user){} subquery so it stays per-user
+        // Each count is a scoped CALL(user){{}} subquery so it stays per-user
         // instead of multiplying into a cartesian product. Mirrors
         // get_influencers_by_reach.
-        CALL (user) {
+        CALL (user) {{
             MATCH (others:User)-[follow:FOLLOWS]->(user)
             WHERE follow.indexed_at >= $from AND follow.indexed_at < $to
             RETURN count(DISTINCT follow) AS followers_count
-        }
-        CALL (user) {
-            MATCH (user)-[tag:TAGGED]->(:Post)
+        }}
+        CALL (user) {{
+            MATCH (user)-[tag:TAGGED]->({tag_targets})
             WHERE tag.indexed_at >= $from AND tag.indexed_at < $to
             RETURN count(DISTINCT tag) AS tags_count
-        }
-        CALL (user) {
+        }}
+        CALL (user) {{
             // Filter on the Post node's indexed_at, like get_influencers_by_reach does.
             // The AUTHORED edge carries no indexed_at property (create_post never sets
             // one), so filtering on the edge would always yield posts_count = 0.
             MATCH (user)-[:AUTHORED]->(post:Post)
             WHERE post.indexed_at >= $from AND post.indexed_at < $to
             RETURN count(DISTINCT post) AS posts_count
-        }
-        WITH {
+        }}
+        WITH {{
             id: user.id,
             score: (tags_count + posts_count) * sqrt(followers_count)
-        } AS influencer
+        }} AS influencer
         WHERE influencer.id IS NOT NULL
 
         ORDER BY influencer.score DESC, influencer.id ASC
         SKIP $skip
         LIMIT $limit
         RETURN COLLECT([influencer.id, influencer.score]) as influencers
-    ",
-    )
-    .param("skip", skip as i64)
-    .param("limit", limit as i64)
-    .param("from", from)
-    .param("to", to)
+    "
+    );
+    Query::new("get_global_influencers", &query_string)
+        .param("skip", skip as i64)
+        .param("limit", limit as i64)
+        .param("from", from)
+        .param("to", to)
 }
 
 pub fn get_files_by_ids(key_pair: &[&[&str]]) -> Query {

--- a/nexus-common/src/models/user/influencers.rs
+++ b/nexus-common/src/models/user/influencers.rs
@@ -196,12 +196,13 @@ impl Influencers {
         match timeframe {
             // AllTime reads come from Sorted:Users:Influencers, the live set that is
             // incrementally maintained by UserStream::add_to_influencers_sorted_set. The
-            // graph query only approximates that incremental score: UserCounts.tagged
-            // counts tags on the user AND their posts, while the graph query counts post
-            // tags only. The fallback therefore seeds an approximation, and per-user
-            // activity rewrites each member's score on their next counts update. Seed that
-            // key so the re-read in get_global_influencers finds the data. No TTL, the set
-            // is kept up to date by user activity.
+            // graph query counts the same tag edges as UserCounts.tagged (tags the user
+            // assigned to posts and to users), so the seeded AllTime score matches the
+            // incremental one, except for edges indexed at or after the query's `to`
+            // snapshot (taken at query build); per-user activity rewrites each member's
+            // score on its next counts update. Seed that key so the re-read in
+            // get_global_influencers finds the data. No TTL, the set is kept up to date
+            // by user activity.
             Timeframe::AllTime => {
                 Influencers::put_index_sorted_set(
                     USER_INFLUENCERS_KEY_PARTS.as_slice(),

--- a/nexus-common/src/models/user/influencers.rs
+++ b/nexus-common/src/models/user/influencers.rs
@@ -105,6 +105,7 @@ impl Influencers {
             return Ok(cached_influencers);
         }
 
+        // Recovery seeds only the top 100; deeper pages return empty until organic activity repopulates the set.
         let query = queries::get::get_global_influencers(0, 100, timeframe);
         let result = fetch_key_from_graph::<Influencers>(query, "influencers").await?;
 
@@ -177,28 +178,53 @@ impl Influencers {
         }
     }
 
-    /// Stores a list of global influencers in the cache as a sorted set for the given timeframe
+    /// Stores a list of global influencers as a sorted set for the given timeframe.
+    ///
+    /// The target key must match the one `get_from_global_cache` reads for that timeframe:
+    /// `AllTime` reads the live `Sorted:Users:Influencers` set, every other timeframe reads
+    /// `Cache:Influencers:{timeframe}`.
     ///
     /// # Arguments
     /// * `result` - The list of influencers with their scores to cache
-    /// * `timeframe` - The timeframe used to generate the cache key and expiry
+    /// * `timeframe` - The timeframe used to select the target key and expiry
     async fn put_to_global_cache(result: Influencers, timeframe: &Timeframe) -> ModelResult<()> {
-        let key_parts = Influencers::get_cache_key_parts(timeframe);
-        let key_parts_vector: Vec<&str> =
-            key_parts.iter().map(|s| s.as_str()).collect::<Vec<&str>>();
+        let elements: Vec<(f64, &str)> = result
+            .iter()
+            .map(|influencer| (influencer.1, influencer.0.as_str()))
+            .collect();
 
-        // store the ranking as sorted set in cache
-        Influencers::put_index_sorted_set(
-            key_parts_vector.as_slice(),
-            result
-                .iter()
-                .map(|influencer| (influencer.1, influencer.0.as_str()))
-                .collect::<Vec<(f64, &str)>>()
-                .as_slice(),
-            Some(GLOBAL_INFLUENCERS_PREFIX),
-            Some(timeframe.to_cache_period()),
-        )
-        .await?;
+        match timeframe {
+            // AllTime reads come from Sorted:Users:Influencers, the live set that is
+            // incrementally maintained by UserStream::add_to_influencers_sorted_set. The
+            // graph query only approximates that incremental score: UserCounts.tagged
+            // counts tags on the user AND their posts, while the graph query counts post
+            // tags only. The fallback therefore seeds an approximation, and per-user
+            // activity rewrites each member's score on their next counts update. Seed that
+            // key so the re-read in get_global_influencers finds the data. No TTL, the set
+            // is kept up to date by user activity.
+            Timeframe::AllTime => {
+                Influencers::put_index_sorted_set(
+                    USER_INFLUENCERS_KEY_PARTS.as_slice(),
+                    elements.as_slice(),
+                    None,
+                    None,
+                )
+                .await?;
+            }
+            // Other timeframes use the TTL-based cache key Cache:Influencers:{timeframe}
+            _ => {
+                let key_parts = Influencers::get_cache_key_parts(timeframe);
+                let key_parts_vector: Vec<&str> = key_parts.iter().map(|s| s.as_str()).collect();
+
+                Influencers::put_index_sorted_set(
+                    key_parts_vector.as_slice(),
+                    elements.as_slice(),
+                    Some(GLOBAL_INFLUENCERS_PREFIX),
+                    Some(timeframe.to_cache_period()),
+                )
+                .await?;
+            }
+        }
         Ok(())
     }
 

--- a/nexus-webapi/tests/stream/user/influencers.rs
+++ b/nexus-webapi/tests/stream/user/influencers.rs
@@ -2,12 +2,14 @@ use std::time::Duration;
 
 use anyhow::Result;
 use axum::http::StatusCode;
+use deadpool_redis::redis::AsyncCommands;
+use nexus_common::db::get_redis_conn;
 use tokio::time::sleep;
 use tracing::debug;
 
 use crate::{
     tags::hot::USER_1,
-    utils::{get_request, invalid_get_request},
+    utils::{get_request, invalid_get_request, server::TestServiceServer},
 };
 
 #[tokio_shared_rt::test(shared)]
@@ -36,6 +38,63 @@ async fn test_global_influencers() -> Result<()> {
     ];
 
     assert!(influencer_ids == expected_user_ids);
+
+    Ok(())
+}
+
+/// Recovery path for the AllTime influencers stream (issue #965): if the live
+/// `Sorted:Users:Influencers` set is lost (e.g. after Redis data loss), the next request
+/// must fall back to the graph, reseed that same key, and still return results.
+#[tokio_shared_rt::test(shared)]
+async fn test_global_influencers_alltime_cache_recovery() -> Result<()> {
+    // Ensure the server is running, so the Redis pool is initialized
+    TestServiceServer::get_test_server().await;
+    let mut redis_conn = get_redis_conn().await?;
+
+    let sorted_set_key = "Sorted:Users:Influencers";
+
+    // Snapshot the live sorted set (members + scores) so it can be restored afterwards.
+    // The graph-derived fallback scores only approximate the counts-derived ones, and
+    // sibling tests assert on the exact original ordering.
+    let snapshot: Vec<(String, f64)> = redis_conn.zrange_withscores(sorted_set_key, 0, -1).await?;
+
+    // Simulate data loss of the live AllTime influencers sorted set
+    let _: () = redis_conn.del(sorted_set_key).await?;
+
+    // The timeframe defaults to AllTime, so this request exercises the graph fallback.
+    // Defer the `?` until after the restore below so a failed request cannot leave the
+    // shared sorted set poisoned for sibling tests.
+    let body_result = get_request("/v0/stream/users?source=influencers").await;
+
+    // The fallback must have reseeded the same key the AllTime read path uses
+    let reseeded: bool = redis_conn.exists(sorted_set_key).await?;
+
+    // Restore the original sorted set exactly (DEL then ZADD of the snapshot) before
+    // asserting, so any later test observes the original counts-derived scores.
+    let _: () = redis_conn.del(sorted_set_key).await?;
+    if !snapshot.is_empty() {
+        let items: Vec<(f64, &str)> = snapshot
+            .iter()
+            .map(|(member, score)| (*score, member.as_str()))
+            .collect();
+        let _: () = redis_conn.zadd_multiple(sorted_set_key, &items).await?;
+    }
+
+    let body = body_result?;
+    assert!(body.is_array());
+
+    let influencers = body
+        .as_array()
+        .expect("Stream influencers should be an array");
+    assert!(
+        !influencers.is_empty(),
+        "Influencers should be repopulated from the graph after the sorted set is lost"
+    );
+
+    assert!(
+        reseeded,
+        "The graph fallback should rewrite the Sorted:Users:Influencers sorted set"
+    );
 
     Ok(())
 }

--- a/nexus-webapi/tests/stream/user/influencers.rs
+++ b/nexus-webapi/tests/stream/user/influencers.rs
@@ -42,7 +42,7 @@ async fn test_global_influencers() -> Result<()> {
     Ok(())
 }
 
-/// Recovery path for the AllTime influencers stream (issue #965): if the live
+/// Recovery path for the AllTime influencers stream: if the live
 /// `Sorted:Users:Influencers` set is lost (e.g. after Redis data loss), the next request
 /// must fall back to the graph, reseed that same key, and still return results.
 #[tokio_shared_rt::test(shared)]


### PR DESCRIPTION
The AllTime influencers read path (`/v0/stream/users?source=influencers`, the default timeframe) reads the live `Sorted:Users:Influencers` set, but the cache-miss fallback wrote its graph result to `Cache:Influencers:AllTime`, which nothing ever reads. After Redis data loss the endpoint ran the whole-graph scoring query on every request and still returned empty until organic activity refilled the set; `Influencers::reindex()` was equally broken.

- The AllTime fallback now seeds the live set (no TTL); other timeframes keep their TTL cache key.
- Also fixes the scoring query counting `posts_count` as always 0: it filtered on `authored.indexed_at`, an edge property that is never written. Now filters `post.indexed_at`, like `get_influencers_by_reach`. Worth fixing here because the seed makes those scores durable.
- The AllTime seed now also counts tags the user assigned to users, not just to posts, matching the `UserCounts.tagged` definition the live set is scored with. Windowed timeframes keep their existing post-tags-only scoring.

The recovery test snapshots and restores the live set and runs in a nextest serial group with the two exact-order sibling tests, so it cannot poison them.

Fixes #965

## Pre-submission Checklist

- [x] I manually reviewed the PR
- [x] I asked one or more LLMs to review the PR
- [x] I asked one or more LLMs to check if this PR can be simplified
- [x] If appropriate, I added tests for the changes in this PR
- [ ] If appropriate, I added performance benchmarks for the APIs added in this PR (n/a)

