### PR TITLE
fix(watcher): add missing PubkyAppPost lock field in engagement test

### DIFF
--- a/nexus-watcher/tests/event_processor/posts/engagement.rs
+++ b/nexus-watcher/tests/event_processor/posts/engagement.rs
@@ -125,6 +125,7 @@ async fn test_post_counts_read_does_not_seed_engagement() -> Result<()> {
         parent: None,
         embed: None,
         attachments: None,
+        lock: None,
     };
     let (post_id, _post_path) = test.create_post(&user_kp, &post).await?;
 


### PR DESCRIPTION
Fixes a compile break on `main`: `nexus-watcher/tests/event_processor/posts/engagement.rs` constructs a `PubkyAppPost` without the `lock` field that the post-lock feature added to `pubky-app-specs`. This is a semantic merge conflict (the post-lock PR added the field; a later counts PR added this initializer without it) that breaks `cargo clippy --tests -- -D warnings` (the `lint` job) and the watcher integration tests on every open PR. The file's other three initializers already set `lock: None`.

# Pre-submission Checklist

- [x] I manually reviewed the PR
- [x] I asked one or more LLMs to review the PR
- [x] I asked one or more LLMs to check if this PR can be simplified
- [ ] If appropriate, I added tests for the changes in this PR
- [ ] If appropriate, I added performance benchmarks for the APIs added in this PR
