### PR TITLE
feat(api): depth-0 self trust set for wot_domain post streams

### DIFF
--- a/docker/test-graph/mocks/wot.cypher
+++ b/docker/test-graph/mocks/wot.cypher
@@ -120,9 +120,15 @@ MATCH (from:User {id: $d1b}), (to:User {id: $btc3}) MERGE (from)-[:TAGGED {label
 MATCH (from:User {id: $d1b}), (to:User {id: $btc1}) MERGE (from)-[:TAGGED {label: $bitcoiner_tag, id: "WOTTAGBTC0004", indexed_at: 1224534095400}]->(to);
 // Endorsed via btc-dev by depth-2 rater D2 -> BTC4
 MATCH (from:User {id: $d2}), (to:User {id: $btc4}) MERGE (from)-[:TAGGED {label: $btcdev_tag, id: "WOTTAGBTC0005", indexed_at: 1224534095500}]->(to);
-// Out of WoT: SPAMMER endorses BTC5 (bitcoiner) and ARTIST1 (artist) -> not visible to O
+// Out of WoT: SPAMMER endorses BTC5 (bitcoiner) and ARTIST1 (artist) -> not visible to O.
+// These double as SPAMMER's own (depth-0 "Me") domain endorsements: a wot_domain
+// stream for SPAMMER at depth=0 surfaces BTC5/ARTIST1's posts (its follow-network is
+// empty, so only its own TAGGED edges count).
 MATCH (from:User {id: $spammer}), (to:User {id: $btc5}) MERGE (from)-[:TAGGED {label: $bitcoiner_tag, id: "WOTTAGBTC0006", indexed_at: 1224534095600}]->(to);
 MATCH (from:User {id: $spammer}), (to:User {id: $artist1}) MERGE (from)-[:TAGGED {label: $artist_tag, id: "WOTTAGART0001", indexed_at: 1224534095700}]->(to);
+// SPAMMER self-tags as bitcoiner: its own post must still be excluded from its
+// own depth-0 feed (self-exclusion applies to the "Me" trust set too).
+MATCH (from:User {id: $spammer}), (to:User {id: $spammer}) MERGE (from)-[:TAGGED {label: $bitcoiner_tag, id: "WOTTAGSELF002", indexed_at: 1224534096300}]->(to);
 // Self-endorsement: D1 (in O's WoT) tags the OBSERVER as bitcoiner. O's own posts
 // must still be excluded from O's wot_domain feed (self-exclusion, like `wot`).
 MATCH (from:User {id: $d1}), (to:User {id: $o_obs}) MERGE (from)-[:TAGGED {label: $bitcoiner_tag, id: "WOTTAGSELF001", indexed_at: 1224534096100}]->(to);

--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -4,6 +4,7 @@ use crate::db::kv::SortOrder;
 use crate::models::post::StreamSource;
 use crate::models::resource::stream::ResourceSorting;
 use crate::types::routes::HotTagsInputDTO;
+use crate::types::DomainTrust;
 use crate::types::Pagination;
 use crate::types::StreamReach;
 use crate::types::StreamSorting;
@@ -919,8 +920,17 @@ pub fn post_stream(
         StreamSource::Wot { depth, .. } => {
             cypher.push_str(&format!("MATCH (observer)-[:FOLLOWS*1..{depth}]->(author)\n"))
         }
-        // CALL collapses the trust reach to distinct taggers before the tag join.
-        StreamSource::WotDomain { depth, .. } => cypher.push_str(&format!(
+        // Me (depth-0): the observer is the sole tagger, so match their TAGGED
+        // edge directly, no traversal and no CALL. Cheaper than the network path.
+        StreamSource::WotDomain {
+            trust: DomainTrust::Me,
+            ..
+        } => cypher.push_str("MATCH (observer)-[endorsement:TAGGED]->(author)\n"),
+        // Network: CALL collapses the trust reach to distinct taggers before the tag join.
+        StreamSource::WotDomain {
+            trust: DomainTrust::Network(depth),
+            ..
+        } => cypher.push_str(&format!(
             "CALL {{ WITH observer MATCH (observer)-[:FOLLOWS*1..{depth}]->(tagger:User) RETURN DISTINCT tagger }}\n\
              MATCH (tagger)-[endorsement:TAGGED]->(author)\n"
         )),

--- a/nexus-common/src/models/post/metrics.rs
+++ b/nexus-common/src/models/post/metrics.rs
@@ -8,7 +8,8 @@
 //! Mapping from these (dotted) instrument names to the spec's metric names. The
 //! `source` and `depth` attributes carry the spec's `{source}`/`{depth}`
 //! dimensions, so `wot` and `wot_domain` share one instrument rather than
-//! splitting into two metric names (the idiomatic low-cardinality OTel shape):
+//! splitting into two metric names (the idiomatic low-cardinality OTel shape).
+//! For `source=wot_domain`, `depth=0` denotes the observer-only ("Me") trust set:
 //!
 //! | Instrument                         | Spec metric                                |
 //! |------------------------------------|--------------------------------------------|

--- a/nexus-common/src/models/post/stream.rs
+++ b/nexus-common/src/models/post/stream.rs
@@ -9,7 +9,7 @@ use crate::models::{
     follow::{Followers, Following, Friends, UserFollows},
     post::search::PostsByTagSearch,
 };
-use crate::types::{Pagination, StreamSorting, WotDepth};
+use crate::types::{DomainTrust, Pagination, StreamSorting, WotDepth};
 use futures::stream::{self, StreamExt};
 use futures::TryStreamExt;
 use pubky_app_specs::{ParsedUri, PubkyAppCollectionContent, PubkyAppPostKind, Resource};
@@ -61,9 +61,10 @@ pub enum StreamSource {
         depth: WotDepth,
     },
     /// Posts by users whom the observer's Web of Trust has tagged with a `domain_tags` label.
+    /// `trust = Me` restricts the taggers to the observer alone (depth-0 self set).
     WotDomain {
         observer_id: String,
-        depth: WotDepth,
+        trust: DomainTrust,
         domain_tags: Vec<String>,
     },
     #[default]
@@ -203,7 +204,14 @@ impl PostStream {
         // label and depth before `source` is consumed by the query below.
         let wot = match &source {
             StreamSource::Wot { depth, .. } => Some(("wot", depth.get())),
-            StreamSource::WotDomain { depth, .. } => Some(("wot_domain", depth.get())),
+            // depth-0 is the "Me" self trust set; 1..=3 is the follow-network reach.
+            StreamSource::WotDomain { trust, .. } => Some((
+                "wot_domain",
+                match trust {
+                    DomainTrust::Me => 0,
+                    DomainTrust::Network(depth) => depth.get(),
+                },
+            )),
             _ => None,
         };
         if let Some((source, depth)) = wot {

--- a/nexus-common/src/types/mod.rs
+++ b/nexus-common/src/types/mod.rs
@@ -75,6 +75,16 @@ impl std::fmt::Display for WotDepth {
     }
 }
 
+/// Trust set for a `wot_domain` post stream. `Me` is the observer's own
+/// `TAGGED` edges (depth-0, no follow traversal); `Network(d)` is the taggers
+/// reached via `FOLLOWS*1..d`. Keeping `Me` on this enum (rather than widening
+/// `WotDepth`) makes depth-0 unrepresentable for `source=wot` and `reach=wot_N`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub enum DomainTrust {
+    Me,
+    Network(WotDepth),
+}
+
 #[derive(Debug, ToSchema, Clone, PartialEq)]
 pub enum StreamReach {
     Followers,

--- a/nexus-webapi/benches/streams_benches/wot.rs
+++ b/nexus-webapi/benches/streams_benches/wot.rs
@@ -3,7 +3,7 @@ use crate::streams_benches::LIMIT_20;
 use criterion::Criterion;
 use nexus_common::db::kv::SortOrder;
 use nexus_common::models::post::{PostStream, StreamSource};
-use nexus_common::types::{StreamSorting, WotDepth};
+use nexus_common::types::{DomainTrust, StreamSorting, WotDepth};
 use tokio::runtime::Runtime;
 
 // Real, high-degree observer from the seeded skunk graph (same as the reach benches).
@@ -67,7 +67,7 @@ pub fn bench_stream_wot_domain_depth2(c: &mut Criterion) {
         b.to_async(&rt).iter(|| async {
             let source = StreamSource::WotDomain {
                 observer_id: OBSERVER_ID.to_string(),
-                depth: WotDepth::default(),
+                trust: DomainTrust::Network(WotDepth::default()),
                 domain_tags: vec!["bitcoin".to_string(), "dev".to_string()],
             };
 

--- a/nexus-webapi/src/routes/v0/stream/posts.rs
+++ b/nexus-webapi/src/routes/v0/stream/posts.rs
@@ -14,7 +14,7 @@ use nexus_common::db::kv::SortOrder;
 use nexus_common::types::StreamSorting;
 use nexus_common::{
     models::post::{PostKeyStream, PostStream, StreamSource},
-    types::WotDepth,
+    types::{DomainTrust, WotDepth},
 };
 use pubky_app_specs::PubkyAppPostKind;
 use serde::Deserialize;
@@ -46,6 +46,19 @@ fn resolve_wot_depth(depth: Option<u8>) -> AppResult<WotDepth> {
     match depth {
         Some(depth) => WotDepth::new(depth).map_err(Error::invalid_input),
         None => Ok(WotDepth::default()),
+    }
+}
+
+/// Resolves the `wot_domain` trust set from `depth`. `depth=0` selects the
+/// observer-only ("Me") set; absent falls back to the default network reach.
+/// Unlike `source=wot`, `depth=0` is valid here and means "no follow traversal".
+fn resolve_domain_trust(depth: Option<u8>) -> AppResult<DomainTrust> {
+    match depth {
+        None => Ok(DomainTrust::Network(WotDepth::default())),
+        Some(0) => Ok(DomainTrust::Me),
+        Some(depth) => WotDepth::new(depth)
+            .map(DomainTrust::Network)
+            .map_err(Error::invalid_input),
     }
 }
 
@@ -141,7 +154,7 @@ fn build_stream_source(
         StreamSourceKind::WotDomain => match (observer_id, domain_tags) {
             (Some(observer_id), Some(domain_tags)) => Ok(StreamSource::WotDomain {
                 observer_id: observer_id.to_string(),
-                depth: resolve_wot_depth(depth)?,
+                trust: resolve_domain_trust(depth)?,
                 domain_tags: domain_tags.to_string_vec(),
             }),
             (None, _) => Err(Error::invalid_input(
@@ -238,8 +251,8 @@ impl PostStreamQuery {
         ("sorting" = Option<StreamSorting>, Query, description = "Sort method (`timeline` or `total_engagement`). Ties are broken by post id; pagination across equal scores is best-effort."),
         ("order" = Option<SortOrder>, Query, description = "Ordering of response list. Either 'ascending' or 'descending'. Defaults to descending."),
         ("tags" = Option<Tags>, Query, description = "Filter by a list of comma-separated tags (max 5). E.g.,`&tags=dev,free,opensource`. Only posts matching at least one of the tags will be returned."),
-        ("depth" = Option<u8>, Query, description = "WoT traversal depth (1-3, default 2) for `source=wot` / `source=wot_domain`. Ignored for other sources."),
-        ("domain_tags" = Option<Tags>, Query, description = "Required for `source=wot_domain`. Comma-separated tag labels (max 5); returns posts by authors tagged with any of these by the observer's WoT. E.g. `&domain_tags=bitcoiner,btc-dev`. Ignored for other sources."),
+        ("depth" = Option<u8>, Query, description = "WoT traversal depth. For `source=wot`: 1-3, default 2. For `source=wot_domain`: 0-3, default 2, where `depth=0` is the observer-only (\"Me\") trust set (posts by authors the observer tagged directly, no follow traversal). `depth=0` is invalid for `source=wot`. Ignored for other sources."),
+        ("domain_tags" = Option<Tags>, Query, description = "Required for `source=wot_domain`. Comma-separated tag labels (max 5); returns posts by authors tagged with any of these by the observer's WoT, or by the observer alone when `depth=0`. E.g. `&domain_tags=bitcoiner,btc-dev`. Ignored for other sources."),
         ("kind" = Option<PubkyAppPostKind>, Query, description = "Filter by post kind: short, long, image, video, link, file, collection."),
         ("skip" = Option<BoundedSkip<10_000>>, Query, description = "Skip N posts (max 10000)"),
         ("limit" = Option<BoundedLimit<10, 50>>, Query, description = "Retrieve N posts (1–50, default 10)"),
@@ -264,7 +277,7 @@ The `source` parameter determines the type of stream. Depending on the `source`,
 - *collection*: Requires **author_id** and **post_id** of the Collection post; items are returned in curator order.
 
 - *wot*: Requires **observer_id**. Posts from users in the observer's Web of Trust (transitive follows, `depth` 1-3, default 2).
-- *wot_domain*: Requires **observer_id** and **domain_tags**. Posts by authors whom the observer's Web of Trust has tagged with any of `domain_tags` — all of those authors' posts, not only topic-tagged ones; combine with `tags=` for topic-scoped posts.
+- *wot_domain*: Requires **observer_id** and **domain_tags**. Posts by authors whom the observer's Web of Trust has tagged with any of `domain_tags`, all of those authors' posts, not only topic-tagged ones; combine with `tags=` for topic-scoped posts. With `depth=0` the trust set is the observer alone ("Me"): posts by authors the observer tagged directly.
 
 Ensure that you provide the necessary parameters based on the selected `source`. If a required parameter is missing, a 400 Bad Request error will be returned."#
 )]
@@ -310,8 +323,8 @@ pub async fn stream_posts_handler(
         ("sorting" = Option<StreamSorting>, Query, description = "Sort method (`timeline` or `total_engagement`). Ties are broken by post id; pagination across equal scores is best-effort."),
         ("order" = Option<SortOrder>, Query, description = "Ordering of response list. Either 'ascending' or 'descending'. Defaults to descending."),
         ("tags" = Option<Tags>, Query, description = "Filter by a list of comma-separated tags (max 5). E.g.,`&tags=dev,free,opensource`. Only posts matching at least one of the tags will be returned."),
-        ("depth" = Option<u8>, Query, description = "WoT traversal depth (1-3, default 2) for `source=wot` / `source=wot_domain`. Ignored for other sources."),
-        ("domain_tags" = Option<Tags>, Query, description = "Required for `source=wot_domain`. Comma-separated tag labels (max 5); returns posts by authors tagged with any of these by the observer's WoT. E.g. `&domain_tags=bitcoiner,btc-dev`. Ignored for other sources."),
+        ("depth" = Option<u8>, Query, description = "WoT traversal depth. For `source=wot`: 1-3, default 2. For `source=wot_domain`: 0-3, default 2, where `depth=0` is the observer-only (\"Me\") trust set (posts by authors the observer tagged directly, no follow traversal). `depth=0` is invalid for `source=wot`. Ignored for other sources."),
+        ("domain_tags" = Option<Tags>, Query, description = "Required for `source=wot_domain`. Comma-separated tag labels (max 5); returns posts by authors tagged with any of these by the observer's WoT, or by the observer alone when `depth=0`. E.g. `&domain_tags=bitcoiner,btc-dev`. Ignored for other sources."),
         ("kind" = Option<PubkyAppPostKind>, Query, description = "Filter by post kind: short, long, image, video, link, file, collection."),
         ("skip" = Option<BoundedSkip<10_000>>, Query, description = "Skip N posts (max 10000)"),
         ("limit" = Option<BoundedLimit<10, 50>>, Query, description = "Retrieve N posts (1–50, default 10)"),
@@ -334,7 +347,7 @@ The `source` parameter determines the type of stream. Depending on the `source`,
 - *collection*: Requires **author_id** and **post_id** of the Collection post; keys are returned in curator order.
 
 - *wot*: Requires **observer_id**. Posts from users in the observer's Web of Trust (transitive follows, `depth` 1-3, default 2).
-- *wot_domain*: Requires **observer_id** and **domain_tags**. Posts by authors whom the observer's Web of Trust has tagged with any of `domain_tags` — all of those authors' posts, not only topic-tagged ones; combine with `tags=` for topic-scoped posts.
+- *wot_domain*: Requires **observer_id** and **domain_tags**. Posts by authors whom the observer's Web of Trust has tagged with any of `domain_tags`, all of those authors' posts, not only topic-tagged ones; combine with `tags=` for topic-scoped posts. With `depth=0` the trust set is the observer alone ("Me"): posts by authors the observer tagged directly.
 
 Ensure that you provide the necessary parameters based on the selected `source`. If a required parameter is missing, a 400 Bad Request error will be returned."#
 )]
@@ -414,3 +427,28 @@ pub async fn stream_posts_by_ids_handler(
     ))
 )]
 pub struct StreamPostsApiDocs;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_domain_trust_maps_depth() {
+        // Absent depth defaults to the network reach (backward compatible).
+        assert_eq!(
+            resolve_domain_trust(None).unwrap(),
+            DomainTrust::Network(WotDepth::default())
+        );
+        // depth=0 selects the observer-only "Me" trust set.
+        assert_eq!(resolve_domain_trust(Some(0)).unwrap(), DomainTrust::Me);
+        // 1..=3 are network reaches.
+        for d in 1..=3 {
+            assert_eq!(
+                resolve_domain_trust(Some(d)).unwrap(),
+                DomainTrust::Network(WotDepth::new(d).unwrap())
+            );
+        }
+        // Out of range is rejected (unlike depth=0, which is valid here).
+        assert!(resolve_domain_trust(Some(4)).is_err());
+    }
+}

--- a/nexus-webapi/tests/stream/post/wot.rs
+++ b/nexus-webapi/tests/stream/post/wot.rs
@@ -130,6 +130,14 @@ async fn test_wot_domain_post_stream() -> Result<()> {
         "artist is not endorsed by the observer's WoT"
     );
 
+    // Backward-compat: omitting `depth` defaults to the depth-2 network reach
+    // (Network(2)), NOT the depth-0 "Me" set. Same result as explicit depth=2.
+    let path = format!(
+        "{ROOT_PATH}?source=wot_domain&observer_id={OBSERVER}&domain_tags=bitcoiner&limit=30"
+    );
+    let body = get_request(&path).await?;
+    assert_exact_set(&body, &[P_BTC1, P_BTC2, P_BTC3]);
+
     Ok(())
 }
 
@@ -160,6 +168,72 @@ async fn test_wot_domain_with_tags_and_engagement_sorting() -> Result<()> {
     Ok(())
 }
 
+// depth=0 is the "Me" trust set: posts by authors the observer tagged directly,
+// with no follow traversal. SPAMMER has an empty follow-network, so only its own
+// TAGGED edges count. It tagged BTC5 (bitcoiner), ARTIST1 (artist) and self-tagged
+// bitcoiner; the self-tag must not surface SPAMMER's own post.
+#[tokio_shared_rt::test(shared)]
+async fn test_wot_domain_me_self_tagged_and_self_excluded() -> Result<()> {
+    let path = format!(
+        "{ROOT_PATH}?source=wot_domain&observer_id={SPAMMER}&depth=0&domain_tags=bitcoiner&limit=30"
+    );
+    let body = get_request(&path).await?;
+    assert_exact_set(&body, &[P_BTC5]);
+    assert_excludes(&body, &[P_S]);
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_wot_domain_me_or_filter_and_empty() -> Result<()> {
+    // OR over the label list.
+    let path = format!(
+        "{ROOT_PATH}?source=wot_domain&observer_id={SPAMMER}&depth=0&domain_tags=bitcoiner,artist&limit=30"
+    );
+    let body = get_request(&path).await?;
+    assert_exact_set(&body, &[P_BTC5, P_ART1]);
+
+    // No self-tag carries this label => empty.
+    let path = format!(
+        "{ROOT_PATH}?source=wot_domain&observer_id={SPAMMER}&depth=0&domain_tags=btc-dev&limit=30"
+    );
+    let body = get_request(&path).await?;
+    assert_exact_set(&body, &[]);
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_wot_domain_me_uses_only_observer_tags() -> Result<()> {
+    // depth=0 consults only the observer's own tags, never the follow-network. O
+    // has no outgoing TAGGED edges (D1->O is D1 tagging O, not O tagging), so O's
+    // "Me" feed is empty, in contrast to O's depth-2 network feed.
+    let me = format!(
+        "{ROOT_PATH}?source=wot_domain&observer_id={OBSERVER}&depth=0&domain_tags=bitcoiner&limit=30"
+    );
+    let body = get_request(&me).await?;
+    assert_exact_set(&body, &[]);
+
+    let network = format!(
+        "{ROOT_PATH}?source=wot_domain&observer_id={OBSERVER}&depth=2&domain_tags=bitcoiner&limit=30"
+    );
+    let body = get_request(&network).await?;
+    assert_exact_set(&body, &[P_BTC1, P_BTC2, P_BTC3]);
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_wot_domain_me_with_topic_tags() -> Result<()> {
+    // depth=0 combined with a post `tags` filter + engagement sort must build
+    // valid Cypher (direct-tag MATCH + self-exclusion + endorsement + tag
+    // conditions in one WHERE/AND chain). No bitcoiner post carries an
+    // `opensource` tag, so the result is exactly empty.
+    let path = format!(
+        "{ROOT_PATH}?source=wot_domain&observer_id={SPAMMER}&depth=0&domain_tags=bitcoiner&tags=opensource&sorting=total_engagement&limit=30"
+    );
+    let body = get_request(&path).await?;
+    assert_exact_set(&body, &[]);
+    Ok(())
+}
+
 #[tokio_shared_rt::test(shared)]
 async fn test_wot_validation_errors() -> Result<()> {
     // wot_domain without domain_tags.
@@ -176,6 +250,14 @@ async fn test_wot_validation_errors() -> Result<()> {
 
     // depth out of range.
     let path = format!("{ROOT_PATH}?source=wot&observer_id={OBSERVER}&depth=4");
+    invalid_get_request(&path, StatusCode::BAD_REQUEST).await?;
+
+    // depth=0 is exclusive to wot_domain; `wot` still rejects it.
+    let path = format!("{ROOT_PATH}?source=wot&observer_id={OBSERVER}&depth=0");
+    invalid_get_request(&path, StatusCode::BAD_REQUEST).await?;
+
+    // wot_domain at depth=0 still requires domain_tags.
+    let path = format!("{ROOT_PATH}?source=wot_domain&observer_id={OBSERVER}&depth=0");
     invalid_get_request(&path, StatusCode::BAD_REQUEST).await?;
 
     Ok(())


### PR DESCRIPTION
Adds a `depth=0` "Me" trust set to `source=wot_domain`: posts by authors the observer tagged directly, no follow traversal. `depth=1..3` unchanged. Modeled as `DomainTrust { Me, Network(WotDepth) }` so `depth=0` stays invalid for `source=wot` / `reach=wot_N`.

Fixes #981

# Pre-submission Checklist

- [x] I manually reviewed the PR
- [x] I asked one or more LLMs to review the PR
- [x] I asked one or more LLMs to check if this PR can be simplified
- [x] If appropriate, I added tests for the changes in this PR
- [ ] If appropriate, I added performance benchmarks for the APIs added in this PR
