### PR TITLE
feat: add trust score to user nodes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,22 @@ jobs:
         with:
           tool: cargo-nextest
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Pre-build the neo4j+GDS image with the GHA layer cache: after the
+      # first run, the ~62MB GDS jar layer is restored from cache instead of
+      # downloaded from graphdatascience.ninja. `docker compose up` below
+      # finds the image under this tag and skips its own build.
+      - name: Build Neo4j image with GDS plugin (cached)
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/neo4j
+          tags: pubky-nexus/neo4j:5.26.27-gds2.13.10
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha
+
       - name: Set up Docker Compose
         working-directory: docker
         run: docker compose --profile tests --env-file .env-sample up -d
@@ -86,6 +102,12 @@ jobs:
       # This test suite uses the TEST_PUBKY_CONNECTION_STRING env variable
       - name: Run WATCHER integration tests
         run: cargo nextest run -p nexus-watcher --no-fail-fast
+
+      # Runs last: the trust recompute writes a `trust` property across all
+      # :User nodes, so keep it after the suites that assert on graph state.
+      # Requires the GDS plugin in the neo4j image (pre-built above).
+      - name: Run NEXUSD integration tests
+        run: cargo nextest run -p nexusd --no-fail-fast
 
       - name: Tear down Docker Compose
         if: always()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3144,6 +3144,7 @@ dependencies = [
 name = "nexusd"
 version = "0.4.1"
 dependencies = [
+ "anyhow",
  "async-trait",
  "chrono",
  "clap",

--- a/README.md
+++ b/README.md
@@ -190,6 +190,10 @@ cargo nextest run -p nexus-webapi --no-fail-fast
 # TEST_PUBKY_CONNECTION_STRING from docker/.env-sample
 # export TEST_PUBKY_CONNECTION_STRING=postgres://test_user:test_pass@localhost:5432/postgres?pubky-test=true
 cargo nextest run -p nexus-watcher --no-fail-fast
+
+# nexusd trust-rank tests require the GDS plugin baked into the neo4j image
+# (docker/neo4j/Dockerfile); the docker compose stack builds it automatically.
+cargo nextest run -p nexusd --no-fail-fast
 ```
 
 To test specific feature(s):

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -26,7 +26,8 @@ services:
       NEO4J_AUTH: ${NEO4J_DB_USERNAME}/${NEO4J_PASSWORD}
       # https://neo4j.com/docs/operations-manual/current/docker/configuration/
       # Modify the default configuration
-      # Raise memory limits
+      # Raise memory limits.
+      # GDS projection lives in heap.
       NEO4J_server_memory_pagecache_size: 1G
       NEO4J_server_memory_heap_initial__size: 2G
       NEO4J_server_memory_heap_max__size: 2G
@@ -41,8 +42,7 @@ services:
       # seeded PageRank trust scores over the follow graph.
       NEO4J_PLUGINS: '["graph-data-science"]'
       NEO4J_dbms_security_procedures_unrestricted: gds.*
-      NEO4J_dbms_security_procedures_allowlist: gds.graph.project,gds.graph.drop,gds.graph.list,gds.pageRank.write
-
+      NEO4J_dbms_security_procedures_allowlist: gds.graph.project,gds.graph.project.estimate,gds.graph.drop,gds.graph.list,gds.pageRank.write
   redis:
     image: redis:8.0.6-alpine
     container_name: redis
@@ -53,7 +53,6 @@ services:
     volumes:
       - .database/redis/data:/data:Z
     restart: always
-
   redisinsight:
     image: redis/redisinsight:3.0.3
     container_name: redisinsight
@@ -67,7 +66,6 @@ services:
     depends_on:
       - redis
     restart: always
-
   # Only used for tests that involve homeservers (requires --profile tests)
   postgres:
     profiles: ["tests"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,11 @@ name: pubky-nexus
 
 services:
   neo4j:
-    image: neo4j:5.26.27-community
+    # Locally-built neo4j with the GDS plugin baked in (see neo4j/Dockerfile);
+    # `docker compose up` builds it on first use, CI pre-builds it with a
+    # GitHub Actions layer cache.
+    build: ./neo4j
+    image: pubky-nexus/neo4j:5.26.27-gds2.13.10
     container_name: neo4j
     restart: unless-stopped
     ports:
@@ -33,6 +37,11 @@ services:
       # https://neo4j.com/docs/operations-manual/current/configuration/configuration-settings/#config_client.allow_telemetry
       NEO4J_client_allow__telemetry: false
       # NEO4J_apoc_uuid_enabled: false
+      # Graph Data Science plugin (free on Community Edition), used to compute
+      # seeded PageRank trust scores over the follow graph.
+      NEO4J_PLUGINS: '["graph-data-science"]'
+      NEO4J_dbms_security_procedures_unrestricted: gds.*
+      NEO4J_dbms_security_procedures_allowlist: gds.graph.project,gds.graph.drop,gds.graph.list,gds.pageRank.write
 
   redis:
     image: redis:8.0.6-alpine

--- a/docker/neo4j/Dockerfile
+++ b/docker/neo4j/Dockerfile
@@ -1,0 +1,20 @@
+# Neo4j Community with the Graph Data Science plugin baked in.
+#
+# GDS ships in /var/lib/neo4j/products/ only in the *enterprise* image; on
+# community, the NEO4J_PLUGINS entrypoint handler falls back to downloading
+# ~62MB from graphdatascience.ninja on every container creation — a startup
+# latency, a CI flake source, and a hard failure on restricted networks.
+# Baking the jar into the products dir makes the stock entrypoint find it via
+# its location glob (/var/lib/neo4j/products/neo4j-graph-data-science-*.jar)
+# and install it offline, plugin default config included.
+#
+# GDS 2.13 is the only GDS series supported on Neo4j 5.26.
+FROM neo4j:5.26.27-community
+
+ARG GDS_VERSION=2.13.10
+# --checksum pins the artifact (supply-chain integrity) and gives BuildKit a
+# stable cache key, so cached builds skip the download entirely.
+ADD --chown=neo4j:neo4j \
+    --checksum=sha256:d3d842653fede3f83d6c7e2a6fafb73ac5b7dce98e2e234c18e755852e432e14 \
+    https://graphdatascience.ninja/neo4j-graph-data-science-${GDS_VERSION}.jar \
+    /var/lib/neo4j/products/neo4j-graph-data-science-${GDS_VERSION}.jar

--- a/nexus-common/default.config.toml
+++ b/nexus-common/default.config.toml
@@ -122,3 +122,30 @@ slow_query_logging_threshold_ms = 100
 #[jobs.example]
 #cron = "0 0 3 * * *"    # daily at 03:00 UTC
 #cron = "0 0 4 * * MON"  # Mondays at 04:00 UTC
+
+# Scheduling for the trust-rank recompute job. Set a cron for automatic
+# recomputes; omit it to leave the job on-demand only (`nexusd jobs run
+# trust-recompute` always works).
+[jobs.trust-recompute]
+# Example: daily at 03:00:
+#cron = "0 0 3 * * *"
+
+# Trust-rank parameters (what the recompute does; when it runs is set under
+# [jobs.trust-recompute] above).
+[trust_rank]
+# Seeds for the personalized PageRank over the follow graph, each weighted
+# equally (v = 1/N). Empty by default: the job refuses to run until set.
+# Duplicate ids are silently deduplicated, keeping first-occurrence order. Example:
+# seed = ["8um71us3fyw6h8wbcxb5ar3rwusy1a6u49956ikzojg3gcwd1dty"]
+seed = []
+# Teleport weight `alpha` in `trust = alpha*v + (1-alpha)*M*trust` (GDS dampingFactor = 1-alpha)
+alpha = 0.35
+# Cap on power-iteration rounds
+max_iterations = 200
+# Convergence tolerance; kept low to run to convergence rather than early-stop
+tolerance = 0.0000001
+# When true, each recompute also writes a CSV report of the run to report_dir
+report_enabled = false
+# Directory recompute reports are written to, created if missing.
+# Files are named trust-report-<UTC timestamp>.csv
+report_dir = "~/.pubky-nexus/trust-reports"

--- a/nexus-common/default.config.toml
+++ b/nexus-common/default.config.toml
@@ -151,3 +151,5 @@ report_enabled = false
 report_dir = "~/.pubky-nexus/trust-reports"
 # Max rows in a report (top users by score).
 report_limit = 10000
+# Hard cap on GDS projection size (bytes). Prevents projection larger than Neo4j heap.
+# max_projection_bytes = 2147483648

--- a/nexus-common/default.config.toml
+++ b/nexus-common/default.config.toml
@@ -149,3 +149,5 @@ report_enabled = false
 # Directory recompute reports are written to, created if missing.
 # Files are named trust-report-<UTC timestamp>.csv
 report_dir = "~/.pubky-nexus/trust-reports"
+# Max rows in a report (top users by score).
+report_limit = 10000

--- a/nexus-common/src/config/daemon.rs
+++ b/nexus-common/src/config/daemon.rs
@@ -6,7 +6,9 @@ use tracing::error;
 
 use crate::{file::CONFIG_FILE_NAME, types::DynError};
 
-use super::{file::ConfigLoader, ApiConfig, JobConfig, StackConfig, WatcherConfig};
+use super::{
+    file::ConfigLoader, ApiConfig, JobConfig, StackConfig, TrustRankConfig, WatcherConfig,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DaemonConfig {
@@ -18,6 +20,9 @@ pub struct DaemonConfig {
     /// Scheduling config per cron job, keyed by job name (`[jobs.<name>]`).
     #[serde(default)]
     pub jobs: HashMap<String, JobConfig>,
+    /// Trust-rank computation parameters (`[trust_rank]`).
+    #[serde(default)]
+    pub trust_rank: TrustRankConfig,
 }
 
 impl DaemonConfig {
@@ -70,7 +75,9 @@ mod tests {
 
     use crate::config::file::{reader::DEFAULT_CONFIG_TOML, ConfigLoader};
     use crate::{
-        config::watcher::DEFAULT_MODERATION_ID, file::validate_and_expand_path, DaemonConfig, Level,
+        config::watcher::DEFAULT_MODERATION_ID, default_trust_report_dir,
+        file::validate_and_expand_path, DaemonConfig, Level, DEFAULT_TRUST_ALPHA,
+        DEFAULT_TRUST_MAX_ITERATIONS, DEFAULT_TRUST_TOLERANCE,
     };
 
     #[tokio_shared_rt::test(shared)]
@@ -123,8 +130,17 @@ mod tests {
         assert_eq!(c.stack.db.redis, "redis://127.0.0.1:6379");
         assert_eq!(c.stack.db.neo4j.uri, "bolt://localhost:7687");
 
-        // No jobs are registered/configured by default.
-        assert!(c.jobs.is_empty());
+        let trust_job = c
+            .jobs
+            .get("trust-recompute")
+            .expect("[jobs.trust-recompute] should be present");
+        assert!(trust_job.cron.is_none());
+        assert!(c.trust_rank.seed.is_empty());
+        assert_eq!(c.trust_rank.alpha, DEFAULT_TRUST_ALPHA);
+        assert_eq!(c.trust_rank.max_iterations, DEFAULT_TRUST_MAX_ITERATIONS);
+        assert_eq!(c.trust_rank.tolerance, DEFAULT_TRUST_TOLERANCE);
+        assert!(!c.trust_rank.report_enabled);
+        assert_eq!(c.trust_rank.report_dir, default_trust_report_dir());
     }
 
     /// A `[jobs.<name>]` section parses into a keyed [`JobConfig`], with its cron
@@ -147,6 +163,133 @@ mod tests {
             .expect("config with an empty job section should parse");
 
         assert!(c.jobs["example"].cron.is_none());
+    }
+
+    /// A valid `[jobs.trust-recompute] cron` expression parses and is stored verbatim.
+    #[test]
+    fn test_trust_job_cron_parsing() {
+        let toml =
+            DEFAULT_CONFIG_TOML.replace(r#"#cron = "0 0 3 * * *""#, r#"cron = "0 0 3 * * *""#);
+
+        let c = DaemonConfig::try_from_str(&toml).expect("config with a valid cron should parse");
+
+        assert_eq!(
+            c.jobs["trust-recompute"].cron.as_deref(),
+            Some("0 0 3 * * *")
+        );
+    }
+
+    /// `trust_rank.report_enabled` and `trust_rank.report_dir` parse, with `~` expanded.
+    #[test]
+    fn test_trust_report_config_parsing() {
+        let toml = DEFAULT_CONFIG_TOML
+            .replace("report_enabled = false", "report_enabled = true")
+            .replace(
+                r#"report_dir = "~/.pubky-nexus/trust-reports""#,
+                r#"report_dir = "~/custom/reports""#,
+            );
+
+        let c = DaemonConfig::try_from_str(&toml)
+            .expect("config with trust reports enabled should parse");
+
+        assert!(c.trust_rank.report_enabled);
+        assert_eq!(
+            c.trust_rank.report_dir,
+            validate_and_expand_path(PathBuf::from_str("~/custom/reports").unwrap()).unwrap()
+        );
+    }
+
+    /// A populated `trust_rank.seed` list parses into `PubkyId` entries, in order.
+    #[test]
+    fn test_trust_seed_parsing() {
+        let hs1 = "8um71us3fyw6h8wbcxb5ar3rwusy1a6u49956ikzojg3gcwd1dty";
+        let hs2 = "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo";
+
+        let toml =
+            DEFAULT_CONFIG_TOML.replace("seed = []", &format!(r#"seed = ["{hs1}", "{hs2}"]"#));
+
+        let c = DaemonConfig::try_from_str(&toml).expect("config with a trust seed should parse");
+
+        assert_eq!(
+            c.trust_rank.seed,
+            vec![
+                PubkyId::try_from(hs1).unwrap(),
+                PubkyId::try_from(hs2).unwrap(),
+            ]
+        );
+    }
+
+    /// Duplicate `trust_rank.seed` ids are silently deduplicated, preserving
+    /// first-occurrence order.
+    #[test]
+    fn test_trust_seed_dedupes_duplicates() {
+        let hs1 = "8um71us3fyw6h8wbcxb5ar3rwusy1a6u49956ikzojg3gcwd1dty";
+        let hs2 = "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo";
+
+        let toml = DEFAULT_CONFIG_TOML.replace(
+            "seed = []",
+            &format!(r#"seed = ["{hs1}", "{hs2}", "{hs1}"]"#),
+        );
+
+        let c =
+            DaemonConfig::try_from_str(&toml).expect("config with duplicated seeds should parse");
+
+        assert_eq!(
+            c.trust_rank.seed,
+            vec![
+                PubkyId::try_from(hs1).unwrap(),
+                PubkyId::try_from(hs2).unwrap(),
+            ],
+            "duplicate seed ids should be removed, keeping first-occurrence order"
+        );
+    }
+
+    /// `trust_rank.alpha` must be in `(0, 1]`; out-of-range values fail config parsing.
+    #[test]
+    fn test_trust_alpha_rejects_out_of_range() {
+        for bad_alpha in ["0.0", "1.5", "-0.1"] {
+            let toml = DEFAULT_CONFIG_TOML.replace("alpha = 0.35", &format!("alpha = {bad_alpha}"));
+            assert!(
+                DaemonConfig::try_from_str(&toml).is_err(),
+                "alpha = {bad_alpha} should be rejected"
+            );
+        }
+    }
+
+    /// An unknown key under `[trust_rank]` (e.g. a typo'd `report_enable`) must
+    /// fail config parsing rather than parse silently into no effect.
+    #[test]
+    fn test_trust_rank_rejects_unknown_key() {
+        let toml = format!("{DEFAULT_CONFIG_TOML}\nreport_enable = true\n");
+        assert!(
+            DaemonConfig::try_from_str(&toml).is_err(),
+            "an unknown [trust_rank] key must be rejected"
+        );
+    }
+
+    /// `trust_rank.max_iterations` must be at least 1; zero fails config parsing.
+    #[test]
+    fn test_trust_max_iterations_rejects_zero() {
+        let toml = DEFAULT_CONFIG_TOML.replace("max_iterations = 200", "max_iterations = 0");
+        assert!(
+            DaemonConfig::try_from_str(&toml).is_err(),
+            "max_iterations = 0 should be rejected"
+        );
+    }
+
+    /// `trust_rank.tolerance` must be finite and non-negative; bad values fail config parsing.
+    #[test]
+    fn test_trust_tolerance_rejects_invalid() {
+        for bad_tolerance in ["-0.1", "nan", "inf"] {
+            let toml = DEFAULT_CONFIG_TOML.replace(
+                "tolerance = 0.0000001",
+                &format!("tolerance = {bad_tolerance}"),
+            );
+            assert!(
+                DaemonConfig::try_from_str(&toml).is_err(),
+                "tolerance = {bad_tolerance} should be rejected"
+            );
+        }
     }
 
     /// A populated `external_hs_pk_blacklist` is parsed into the expected

--- a/nexus-common/src/config/daemon.rs
+++ b/nexus-common/src/config/daemon.rs
@@ -77,7 +77,7 @@ mod tests {
     use crate::{
         config::watcher::DEFAULT_MODERATION_ID, default_trust_report_dir,
         file::validate_and_expand_path, DaemonConfig, Level, DEFAULT_TRUST_ALPHA,
-        DEFAULT_TRUST_MAX_ITERATIONS, DEFAULT_TRUST_TOLERANCE,
+        DEFAULT_TRUST_MAX_ITERATIONS, DEFAULT_TRUST_REPORT_LIMIT, DEFAULT_TRUST_TOLERANCE,
     };
 
     #[tokio_shared_rt::test(shared)]
@@ -141,6 +141,7 @@ mod tests {
         assert_eq!(c.trust_rank.tolerance, DEFAULT_TRUST_TOLERANCE);
         assert!(!c.trust_rank.report_enabled);
         assert_eq!(c.trust_rank.report_dir, default_trust_report_dir());
+        assert_eq!(c.trust_rank.report_limit, DEFAULT_TRUST_REPORT_LIMIT);
     }
 
     /// A `[jobs.<name>]` section parses into a keyed [`JobConfig`], with its cron
@@ -274,6 +275,16 @@ mod tests {
         assert!(
             DaemonConfig::try_from_str(&toml).is_err(),
             "max_iterations = 0 should be rejected"
+        );
+    }
+
+    /// `report_limit` must be ≥ 1; zero fails parsing.
+    #[test]
+    fn test_trust_report_limit_rejects_zero() {
+        let toml = DEFAULT_CONFIG_TOML.replace("report_limit = 10000", "report_limit = 0");
+        assert!(
+            DaemonConfig::try_from_str(&toml).is_err(),
+            "report_limit = 0 should be rejected"
         );
     }
 

--- a/nexus-common/src/config/mod.rs
+++ b/nexus-common/src/config/mod.rs
@@ -32,7 +32,7 @@ pub use net::NetConfig;
 pub use stack::{default_stack, OtlpConfig, StackConfig};
 pub use trust::{
     default_trust_report_dir, TrustRankConfig, DEFAULT_TRUST_ALPHA, DEFAULT_TRUST_MAX_ITERATIONS,
-    DEFAULT_TRUST_TOLERANCE,
+    DEFAULT_TRUST_REPORT_LIMIT, DEFAULT_TRUST_TOLERANCE,
 };
 pub use watcher::{
     EventRetryConfig, WatcherConfig, DEFAULT_HS_RESOLVER_TTL, DEFAULT_INITIAL_BACKOFF_SECS,

--- a/nexus-common/src/config/mod.rs
+++ b/nexus-common/src/config/mod.rs
@@ -22,6 +22,7 @@ pub mod file;
 mod job;
 mod net;
 mod stack;
+mod trust;
 pub mod watcher;
 
 pub use api::{ApiConfig, RateLimitBucketConfig, RateLimitConfig};
@@ -29,6 +30,10 @@ pub use daemon::DaemonConfig;
 pub use job::JobConfig;
 pub use net::NetConfig;
 pub use stack::{default_stack, OtlpConfig, StackConfig};
+pub use trust::{
+    default_trust_report_dir, TrustRankConfig, DEFAULT_TRUST_ALPHA, DEFAULT_TRUST_MAX_ITERATIONS,
+    DEFAULT_TRUST_TOLERANCE,
+};
 pub use watcher::{
     EventRetryConfig, WatcherConfig, DEFAULT_HS_RESOLVER_TTL, DEFAULT_INITIAL_BACKOFF_SECS,
     DEFAULT_MAX_BACKOFF_SECS, DEFAULT_MAX_FILE_SIZE, MAX_EVENTS_LIMIT, MAX_KEY_BASED_EVENTS_LIMIT,

--- a/nexus-common/src/config/trust.rs
+++ b/nexus-common/src/config/trust.rs
@@ -109,6 +109,8 @@ pub struct TrustRankConfig {
     /// Max rows in a recompute report (top users by score). Must be ≥ 1.
     #[serde(deserialize_with = "deserialize_report_limit")]
     pub report_limit: usize,
+    /// Hard cap on the GDS projection size (bytes). Default: None (no cap).
+    pub max_projection_bytes: Option<u64>,
 }
 
 impl Default for TrustRankConfig {
@@ -121,6 +123,7 @@ impl Default for TrustRankConfig {
             report_enabled: false,
             report_dir: default_trust_report_dir(),
             report_limit: DEFAULT_TRUST_REPORT_LIMIT,
+            max_projection_bytes: None,
         }
     }
 }

--- a/nexus-common/src/config/trust.rs
+++ b/nexus-common/src/config/trust.rs
@@ -1,0 +1,112 @@
+use pubky_app_specs::PubkyId;
+use serde::{de::Error, Deserialize, Deserializer, Serialize};
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use super::file::{default_config_dir_path, validate_and_expand_path};
+
+/// Default teleport weight (`alpha` in `trust = alpha*v + (1-alpha)*M*trust`).
+/// GDS's `dampingFactor` is `1 - alpha`.
+pub const DEFAULT_TRUST_ALPHA: f64 = 0.35;
+/// Default cap on PageRank power-iteration rounds.
+pub const DEFAULT_TRUST_MAX_ITERATIONS: u32 = 200;
+/// Default convergence tolerance: run close to full convergence rather than early-stop.
+pub const DEFAULT_TRUST_TOLERANCE: f64 = 0.0000001;
+
+/// Dedupes the seed list, keeping first-occurrence order: duplicate ids would
+/// otherwise inflate `sourceNodes` and skew the configured-vs-matched seed check.
+fn deserialize_seed<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<PubkyId>, D::Error> {
+    let seeds = Vec::<PubkyId>::deserialize(d)?;
+    let mut seen = HashSet::new();
+    Ok(seeds
+        .into_iter()
+        .filter(|id| seen.insert(id.clone()))
+        .collect())
+}
+
+fn deserialize_alpha<'de, D: Deserializer<'de>>(d: D) -> Result<f64, D::Error> {
+    let alpha = f64::deserialize(d)?;
+    if !alpha.is_finite() || alpha <= 0.0 || alpha > 1.0 {
+        return Err(D::Error::custom(format!(
+            "trust.alpha ({alpha}) must be in the range (0, 1]"
+        )));
+    }
+    Ok(alpha)
+}
+
+fn deserialize_max_iterations<'de, D: Deserializer<'de>>(d: D) -> Result<u32, D::Error> {
+    let max_iterations = u32::deserialize(d)?;
+    if max_iterations == 0 {
+        return Err(D::Error::custom("trust.max_iterations must be at least 1"));
+    }
+    Ok(max_iterations)
+}
+
+fn deserialize_tolerance<'de, D: Deserializer<'de>>(d: D) -> Result<f64, D::Error> {
+    let tolerance = f64::deserialize(d)?;
+    if !tolerance.is_finite() || tolerance < 0.0 {
+        return Err(D::Error::custom(format!(
+            "trust.tolerance ({tolerance}) must be a finite, non-negative number"
+        )));
+    }
+    Ok(tolerance)
+}
+
+fn deserialize_report_dir<'de, D: Deserializer<'de>>(d: D) -> Result<PathBuf, D::Error> {
+    let path = PathBuf::deserialize(d)?;
+    validate_and_expand_path(path).map_err(D::Error::custom)
+}
+
+/// Default directory for scheduled-run CSV reports.
+pub fn default_trust_report_dir() -> PathBuf {
+    default_config_dir_path().join("trust-reports")
+}
+
+/// Parameters for the seeded (personalized) PageRank trust computation, run via
+/// the Neo4j GDS `pageRank` procedure over the follow graph. Covers *what* the
+/// computation does; *when* it runs is a job concern (see
+/// `[jobs.trust-recompute]` / [`super::JobConfig`]).
+///
+/// Seeds are weighted equally (`v` uniform, `1/N` over `seed`): GDS 2.13 (the
+/// only version on Neo4j 5.26) has no weighted `sourceNodes`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(default, deny_unknown_fields)]
+pub struct TrustRankConfig {
+    /// Users trust originates from, each weighted equally (`v = 1/N`). Empty
+    /// by default: an operator must configure a seed set before trust rank
+    /// can be computed. Duplicate ids are silently deduplicated, keeping
+    /// first-occurrence order.
+    #[serde(deserialize_with = "deserialize_seed")]
+    pub seed: Vec<PubkyId>,
+    /// Teleport weight `alpha` in `trust = alpha*v + (1-alpha)*M*trust`.
+    /// GDS's `dampingFactor` is derived as `1 - alpha`. Must be in (0, 1].
+    #[serde(deserialize_with = "deserialize_alpha")]
+    pub alpha: f64,
+    /// Cap on power-iteration rounds. Must be at least 1.
+    #[serde(deserialize_with = "deserialize_max_iterations")]
+    pub max_iterations: u32,
+    /// Convergence tolerance passed to GDS; kept low so the computation runs to
+    /// convergence rather than stopping early. Must be finite and non-negative.
+    #[serde(deserialize_with = "deserialize_tolerance")]
+    pub tolerance: f64,
+    /// When true, each recompute also writes a CSV report of the run to
+    /// `report_dir` (default: false).
+    pub report_enabled: bool,
+    /// Directory recompute reports are written to, created if missing.
+    /// Files are named `trust-report-<UTC timestamp>.csv`.
+    #[serde(deserialize_with = "deserialize_report_dir")]
+    pub report_dir: PathBuf,
+}
+
+impl Default for TrustRankConfig {
+    fn default() -> Self {
+        Self {
+            seed: Vec::new(),
+            alpha: DEFAULT_TRUST_ALPHA,
+            max_iterations: DEFAULT_TRUST_MAX_ITERATIONS,
+            tolerance: DEFAULT_TRUST_TOLERANCE,
+            report_enabled: false,
+            report_dir: default_trust_report_dir(),
+        }
+    }
+}

--- a/nexus-common/src/config/trust.rs
+++ b/nexus-common/src/config/trust.rs
@@ -12,6 +12,8 @@ pub const DEFAULT_TRUST_ALPHA: f64 = 0.35;
 pub const DEFAULT_TRUST_MAX_ITERATIONS: u32 = 200;
 /// Default convergence tolerance: run close to full convergence rather than early-stop.
 pub const DEFAULT_TRUST_TOLERANCE: f64 = 0.0000001;
+/// Default max rows in a recompute CSV report.
+pub const DEFAULT_TRUST_REPORT_LIMIT: usize = 10_000;
 
 /// Dedupes the seed list, keeping first-occurrence order: duplicate ids would
 /// otherwise inflate `sourceNodes` and skew the configured-vs-matched seed check.
@@ -40,6 +42,14 @@ fn deserialize_max_iterations<'de, D: Deserializer<'de>>(d: D) -> Result<u32, D:
         return Err(D::Error::custom("trust.max_iterations must be at least 1"));
     }
     Ok(max_iterations)
+}
+
+fn deserialize_report_limit<'de, D: Deserializer<'de>>(d: D) -> Result<usize, D::Error> {
+    let report_limit = usize::deserialize(d)?;
+    if report_limit == 0 {
+        return Err(D::Error::custom("trust.report_limit must be at least 1"));
+    }
+    Ok(report_limit)
 }
 
 fn deserialize_tolerance<'de, D: Deserializer<'de>>(d: D) -> Result<f64, D::Error> {
@@ -96,6 +106,9 @@ pub struct TrustRankConfig {
     /// Files are named `trust-report-<UTC timestamp>.csv`.
     #[serde(deserialize_with = "deserialize_report_dir")]
     pub report_dir: PathBuf,
+    /// Max rows in a recompute report (top users by score). Must be ≥ 1.
+    #[serde(deserialize_with = "deserialize_report_limit")]
+    pub report_limit: usize,
 }
 
 impl Default for TrustRankConfig {
@@ -107,6 +120,7 @@ impl Default for TrustRankConfig {
             tolerance: DEFAULT_TRUST_TOLERANCE,
             report_enabled: false,
             report_dir: default_trust_report_dir(),
+            report_limit: DEFAULT_TRUST_REPORT_LIMIT,
         }
     }
 }

--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -563,35 +563,75 @@ pub fn get_viewer_trusted_network_post_tags(
         .param("limit_taggers", limit_taggers as i64)
 }
 
+/// Per-user count fields, as `(alias, COUNT {} subquery)` pairs bound to the
+/// node variable `u`. Single source of truth shared by [`user_counts`] (map
+/// form) and the trust report (column form), so their filters — especially the
+/// collection/bookmark rules — can't drift between the two queries.
+const USER_COUNT_FIELDS: &[(&str, &str)] = &[
+    ("following", "COUNT { (u)-[:FOLLOWS]->(:User) }"),
+    ("followers", "COUNT { (:User)-[:FOLLOWS]->(u) }"),
+    (
+        "friends",
+        "COUNT { (u)-[:FOLLOWS]->(friend:User) WHERE (friend)-[:FOLLOWS]->(u) }",
+    ),
+    ("posts", "COUNT { (u)-[:AUTHORED]->(:Post) }"),
+    (
+        "replies",
+        "COUNT { (u)-[:AUTHORED]->(:Post)-[:REPLIED]->(:Post) }",
+    ),
+    (
+        "collections",
+        "COUNT { (u)-[:AUTHORED]->(p:Post) WHERE p.kind = 'collection' }",
+    ),
+    // A collection-follow is stored as a bookmark; keep it out of the count.
+    (
+        "bookmarks",
+        "COUNT { (u)-[:BOOKMARKED]->(bp:Post) WHERE (bp.kind IS NULL OR bp.kind <> 'collection') }",
+    ),
+    // tagged = tags this user assigned to users + to posts
+    (
+        "tagged",
+        "COUNT { (u)-[:TAGGED]->(:User) } + COUNT { (u)-[:TAGGED]->(:Post) }",
+    ),
+    ("tags", "COUNT { (:User)-[:TAGGED]->(u) }"),
+    (
+        "unique_tags",
+        "COUNT { MATCH (u)<-[t:TAGGED]-(:User) RETURN DISTINCT t.label }",
+    ),
+];
+
+/// Renders [`USER_COUNT_FIELDS`] as `field: COUNT {…}, …` for a Cypher map literal.
+fn user_count_fields_map() -> String {
+    USER_COUNT_FIELDS
+        .iter()
+        .map(|(name, expr)| format!("{name}: {expr}"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Renders [`USER_COUNT_FIELDS`] as `COUNT {…} AS field, …` for a flat RETURN.
+pub fn user_count_fields_columns() -> String {
+    USER_COUNT_FIELDS
+        .iter()
+        .map(|(name, expr)| format!("{expr} AS {name}"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 pub fn user_counts(user_id: &str) -> Query {
-    Query::new(
-        "user_counts",
-        "
-        MATCH (u:User {id: $user_id})
-        // Each field is an independent COUNT { } subquery off the single (u) row.
-        // Do NOT precede this with a row-multiplying OPTIONAL MATCH (e.g. over
-        // received tags): that makes every subquery a per-row grouping key, so the
-        // whole block runs once per received tag, i.e. O(received_tags x authored_posts)
-        // and hangs on heavy users. See issue #935.
-        RETURN
-            u IS NOT NULL AS exists,
-            {
-                following: COUNT { (u)-[:FOLLOWS]->(:User) },
-                followers: COUNT { (:User)-[:FOLLOWS]->(u) },
-                friends: COUNT { (u)-[:FOLLOWS]->(friend:User) WHERE (friend)-[:FOLLOWS]->(u) },
-                posts: COUNT { (u)-[:AUTHORED]->(:Post) },
-                replies: COUNT { (u)-[:AUTHORED]->(:Post)-[:REPLIED]->(:Post) },
-                collections: COUNT { (u)-[:AUTHORED]->(p:Post) WHERE p.kind = 'collection' },
-                // A collection-follow is stored as a bookmark; keep it out of the count.
-                bookmarks: COUNT { (u)-[:BOOKMARKED]->(bp:Post) WHERE (bp.kind IS NULL OR bp.kind <> 'collection') },
-                // tagged = tags this user assigned to users + to posts
-                tagged: COUNT { (u)-[:TAGGED]->(:User) } + COUNT { (u)-[:TAGGED]->(:Post) },
-                tags: COUNT { (:User)-[:TAGGED]->(u) },
-                unique_tags: COUNT { MATCH (u)<-[t:TAGGED]-(:User) RETURN DISTINCT t.label }
-            } AS counts;
-        ",
-    )
-    .param("user_id", user_id)
+    // Each field is an independent COUNT { } subquery off the single (u) row.
+    // Do NOT precede this with a row-multiplying OPTIONAL MATCH (e.g. over
+    // received tags): that makes every subquery a per-row grouping key, so the
+    // whole block runs once per received tag, i.e. O(received_tags x authored_posts)
+    // and hangs on heavy users. See issue #935.
+    let cypher = format!(
+        "MATCH (u:User {{id: $user_id}})
+         RETURN
+             u IS NOT NULL AS exists,
+             {{ {fields} }} AS counts;",
+        fields = user_count_fields_map()
+    );
+    Query::new("user_counts", cypher).param("user_id", user_id)
 }
 
 pub fn get_user_followers(user_id: &str, skip: Option<usize>, limit: Option<usize>) -> Query {

--- a/nexusd/Cargo.toml
+++ b/nexusd/Cargo.toml
@@ -26,6 +26,7 @@ tokio = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
+anyhow = { workspace = true }
 tokio-shared-rt = { workspace = true }
 tempfile = { workspace = true }
 tracing-test = { workspace = true }

--- a/nexusd/src/jobs/lock.rs
+++ b/nexusd/src/jobs/lock.rs
@@ -17,7 +17,7 @@ pub(super) const MAX_RUN: Duration = Duration::from_secs(3600);
 const LEASE_MARGIN: Duration = Duration::from_secs(60);
 
 /// Lease TTL, sized from the deadline it has to outlast.
-const LOCK_TTL_SECS: u64 = MAX_RUN.as_secs() + LEASE_MARGIN.as_secs();
+pub const LOCK_TTL_SECS: u64 = MAX_RUN.as_secs() + LEASE_MARGIN.as_secs();
 
 /// Cross-process mutual exclusion for a job's runs (the scheduler already
 /// serializes within one process). Injected so the scheduler is testable

--- a/nexusd/src/jobs/mod.rs
+++ b/nexusd/src/jobs/mod.rs
@@ -16,6 +16,7 @@ use tracing::error;
 
 pub use error::{CronParseError, JobError};
 use lock::RedisRunLock;
+pub use lock::LOCK_TTL_SECS;
 pub use scheduler::validate_cron;
 
 /// Resolves and validates a job's cron: `None` when unscheduled, else the

--- a/nexusd/src/jobs/mod.rs
+++ b/nexusd/src/jobs/mod.rs
@@ -284,6 +284,21 @@ mod tests {
             .expect("config with the appended section should parse")
     }
 
+    /// A registry with `extra` plus a stub for every other `[jobs.<name>]`
+    /// section `config` carries, so validation against the full default config
+    /// sees a known job per shipped section without this generic test naming a
+    /// specific one.
+    fn registry_covering(config: &DaemonConfig, extra: &'static str) -> JobRegistry {
+        let mut jobs: Vec<Arc<dyn Job>> = vec![Arc::new(CountingJob::new(extra))];
+        for name in config.jobs.keys() {
+            if name != extra {
+                let name: &'static str = Box::leak(name.clone().into_boxed_str());
+                jobs.push(Arc::new(CountingJob::new(name)));
+            }
+        }
+        JobRegistry::new(jobs)
+    }
+
     #[tokio::test]
     async fn run_once_locked_reports_a_held_lock_as_already_running() {
         let lock: Arc<dyn lock::RunLock> = FakeLock::new(AcquireOutcome::Denied);
@@ -369,8 +384,8 @@ mod tests {
 
     #[tokio::test]
     async fn run_on_demand_validates_jobs_config() {
-        let registry = JobRegistry::new(vec![Arc::new(CountingJob::new("stub"))]);
         let config = default_config_with("[jobs.stub]\ncron = \"not a cron\"\n").await;
+        let registry = registry_covering(&config, "stub");
 
         // The bad cron is caught before StackManager::setup, so no stack is needed.
         let err = match registry.run_on_demand("stub", &config).await {
@@ -397,9 +412,8 @@ mod tests {
 
     #[tokio::test]
     async fn scheduled_jobs_fails_fast_on_malformed_cron() {
-        let registry = JobRegistry::new(vec![Arc::new(CountingJob::new("stub"))]);
-
         let config = default_config_with("[jobs.stub]\ncron = \"not a cron\"\n").await;
+        let registry = registry_covering(&config, "stub");
 
         // scheduled_jobs only resolves; it never spawns. The error must name the
         // offending job so the operator needn't grep the config.

--- a/nexusd/src/lib.rs
+++ b/nexusd/src/lib.rs
@@ -2,5 +2,6 @@ pub mod cli;
 pub mod jobs;
 mod launcher;
 pub mod migrations;
+pub mod trust;
 
 pub use launcher::DaemonLauncher;

--- a/nexusd/src/main.rs
+++ b/nexusd/src/main.rs
@@ -17,14 +17,18 @@ use nexusd::DaemonLauncher;
 
 /// The registry of jobs available to the daemon, built from config. Config-free
 /// callers (e.g. `jobs list`) can pass `TrustRankConfig::default()`.
-fn job_registry(trust_rank: &TrustRankConfig) -> JobRegistry {
-    JobRegistry::new(vec![Arc::new(TrustRecomputeJob::from_config(trust_rank))])
+fn job_registry(trust_rank: &TrustRankConfig, lock_ttl_secs: u64) -> JobRegistry {
+    JobRegistry::new(vec![Arc::new(TrustRecomputeJob::build(
+        trust_rank,
+        lock_ttl_secs,
+    ))])
 }
 
 #[tokio::main]
 async fn main() -> Result<(), DynError> {
     let cli = Cli::parse();
     let command = Cli::receive_command(cli);
+    let lock_ttl_secs = nexusd::jobs::LOCK_TTL_SECS;
 
     match command {
         NexusCommands::Db(db_command) => match db_command {
@@ -68,20 +72,25 @@ async fn main() -> Result<(), DynError> {
                 let config = DaemonConfig::read_or_create_config_file(config_dir).await?;
                 // run_on_demand validates [jobs.*], so a typo'd section fails here
                 // just like `nexusd run`.
-                job_registry(&config.trust_rank)
+                job_registry(&config.trust_rank, lock_ttl_secs)
                     .run_on_demand(&name, &config)
                     .await?;
             }
             JobCommands::List => {
                 // Listing needs only job names, so a default config suffices.
-                for name in job_registry(&TrustRankConfig::default()).job_names() {
+                for name in job_registry(&TrustRankConfig::default(), lock_ttl_secs).job_names() {
                     println!("{name}");
                 }
             }
         },
         NexusCommands::Run { config_dir } => {
             let config = DaemonConfig::read_or_create_config_file(config_dir.clone()).await?;
-            DaemonLauncher::start(config_dir, &job_registry(&config.trust_rank), None).await?;
+            DaemonLauncher::start(
+                config_dir,
+                &job_registry(&config.trust_rank, lock_ttl_secs),
+                None,
+            )
+            .await?;
         }
     }
 

--- a/nexusd/src/main.rs
+++ b/nexusd/src/main.rs
@@ -1,6 +1,8 @@
+use std::sync::Arc;
+
 use clap::Parser;
 use nexus_common::types::DynError;
-use nexus_common::{DaemonConfig, StackManager};
+use nexus_common::{DaemonConfig, StackManager, TrustRankConfig};
 use nexus_watcher::service::NexusWatcher;
 use nexus_webapi::mock::MockDb;
 use nexus_webapi::NexusApi;
@@ -10,13 +12,19 @@ use nexusd::cli::{
 };
 use nexusd::jobs::JobRegistry;
 use nexusd::migrations::{import_migrations, MigrationBuilder, MigrationManager};
+use nexusd::trust::TrustRecomputeJob;
 use nexusd::DaemonLauncher;
+
+/// The registry of jobs available to the daemon, built from config. Config-free
+/// callers (e.g. `jobs list`) can pass `TrustRankConfig::default()`.
+fn job_registry(trust_rank: &TrustRankConfig) -> JobRegistry {
+    JobRegistry::new(vec![Arc::new(TrustRecomputeJob::from_config(trust_rank))])
+}
 
 #[tokio::main]
 async fn main() -> Result<(), DynError> {
     let cli = Cli::parse();
     let command = Cli::receive_command(cli);
-    let job_registry = JobRegistry::new(Vec::new());
 
     match command {
         NexusCommands::Db(db_command) => match db_command {
@@ -60,16 +68,20 @@ async fn main() -> Result<(), DynError> {
                 let config = DaemonConfig::read_or_create_config_file(config_dir).await?;
                 // run_on_demand validates [jobs.*], so a typo'd section fails here
                 // just like `nexusd run`.
-                job_registry.run_on_demand(&name, &config).await?;
+                job_registry(&config.trust_rank)
+                    .run_on_demand(&name, &config)
+                    .await?;
             }
             JobCommands::List => {
-                for name in job_registry.job_names() {
+                // Listing needs only job names, so a default config suffices.
+                for name in job_registry(&TrustRankConfig::default()).job_names() {
                     println!("{name}");
                 }
             }
         },
         NexusCommands::Run { config_dir } => {
-            DaemonLauncher::start(config_dir, &job_registry, None).await?;
+            let config = DaemonConfig::read_or_create_config_file(config_dir.clone()).await?;
+            DaemonLauncher::start(config_dir, &job_registry(&config.trust_rank), None).await?;
         }
     }
 

--- a/nexusd/src/trust/engine.rs
+++ b/nexusd/src/trust/engine.rs
@@ -15,6 +15,8 @@ pub struct TrustRankParams {
     pub max_iterations: u32,
     /// Convergence tolerance.
     pub tolerance: f64,
+    /// Optional hard cap on the GDS projection size (bytes).
+    pub max_projection_bytes: Option<u64>,
 }
 
 impl From<&TrustRankConfig> for TrustRankParams {
@@ -24,6 +26,7 @@ impl From<&TrustRankConfig> for TrustRankParams {
             alpha: config.alpha,
             max_iterations: config.max_iterations,
             tolerance: config.tolerance,
+            max_projection_bytes: config.max_projection_bytes,
         }
     }
 }

--- a/nexusd/src/trust/engine.rs
+++ b/nexusd/src/trust/engine.rs
@@ -1,0 +1,49 @@
+use async_trait::async_trait;
+use nexus_common::types::DynError;
+use nexus_common::TrustRankConfig;
+
+/// Inputs for a seeded PageRank computation, decoupling [`TrustRankEngine`]
+/// from [`TrustRankConfig`] so implementations ignore config fields they don't
+/// use (e.g. `report_dir`).
+#[derive(Debug, Clone)]
+pub struct TrustRankParams {
+    /// Users trust originates from, each weighted equally (`v = 1/N`).
+    pub seed_ids: Vec<String>,
+    /// Teleport weight `alpha` in `trust = alpha*v + (1-alpha)*M*trust`.
+    pub alpha: f64,
+    /// Cap on power-iteration rounds.
+    pub max_iterations: u32,
+    /// Convergence tolerance.
+    pub tolerance: f64,
+}
+
+impl From<&TrustRankConfig> for TrustRankParams {
+    fn from(config: &TrustRankConfig) -> Self {
+        Self {
+            seed_ids: config.seed.iter().map(|id| id.to_string()).collect(),
+            alpha: config.alpha,
+            max_iterations: config.max_iterations,
+            tolerance: config.tolerance,
+        }
+    }
+}
+
+/// Summary of a completed trust-rank run.
+#[derive(Debug, Clone)]
+pub struct TrustRankStats {
+    /// Number of users a score was written for.
+    pub users_written: u64,
+    /// Power-iteration rounds actually run.
+    pub ran_iterations: u64,
+    /// Whether the computation converged within `max_iterations`.
+    pub did_converge: bool,
+}
+
+/// Computes seeded (personalized) PageRank trust, persisting each user's
+/// score as a side effect and returning only run stats.
+#[async_trait]
+pub trait TrustRankEngine: Send + Sync {
+    /// Runs the computation for `params` and returns run stats. Input
+    /// validation (seed set, empty graph) is the implementation's job.
+    async fn compute(&self, params: &TrustRankParams) -> Result<TrustRankStats, DynError>;
+}

--- a/nexusd/src/trust/export.rs
+++ b/nexusd/src/trust/export.rs
@@ -1,0 +1,176 @@
+use chrono::{DateTime, Utc};
+use nexus_common::db::fetch_all_rows_from_graph;
+use nexus_common::models::error::ModelResult;
+use nexus_common::types::DynError;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use super::neo4j::queries::{read_trust_scores, trust_report_user_details};
+
+/// Reads the `trust` scores written by the last recompute, highest first.
+/// Used by the CSV report and callers needing scores back after a
+/// [`super::TrustRankEngine::compute`].
+pub async fn read_scores() -> ModelResult<Vec<(String, f64)>> {
+    let rows = fetch_all_rows_from_graph(read_trust_scores()).await?;
+    let mut scores = Vec::with_capacity(rows.len());
+    for row in rows {
+        let user_id: String = row.get("user_id")?;
+        let score: f64 = row.get("score")?;
+        scores.push((user_id, score));
+    }
+    Ok(scores)
+}
+
+#[derive(Default, Clone)]
+struct UserReportRow {
+    name: String,
+    following: i64,
+    followers: i64,
+    friends: i64,
+    posts: i64,
+    replies: i64,
+    collections: i64,
+    bookmarks: i64,
+    tagged: i64,
+    tags: i64,
+    unique_tags: i64,
+}
+
+/// Writes a CSV report joining trust scores with user details and counts, for
+/// investigating who ranked where and why. Read straight from the graph (not
+/// Redis), so it reflects current state even where the cache is stale or empty.
+///
+/// Columns: id, name, score, followers, following, friends, posts, replies,
+/// tagged, tags, unique_tags, bookmarks, collections. `scores` must be
+/// highest-first (as [`super::read_scores`] returns); rows preserve that order.
+pub async fn write_csv(path: &Path, scores: &[(String, f64)]) -> Result<(), DynError> {
+    let ids: Vec<String> = scores.iter().map(|(id, _)| id.clone()).collect();
+
+    let rows = fetch_all_rows_from_graph(trust_report_user_details(&ids)).await?;
+
+    let mut details: HashMap<String, UserReportRow> = HashMap::with_capacity(rows.len());
+    for row in rows {
+        let id: String = row.get("id")?;
+        let name: Option<String> = row.get("name").unwrap_or(None);
+        details.insert(
+            id,
+            UserReportRow {
+                name: name.unwrap_or_default(),
+                following: row.get("following").unwrap_or_default(),
+                followers: row.get("followers").unwrap_or_default(),
+                friends: row.get("friends").unwrap_or_default(),
+                posts: row.get("posts").unwrap_or_default(),
+                replies: row.get("replies").unwrap_or_default(),
+                collections: row.get("collections").unwrap_or_default(),
+                bookmarks: row.get("bookmarks").unwrap_or_default(),
+                tagged: row.get("tagged").unwrap_or_default(),
+                tags: row.get("tags").unwrap_or_default(),
+                unique_tags: row.get("unique_tags").unwrap_or_default(),
+            },
+        );
+    }
+
+    let mut csv = String::from(
+        "id,name,score,followers,following,friends,posts,replies,tagged,tags,unique_tags,bookmarks,collections\n",
+    );
+    for (id, score) in scores {
+        // Every requested id yields a row (OPTIONAL MATCH), but default missing.
+        let d = details.get(id).cloned().unwrap_or_default();
+
+        csv.push_str(&csv_field(id));
+        csv.push(',');
+        csv.push_str(&csv_field(&d.name));
+        csv.push(',');
+        csv.push_str(&format!(
+            "{score},{},{},{},{},{},{},{},{},{},{}\n",
+            d.followers,
+            d.following,
+            d.friends,
+            d.posts,
+            d.replies,
+            d.tagged,
+            d.tags,
+            d.unique_tags,
+            d.bookmarks,
+            d.collections,
+        ));
+    }
+
+    // Create the target dir so a write into a missing dir doesn't fail.
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+    }
+    tokio::fs::write(path, csv).await?;
+    Ok(())
+}
+
+/// Writes a scheduled-run report into `dir` as `trust-report-<UTC timestamp>.csv`
+/// (columns per [`write_csv`]), creating `dir` if missing. Returns the path.
+pub async fn write_timestamped_csv(
+    dir: &Path,
+    scores: &[(String, f64)],
+) -> Result<PathBuf, DynError> {
+    tokio::fs::create_dir_all(dir).await?;
+    let path = dir.join(report_file_name(Utc::now()));
+    write_csv(&path, scores).await?;
+    Ok(path)
+}
+
+/// Second precision is enough: scheduled runs are minutes apart at their densest.
+fn report_file_name(now: DateTime<Utc>) -> String {
+    format!("trust-report-{}.csv", now.format("%Y%m%dT%H%M%SZ"))
+}
+
+/// Quotes a CSV field per RFC 4180 and neutralizes spreadsheet formula
+/// injection: a leading trigger char (`= + - @` etc.) gets an `'` prefix.
+/// Tradeoff: a legit name starting with `-` gains an apostrophe — fine here.
+fn csv_field(s: &str) -> String {
+    let s = if s.starts_with(['=', '+', '-', '@', '\t', '\r']) {
+        format!("'{s}")
+    } else {
+        s.to_string()
+    };
+    if s.contains([',', '"', '\n', '\r']) {
+        format!("\"{}\"", s.replace('"', "\"\""))
+    } else {
+        s
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Report filenames are timestamped and filesystem-safe (no `:` or spaces).
+    #[test]
+    fn test_report_file_name() {
+        let ts = DateTime::parse_from_rfc3339("2026-07-08T03:00:05Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        assert_eq!(report_file_name(ts), "trust-report-20260708T030005Z.csv");
+    }
+
+    /// Formula trigger chars get a leading `'` so they don't execute on open.
+    #[test]
+    fn csv_field_neutralizes_formula_triggers() {
+        assert_eq!(csv_field("=SUM(A1)"), "'=SUM(A1)");
+        assert_eq!(csv_field("+1"), "'+1");
+        assert_eq!(csv_field("@foo"), "'@foo");
+    }
+
+    /// Neutralization composes with RFC 4180 quoting.
+    #[test]
+    fn csv_field_neutralization_composes_with_quoting() {
+        assert_eq!(csv_field("=a,b"), "\"'=a,b\"");
+    }
+
+    /// Fields without a trigger char are unchanged.
+    #[test]
+    fn csv_field_leaves_safe_fields_untouched() {
+        assert_eq!(csv_field("plain"), "plain");
+        assert_eq!(csv_field("a\"b"), "\"a\"\"b\"");
+    }
+}

--- a/nexusd/src/trust/export.rs
+++ b/nexusd/src/trust/export.rs
@@ -4,8 +4,12 @@ use nexus_common::models::error::ModelResult;
 use nexus_common::types::DynError;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use super::neo4j::queries::{read_trust_scores, trust_report_user_details};
+
+// Per-process counter so two reports in the same second get distinct names.
+static REPORT_SEQ: AtomicU64 = AtomicU64::new(0);
 
 /// Reads the `trust` scores written by the last recompute, highest first.
 /// Used by the CSV report and callers needing scores back after a
@@ -118,9 +122,14 @@ pub async fn write_timestamped_csv(
     Ok(path)
 }
 
-/// Second precision is enough: scheduled runs are minutes apart at their densest.
+// Second-precision timestamp stays readable/sortable; the per-process counter
+// makes the name unique so two runs in the same second can't overwrite it.
 fn report_file_name(now: DateTime<Utc>) -> String {
-    format!("trust-report-{}.csv", now.format("%Y%m%dT%H%M%SZ"))
+    format!(
+        "trust-report-{}-{:06}.csv",
+        now.format("%Y%m%dT%H%M%SZ"),
+        REPORT_SEQ.fetch_add(1, Ordering::Relaxed)
+    )
 }
 
 /// Quotes a CSV field per RFC 4180 and neutralizes spreadsheet formula
@@ -143,14 +152,27 @@ fn csv_field(s: &str) -> String {
 mod tests {
     use super::*;
 
-    /// Report filenames are timestamped and filesystem-safe (no `:` or spaces).
+    /// Filenames are timestamped, filesystem-safe (no `:` or spaces), and the
+    /// per-process counter makes two same-second runs distinct.
     #[test]
     fn test_report_file_name() {
         let ts = DateTime::parse_from_rfc3339("2026-07-08T03:00:05Z")
             .unwrap()
             .with_timezone(&Utc);
 
-        assert_eq!(report_file_name(ts), "trust-report-20260708T030005Z.csv");
+        let first = report_file_name(ts);
+        assert!(first.starts_with("trust-report-20260708T030005Z-"));
+        assert!(first.ends_with(".csv"));
+
+        // The counter segment is numeric.
+        let seq = first
+            .strip_prefix("trust-report-20260708T030005Z-")
+            .and_then(|s| s.strip_suffix(".csv"))
+            .expect("name has the expected prefix/suffix");
+        assert!(seq.chars().all(|c| c.is_ascii_digit()));
+
+        // Same timestamp, second run → different name (no overwrite).
+        assert_ne!(first, report_file_name(ts));
     }
 
     /// Formula trigger chars get a leading `'` so they don't execute on open.

--- a/nexusd/src/trust/export.rs
+++ b/nexusd/src/trust/export.rs
@@ -11,11 +11,9 @@ use super::neo4j::queries::{read_trust_scores, trust_report_user_details};
 // Per-process counter so two reports in the same second get distinct names.
 static REPORT_SEQ: AtomicU64 = AtomicU64::new(0);
 
-/// Reads the `trust` scores written by the last recompute, highest first.
-/// Used by the CSV report and callers needing scores back after a
-/// [`super::TrustRankEngine::compute`].
-pub async fn read_scores() -> ModelResult<Vec<(String, f64)>> {
-    let rows = fetch_all_rows_from_graph(read_trust_scores()).await?;
+/// Reads the top `limit` trust scores from the last recompute, highest first.
+pub async fn read_scores(limit: usize) -> ModelResult<Vec<(String, f64)>> {
+    let rows = fetch_all_rows_from_graph(read_trust_scores(limit)).await?;
     let mut scores = Vec::with_capacity(rows.len());
     for row in rows {
         let user_id: String = row.get("user_id")?;
@@ -25,7 +23,7 @@ pub async fn read_scores() -> ModelResult<Vec<(String, f64)>> {
     Ok(scores)
 }
 
-#[derive(Default, Clone)]
+#[derive(Default)]
 struct UserReportRow {
     name: String,
     following: i64,
@@ -47,7 +45,7 @@ struct UserReportRow {
 /// Columns: id, name, score, followers, following, friends, posts, replies,
 /// tagged, tags, unique_tags, bookmarks, collections. `scores` must be
 /// highest-first (as [`super::read_scores`] returns); rows preserve that order.
-pub async fn write_csv(path: &Path, scores: &[(String, f64)]) -> Result<(), DynError> {
+async fn write_csv(path: &Path, scores: &[(String, f64)]) -> Result<(), DynError> {
     let ids: Vec<String> = scores.iter().map(|(id, _)| id.clone()).collect();
 
     let rows = fetch_all_rows_from_graph(trust_report_user_details(&ids)).await?;
@@ -77,9 +75,11 @@ pub async fn write_csv(path: &Path, scores: &[(String, f64)]) -> Result<(), DynE
     let mut csv = String::from(
         "id,name,score,followers,following,friends,posts,replies,tagged,tags,unique_tags,bookmarks,collections\n",
     );
+    // Shared default for missing ids; avoids cloning per row.
+    let missing = UserReportRow::default();
     for (id, score) in scores {
         // Every requested id yields a row (OPTIONAL MATCH), but default missing.
-        let d = details.get(id).cloned().unwrap_or_default();
+        let d = details.get(id).unwrap_or(&missing);
 
         csv.push_str(&csv_field(id));
         csv.push(',');
@@ -112,7 +112,7 @@ pub async fn write_csv(path: &Path, scores: &[(String, f64)]) -> Result<(), DynE
 
 /// Writes a scheduled-run report into `dir` as `trust-report-<UTC timestamp>.csv`
 /// (columns per [`write_csv`]), creating `dir` if missing. Returns the path.
-pub async fn write_timestamped_csv(
+pub(super) async fn write_timestamped_csv(
     dir: &Path,
     scores: &[(String, f64)],
 ) -> Result<PathBuf, DynError> {

--- a/nexusd/src/trust/job.rs
+++ b/nexusd/src/trust/job.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use nexus_common::types::DynError;
@@ -13,8 +14,8 @@ use crate::jobs::Job;
 /// The trust-rank recompute as a runnable [`Job`]: runs the seeded PageRank
 /// computation and, when a report dir is set, writes a CSV report of the run.
 /// Build from resolved inputs with [`TrustRecomputeJob::new`] or from config
-/// with [`TrustRecomputeJob::from_config`]; the job runner resolves its
-/// schedule from the `[jobs.trust-recompute]` cron.
+/// with [`TrustRecomputeJob::build`]; the job runner resolves its schedule from
+/// the `[jobs.trust-recompute]` cron.
 pub struct TrustRecomputeJob {
     params: TrustRankParams,
     engine: Box<dyn TrustRankEngine>,
@@ -36,12 +37,13 @@ impl TrustRecomputeJob {
         }
     }
 
-    /// Builds the job from its trust-rank config. The cron is resolved
-    /// separately from the `[jobs.trust-recompute]` section.
-    pub fn from_config(config: &TrustRankConfig) -> Self {
+    /// Builds the job from its trust-rank config and the run lease TTL.
+    pub fn build(config: &TrustRankConfig, lock_ttl_secs: u64) -> Self {
+        // Sweep age = 2× the lease TTL (which already includes LEASE_MARGIN), so
+        // it sits well past lease expiry and the sweep can never race a live run.
         Self::new(
             TrustRankParams::from(config),
-            Box::new(GdsNeo4j::default()),
+            Box::new(GdsNeo4j::new(true, Duration::from_secs(2 * lock_ttl_secs))),
             config.report_enabled.then(|| config.report_dir.clone()),
         )
     }

--- a/nexusd/src/trust/job.rs
+++ b/nexusd/src/trust/job.rs
@@ -112,6 +112,7 @@ mod tests {
             alpha: 0.85,
             max_iterations: 20,
             tolerance: 1e-6,
+            max_projection_bytes: None,
         }
     }
 

--- a/nexusd/src/trust/job.rs
+++ b/nexusd/src/trust/job.rs
@@ -41,7 +41,7 @@ impl TrustRecomputeJob {
     pub fn from_config(config: &TrustRankConfig) -> Self {
         Self::new(
             TrustRankParams::from(config),
-            Box::new(GdsNeo4j),
+            Box::new(GdsNeo4j::default()),
             config.report_enabled.then(|| config.report_dir.clone()),
         )
     }

--- a/nexusd/src/trust/job.rs
+++ b/nexusd/src/trust/job.rs
@@ -20,20 +20,23 @@ pub struct TrustRecomputeJob {
     params: TrustRankParams,
     engine: Box<dyn TrustRankEngine>,
     report_dir: Option<PathBuf>,
+    report_limit: usize,
 }
 
 impl TrustRecomputeJob {
-    /// Builds the job from already-resolved inputs. `report_dir` is `Some` to
-    /// write a CSV report after each run, `None` to skip reporting.
+    /// Builds the job from inputs. `report_dir` is `Some` to write a CSV, `None` to skip;
+    /// `report_limit` caps rows in the report.
     pub fn new(
         params: TrustRankParams,
         engine: Box<dyn TrustRankEngine>,
         report_dir: Option<PathBuf>,
+        report_limit: usize,
     ) -> Self {
         Self {
             params,
             engine,
             report_dir,
+            report_limit,
         }
     }
 
@@ -45,6 +48,7 @@ impl TrustRecomputeJob {
             TrustRankParams::from(config),
             Box::new(GdsNeo4j::new(true, Duration::from_secs(2 * lock_ttl_secs))),
             config.report_enabled.then(|| config.report_dir.clone()),
+            config.report_limit,
         )
     }
 }
@@ -60,7 +64,7 @@ impl Job for TrustRecomputeJob {
 
         // Report failures are logged, not fatal: scores are already persisted.
         if let Some(dir) = &self.report_dir {
-            match read_scores().await {
+            match read_scores(self.report_limit).await {
                 Ok(scores) => match write_timestamped_csv(dir, &scores).await {
                     Ok(path) => info!(path = %path.display(), "Trust rank report written"),
                     Err(e) => error!("Failed to write trust rank report: {e:?}"),
@@ -119,7 +123,7 @@ mod tests {
             calls: Arc::clone(&calls),
             fail: false,
         };
-        let job = TrustRecomputeJob::new(params(), Box::new(engine), None);
+        let job = TrustRecomputeJob::new(params(), Box::new(engine), None, 10);
 
         job.run().await.expect("run should succeed");
 
@@ -139,6 +143,7 @@ mod tests {
             params(),
             Box::new(engine),
             Some(PathBuf::from("/does-not-matter")),
+            10,
         );
 
         let err = job.run().await.expect_err("run should fail");

--- a/nexusd/src/trust/job.rs
+++ b/nexusd/src/trust/job.rs
@@ -1,0 +1,71 @@
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+use nexus_common::types::DynError;
+use nexus_common::TrustRankConfig;
+use tracing::{error, info};
+
+use super::engine::{TrustRankEngine, TrustRankParams};
+use super::export::{read_scores, write_timestamped_csv};
+use super::neo4j::GdsNeo4j;
+use crate::jobs::Job;
+
+/// The trust-rank recompute as a runnable [`Job`]: runs the seeded PageRank
+/// computation and, when a report dir is set, writes a CSV report of the run.
+/// Build from resolved inputs with [`TrustRecomputeJob::new`] or from config
+/// with [`TrustRecomputeJob::from_config`]; the job runner resolves its
+/// schedule from the `[jobs.trust-recompute]` cron.
+pub struct TrustRecomputeJob {
+    params: TrustRankParams,
+    engine: Box<dyn TrustRankEngine>,
+    report_dir: Option<PathBuf>,
+}
+
+impl TrustRecomputeJob {
+    /// Builds the job from already-resolved inputs. `report_dir` is `Some` to
+    /// write a CSV report after each run, `None` to skip reporting.
+    pub fn new(
+        params: TrustRankParams,
+        engine: Box<dyn TrustRankEngine>,
+        report_dir: Option<PathBuf>,
+    ) -> Self {
+        Self {
+            params,
+            engine,
+            report_dir,
+        }
+    }
+
+    /// Builds the job from its trust-rank config. The cron is resolved
+    /// separately from the `[jobs.trust-recompute]` section.
+    pub fn from_config(config: &TrustRankConfig) -> Self {
+        Self::new(
+            TrustRankParams::from(config),
+            Box::new(GdsNeo4j),
+            config.report_enabled.then(|| config.report_dir.clone()),
+        )
+    }
+}
+
+#[async_trait]
+impl Job for TrustRecomputeJob {
+    fn name(&self) -> &'static str {
+        "trust-recompute"
+    }
+
+    async fn run(&self) -> Result<(), DynError> {
+        self.engine.compute(&self.params).await?;
+
+        // Report failures are logged, not fatal: scores are already persisted.
+        if let Some(dir) = &self.report_dir {
+            match read_scores().await {
+                Ok(scores) => match write_timestamped_csv(dir, &scores).await {
+                    Ok(path) => info!(path = %path.display(), "Trust rank report written"),
+                    Err(e) => error!("Failed to write trust rank report: {e:?}"),
+                },
+                Err(e) => error!("Failed to read trust scores for report: {e:?}"),
+            }
+        }
+        Ok(())
+    }
+}

--- a/nexusd/src/trust/job.rs
+++ b/nexusd/src/trust/job.rs
@@ -69,3 +69,79 @@ impl Job for TrustRecomputeJob {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Arc;
+
+    use super::super::engine::{TrustRankEngine, TrustRankParams, TrustRankStats};
+    use super::*;
+
+    // Dumb stub: bumps a shared counter and replays a canned result. The counter
+    // is shared so the test can inspect it after the engine moves into the job.
+    struct MockEngine {
+        calls: Arc<AtomicU32>,
+        fail: bool,
+    }
+
+    #[async_trait]
+    impl TrustRankEngine for MockEngine {
+        async fn compute(&self, _params: &TrustRankParams) -> Result<TrustRankStats, DynError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            if self.fail {
+                return Err("compute failed".into());
+            }
+            Ok(TrustRankStats {
+                users_written: 1,
+                ran_iterations: 1,
+                did_converge: true,
+            })
+        }
+    }
+
+    fn params() -> TrustRankParams {
+        TrustRankParams {
+            seed_ids: vec!["seed".to_string()],
+            alpha: 0.85,
+            max_iterations: 20,
+            tolerance: 1e-6,
+        }
+    }
+
+    // No report_dir: run() computes and returns without touching the store.
+    #[tokio::test]
+    async fn run_without_report_computes_and_skips_report() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let engine = MockEngine {
+            calls: Arc::clone(&calls),
+            fail: false,
+        };
+        let job = TrustRecomputeJob::new(params(), Box::new(engine), None);
+
+        job.run().await.expect("run should succeed");
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    // A compute error propagates and short-circuits before the report block,
+    // so run() fails without ever reaching the store (report_dir is Some here).
+    #[tokio::test]
+    async fn run_propagates_compute_error_before_report() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let engine = MockEngine {
+            calls: Arc::clone(&calls),
+            fail: true,
+        };
+        let job = TrustRecomputeJob::new(
+            params(),
+            Box::new(engine),
+            Some(PathBuf::from("/does-not-matter")),
+        );
+
+        let err = job.run().await.expect_err("run should fail");
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(err.to_string(), "compute failed");
+    }
+}

--- a/nexusd/src/trust/job.rs
+++ b/nexusd/src/trust/job.rs
@@ -4,12 +4,17 @@ use std::time::Duration;
 use async_trait::async_trait;
 use nexus_common::types::DynError;
 use nexus_common::TrustRankConfig;
-use tracing::{debug, error, info};
+use opentelemetry::global;
+use opentelemetry::metrics::{Counter, Meter};
+use tracing::{debug, error, info, warn};
 
 use super::engine::{TrustRankEngine, TrustRankParams};
 use super::export::{read_scores, write_timestamped_csv};
 use super::neo4j::GdsNeo4j;
 use crate::jobs::Job;
+
+/// OpenTelemetry meter name for all trust-rank metrics.
+const METER_NAME: &str = "nexus.trust";
 
 /// The trust-rank recompute as a runnable [`Job`]: runs the seeded PageRank
 /// computation and, when a report dir is set, writes a CSV report of the run.
@@ -21,22 +26,50 @@ pub struct TrustRecomputeJob {
     engine: Box<dyn TrustRankEngine>,
     report_dir: Option<PathBuf>,
     report_limit: usize,
+    /// Runs that exhausted `max_iterations` without converging, so the written
+    /// scores are the last (unconverged) iterate. A sustained nonzero rate means
+    /// `max_iterations` or `tolerance` needs raising.
+    max_iterations_reached: Counter<u64>,
 }
 
 impl TrustRecomputeJob {
     /// Builds the job from inputs. `report_dir` is `Some` to write a CSV, `None` to skip;
-    /// `report_limit` caps rows in the report.
+    /// `report_limit` caps rows in the report. Instruments come from the global
+    /// meter (no-ops until an `SdkMeterProvider` is installed).
     pub fn new(
         params: TrustRankParams,
         engine: Box<dyn TrustRankEngine>,
         report_dir: Option<PathBuf>,
         report_limit: usize,
     ) -> Self {
+        Self::with_meter(
+            params,
+            engine,
+            report_dir,
+            report_limit,
+            global::meter(METER_NAME),
+        )
+    }
+
+    /// [`new`](Self::new) with an explicit `meter`, so tests can install a local
+    /// `SdkMeterProvider` and read the counter back.
+    pub(crate) fn with_meter(
+        params: TrustRankParams,
+        engine: Box<dyn TrustRankEngine>,
+        report_dir: Option<PathBuf>,
+        report_limit: usize,
+        meter: Meter,
+    ) -> Self {
+        let max_iterations_reached = meter
+            .u64_counter("trust.recompute.max_iterations_reached")
+            .with_description("Trust rank runs that hit max_iterations without converging")
+            .build();
         Self {
             params,
             engine,
             report_dir,
             report_limit,
+            max_iterations_reached,
         }
     }
 
@@ -67,6 +100,14 @@ impl Job for TrustRecomputeJob {
             did_converge = stats.did_converge,
             "Trust rank run stats"
         );
+        if !stats.did_converge {
+            self.max_iterations_reached.add(1, &[]);
+            warn!(
+                max_iterations = self.params.max_iterations,
+                tolerance = self.params.tolerance,
+                "Trust rank hit max_iterations without converging"
+            );
+        }
 
         // Report failures are logged, not fatal: scores are already persisted.
         if let Some(dir) = &self.report_dir {
@@ -87,6 +128,10 @@ mod tests {
     use std::sync::atomic::{AtomicU32, Ordering};
     use std::sync::Arc;
 
+    use opentelemetry::metrics::MeterProvider;
+    use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData, ResourceMetrics};
+    use opentelemetry_sdk::metrics::{InMemoryMetricExporter, SdkMeterProvider};
+
     use super::super::engine::{TrustRankEngine, TrustRankParams, TrustRankStats};
     use super::*;
 
@@ -95,6 +140,17 @@ mod tests {
     struct MockEngine {
         calls: Arc<AtomicU32>,
         fail: bool,
+        did_converge: bool,
+    }
+
+    impl MockEngine {
+        fn new(calls: &Arc<AtomicU32>, fail: bool) -> Self {
+            Self {
+                calls: Arc::clone(calls),
+                fail,
+                did_converge: true,
+            }
+        }
     }
 
     #[async_trait]
@@ -107,9 +163,38 @@ mod tests {
             Ok(TrustRankStats {
                 users_written: 1,
                 ran_iterations: 1,
-                did_converge: true,
+                did_converge: self.did_converge,
             })
         }
+    }
+
+    /// A job whose counters feed an in-memory exporter. Call
+    /// `provider.force_flush()` before reading `exporter.get_finished_metrics()`.
+    fn metered_job(
+        engine: Box<dyn TrustRankEngine>,
+    ) -> (TrustRecomputeJob, SdkMeterProvider, InMemoryMetricExporter) {
+        let exporter = InMemoryMetricExporter::default();
+        let provider = SdkMeterProvider::builder()
+            .with_periodic_exporter(exporter.clone())
+            .build();
+        let job = TrustRecomputeJob::with_meter(params(), engine, None, 10, provider.meter("test"));
+        (job, provider, exporter)
+    }
+
+    /// Sum of a `u64` counter's data points across all exported metrics.
+    fn counter_value(metrics: &[ResourceMetrics], name: &str) -> u64 {
+        let mut total = 0;
+        for rm in metrics {
+            for sm in rm.scope_metrics() {
+                for m in sm.metrics().filter(|m| m.name() == name) {
+                    let AggregatedMetrics::U64(MetricData::Sum(sum)) = m.data() else {
+                        continue;
+                    };
+                    total += sum.data_points().map(|dp| dp.value()).sum::<u64>();
+                }
+            }
+        }
+        total
     }
 
     fn params() -> TrustRankParams {
@@ -126,10 +211,7 @@ mod tests {
     #[tokio::test]
     async fn run_without_report_computes_and_skips_report() {
         let calls = Arc::new(AtomicU32::new(0));
-        let engine = MockEngine {
-            calls: Arc::clone(&calls),
-            fail: false,
-        };
+        let engine = MockEngine::new(&calls, false);
         let job = TrustRecomputeJob::new(params(), Box::new(engine), None, 10);
 
         job.run().await.expect("run should succeed");
@@ -142,10 +224,7 @@ mod tests {
     #[tokio::test]
     async fn run_propagates_compute_error_before_report() {
         let calls = Arc::new(AtomicU32::new(0));
-        let engine = MockEngine {
-            calls: Arc::clone(&calls),
-            fail: true,
-        };
+        let engine = MockEngine::new(&calls, true);
         let job = TrustRecomputeJob::new(
             params(),
             Box::new(engine),
@@ -157,5 +236,45 @@ mod tests {
 
         assert_eq!(calls.load(Ordering::SeqCst), 1);
         assert_eq!(err.to_string(), "compute failed");
+    }
+
+    // A run that exhausted max_iterations bumps the counter.
+    #[tokio::test]
+    async fn run_counts_max_iterations_reached_when_not_converged() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let engine = MockEngine {
+            did_converge: false,
+            ..MockEngine::new(&calls, false)
+        };
+        let (job, provider, exporter) = metered_job(Box::new(engine));
+
+        job.run().await.expect("run should succeed");
+        provider.force_flush().expect("flush should succeed");
+
+        let metrics = exporter
+            .get_finished_metrics()
+            .expect("metrics should be exported");
+        assert_eq!(
+            counter_value(&metrics, "trust.recompute.max_iterations_reached"),
+            1
+        );
+    }
+
+    // A converged run leaves the counter untouched.
+    #[tokio::test]
+    async fn run_does_not_count_max_iterations_reached_when_converged() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let (job, provider, exporter) = metered_job(Box::new(MockEngine::new(&calls, false)));
+
+        job.run().await.expect("run should succeed");
+        provider.force_flush().expect("flush should succeed");
+
+        let metrics = exporter
+            .get_finished_metrics()
+            .expect("metrics should be exported");
+        assert_eq!(
+            counter_value(&metrics, "trust.recompute.max_iterations_reached"),
+            0
+        );
     }
 }

--- a/nexusd/src/trust/job.rs
+++ b/nexusd/src/trust/job.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use nexus_common::types::DynError;
 use nexus_common::TrustRankConfig;
-use tracing::{error, info};
+use tracing::{debug, error, info};
 
 use super::engine::{TrustRankEngine, TrustRankParams};
 use super::export::{read_scores, write_timestamped_csv};
@@ -60,7 +60,13 @@ impl Job for TrustRecomputeJob {
     }
 
     async fn run(&self) -> Result<(), DynError> {
-        self.engine.compute(&self.params).await?;
+        let stats = self.engine.compute(&self.params).await?;
+        debug!(
+            users_written = stats.users_written,
+            ran_iterations = stats.ran_iterations,
+            did_converge = stats.did_converge,
+            "Trust rank run stats"
+        );
 
         // Report failures are logged, not fatal: scores are already persisted.
         if let Some(dir) = &self.report_dir {

--- a/nexusd/src/trust/mod.rs
+++ b/nexusd/src/trust/mod.rs
@@ -1,0 +1,9 @@
+mod engine;
+mod export;
+mod job;
+mod neo4j;
+
+pub use engine::{TrustRankEngine, TrustRankParams, TrustRankStats};
+pub use export::read_scores;
+pub use job::TrustRecomputeJob;
+pub use neo4j::GdsNeo4j;

--- a/nexusd/src/trust/neo4j/mod.rs
+++ b/nexusd/src/trust/neo4j/mod.rs
@@ -1,0 +1,131 @@
+//! Neo4j/GDS-backed implementation of [`TrustRankEngine`], plus its Cypher
+//! queries. All Neo4j specifics live here; the abstraction is in `super::engine`.
+
+pub mod queries;
+
+use async_trait::async_trait;
+use nexus_common::db::fetch_row_from_graph;
+use nexus_common::types::DynError;
+use tracing::{info, warn};
+
+use super::engine::{TrustRankEngine, TrustRankParams, TrustRankStats};
+use queries::{
+    count_matching_seeds, drop_stale_trust_graphs, drop_trust_graph, project_trust_graph,
+    trust_rank_pagerank_write, TRUST_GRAPH_PREFIX,
+};
+
+/// Computes trust rank via the Neo4j GDS `pageRank` procedure in write mode,
+/// storing the result on each `:User` node as the `trust` property.
+///
+/// Seeds are weighted equally (`v` uniform, `1/N` over `params.seed_ids`): GDS
+/// 2.13 (the only version on Neo4j 5.26) has no weighted `sourceNodes`. The GDS
+/// projection is rebuilt each run — Neo4j Community has no incremental update.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct GdsNeo4j;
+
+#[async_trait]
+impl TrustRankEngine for GdsNeo4j {
+    async fn compute(&self, params: &TrustRankParams) -> Result<TrustRankStats, DynError> {
+        if params.seed_ids.is_empty() {
+            return Err(
+                "trust_rank.seed is empty; refusing to compute trust rank without a seed set"
+                    .into(),
+            );
+        }
+
+        let damping_factor = 1.0 - params.alpha;
+
+        // No matching seed → GDS gets an empty sourceNodes list, treats it as
+        // unset, and computes non-personalized (Sybil-vulnerable) PageRank.
+        // Fail fast instead.
+        let matched: i64 = fetch_row_from_graph(count_matching_seeds(&params.seed_ids))
+            .await?
+            .map(|row| row.get("matched"))
+            .transpose()?
+            .unwrap_or(0);
+        let configured = params.seed_ids.len() as i64;
+        if matched == 0 {
+            return Err(format!(
+                "none of the {configured} configured trust seeds exist as users in the graph; refusing to compute trust rank"
+            )
+            .into());
+        }
+        if matched < configured {
+            warn!(
+                matched,
+                configured, "Some configured trust seeds do not exist in the graph"
+            );
+        }
+
+        // Per-run unique name so a concurrent run can't clobber this
+        // run's in-flight projection.
+        let graph_name = format!(
+            "{TRUST_GRAPH_PREFIX}-{}-{}",
+            std::process::id(),
+            chrono::Utc::now().timestamp_millis()
+        );
+
+        // Sweep projections leaked by crashed runs (age-gated, can't race a live
+        // run). Catalog calls use fetch_row_from_graph (PULL): GDS runs the side
+        // effect only when the row is pulled.
+        if let Some(row) = fetch_row_from_graph(drop_stale_trust_graphs()).await? {
+            let dropped: Vec<String> = row.get("dropped").unwrap_or_default();
+            if !dropped.is_empty() {
+                warn!(
+                    ?dropped,
+                    "Dropped stale trust graph projections left by crashed runs"
+                );
+            }
+        }
+
+        let projected = fetch_row_from_graph(project_trust_graph(&graph_name)).await?;
+        if let Some(row) = &projected {
+            let node_count: i64 = row.get("nodeCount").unwrap_or_default();
+            let relationship_count: i64 = row.get("relationshipCount").unwrap_or_default();
+            info!(
+                node_count,
+                relationship_count, "Projected trust graph for GDS PageRank"
+            );
+        }
+
+        let write_result = fetch_row_from_graph(trust_rank_pagerank_write(
+            &graph_name,
+            &params.seed_ids,
+            damping_factor,
+            params.max_iterations,
+            params.tolerance,
+        ))
+        .await;
+
+        // Always drop the projection so a failed run doesn't leak GDS memory.
+        // Log-and-continue: a `?` would shadow the pagerank error; the stale
+        // sweep reclaims any leak on a later run.
+        if let Err(e) = fetch_row_from_graph(drop_trust_graph(&graph_name)).await {
+            warn!(
+                graph_name,
+                "Failed to drop trust graph projection after run: {e:?}"
+            );
+        }
+
+        let row = write_result?
+            .ok_or_else(|| -> DynError { "GDS pageRank.write returned no summary row".into() })?;
+        let users_written: i64 = row.get("nodePropertiesWritten").unwrap_or_default();
+        let ran_iterations: i64 = row.get("ranIterations").unwrap_or_default();
+        let did_converge: bool = row.get("didConverge").unwrap_or_default();
+
+        if users_written == 0 {
+            return Err(
+                "trust rank computation wrote no scores; check the seed set and follow graph"
+                    .into(),
+            );
+        }
+
+        info!(users_written, did_converge, "Trust rank recomputed");
+
+        Ok(TrustRankStats {
+            users_written: users_written as u64,
+            ran_iterations: ran_iterations as u64,
+            did_converge,
+        })
+    }
+}

--- a/nexusd/src/trust/neo4j/mod.rs
+++ b/nexusd/src/trust/neo4j/mod.rs
@@ -12,8 +12,8 @@ use tracing::{info, warn};
 
 use super::engine::{TrustRankEngine, TrustRankParams, TrustRankStats};
 use queries::{
-    count_matching_seeds, drop_stale_trust_graphs, drop_trust_graph, project_trust_graph,
-    trust_rank_pagerank_write, TRUST_GRAPH_PREFIX,
+    count_matching_seeds, drop_stale_trust_graphs, drop_trust_graph, estimate_trust_graph,
+    project_trust_graph, trust_rank_pagerank_write, TRUST_GRAPH_PREFIX,
 };
 
 /// Computes trust rank via the Neo4j GDS `pageRank` procedure in write mode,
@@ -99,6 +99,42 @@ impl TrustRankEngine for GdsNeo4j {
                 );
             }
         }
+
+        // Estimate projection size (dry-run, allocates nothing). When no cap is
+        // configured the estimate is a log-only breadcrumb — failures (e.g. the
+        // procedure missing from the allowlist) warn and continue. When a cap is
+        // set the estimate is load-bearing and errors propagate.
+        let estimate_ok = match fetch_row_from_graph(estimate_trust_graph()).await {
+            Ok(row) => {
+                if let Some(row) = &row {
+                    let required_memory: String = row.get("requiredMemory").unwrap_or_default();
+                    let bytes_max: u64 = row.get("bytesMax").unwrap_or_default();
+                    let est_nodes: i64 = row.get("nodeCount").unwrap_or_default();
+                    let est_rels: i64 = row.get("relationshipCount").unwrap_or_default();
+                    info!(
+                        required_memory = %required_memory,
+                        bytes_max, estimate_nodes = est_nodes, estimate_rels = est_rels,
+                        "GDS projection estimate"
+                    );
+                    if let Some(cap) = params.max_projection_bytes {
+                        if bytes_max > cap {
+                            return Err(format!(
+                                "GDS projection estimate ({bytes_max} bytes / {required_memory}) exceeds configured cap ({cap} bytes); increase NEO4J_server_memory_heap_max__size or raise trust_rank.max_projection_bytes"
+                            ).into());
+                        }
+                    }
+                }
+                true
+            }
+            Err(e) => {
+                if params.max_projection_bytes.is_some() {
+                    return Err(e.into());
+                }
+                warn!("GDS projection estimate failed (continuing without cap check): {e:?}");
+                false
+            }
+        };
+        let _ = estimate_ok;
 
         let projected = fetch_row_from_graph(project_trust_graph(&graph_name)).await?;
         if let Some(row) = &projected {

--- a/nexusd/src/trust/neo4j/mod.rs
+++ b/nexusd/src/trust/neo4j/mod.rs
@@ -136,6 +136,13 @@ impl TrustRankEngine for GdsNeo4j {
         };
         let _ = estimate_ok;
 
+        // GDS work below runs server-side. A run abandoned at the job's MAX_RUN
+        // drops this future but can't cancel the in-flight projection/pageRank:
+        // it keeps grinding and its projection stays resident, so the next tick
+        // can project a second graph on top (double memory). We can't bound it
+        // per-query yet — neo4rs 0.8 exposes no RUN tx_timeout metadata (needs
+        // 0.9's Query::extra, currently only an RC). The age-gated stale sweep
+        // above is the backstop until then.
         let projected = fetch_row_from_graph(project_trust_graph(&graph_name)).await?;
         if let Some(row) = &projected {
             let node_count: i64 = row.get("nodeCount").unwrap_or_default();

--- a/nexusd/src/trust/neo4j/mod.rs
+++ b/nexusd/src/trust/neo4j/mod.rs
@@ -20,8 +20,27 @@ use queries::{
 /// Seeds are weighted equally (`v` uniform, `1/N` over `params.seed_ids`): GDS
 /// 2.13 (the only version on Neo4j 5.26) has no weighted `sourceNodes`. The GDS
 /// projection is rebuilt each run — Neo4j Community has no incremental update.
-#[derive(Debug, Default, Clone, Copy)]
-pub struct GdsNeo4j;
+#[derive(Debug, Clone, Copy)]
+pub struct GdsNeo4j {
+    /// L1-normalize the written scores into a distribution (summing to 1). On in
+    /// production; tests turn it off to observe the raw scores, which expose the
+    /// mass a reachable dangling node leaks (that L1Norm otherwise rescales away).
+    use_l1norm: bool,
+}
+
+impl Default for GdsNeo4j {
+    fn default() -> Self {
+        Self { use_l1norm: true }
+    }
+}
+
+impl GdsNeo4j {
+    /// Engine with an explicit scaling choice. `GdsNeo4j::default()` gives the
+    /// production `L1Norm`; tests pass `false` to observe the raw scores.
+    pub fn new(use_l1norm: bool) -> Self {
+        Self { use_l1norm }
+    }
+}
 
 #[async_trait]
 impl TrustRankEngine for GdsNeo4j {
@@ -94,6 +113,7 @@ impl TrustRankEngine for GdsNeo4j {
             damping_factor,
             params.max_iterations,
             params.tolerance,
+            if self.use_l1norm { "L1Norm" } else { "NONE" },
         ))
         .await;
 

--- a/nexusd/src/trust/neo4j/mod.rs
+++ b/nexusd/src/trust/neo4j/mod.rs
@@ -3,6 +3,8 @@
 
 pub mod queries;
 
+use std::time::Duration;
+
 use async_trait::async_trait;
 use nexus_common::db::fetch_row_from_graph;
 use nexus_common::types::DynError;
@@ -26,19 +28,19 @@ pub struct GdsNeo4j {
     /// production; tests turn it off to observe the raw scores, which expose the
     /// mass a reachable dangling node leaks (that L1Norm otherwise rescales away).
     use_l1norm: bool,
-}
-
-impl Default for GdsNeo4j {
-    fn default() -> Self {
-        Self { use_l1norm: true }
-    }
+    /// GDS projections older than this are swept as crash leftovers.
+    stale_graph_age: Duration,
 }
 
 impl GdsNeo4j {
-    /// Engine with an explicit scaling choice. `GdsNeo4j::default()` gives the
-    /// production `L1Norm`; tests pass `false` to observe the raw scores.
-    pub fn new(use_l1norm: bool) -> Self {
-        Self { use_l1norm }
+    /// Engine with an explicit scaling choice (`use_l1norm`: `L1Norm` in
+    /// production, `false` in tests to observe raw scores) and the stale-graph
+    /// sweep age (see [`GdsNeo4j::stale_graph_age`]).
+    pub fn new(use_l1norm: bool, stale_graph_age: Duration) -> Self {
+        Self {
+            use_l1norm,
+            stale_graph_age,
+        }
     }
 }
 
@@ -87,7 +89,8 @@ impl TrustRankEngine for GdsNeo4j {
         // Sweep projections leaked by crashed runs (age-gated, can't race a live
         // run). Catalog calls use fetch_row_from_graph (PULL): GDS runs the side
         // effect only when the row is pulled.
-        if let Some(row) = fetch_row_from_graph(drop_stale_trust_graphs()).await? {
+        let stale_secs = self.stale_graph_age.as_secs() as i64;
+        if let Some(row) = fetch_row_from_graph(drop_stale_trust_graphs(stale_secs)).await? {
             let dropped: Vec<String> = row.get("dropped").unwrap_or_default();
             if !dropped.is_empty() {
                 warn!(

--- a/nexusd/src/trust/neo4j/mod.rs
+++ b/nexusd/src/trust/neo4j/mod.rs
@@ -186,8 +186,6 @@ impl TrustRankEngine for GdsNeo4j {
             );
         }
 
-        info!(users_written, did_converge, "Trust rank recomputed");
-
         Ok(TrustRankStats {
             users_written: users_written as u64,
             ran_iterations: ran_iterations as u64,

--- a/nexusd/src/trust/neo4j/queries.rs
+++ b/nexusd/src/trust/neo4j/queries.rs
@@ -1,0 +1,176 @@
+use nexus_common::db::graph::Query;
+
+/// Name prefix of the per-run GDS graph projections. Each run projects under a
+/// unique `{prefix}-{pid}-{millis}` name so concurrent runs can't clobber each
+/// other; crash leftovers are swept by [`drop_stale_trust_graphs`].
+pub const TRUST_GRAPH_PREFIX: &str = "nexusTrustGraph";
+
+/// Drops the named GDS graph projection if it exists; a no-op otherwise (`failIfMissing: false`).
+pub fn drop_trust_graph(graph_name: &str) -> Query {
+    Query::new(
+        "drop_trust_graph",
+        "CALL gds.graph.drop($graph_name, false) YIELD graphName RETURN graphName",
+    )
+    .param("graph_name", graph_name.to_string())
+}
+
+/// Age gate for the stale-projection sweep, in hours. Set to 2× the run
+/// deadline (`MAX_RUN`, 1h) so the sweep can never race a lock-holding run.
+const STALE_GRAPH_SWEEP_HOURS: i64 = 2;
+
+/// Reclaims GDS projections left by a run that died before dropping its own:
+/// prefix-matched entries older than [`STALE_GRAPH_SWEEP_HOURS`]. A run drops
+/// its projection on success and on error, so a leak means a hard crash
+/// (SIGKILL/OOM) or a shutdown-cancelled run.
+///
+/// Age proxies for "the owner is dead". The real invariant comes from the run
+/// lock: a run is abandoned at its deadline (`nexusd::jobs::lock::MAX_RUN`, 1h)
+/// and its lease expires shortly after, after which a second run may start. The
+/// sweep gate is 2× that deadline, comfortably past the lease, so a projection
+/// old enough to sweep cannot belong to a run still holding (or able to hold)
+/// the lock — the sweep never races a live computation. If `MAX_RUN` changes,
+/// revisit this margin.
+pub fn drop_stale_trust_graphs() -> Query {
+    Query::new(
+        "drop_stale_trust_graphs",
+        "CALL gds.graph.list() YIELD graphName, creationTime
+         WHERE graphName STARTS WITH $prefix AND creationTime < datetime() - duration({hours: $stale_hours})
+         CALL gds.graph.drop(graphName, false) YIELD graphName AS dropped
+         RETURN collect(dropped) AS dropped",
+    )
+    .param("prefix", TRUST_GRAPH_PREFIX)
+    .param("stale_hours", STALE_GRAPH_SWEEP_HOURS)
+}
+
+/// Projects the follow graph (`User` nodes, `FOLLOWS` edges) into the GDS in-memory catalog.
+pub fn project_trust_graph(graph_name: &str) -> Query {
+    Query::new(
+        "project_trust_graph",
+        "CALL gds.graph.project($graph_name, 'User', 'FOLLOWS')
+         YIELD graphName, nodeCount, relationshipCount
+         RETURN graphName, nodeCount, relationshipCount",
+    )
+    .param("graph_name", graph_name.to_string())
+}
+
+/// Counts how many of the configured seed ids exist as `:User` nodes.
+///
+/// Run before the PageRank query: if zero seeds match, GDS gets an empty
+/// `sourceNodes`, treats it as unset, and computes non-personalized PageRank
+/// instead of the seeded trust ranking.
+pub fn count_matching_seeds(seed_ids: &[String]) -> Query {
+    Query::new(
+        "count_matching_seeds",
+        "MATCH (seed:User) WHERE seed.id IN $seed_ids RETURN count(seed) AS matched",
+    )
+    .param("seed_ids", seed_ids.to_vec())
+}
+
+/// Runs personalized PageRank over the projected follow graph in GDS **write
+/// mode**, storing each score on its `:User` node as the `trust` property.
+/// Teleports uniformly across `seed_ids` (`v = 1/N`); GDS 2.13 (the only
+/// version on Neo4j 5.26) has no weighted `sourceNodes`.
+///
+/// `scaler: 'L1Norm'` writes scores as an L1-normalized distribution (summing
+/// to 1) rather than raw rank values. Write mode overwrites `trust` on every
+/// projected `:User` each run, so scores never go stale.
+///
+/// The `size(sourceNodes) > 0` guard makes the query produce no rows when no
+/// seed matches, so a raced seed deletion can never fall back to
+/// non-personalized PageRank — the caller's "no summary row" path fires instead.
+pub fn trust_rank_pagerank_write(
+    graph_name: &str,
+    seed_ids: &[String],
+    damping_factor: f64,
+    max_iterations: u32,
+    tolerance: f64,
+) -> Query {
+    Query::new(
+        "trust_rank_pagerank_write",
+        "MATCH (seed:User) WHERE seed.id IN $seed_ids
+         WITH collect(seed) AS sourceNodes
+         WHERE size(sourceNodes) > 0
+         CALL gds.pageRank.write($graph_name, {
+             writeProperty: 'trust',
+             sourceNodes: sourceNodes,
+             dampingFactor: $damping_factor,
+             maxIterations: $max_iterations,
+             tolerance: $tolerance,
+             scaler: 'L1Norm'
+         })
+         YIELD nodePropertiesWritten, ranIterations, didConverge
+         RETURN nodePropertiesWritten, ranIterations, didConverge",
+    )
+    .param("graph_name", graph_name.to_string())
+    .param("seed_ids", seed_ids.to_vec())
+    .param("damping_factor", damping_factor)
+    .param("max_iterations", max_iterations as i64)
+    .param("tolerance", tolerance)
+}
+
+/// Reads back the `trust` scores written by [`trust_rank_pagerank_write`],
+/// highest first. Off any hot path, so a full scan of scored users is fine.
+pub fn read_trust_scores() -> Query {
+    Query::new(
+        "read_trust_scores",
+        "MATCH (u:User) WHERE u.trust IS NOT NULL
+         RETURN u.id AS user_id, u.trust AS score
+         ORDER BY score DESC",
+    )
+}
+
+/// Batched name + counts for a list of user ids, read straight from the graph
+/// (no Redis) so the report's numbers reflect current state, not a stale cache.
+///
+/// `OPTIONAL MATCH` keeps one row per requested id even if a user is missing;
+/// each `COUNT {}` subquery mirrors `nexus_common`'s `user_counts` and stays
+/// O(1) per field, as no row-multiplying match precedes them.
+pub fn trust_report_user_details(user_ids: &[String]) -> Query {
+    Query::new(
+        "trust_report_user_details",
+        "
+        UNWIND $user_ids AS user_id
+        OPTIONAL MATCH (u:User {id: user_id})
+        RETURN
+            user_id AS id,
+            u.name AS name,
+            COUNT { (u)-[:FOLLOWS]->(:User) } AS following,
+            COUNT { (:User)-[:FOLLOWS]->(u) } AS followers,
+            COUNT { (u)-[:FOLLOWS]->(friend:User) WHERE (friend)-[:FOLLOWS]->(u) } AS friends,
+            COUNT { (u)-[:AUTHORED]->(:Post) } AS posts,
+            COUNT { (u)-[:AUTHORED]->(:Post)-[:REPLIED]->(:Post) } AS replies,
+            COUNT { (u)-[:AUTHORED]->(p:Post) WHERE p.kind = 'collection' } AS collections,
+            COUNT { (u)-[:BOOKMARKED]->(bp:Post) WHERE (bp.kind IS NULL OR bp.kind <> 'collection') } AS bookmarks,
+            COUNT { (u)-[:TAGGED]->(:User) } + COUNT { (u)-[:TAGGED]->(:Post) } AS tagged,
+            COUNT { (:User)-[:TAGGED]->(u) } AS tags,
+            COUNT { MATCH (u)<-[t:TAGGED]-(:User) RETURN DISTINCT t.label } AS unique_tags
+        ",
+    )
+    .param("user_ids", user_ids.to_vec())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trust_rank_pagerank_write_populates_seed_ids() {
+        let seed_ids = vec!["alice".to_string(), "bob".to_string()];
+        let q = trust_rank_pagerank_write("nexusTrustGraph-1-2", &seed_ids, 0.65, 200, 0.0000001);
+        let populated = q.to_cypher_populated();
+        assert!(populated.contains("['alice', 'bob']"));
+        assert!(populated.contains("0.65"));
+        assert!(populated.contains("'nexusTrustGraph-1-2'"));
+        assert!(populated.contains("writeProperty: 'trust'"));
+        // Guard closing the seed-deletion race; empty match → no rows, not global PageRank.
+        assert!(populated.contains("size(sourceNodes) > 0"));
+    }
+
+    #[test]
+    fn count_matching_seeds_populates_seed_ids() {
+        let seed_ids = vec!["alice".to_string(), "bob".to_string()];
+        let populated = count_matching_seeds(&seed_ids).to_cypher_populated();
+        assert!(populated.contains("['alice', 'bob']"));
+        assert!(populated.contains("count(seed) AS matched"));
+    }
+}

--- a/nexusd/src/trust/neo4j/queries.rs
+++ b/nexusd/src/trust/neo4j/queries.rs
@@ -46,6 +46,17 @@ pub fn project_trust_graph(graph_name: &str) -> Query {
     .param("graph_name", graph_name.to_string())
 }
 
+/// Dry-run estimate for the User+FOLLOWS GDS projection (allocates nothing).
+/// Returns `requiredMemory`, `bytesMax`, `nodeCount`, and `relationshipCount`.
+pub fn estimate_trust_graph() -> Query {
+    Query::new(
+        "estimate_trust_graph",
+        "CALL gds.graph.project.estimate('User', 'FOLLOWS')
+         YIELD requiredMemory, bytesMax, nodeCount, relationshipCount
+         RETURN requiredMemory, bytesMax, nodeCount, relationshipCount",
+    )
+}
+
 /// Counts how many of the configured seed ids exist as `:User` nodes.
 ///
 /// Run before the PageRank query: if zero seeds match, GDS gets an empty

--- a/nexusd/src/trust/neo4j/queries.rs
+++ b/nexusd/src/trust/neo4j/queries.rs
@@ -15,32 +15,24 @@ pub fn drop_trust_graph(graph_name: &str) -> Query {
     .param("graph_name", graph_name.to_string())
 }
 
-/// Age gate for the stale-projection sweep, in hours. Set to 2× the run
-/// deadline (`MAX_RUN`, 1h) so the sweep can never race a lock-holding run.
-const STALE_GRAPH_SWEEP_HOURS: i64 = 2;
-
 /// Reclaims GDS projections left by a run that died before dropping its own:
-/// prefix-matched entries older than [`STALE_GRAPH_SWEEP_HOURS`]. A run drops
-/// its projection on success and on error, so a leak means a hard crash
-/// (SIGKILL/OOM) or a shutdown-cancelled run.
+/// prefix-matched entries older than `stale_seconds`. A run drops its projection
+/// on success and on error, so a leak means a hard crash (SIGKILL/OOM) or a
+/// shutdown-cancelled run.
 ///
-/// Age proxies for "the owner is dead". The real invariant comes from the run
-/// lock: a run is abandoned at its deadline (`nexusd::jobs::lock::MAX_RUN`, 1h)
-/// and its lease expires shortly after, after which a second run may start. The
-/// sweep gate is 2× that deadline, comfortably past the lease, so a projection
-/// old enough to sweep cannot belong to a run still holding (or able to hold)
-/// the lock — the sweep never races a live computation. If `MAX_RUN` changes,
-/// revisit this margin.
-pub fn drop_stale_trust_graphs() -> Query {
+/// Age proxies for "the owner is dead". The caller sizes `stale_seconds` past a
+/// run's lease expiry so a projection old enough to sweep cannot belong to a run
+/// still holding (or able to hold) the lock.
+pub fn drop_stale_trust_graphs(stale_seconds: i64) -> Query {
     Query::new(
         "drop_stale_trust_graphs",
         "CALL gds.graph.list() YIELD graphName, creationTime
-         WHERE graphName STARTS WITH $prefix AND creationTime < datetime() - duration({hours: $stale_hours})
+         WHERE graphName STARTS WITH $prefix AND creationTime < datetime() - duration({seconds: $stale_seconds})
          CALL gds.graph.drop(graphName, false) YIELD graphName AS dropped
          RETURN collect(dropped) AS dropped",
     )
     .param("prefix", TRUST_GRAPH_PREFIX)
-    .param("stale_hours", STALE_GRAPH_SWEEP_HOURS)
+    .param("stale_seconds", stale_seconds)
 }
 
 /// Projects the follow graph (`User` nodes, `FOLLOWS` edges) into the GDS in-memory catalog.

--- a/nexusd/src/trust/neo4j/queries.rs
+++ b/nexusd/src/trust/neo4j/queries.rs
@@ -71,8 +71,11 @@ pub fn count_matching_seeds(seed_ids: &[String]) -> Query {
 /// Teleports uniformly across `seed_ids` (`v = 1/N`); GDS 2.13 (the only
 /// version on Neo4j 5.26) has no weighted `sourceNodes`.
 ///
-/// `scaler: 'L1Norm'` writes scores as an L1-normalized distribution (summing
-/// to 1) rather than raw rank values. Write mode overwrites `trust` on every
+/// `scaler` picks the GDS output scaling: `L1Norm` (production) writes an
+/// L1-normalized distribution (summing to 1); `NONE` writes raw rank values.
+/// GDS drops — never teleport-redistributes — the mass of reachable dangling
+/// nodes, so raw single-seed scores sum to < 1; `L1Norm` rescales that back to a
+/// distribution, hiding the leak. Write mode overwrites `trust` on every
 /// projected `:User` each run, so scores never go stale.
 ///
 /// The `size(sourceNodes) > 0` guard makes the query produce no rows when no
@@ -84,6 +87,7 @@ pub fn trust_rank_pagerank_write(
     damping_factor: f64,
     max_iterations: u32,
     tolerance: f64,
+    scaler: &str,
 ) -> Query {
     Query::new(
         "trust_rank_pagerank_write",
@@ -96,7 +100,7 @@ pub fn trust_rank_pagerank_write(
              dampingFactor: $damping_factor,
              maxIterations: $max_iterations,
              tolerance: $tolerance,
-             scaler: 'L1Norm'
+             scaler: $scaler
          })
          YIELD nodePropertiesWritten, ranIterations, didConverge
          RETURN nodePropertiesWritten, ranIterations, didConverge",
@@ -106,6 +110,7 @@ pub fn trust_rank_pagerank_write(
     .param("damping_factor", damping_factor)
     .param("max_iterations", max_iterations as i64)
     .param("tolerance", tolerance)
+    .param("scaler", scaler.to_string())
 }
 
 /// Reads back the `trust` scores written by [`trust_rank_pagerank_write`],
@@ -156,12 +161,21 @@ mod tests {
     #[test]
     fn trust_rank_pagerank_write_populates_seed_ids() {
         let seed_ids = vec!["alice".to_string(), "bob".to_string()];
-        let q = trust_rank_pagerank_write("nexusTrustGraph-1-2", &seed_ids, 0.65, 200, 0.0000001);
+        let q = trust_rank_pagerank_write(
+            "nexusTrustGraph-1-2",
+            &seed_ids,
+            0.65,
+            200,
+            0.0000001,
+            "L1Norm",
+        );
         let populated = q.to_cypher_populated();
         assert!(populated.contains("['alice', 'bob']"));
         assert!(populated.contains("0.65"));
         assert!(populated.contains("'nexusTrustGraph-1-2'"));
         assert!(populated.contains("writeProperty: 'trust'"));
+        // Scaler is parameterized (toggled between L1Norm and NONE), not hardcoded.
+        assert!(populated.contains("'L1Norm'"));
         // Guard closing the seed-deletion race; empty match → no rows, not global PageRank.
         assert!(populated.contains("size(sourceNodes) > 0"));
     }

--- a/nexusd/src/trust/neo4j/queries.rs
+++ b/nexusd/src/trust/neo4j/queries.rs
@@ -69,7 +69,9 @@ pub fn count_matching_seeds(seed_ids: &[String]) -> Query {
 /// GDS drops — never teleport-redistributes — the mass of reachable dangling
 /// nodes, so raw single-seed scores sum to < 1; `L1Norm` rescales that back to a
 /// distribution, hiding the leak. Write mode overwrites `trust` on every
-/// projected `:User` each run, so scores never go stale.
+/// projected `:User` each run; the projection is a snapshot, so users created
+/// after it carry no score until the next run picks them up (normal for a batch
+/// job).
 ///
 /// The `size(sourceNodes) > 0` guard makes the query produce no rows when no
 /// seed matches, so a raced seed deletion can never fall back to

--- a/nexusd/src/trust/neo4j/queries.rs
+++ b/nexusd/src/trust/neo4j/queries.rs
@@ -108,15 +108,16 @@ pub fn trust_rank_pagerank_write(
     .param("scaler", scaler.to_string())
 }
 
-/// Reads back the `trust` scores written by [`trust_rank_pagerank_write`],
-/// highest first. Off any hot path, so a full scan of scored users is fine.
-pub fn read_trust_scores() -> Query {
+/// Reads the top `limit` trust scores, highest first. `LIMIT` prevents scanning the entire user base.
+pub fn read_trust_scores(limit: usize) -> Query {
     Query::new(
         "read_trust_scores",
         "MATCH (u:User) WHERE u.trust IS NOT NULL
          RETURN u.id AS user_id, u.trust AS score
-         ORDER BY score DESC",
+         ORDER BY score DESC
+         LIMIT $limit",
     )
+    .param("limit", limit as i64)
 }
 
 /// Batched name + counts for a list of user ids, read straight from the graph

--- a/nexusd/src/trust/neo4j/queries.rs
+++ b/nexusd/src/trust/neo4j/queries.rs
@@ -1,3 +1,4 @@
+use nexus_common::db::graph::queries::get::user_count_fields_columns;
 use nexus_common::db::graph::Query;
 
 /// Name prefix of the per-run GDS graph projections. Each run projects under a
@@ -127,31 +128,22 @@ pub fn read_trust_scores() -> Query {
 /// Batched name + counts for a list of user ids, read straight from the graph
 /// (no Redis) so the report's numbers reflect current state, not a stale cache.
 ///
+/// The count columns come from `nexus_common`'s shared `USER_COUNT_FIELDS` (via
+/// [`user_count_fields_columns`]), so the filters can't drift from `user_counts`.
 /// `OPTIONAL MATCH` keeps one row per requested id even if a user is missing;
-/// each `COUNT {}` subquery mirrors `nexus_common`'s `user_counts` and stays
-/// O(1) per field, as no row-multiplying match precedes them.
+/// that match is single-row per id (not row-multiplying), so each `COUNT {}`
+/// stays O(1) per field.
 pub fn trust_report_user_details(user_ids: &[String]) -> Query {
-    Query::new(
-        "trust_report_user_details",
-        "
-        UNWIND $user_ids AS user_id
-        OPTIONAL MATCH (u:User {id: user_id})
-        RETURN
-            user_id AS id,
-            u.name AS name,
-            COUNT { (u)-[:FOLLOWS]->(:User) } AS following,
-            COUNT { (:User)-[:FOLLOWS]->(u) } AS followers,
-            COUNT { (u)-[:FOLLOWS]->(friend:User) WHERE (friend)-[:FOLLOWS]->(u) } AS friends,
-            COUNT { (u)-[:AUTHORED]->(:Post) } AS posts,
-            COUNT { (u)-[:AUTHORED]->(:Post)-[:REPLIED]->(:Post) } AS replies,
-            COUNT { (u)-[:AUTHORED]->(p:Post) WHERE p.kind = 'collection' } AS collections,
-            COUNT { (u)-[:BOOKMARKED]->(bp:Post) WHERE (bp.kind IS NULL OR bp.kind <> 'collection') } AS bookmarks,
-            COUNT { (u)-[:TAGGED]->(:User) } + COUNT { (u)-[:TAGGED]->(:Post) } AS tagged,
-            COUNT { (:User)-[:TAGGED]->(u) } AS tags,
-            COUNT { MATCH (u)<-[t:TAGGED]-(:User) RETURN DISTINCT t.label } AS unique_tags
-        ",
-    )
-    .param("user_ids", user_ids.to_vec())
+    let cypher = format!(
+        "UNWIND $user_ids AS user_id
+         OPTIONAL MATCH (u:User {{id: user_id}})
+         RETURN
+             user_id AS id,
+             u.name AS name,
+             {fields}",
+        fields = user_count_fields_columns()
+    );
+    Query::new("trust_report_user_details", cypher).param("user_ids", user_ids.to_vec())
 }
 
 #[cfg(test)]
@@ -186,5 +178,15 @@ mod tests {
         let populated = count_matching_seeds(&seed_ids).to_cypher_populated();
         assert!(populated.contains("['alice', 'bob']"));
         assert!(populated.contains("count(seed) AS matched"));
+    }
+
+    // Smoke test: the trust report has no integration coverage (nexusd-side),
+    // so just check the composed Cypher is well-formed off the OPTIONAL MATCH.
+    #[test]
+    fn trust_report_user_details_is_well_formed() {
+        let cypher = trust_report_user_details(&["alice".to_string()]).to_cypher_populated();
+        assert!(cypher.contains("OPTIONAL MATCH (u:User {id: user_id})"));
+        assert!(cypher.contains("AS following"));
+        assert!(cypher.contains("bp.kind <> 'collection'"));
     }
 }

--- a/nexusd/tests/trust/main.rs
+++ b/nexusd/tests/trust/main.rs
@@ -1,0 +1,3 @@
+//! Integration tests for trust-rank computation, one module per engine backend.
+
+mod neo4j;

--- a/nexusd/tests/trust/neo4j.rs
+++ b/nexusd/tests/trust/neo4j.rs
@@ -1,0 +1,158 @@
+//! Integration test for the Neo4j/GDS [`GdsNeo4j`] trust-rank engine.
+//!
+//! Builds a tiny, self-contained follow graph (so it doesn't depend on any
+//! seeded fixtures), runs a real GDS PageRank recompute against the Neo4j
+//! stack, and asserts the `trust` property is written back onto the `:User`
+//! nodes with the shape a seeded/personalized ranking must have.
+//!
+//! Requires the docker stack (Neo4j with the GDS plugin + Redis) to be up.
+
+use anyhow::{Context, Result};
+use nexus_common::db::graph::Query;
+use nexus_common::db::{exec_single_row, fetch_all_rows_from_graph};
+use nexus_common::{StackConfig, StackManager};
+use nexusd::trust::{read_scores, GdsNeo4j, TrustRankEngine, TrustRankParams};
+use std::collections::HashMap;
+
+/// Creates four `:User` nodes and the follow chain `seed -> a -> b`, leaving
+/// `c` isolated (followed by no one, following no one).
+async fn create_follow_graph(seed: &str, a: &str, b: &str, c: &str) -> Result<()> {
+    let query = Query::new(
+        "trusttest_create_follow_graph",
+        "CREATE (s:User {id: $seed, name: 'trusttest seed'})
+         CREATE (a:User {id: $a, name: 'trusttest a'})
+         CREATE (b:User {id: $b, name: 'trusttest b'})
+         CREATE (c:User {id: $c, name: 'trusttest c'})
+         CREATE (s)-[:FOLLOWS]->(a)
+         CREATE (a)-[:FOLLOWS]->(b)",
+    )
+    .param("seed", seed.to_string())
+    .param("a", a.to_string())
+    .param("b", b.to_string())
+    .param("c", c.to_string());
+    exec_single_row(query).await?;
+    Ok(())
+}
+
+/// Removes the test nodes (and their edges) so the shared graph is left clean.
+async fn delete_users(ids: &[&str]) -> Result<()> {
+    let query = Query::new(
+        "trusttest_delete_users",
+        "MATCH (u:User) WHERE u.id IN $ids DETACH DELETE u",
+    )
+    .param("ids", ids.iter().map(|s| s.to_string()).collect::<Vec<_>>());
+    exec_single_row(query).await?;
+    Ok(())
+}
+
+/// Reads a single user's `trust` property straight from the graph.
+async fn trust_of(id: &str) -> Result<Option<f64>> {
+    let query = Query::new(
+        "trusttest_read_trust",
+        "MATCH (u:User {id: $id}) RETURN u.trust AS trust",
+    )
+    .param("id", id.to_string());
+    let rows = fetch_all_rows_from_graph(query).await?;
+    match rows.first() {
+        Some(row) => Ok(row.get("trust").ok()),
+        None => Ok(None),
+    }
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_trust_recompute_assigns_scores_to_graph_nodes() -> Result<()> {
+    StackManager::setup(&StackConfig::default())
+        .await
+        .map_err(|e| anyhow::anyhow!("could not initialise the stack: {e:?}"))?;
+
+    // Unique ids per run so parallel/repeat runs never collide with each other
+    // or with any existing user in the shared graph.
+    let tag = format!(
+        "{}-{}",
+        std::process::id(),
+        chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+    );
+    let seed = format!("trusttest-{tag}-seed");
+    let a = format!("trusttest-{tag}-a");
+    let b = format!("trusttest-{tag}-b");
+    let c = format!("trusttest-{tag}-c");
+
+    create_follow_graph(&seed, &a, &b, &c).await?;
+
+    // Recompute seeded PageRank teleporting only from `seed`.
+    let params = TrustRankParams {
+        seed_ids: vec![seed.clone()],
+        alpha: 0.35,
+        max_iterations: 200,
+        tolerance: 1e-7,
+    };
+    let recompute_result = GdsNeo4j.compute(&params).await;
+
+    // Read the scores that were written onto the nodes before tearing them
+    // down, so the assertions below run against a clean graph regardless of
+    // whether they pass or panic.
+    let read_result = async {
+        let stats = recompute_result.map_err(|e| anyhow::anyhow!("{e}"))?;
+        let seed_score = trust_of(&seed).await?.context("seed has no trust score")?;
+        let a_score = trust_of(&a)
+            .await?
+            .context("followee `a` has no trust score")?;
+        let b_score = trust_of(&b)
+            .await?
+            .context("followee `b` has no trust score")?;
+        // An unreachable node scores exactly 0; GDS may write 0.0 or leave the
+        // property unset — both mean "no trust".
+        let c_score = trust_of(&c).await?.unwrap_or(0.0);
+        // The full read-back path (used by the CLI/report) must also surface these.
+        let all_scores: HashMap<String, f64> = read_scores().await?.into_iter().collect();
+        anyhow::Ok((stats, seed_score, a_score, b_score, c_score, all_scores))
+    }
+    .await;
+
+    delete_users(&[&seed, &a, &b, &c]).await?;
+
+    let (stats, seed_score, a_score, b_score, c_score, all_scores) = read_result?;
+
+    // Scores were actually written to the graph.
+    assert!(
+        stats.users_written > 0,
+        "recompute should report writing at least one user"
+    );
+
+    // Seed and everything reachable from it along FOLLOWS gets positive trust.
+    assert!(
+        seed_score > 0.0,
+        "seed should have positive trust, got {seed_score}"
+    );
+    assert!(
+        a_score > 0.0,
+        "directly-followed node `a` should inherit trust, got {a_score}"
+    );
+    assert!(
+        b_score > 0.0,
+        "transitively-followed node `b` should inherit trust, got {b_score}"
+    );
+
+    // A node unreachable from the seed set gets zero trust — the whole point of
+    // a *seeded* (Sybil-resistant) ranking versus plain global PageRank.
+    assert_eq!(
+        c_score, 0.0,
+        "isolated node `c` should have zero trust, got {c_score}"
+    );
+
+    // Trust decays as it flows along the follow chain: seed > a > b.
+    assert!(
+        seed_score > a_score,
+        "seed ({seed_score}) should outrank its followee `a` ({a_score})"
+    );
+    assert!(
+        a_score > b_score,
+        "`a` ({a_score}) should outrank the node it follows, `b` ({b_score})"
+    );
+
+    // The read-back helper returns the same scores it wrote.
+    assert_eq!(all_scores.get(&seed).copied(), Some(seed_score));
+    assert_eq!(all_scores.get(&a).copied(), Some(a_score));
+
+    Ok(())
+}

--- a/nexusd/tests/trust/neo4j.rs
+++ b/nexusd/tests/trust/neo4j.rs
@@ -35,6 +35,54 @@ async fn create_follow_graph(seed: &str, a: &str, b: &str, c: &str) -> Result<()
     Ok(())
 }
 
+/// `max_projection_bytes` cap aborts compute when the estimate exceeds the limit.
+#[tokio_shared_rt::test(shared)]
+async fn test_compute_aborts_when_estimate_exceeds_cap() -> Result<()> {
+    StackManager::setup(&StackConfig::default())
+        .await
+        .map_err(|e| anyhow::anyhow!("could not initialise the stack: {e:?}"))?;
+
+    let tag = format!(
+        "{}-{}",
+        std::process::id(),
+        chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+    );
+    let seed = format!("cap-{tag}-seed");
+    let a = format!("cap-{tag}-a");
+    let b = format!("cap-{tag}-b");
+    let c = format!("cap-{tag}-c");
+
+    create_follow_graph(&seed, &a, &b, &c).await?;
+
+    let params = TrustRankParams {
+        seed_ids: vec![seed.clone()],
+        alpha: 0.35,
+        max_iterations: 200,
+        tolerance: 1e-7,
+        max_projection_bytes: Some(1), // Deliberately tiny cap
+    };
+
+    let sweep_age = Duration::from_secs(3600);
+    let compute_result = GdsNeo4j::new(true, sweep_age).compute(&params).await;
+
+    delete_users(&[&seed, &a, &b, &c]).await?;
+
+    let err = compute_result
+        .err()
+        .expect("compute should fail with a tiny cap");
+    let err_msg = format!("{err}");
+    assert!(
+        err_msg.contains("exceeds configured cap"),
+        "error should mention cap violation, got: {err_msg}"
+    );
+    assert!(
+        err_msg.contains("cap (1 bytes)"),
+        "error should name the cap value, got: {err_msg}"
+    );
+
+    Ok(())
+}
+
 /// Removes the test nodes (and their edges) so the shared graph is left clean.
 async fn delete_users(ids: &[&str]) -> Result<()> {
     let query = Query::new(
@@ -109,6 +157,7 @@ async fn test_trust_recompute_assigns_scores_to_graph_nodes() -> Result<()> {
         alpha: 0.35,
         max_iterations: 200,
         tolerance: 1e-7,
+        max_projection_bytes: None,
     };
 
     // Read every score written onto the nodes before tearing them down, so the

--- a/nexusd/tests/trust/neo4j.rs
+++ b/nexusd/tests/trust/neo4j.rs
@@ -13,6 +13,7 @@ use nexus_common::db::{exec_single_row, fetch_all_rows_from_graph};
 use nexus_common::{StackConfig, StackManager};
 use nexusd::trust::{read_scores, GdsNeo4j, TrustRankEngine, TrustRankParams};
 use std::collections::HashMap;
+use std::time::Duration;
 
 /// Creates four `:User` nodes and the follow chain `seed -> a -> b`, leaving
 /// `c` isolated (followed by no one, following no one).
@@ -91,9 +92,12 @@ async fn test_trust_recompute_assigns_scores_to_graph_nodes() -> Result<()> {
     // scalings run in one test: `gds.pageRank.write` writes `trust` on *every*
     // projected user, so splitting them into two tests would let concurrent runs
     // clobber each other's nodes (production serializes via the job lock).
+    // This test never asserts on the stale-projection sweep; a long age keeps it
+    // from touching any live projection so the value is otherwise irrelevant.
+    let sweep_age = Duration::from_secs(3600);
     let read_result = async {
         // L1Norm (production scaling): the shape a seeded ranking must have.
-        let stats = GdsNeo4j::default()
+        let stats = GdsNeo4j::new(true, sweep_age)
             .compute(&params)
             .await
             .map_err(|e| anyhow::anyhow!("{e}"))?;
@@ -111,7 +115,7 @@ async fn test_trust_recompute_assigns_scores_to_graph_nodes() -> Result<()> {
         let all_scores: HashMap<String, f64> = read_scores().await?.into_iter().collect();
 
         // Raw (L1Norm off): same run un-normalized, to observe the mass leak.
-        GdsNeo4j::new(false)
+        GdsNeo4j::new(false, sweep_age)
             .compute(&params)
             .await
             .map_err(|e| anyhow::anyhow!("{e}"))?;

--- a/nexusd/tests/trust/neo4j.rs
+++ b/nexusd/tests/trust/neo4j.rs
@@ -46,6 +46,30 @@ async fn delete_users(ids: &[&str]) -> Result<()> {
     Ok(())
 }
 
+/// Creates `n` scored users (`trust: 1.0..=n`) without GDS.
+async fn create_scored_users(prefix: &str, n: usize) -> Result<()> {
+    let query = Query::new(
+        "trusttest_create_scored_users",
+        "UNWIND range(1, $n) AS i
+         CREATE (:User {id: $prefix + toString(i), trust: toFloat(i)})",
+    )
+    .param("prefix", prefix.to_string())
+    .param("n", n as i64);
+    exec_single_row(query).await?;
+    Ok(())
+}
+
+/// Removes users by id prefix.
+async fn delete_users_by_prefix(prefix: &str) -> Result<()> {
+    let query = Query::new(
+        "trusttest_delete_by_prefix",
+        "MATCH (u:User) WHERE u.id STARTS WITH $prefix DETACH DELETE u",
+    )
+    .param("prefix", prefix.to_string());
+    exec_single_row(query).await?;
+    Ok(())
+}
+
 /// Reads a single user's `trust` property straight from the graph.
 async fn trust_of(id: &str) -> Result<Option<f64>> {
     let query = Query::new(
@@ -111,8 +135,8 @@ async fn test_trust_recompute_assigns_scores_to_graph_nodes() -> Result<()> {
         // An unreachable node scores exactly 0; GDS may write 0.0 or leave the
         // property unset — both mean "no trust".
         let c_score = trust_of(&c).await?.unwrap_or(0.0);
-        // The full read-back path (used by the CLI/report) must also surface these.
-        let all_scores: HashMap<String, f64> = read_scores().await?.into_iter().collect();
+        // Read-back path must surface all scores (limit > graph size).
+        let all_scores: HashMap<String, f64> = read_scores(1000).await?.into_iter().collect();
 
         // Raw (L1Norm off): same run un-normalized, to observe the mass leak.
         GdsNeo4j::new(false, sweep_age)
@@ -197,6 +221,44 @@ async fn test_trust_recompute_assigns_scores_to_graph_nodes() -> Result<()> {
     assert!(
         (raw_ratio - l1_ratio).abs() < 1e-6,
         "a/seed ratio should survive scaling: raw {raw_ratio} vs l1norm {l1_ratio}"
+    );
+
+    Ok(())
+}
+
+/// `read_scores(limit)` bounds results to `limit` rows, highest-first.
+#[tokio_shared_rt::test(shared)]
+async fn test_read_scores_respects_limit() -> Result<()> {
+    StackManager::setup(&StackConfig::default())
+        .await
+        .map_err(|e| anyhow::anyhow!("could not initialise the stack: {e:?}"))?;
+
+    let prefix = format!(
+        "trusttest-cap-{}-{}-",
+        std::process::id(),
+        chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+    );
+
+    // More users than limit to force row trimming.
+    let limit = 5;
+    create_scored_users(&prefix, limit + 3).await?;
+
+    let read_result = read_scores(limit).await.map_err(|e| anyhow::anyhow!("{e}"));
+
+    delete_users_by_prefix(&prefix).await?;
+
+    let scores = read_result?;
+
+    // LIMIT trims to exactly `limit` rows.
+    assert_eq!(
+        scores.len(),
+        limit,
+        "read_scores must return exactly `limit` rows when more scored users exist"
+    );
+    // Rows remain highest-first.
+    assert!(
+        scores.windows(2).all(|w| w[0].1 >= w[1].1),
+        "capped scores must remain sorted highest-first, got {scores:?}"
     );
 
     Ok(())

--- a/nexusd/tests/trust/neo4j.rs
+++ b/nexusd/tests/trust/neo4j.rs
@@ -67,9 +67,7 @@ async fn test_compute_aborts_when_estimate_exceeds_cap() -> Result<()> {
 
     delete_users(&[&seed, &a, &b, &c]).await?;
 
-    let err = compute_result
-        .err()
-        .expect("compute should fail with a tiny cap");
+    let err = compute_result.expect_err("compute should fail with a tiny cap");
     let err_msg = format!("{err}");
     assert!(
         err_msg.contains("exceeds configured cap"),

--- a/nexusd/tests/trust/neo4j.rs
+++ b/nexusd/tests/trust/neo4j.rs
@@ -79,20 +79,24 @@ async fn test_trust_recompute_assigns_scores_to_graph_nodes() -> Result<()> {
 
     create_follow_graph(&seed, &a, &b, &c).await?;
 
-    // Recompute seeded PageRank teleporting only from `seed`.
     let params = TrustRankParams {
         seed_ids: vec![seed.clone()],
         alpha: 0.35,
         max_iterations: 200,
         tolerance: 1e-7,
     };
-    let recompute_result = GdsNeo4j.compute(&params).await;
 
-    // Read the scores that were written onto the nodes before tearing them
-    // down, so the assertions below run against a clean graph regardless of
-    // whether they pass or panic.
+    // Read every score written onto the nodes before tearing them down, so the
+    // assertions below run against a clean graph regardless of pass/panic. Both
+    // scalings run in one test: `gds.pageRank.write` writes `trust` on *every*
+    // projected user, so splitting them into two tests would let concurrent runs
+    // clobber each other's nodes (production serializes via the job lock).
     let read_result = async {
-        let stats = recompute_result.map_err(|e| anyhow::anyhow!("{e}"))?;
+        // L1Norm (production scaling): the shape a seeded ranking must have.
+        let stats = GdsNeo4j::default()
+            .compute(&params)
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
         let seed_score = trust_of(&seed).await?.context("seed has no trust score")?;
         let a_score = trust_of(&a)
             .await?
@@ -105,13 +109,26 @@ async fn test_trust_recompute_assigns_scores_to_graph_nodes() -> Result<()> {
         let c_score = trust_of(&c).await?.unwrap_or(0.0);
         // The full read-back path (used by the CLI/report) must also surface these.
         let all_scores: HashMap<String, f64> = read_scores().await?.into_iter().collect();
-        anyhow::Ok((stats, seed_score, a_score, b_score, c_score, all_scores))
+
+        // Raw (L1Norm off): same run un-normalized, to observe the mass leak.
+        GdsNeo4j::new(false)
+            .compute(&params)
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let raw_seed = trust_of(&seed).await?.context("raw seed score")?;
+        let raw_a = trust_of(&a).await?.context("raw a score")?;
+        let raw_b = trust_of(&b).await?.context("raw b score")?;
+
+        anyhow::Ok((
+            stats, seed_score, a_score, b_score, c_score, all_scores, raw_seed, raw_a, raw_b,
+        ))
     }
     .await;
 
     delete_users(&[&seed, &a, &b, &c]).await?;
 
-    let (stats, seed_score, a_score, b_score, c_score, all_scores) = read_result?;
+    let (stats, seed_score, a_score, b_score, c_score, all_scores, raw_seed, raw_a, raw_b) =
+        read_result?;
 
     // Scores were actually written to the graph.
     assert!(
@@ -153,6 +170,30 @@ async fn test_trust_recompute_assigns_scores_to_graph_nodes() -> Result<()> {
     // The read-back helper returns the same scores it wrote.
     assert_eq!(all_scores.get(&seed).copied(), Some(seed_score));
     assert_eq!(all_scores.get(&a).copied(), Some(a_score));
+
+    // Scaler toggle. `b` is a dangling node (reachable, but follows nobody). GDS
+    // drops — never teleport-redistributes — its mass, so with a single seed the
+    // raw scores leak below 1; L1Norm rescales the same vector back to a
+    // distribution summing to 1, hiding the leak.
+    let raw_sum = raw_seed + raw_a + raw_b;
+    assert!(
+        raw_sum < 1.0 - 1e-6,
+        "raw scores should leak below 1 at the dangling node, summed to {raw_sum}"
+    );
+    let l1_sum = seed_score + a_score + b_score;
+    assert!(
+        (l1_sum - 1.0).abs() < 1e-6,
+        "l1norm scores should sum to 1, summed to {l1_sum}"
+    );
+
+    // The rescale is uniform: node ratios are unchanged, so L1Norm only hides the
+    // leak — it does not re-flow the leaked mass to other nodes.
+    let raw_ratio = raw_a / raw_seed;
+    let l1_ratio = a_score / seed_score;
+    assert!(
+        (raw_ratio - l1_ratio).abs() < 1e-6,
+        "a/seed ratio should survive scaling: raw {raw_ratio} vs l1norm {l1_ratio}"
+    );
 
     Ok(())
 }

--- a/scripts/inject_sybil_community.py
+++ b/scripts/inject_sybil_community.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Generate a Cypher script that injects a synthetic Sybil community into the
+follow graph, for validating TrustRank's Sybil resistance (does a dense cluster
+of fake accounts gain outsized trust despite few/no genuine incoming follows?).
+
+Every injected node gets label `:Sybil` and property `sybil_cluster: <name>`
+(in addition to `:User`, so it participates in the GDS projection like a real
+account) — this makes cleanup a single query:
+
+    MATCH (s:Sybil {sybil_cluster: "<name>"}) DETACH DELETE s;
+
+Run the generated script with cypher-shell, e.g.:
+
+    python3 scripts/inject_sybil_community.py --count 50 --pattern clique \\
+        --infiltrate-from <real_user_id> > sybil_wave1.cypher
+    docker exec -i neo4j cypher-shell -u neo4j -p <password> < sybil_wave1.cypher
+
+Then re-run `nexusd jobs run trust-recompute` (with `[trust] report_enabled = true`
+to get a CSV in report_dir) and check whether the cluster's members show up with
+non-negligible trust scores.
+"""
+
+import argparse
+import random
+import sys
+
+# z-base32 alphabet used by real pubky ids (opaque here - no crypto validity needed,
+# trust-rank code reads ids as plain strings, not the validated PubkyId type).
+Z32_ALPHABET = "ybndrfg8ejkmcpqxot1uwisza345h769"
+ID_LENGTH = 52
+
+
+def fake_id(rng: random.Random) -> str:
+    return "".join(rng.choices(Z32_ALPHABET, k=ID_LENGTH))
+
+
+def build_edges(ids: list[str], pattern: str, density: float, rng: random.Random) -> list[tuple[str, str]]:
+    edges = []
+    n = len(ids)
+    if pattern == "clique":
+        edges = [(a, b) for a in ids for b in ids if a != b]
+    elif pattern == "ring":
+        edges = [(ids[i], ids[(i + 1) % n]) for i in range(n)]
+    elif pattern == "random":
+        edges = [(a, b) for a in ids for b in ids if a != b and rng.random() < density]
+    return edges
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--count", type=int, default=20, help="Number of Sybil accounts to create (default: 20)")
+    parser.add_argument("--cluster", default="wave1", help="Cluster name, tags nodes for later cleanup (default: wave1)")
+    parser.add_argument(
+        "--pattern",
+        choices=["clique", "ring", "random"],
+        default="clique",
+        help="Internal follow topology: clique = everyone follows everyone (classic naive attack), "
+        "ring = each follows the next, random = each pair connected with --density probability",
+    )
+    parser.add_argument("--density", type=float, default=0.3, help="Edge probability for --pattern random (default: 0.3)")
+    parser.add_argument(
+        "--infiltrate-from",
+        nargs="*",
+        default=[],
+        metavar="REAL_USER_ID",
+        help="Real user ids that will each follow every Sybil node (simulates the cluster tricking "
+        "genuine users into following it - this is the only path trust can actually reach the cluster through)",
+    )
+    parser.add_argument(
+        "--target-follows",
+        nargs="*",
+        default=[],
+        metavar="REAL_USER_ID",
+        help="Real user ids that every Sybil node will follow (simulates follower-count inflation "
+        "of a target account; doesn't help the Sybils' own trust score, but stress-tests any "
+        "follower-count-based metric alongside TrustRank)",
+    )
+    parser.add_argument("--seed", type=int, default=None, help="Random seed, for reproducible generation")
+    args = parser.parse_args()
+
+    rng = random.Random(args.seed)
+    ids = [fake_id(rng) for _ in range(args.count)]
+    internal_edges = build_edges(ids, args.pattern, args.density, rng)
+
+    print(f"// Sybil community injection: cluster={args.cluster!r} count={args.count} pattern={args.pattern}")
+    print(f"// Cleanup: MATCH (s:Sybil {{sybil_cluster: {args.cluster!r}}}) DETACH DELETE s;")
+    print()
+    print("// ── Sybil nodes ──")
+    for i, uid in enumerate(ids):
+        print(
+            f'MERGE (u:User:Sybil {{id: "{uid}"}}) '
+            f'SET u.name = "SYBIL_{args.cluster}_{i}", u.bio = "", u.status = "undefined", '
+            f'u.links = "[]", u.indexed_at = timestamp(), u.sybil_cluster = "{args.cluster}";'
+        )
+
+    print()
+    print(f"// ── Internal follows ({args.pattern}, {len(internal_edges)} edges) ──")
+    for a, b in internal_edges:
+        print(
+            f'MATCH (u1:User {{id: "{a}"}}), (u2:User {{id: "{b}"}}) '
+            f'MERGE (u1)-[:FOLLOWS {{indexed_at: timestamp()}}]->(u2);'
+        )
+
+    if args.infiltrate_from:
+        print()
+        print(f"// ── Infiltration follows: real users -> every Sybil ({len(args.infiltrate_from)} x {args.count}) ──")
+        for real_id in args.infiltrate_from:
+            for uid in ids:
+                print(
+                    f'MATCH (u1:User {{id: "{real_id}"}}), (u2:User {{id: "{uid}"}}) '
+                    f'MERGE (u1)-[:FOLLOWS {{indexed_at: timestamp()}}]->(u2);'
+                )
+
+    if args.target_follows:
+        print()
+        print(f"// ── Target inflation: every Sybil -> real target ({args.count} x {len(args.target_follows)}) ──")
+        for target_id in args.target_follows:
+            for uid in ids:
+                print(
+                    f'MATCH (u1:User {{id: "{uid}"}}), (u2:User {{id: "{target_id}"}}) '
+                    f'MERGE (u1)-[:FOLLOWS {{indexed_at: timestamp()}}]->(u2);'
+                )
+
+    total_edges = len(internal_edges) + len(args.infiltrate_from) * args.count + args.count * len(args.target_follows)
+    print(
+        f"// {args.count} Sybil nodes, {total_edges} follow edges generated. "
+        f"Cleanup: MATCH (s:Sybil {{sybil_cluster: {args.cluster!r}}}) DETACH DELETE s;",
+        file=sys.stderr,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds seeded pagerank trust scores to User nodes.

* Trust scores are computed either by cron job or ad hoc by CLI
* PageRank teleportation vector factor can be cusomized through `alpha` parameter. It also affects damping factor which is `1 - alpha`
* Trust computation runs till one of two conditions are met: max iterations or convergance
* Scheduled recomputation can be disabled
* Contains optional report generation
