### PR TITLE
chore: gate postgres behind dev compose profile

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Set up Docker Compose
         working-directory: docker
-        run: docker compose --profile dev --env-file .env-sample up -d
+        run: docker compose --profile tests --env-file .env-sample up -d
 
       # Install imagemagick after docker containers are started and before waiting for services to be up
       # This ensures services are starting up during this step, saving time in the "wait for services" step
@@ -90,4 +90,4 @@ jobs:
       - name: Tear down Docker Compose
         if: always()
         working-directory: docker
-        run: docker compose --profile dev down --volumes
+        run: docker compose --profile tests down --volumes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Set up Docker Compose
         working-directory: docker
-        run: docker compose --env-file .env-sample up -d
+        run: docker compose --profile dev --env-file .env-sample up -d
 
       # Install imagemagick after docker containers are started and before waiting for services to be up
       # This ensures services are starting up during this step, saving time in the "wait for services" step
@@ -69,6 +69,11 @@ jobs:
             || (echo "Neo4j failed to start" && exit 1)
           echo "Neo4j is ready"
 
+          echo "Waiting for Postgres..."
+          timeout 60 bash -c 'until nc -z 127.0.0.1 5432; do sleep 1; done' \
+            || (echo "Postgres failed to start" && exit 1)
+          echo "Postgres is ready"
+
       - name: Load Mock Data
         run: cargo run -p nexusd -- db mock
 
@@ -85,4 +90,4 @@ jobs:
       - name: Tear down Docker Compose
         if: always()
         working-directory: docker
-        run: docker compose down --volumes
+        run: docker compose --profile dev down --volumes

--- a/README.md
+++ b/README.md
@@ -57,8 +57,15 @@ To get started with Nexus, first set up the required databases: Neo4j and Redis.
 ```bash
 cd docker
 cp .env-sample .env
+
+# Lean stack: Neo4j + Redis + Redis Insight
 docker compose up -d
+
+# Full dev: Lean stack + Postgres (for watcher tests)
+docker compose --profile dev up -d
 ```
+
+To always use the full dev stack without passing `--profile dev`, uncomment `COMPOSE_PROFILES=dev` in `.env`.
 
 3. Optionally, populate the Neo4j database with initial mock data. Follow [Running Tests](#-running-tests) section about setting up mock data.
 
@@ -152,7 +159,8 @@ cargo nextest run -p nexus-common --no-fail-fast
 
 cargo nextest run -p nexus-webapi --no-fail-fast
 
-# nexus-watcher tests need the Postgres Connection URL as env variable, adjust it as needed
+# nexus-watcher tests need Postgres (docker compose --profile dev up -d) and
+# TEST_PUBKY_CONNECTION_STRING from docker/.env-sample
 # export TEST_PUBKY_CONNECTION_STRING=postgres://test_user:test_pass@localhost:5432/postgres?pubky-test=true
 cargo nextest run -p nexus-watcher --no-fail-fast
 ```

--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ cp .env-sample .env
 # Lean stack: Neo4j + Redis + Redis Insight
 docker compose up -d
 
-# Full dev: Lean stack + Postgres (for watcher tests)
-docker compose --profile dev up -d
+# With Postgres (for watcher tests)
+docker compose --profile tests up -d
 ```
 
-To always use the full dev stack without passing `--profile dev`, uncomment `COMPOSE_PROFILES=dev` in `.env`.
+To always start Postgres without passing `--profile tests`, uncomment `COMPOSE_PROFILES=tests` in `.env`.
 
 3. Optionally, populate the Neo4j database with initial mock data. Follow [Running Tests](#-running-tests) section about setting up mock data.
 
@@ -159,7 +159,7 @@ cargo nextest run -p nexus-common --no-fail-fast
 
 cargo nextest run -p nexus-webapi --no-fail-fast
 
-# nexus-watcher tests need Postgres (docker compose --profile dev up -d) and
+# nexus-watcher tests need Postgres (docker compose --profile tests up -d) and
 # TEST_PUBKY_CONNECTION_STRING from docker/.env-sample
 # export TEST_PUBKY_CONNECTION_STRING=postgres://test_user:test_pass@localhost:5432/postgres?pubky-test=true
 cargo nextest run -p nexus-watcher --no-fail-fast

--- a/docker/.env-sample
+++ b/docker/.env-sample
@@ -1,3 +1,6 @@
+# Uncomment to always start optional services (redisinsight, postgres) with `docker compose up -d`
+# COMPOSE_PROFILES=dev
+
 # Neo4J Community Edition does not support custom db_name and db_username
 # the default ones are `neo4j`
 NEO4J_DB_NAME=neo4j

--- a/docker/.env-sample
+++ b/docker/.env-sample
@@ -1,4 +1,4 @@
-# Uncomment to always start optional services (redisinsight, postgres) with `docker compose up -d`
+# Uncomment to always start optional services (postgres) with `docker compose up -d`
 # COMPOSE_PROFILES=dev
 
 # Neo4J Community Edition does not support custom db_name and db_username

--- a/docker/.env-sample
+++ b/docker/.env-sample
@@ -1,5 +1,5 @@
 # Uncomment to always start optional services (postgres) with `docker compose up -d`
-# COMPOSE_PROFILES=dev
+# COMPOSE_PROFILES=tests
 
 # Neo4J Community Edition does not support custom db_name and db_username
 # the default ones are `neo4j`

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,3 +1,5 @@
+name: pubky-nexus
+
 services:
   neo4j:
     image: neo4j:5.26.27-community
@@ -57,8 +59,9 @@ services:
       - redis
     restart: always
 
-  # Only used for tests that involve homeservers
+  # Only used for tests that involve homeservers (requires --profile dev)
   postgres:
+    profiles: ["dev"]
     image: postgres:18-alpine
     container_name: postgres
     environment:
@@ -73,17 +76,6 @@ services:
       timeout: 5s
       retries: 5
 
-  # jaeger:
-  #   image: jaegertracing/all-in-one:1.65.0
-  #   container_name: jaeger
-  #   environment:
-      # This ensures the Jaeger container also listens for OTLP signals
-      # COLLECTOR_OTLP_ENABLED: "true"
-    # ports:
-    #   - "127.0.0.1:16686:16686"    # Jaeger UI
-    #   - "127.0.0.1:4317:4317"      # OTLP/gRPC
-    #   - "4318:4318"      # OTLP/HTTP
-    # networks:
-    #   - default
-    # restart: unless-stopped
-    # network_mode: host
+networks:
+  default:
+    name: pubky-nexus

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -59,9 +59,9 @@ services:
       - redis
     restart: always
 
-  # Only used for tests that involve homeservers (requires --profile dev)
+  # Only used for tests that involve homeservers (requires --profile tests)
   postgres:
-    profiles: ["dev"]
+    profiles: ["tests"]
     image: postgres:18-alpine
     container_name: postgres
     environment:


### PR DESCRIPTION
## Summary
Make Postgres optional in the local Docker stack using Compose profiles, and pin the Compose project/network name so external containers can join reliably.

Postgres is only needed for `nexus-watcher` integration tests (homeserver scenarios). Previously, `docker compose up -d` always started it alongside Neo4j and Redis. This change keeps the default stack lean and starts Postgres only when the dev profile is enabled.

Also pins the Compose project and Docker network to `pubky-nexus`, so other containers or compose projects can attach via a stable network name instead of the directory-derived _docker_default_.

### Usage

```bash
cd docker
# Default: Neo4j + Redis + Redis Insight
docker compose up -d
# With Postgres (watcher tests)
docker compose --profile dev up -d
# Or set once in .env
COMPOSE_PROFILES=dev
```

### Pre-submission Checklist

- [x] I manually reviewed the PR
- [ ] I asked one or more LLMs to review the PR
- [ ] I asked one or more LLMs to check if this PR can be simplified [^1]
- [ ] If appropriate, I added tests for the changes in this PR
- [ ] If appropriate, I added performance benchmarks for the APIs added in this PR [^2]

[^1]: Sample prompt: "Can this be simplified? Can the code, comments, or logic introduced by these changes be simplfied, clarified or otherwise made more terse, concise and understandable, without affecting functionality?"
[^2]: `cargo bench -p nexus-webapi`
