### PR TITLE
ref(watcher): remove `files_path` from `Event`

### DIFF
--- a/nexus-watcher/src/events/event.rs
+++ b/nexus-watcher/src/events/event.rs
@@ -4,7 +4,7 @@ use nexus_common::universal_tag::homeserver_parsed_uri::HomeserverParsedUri;
 use pubky::Event as StreamEvent;
 use pubky_app_specs::Resource;
 use serde::{Deserialize, Serialize};
-use std::{fmt, path::PathBuf};
+use std::fmt;
 use tracing::{debug, warn};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -71,19 +71,13 @@ pub struct Event {
     /// Parsed representation of [`Self::uri`].
     pub parsed_uri: HomeserverParsedUri,
 
-    /// Local files directory on Nexus used for file-backed events.
-    pub files_path: PathBuf,
-
     /// Original event line as received from the homeserver.
     event_line: String,
 }
 
 impl Event {
     /// Parse event from a line returned by the homeserver's `/events` endpoint.
-    pub fn parse_event(
-        line: &str,
-        files_path: PathBuf,
-    ) -> Result<ParseResult, EventProcessorError> {
+    pub fn parse_event(line: &str) -> Result<ParseResult, EventProcessorError> {
         debug!("New event: {}", line);
         let parts: Vec<&str> = line.split(' ').collect();
         if parts.len() != 2 {
@@ -103,14 +97,13 @@ impl Event {
         let uri = parts[1].to_string();
         let event_line = line.to_string();
 
-        Self::parse_event_parts(event_type, uri, event_line, files_path)
+        Self::parse_event_parts(event_type, uri, event_line)
     }
 
     /// Constructs a nexus [`Event`] directly from a [`StreamEvent`], avoiding
     /// the string round-trip through [`Self::parse_event`].
     pub fn from_stream_event(
         stream_event: &StreamEvent,
-        files_path: PathBuf,
     ) -> Result<Option<Self>, EventProcessorError> {
         let event_type: EventType = stream_event.event_type.clone().into();
 
@@ -118,7 +111,7 @@ impl Event {
         debug!("New stream event: {event_type} {uri}");
 
         let event_line = format!("{event_type} {uri}");
-        match Self::parse_event_parts(event_type, uri, event_line, files_path)? {
+        match Self::parse_event_parts(event_type, uri, event_line)? {
             ParseResult::Parsed(event) => Ok(Some(event)),
             ParseResult::Skipped => Ok(None),
             ParseResult::UnrecognizedUri { reason, .. } => {
@@ -132,7 +125,6 @@ impl Event {
         event_type: EventType,
         uri: String,
         event_line: String,
-        files_path: PathBuf,
     ) -> Result<ParseResult, EventProcessorError> {
         // Validate and parse the URI using HomeserverParsedUri. This handles both
         // standard pubky-app-specs URIs and universal tag URIs from other apps.
@@ -159,7 +151,6 @@ impl Event {
             uri,
             event_type,
             parsed_uri,
-            files_path,
             event_line,
         }))
     }

--- a/nexus-watcher/src/events/handlers/file.rs
+++ b/nexus-watcher/src/events/handlers/file.rs
@@ -80,7 +80,7 @@ async fn ingest(
     let response = pubky.public_storage().get(&pubkyapp_file.src).await?;
 
     let path = Path::new(&user_id.to_string()).join(file_id);
-    let full_path = files_path.join(path.clone());
+    let full_path = files_path.join(&path);
 
     let blob = fetch_capped(response, max_file_size).await?;
     let pubky_app_object = PubkyAppObject::from_resource(&parsed_source_uri.resource, &blob)

--- a/nexus-watcher/src/events/handlers/file.rs
+++ b/nexus-watcher/src/events/handlers/file.rs
@@ -10,7 +10,7 @@ use nexus_common::models::{
     traits::Collection,
 };
 use pubky_app_specs::{ParsedUri, PubkyAppFile, PubkyAppObject, PubkyId};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use tokio::fs::remove_dir_all;
 use tracing::{debug, warn};
 
@@ -20,7 +20,7 @@ pub async fn sync_put(
     uri: String,
     user_id: PubkyId,
     file_id: String,
-    files_path: PathBuf,
+    files_path: &Path,
     max_file_size: u64,
     ingestor: &UserIngestor,
 ) -> Result<(), EventProcessorError> {
@@ -61,7 +61,7 @@ async fn ingest(
     user_id: &PubkyId,
     file_id: &str,
     pubkyapp_file: &PubkyAppFile,
-    files_path: PathBuf,
+    files_path: &Path,
     max_file_size: u64,
     ingestor: &UserIngestor,
 ) -> Result<FileMeta, EventProcessorError> {
@@ -109,7 +109,7 @@ async fn ingest(
 pub async fn del(
     user_id: &PubkyId,
     file_id: String,
-    files_path: PathBuf,
+    files_path: &Path,
 ) -> Result<(), EventProcessorError> {
     debug!("Deleting File resource at {}/{}", user_id, file_id);
     let result = FileDetails::get_by_ids(&[&[user_id, &file_id]]).await?;

--- a/nexus-watcher/src/events/mod.rs
+++ b/nexus-watcher/src/events/mod.rs
@@ -7,7 +7,10 @@ use crate::errors::EventProcessorError;
 use nexus_common::universal_tag::homeserver_parsed_uri::HomeserverParsedUri;
 use nexus_common::WatcherConfig;
 use pubky_app_specs::{PubkyAppObject, Resource};
-use std::sync::Arc;
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 use tracing::debug;
 
 mod fetch;
@@ -35,6 +38,9 @@ pub struct DefaultEventHandler {
     moderation: Arc<Moderation>,
     ingestor: Arc<UserIngestor>,
     max_file_size: u64,
+
+    /// Local files directory on Nexus used for file-backed events.
+    files_path: PathBuf,
 }
 
 impl DefaultEventHandler {
@@ -42,11 +48,13 @@ impl DefaultEventHandler {
         moderation: Arc<Moderation>,
         ingestor: Arc<UserIngestor>,
         max_file_size: u64,
+        files_path: PathBuf,
     ) -> Self {
         Self {
             moderation,
             ingestor,
             max_file_size,
+            files_path,
         }
     }
 
@@ -56,6 +64,7 @@ impl DefaultEventHandler {
             Moderation::from_config(config),
             Arc::new(UserIngestor::from_config(&config.stack)),
             config.max_file_size,
+            config.stack.files_path.clone(),
         )
     }
 }
@@ -68,12 +77,15 @@ impl EventHandler for DefaultEventHandler {
                 handle_put_event(
                     event,
                     self.max_file_size,
+                    self.files_path.as_path(),
                     self.moderation.clone(),
                     self.ingestor.clone(),
                 )
                 .await
             }
-            EventType::Del => handle_del_event(event, self.ingestor.clone()).await,
+            EventType::Del => {
+                handle_del_event(event, self.files_path.as_path(), self.ingestor.clone()).await
+            }
         }?;
 
         event.to_event_line().store().await?;
@@ -84,6 +96,7 @@ impl EventHandler for DefaultEventHandler {
 pub async fn handle_put_event(
     event: &Event,
     max_file_size: u64,
+    files_path: &Path,
     moderation: Arc<Moderation>,
     ingestor: Arc<UserIngestor>,
 ) -> Result<(), EventProcessorError> {
@@ -136,10 +149,8 @@ pub async fn handle_put_event(
             handlers::bookmark::sync_put(user_id, bookmark, bookmark_id).await?
         }
         (PubkyAppObject::Tag(tag), Resource::Tag(tag_id)) => {
-            if moderation.should_delete(&tag, user_id.clone()) {
-                moderation
-                    .apply_moderation(tag, event.files_path.clone())
-                    .await?
+            if moderation.should_delete(&tag, &user_id) {
+                moderation.apply_moderation(tag, files_path).await?
             } else {
                 // Route universal tag events (non-pubky.app apps) to sync_put_resource
                 // which handles Resource nodes for InternalUnknown/InternalUnknown URIs.
@@ -163,7 +174,7 @@ pub async fn handle_put_event(
                 event.uri.clone(),
                 user_id,
                 file_id,
-                event.files_path.clone(),
+                files_path,
                 max_file_size,
                 &ingestor,
             )
@@ -177,6 +188,7 @@ pub async fn handle_put_event(
 /// Handles a DEL event by dispatching to the appropriate handler.
 pub async fn handle_del_event(
     event: &Event,
+    files_path: &Path,
     ingestor: Arc<UserIngestor>,
 ) -> Result<(), EventProcessorError> {
     debug!("Handling DEL event for URI: {}", event.uri);
@@ -194,7 +206,7 @@ pub async fn handle_del_event(
         }
         Resource::Tag(_) => handlers::tag::del(&event.uri).await?,
         Resource::File(file_id) => {
-            handlers::file::del(&user_id, file_id.clone(), event.files_path.clone()).await?
+            handlers::file::del(&user_id, file_id.clone(), files_path).await?
         }
         other => debug!("DEL event type not handled for resource: {other:?}"),
     }

--- a/nexus-watcher/src/events/moderation.rs
+++ b/nexus-watcher/src/events/moderation.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::Path;
 use std::sync::Arc;
 
 use crate::errors::EventProcessorError;
@@ -26,8 +26,8 @@ impl Moderation {
     ///
     /// Returns `true` if the tag was applied by the moderator and matches
     /// a moderated tag label.
-    pub fn should_delete(&self, tag: &PubkyAppTag, tagger_id: PubkyId) -> bool {
-        tagger_id == self.id && self.tags.contains(&tag.label)
+    pub fn should_delete(&self, tag: &PubkyAppTag, tagger_id: &PubkyId) -> bool {
+        tagger_id == &self.id && self.tags.contains(&tag.label)
     }
 
     /// Apply moderation by deleting the tagged resource.
@@ -38,7 +38,7 @@ impl Moderation {
     pub async fn apply_moderation(
         &self,
         moderator_tag: PubkyAppTag,
-        files_path: PathBuf,
+        files_path: &Path,
     ) -> Result<(), EventProcessorError> {
         let lahel = moderator_tag.label;
         let moderated_uri = &moderator_tag.uri;

--- a/nexus-watcher/src/events/retry/processor.rs
+++ b/nexus-watcher/src/events/retry/processor.rs
@@ -1,5 +1,4 @@
 use std::cmp::min;
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::errors::EventProcessorError;
@@ -22,7 +21,6 @@ const RETRY_BATCH_SIZE: usize = 100;
 
 /// Processor for retrying events that failed due to missing dependencies
 pub struct RetryProcessor {
-    pub files_path: PathBuf,
     pub event_handler: Arc<dyn EventHandler>,
     pub shutdown_rx: Receiver<bool>,
     pub config: EventRetryConfig,
@@ -33,10 +31,6 @@ pub struct RetryProcessor {
 
 #[async_trait::async_trait]
 impl TEventProcessor for RetryProcessor {
-    fn files_path(&self) -> &PathBuf {
-        &self.files_path
-    }
-
     fn event_handler(&self) -> &Arc<dyn EventHandler> {
         &self.event_handler
     }
@@ -78,7 +72,6 @@ impl RetryProcessor {
     pub fn new(config: &WatcherConfig, shutdown_rx: Receiver<bool>) -> Self {
         let store: Arc<dyn RetryStore> = Arc::new(RedisRetryStore::new());
         Self {
-            files_path: config.stack.files_path.clone(),
             event_handler: Arc::new(DefaultEventHandler::from_config(config)),
             shutdown_rx,
             config: config.retry.clone(),
@@ -107,7 +100,7 @@ impl RetryProcessor {
         let event_line = format!("{} {}", retry_event.event_type, retry_event.event_uri);
 
         // Parse the event from the line - if corrupted, remove and continue
-        let event = match Event::parse_event(&event_line, self.files_path().clone()) {
+        let event = match Event::parse_event(&event_line) {
             Ok(ParseResult::Parsed(event)) => event,
             Ok(ParseResult::Skipped) | Err(_) => {
                 warn!("Corrupted retry entry for key {index_key}, removing: '{event_line}'");

--- a/nexus-watcher/src/service/indexer/homeserver.rs
+++ b/nexus-watcher/src/service/indexer/homeserver.rs
@@ -9,7 +9,6 @@ use opentelemetry::{global, KeyValue};
 use pubky::Method;
 use pubky_app_specs::PubkyId;
 use std::collections::HashMap;
-use std::path::PathBuf;
 use std::sync::{Arc, LazyLock};
 use tokio::sync::watch::Receiver;
 use tokio::sync::Mutex;
@@ -48,7 +47,6 @@ pub struct HsEventProcessor {
 
     /// See [WatcherConfig::events_limit]
     pub limit: u16,
-    pub files_path: PathBuf,
     pub event_handler: Arc<dyn EventHandler>,
     pub shutdown_rx: Receiver<bool>,
 
@@ -66,10 +64,6 @@ pub struct HsEventProcessor {
 
 #[async_trait::async_trait]
 impl TEventProcessor for HsEventProcessor {
-    fn files_path(&self) -> &PathBuf {
-        &self.files_path
-    }
-
     fn event_handler(&self) -> &Arc<dyn EventHandler> {
         &self.event_handler
     }

--- a/nexus-watcher/src/service/indexer/key_based.rs
+++ b/nexus-watcher/src/service/indexer/key_based.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 use crate::errors::EventProcessorError;
 use crate::events::Event;
@@ -82,7 +82,6 @@ pub struct KeyBasedEventProcessor {
     /// Bounds execution time per user, preventing timeout and starvation.
     pub limit: u16,
 
-    pub files_path: PathBuf,
     pub event_handler: Arc<dyn EventHandler>,
     pub event_source: Arc<dyn KeyBasedEventSource>,
     pub user_not_found_backoff: Arc<UserNotFoundBackoff>,
@@ -100,10 +99,6 @@ pub struct KeyBasedEventProcessor {
 
 #[async_trait::async_trait]
 impl TEventProcessor for KeyBasedEventProcessor {
-    fn files_path(&self) -> &PathBuf {
-        &self.files_path
-    }
-
     fn event_handler(&self) -> &Arc<dyn EventHandler> {
         &self.event_handler
     }
@@ -315,7 +310,7 @@ impl KeyBasedEventProcessor {
 
             let cursor_id = stream_event.cursor.id();
 
-            match Event::from_stream_event(&stream_event, self.files_path.clone()) {
+            match Event::from_stream_event(&stream_event) {
                 Ok(Some(event)) => {
                     // External homeservers must not index another user's URI.
                     if let Err(err) = Self::validate_user_id(hs_id, &event, user_id) {

--- a/nexus-watcher/src/service/indexer/mod.rs
+++ b/nexus-watcher/src/service/indexer/mod.rs
@@ -3,7 +3,7 @@ mod key_based;
 
 pub use homeserver::HsEventProcessor;
 pub use key_based::{KeyBasedEventProcessor, KeyBasedEventSource, PubkyKeyBasedEventSource};
-use std::{fmt::Display, path::PathBuf, sync::Arc, time::Duration};
+use std::{fmt::Display, sync::Arc, time::Duration};
 
 use tracing::Instrument;
 
@@ -57,8 +57,6 @@ impl Display for RunError {
 ///   different processor implementations
 #[async_trait::async_trait]
 pub trait TEventProcessor: Send + Sync + 'static {
-    fn files_path(&self) -> &PathBuf;
-
     /// Returns the event handler used to process events.
     ///
     /// This allows for flexible event handling implementations, including mocked versions for testing.
@@ -126,7 +124,7 @@ pub trait TEventProcessor: Send + Sync + 'static {
     /// Unknown resource events are handled via `HomeserverParsedUri::UnknownResource` →
     /// `DefaultEventHandler` → `tag::sync_put_resource` (main flow).
     async fn process_event_line(&self, line: &str) -> Result<(), EventProcessorError> {
-        match Event::parse_event(line, self.files_path().clone()) {
+        match Event::parse_event(line) {
             // Invalid event lines come from untrusted homeservers; treat as bad peer data, not Nexus errors.
             Err(e) => warn!("{e}"),
             Ok(ParseResult::Skipped) => {}

--- a/nexus-watcher/src/service/runner/homeserver.rs
+++ b/nexus-watcher/src/service/runner/homeserver.rs
@@ -6,7 +6,6 @@ use nexus_common::models::homeserver::Homeserver;
 use nexus_common::types::DynError;
 use nexus_common::WatcherConfig;
 use pubky_app_specs::PubkyId;
-use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::watch::Receiver;
 
@@ -14,7 +13,6 @@ pub struct HsEventProcessorRunner {
     /// See [WatcherConfig::events_limit]
     pub limit: u16,
 
-    pub files_path: PathBuf,
     pub event_handler: Arc<dyn EventHandler>,
     pub shutdown_rx: Receiver<bool>,
 
@@ -30,7 +28,6 @@ impl HsEventProcessorRunner {
     pub fn from_config(config: &WatcherConfig, shutdown_rx: Receiver<bool>) -> Self {
         Self {
             limit: config.events_limit,
-            files_path: config.stack.files_path.clone(),
             event_handler: Arc::new(DefaultEventHandler::from_config(config)),
             shutdown_rx,
             default_homeserver: config.homeserver.clone(),
@@ -59,7 +56,6 @@ impl TEventProcessorRunner for HsEventProcessorRunner {
         Ok(Arc::new(HsEventProcessor {
             homeserver,
             limit: self.limit,
-            files_path: self.files_path.clone(),
             event_handler: self.event_handler.clone(),
             shutdown_rx: self.shutdown_rx.clone(),
             retry_scheduler: self.retry_scheduler.clone(),

--- a/nexus-watcher/src/service/runner/key_based.rs
+++ b/nexus-watcher/src/service/runner/key_based.rs
@@ -10,7 +10,6 @@ use nexus_common::models::homeserver::{Homeserver, HsBlacklist};
 use nexus_common::types::DynError;
 use nexus_common::WatcherConfig;
 use pubky_app_specs::PubkyId;
-use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::{watch::Receiver, Mutex};
 use tracing::{debug, info, warn};
@@ -23,7 +22,6 @@ pub struct KeyBasedEventProcessorRunner {
     /// See [WatcherConfig::monitored_homeservers_limit]
     pub monitored_hs_limit: usize,
 
-    pub files_path: PathBuf,
     pub event_handler: Arc<dyn EventHandler>,
     pub event_source: Arc<dyn KeyBasedEventSource>,
     pub shutdown_rx: Receiver<bool>,
@@ -50,7 +48,6 @@ impl KeyBasedEventProcessorRunner {
         Self {
             limit: config.key_based_events_limit,
             monitored_hs_limit: config.monitored_homeservers_limit,
-            files_path: config.stack.files_path.clone(),
             event_handler: Arc::new(DefaultEventHandler::from_config(config)),
             event_source: Arc::new(PubkyKeyBasedEventSource),
             shutdown_rx,
@@ -93,7 +90,6 @@ impl TEventProcessorRunner for KeyBasedEventProcessorRunner {
         Ok(Arc::new(KeyBasedEventProcessor {
             homeserver_id,
             limit: self.limit,
-            files_path: self.files_path.clone(),
             event_handler: self.event_handler.clone(),
             event_source: self.event_source.clone(),
             user_not_found_backoff: self.user_not_found_backoff.clone(),

--- a/nexus-watcher/tests/event_processor/files/blacklist.rs
+++ b/nexus-watcher/tests/event_processor/files/blacklist.rs
@@ -68,7 +68,7 @@ async fn test_file_ingest_aborts_on_blacklisted_source_homeserver() -> Result<()
         file_uri,
         user_pubky_id,
         file_id.clone(),
-        test.temp_dir.path().to_path_buf(),
+        test.temp_dir.path(),
         DEFAULT_MAX_FILE_SIZE,
         &ingestor,
     )
@@ -128,7 +128,7 @@ async fn test_file_ingest_aborts_when_source_is_blacklisted_hs_pk_directly() -> 
         file_uri,
         owner_id.clone(),
         file_id.clone(),
-        test.temp_dir.path().to_path_buf(),
+        test.temp_dir.path(),
         DEFAULT_MAX_FILE_SIZE,
         &ingestor,
     )
@@ -177,7 +177,7 @@ async fn test_file_ingest_proceeds_when_source_homeserver_not_blacklisted() -> R
         file_uri,
         user_pubky_id,
         file_id.clone(),
-        test.temp_dir.path().to_path_buf(),
+        test.temp_dir.path(),
         DEFAULT_MAX_FILE_SIZE,
         &ingestor,
     )

--- a/nexus-watcher/tests/event_processor/files/delete.rs
+++ b/nexus-watcher/tests/event_processor/files/delete.rs
@@ -127,8 +127,7 @@ async fn test_delete_pubkyapp_file_is_idempotent() -> Result<()> {
 
     // Simulate a replay: call the DEL handler again directly (e.g. crash between FS delete and store_event)
     let user_pubky_id = PubkyId::try_from(user_id.as_str()).map_err(anyhow::Error::msg)?;
-    let result =
-        handlers::file::del(&user_pubky_id, file_id, test.temp_dir.path().to_path_buf()).await;
+    let result = handlers::file::del(&user_pubky_id, file_id, test.temp_dir.path()).await;
 
     assert!(
         result.is_ok(),

--- a/nexus-watcher/tests/event_processor/utils/watcher.rs
+++ b/nexus-watcher/tests/event_processor/utils/watcher.rs
@@ -3,7 +3,6 @@ use anyhow::{anyhow, Error, Result};
 use base32::{encode, Alphabet};
 use chrono::Utc;
 use nexus_common::db::PubkyConnector;
-use nexus_common::get_files_dir_pathbuf;
 use nexus_common::models::file::FileDetails;
 use nexus_common::models::homeserver::Homeserver;
 use nexus_common::models::traits::Collection;
@@ -91,6 +90,7 @@ impl WatcherTest {
             default_moderation_tests(),
             default_ingestor_tests(),
             max_file_size,
+            files_path.clone(),
         ));
 
         let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
@@ -106,7 +106,6 @@ impl WatcherTest {
 
         HsEventProcessorRunner {
             limit: 1000,
-            files_path,
             event_handler,
             shutdown_rx,
             default_homeserver,
@@ -378,7 +377,7 @@ pub async fn retrieve_and_handle_event_line(
     event_line: &str,
     event_handler: Arc<dyn EventHandler>,
 ) -> Result<(), EventProcessorError> {
-    match Event::parse_event(event_line, get_files_dir_pathbuf())? {
+    match Event::parse_event(event_line)? {
         ParseResult::Parsed(event) => event_handler.handle(&event).await,
         ParseResult::Skipped | ParseResult::UnrecognizedUri { .. } => Ok(()),
     }

--- a/nexus-watcher/tests/event_processor/utils/watcher.rs
+++ b/nexus-watcher/tests/event_processor/utils/watcher.rs
@@ -90,7 +90,7 @@ impl WatcherTest {
             default_moderation_tests(),
             default_ingestor_tests(),
             max_file_size,
-            files_path.clone(),
+            files_path,
         ));
 
         let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);

--- a/nexus-watcher/tests/service/event_processor_prioritization.rs
+++ b/nexus-watcher/tests/service/event_processor_prioritization.rs
@@ -30,6 +30,7 @@ async fn test_event_processor_runner_default_homeserver_excluded() -> Result<(),
         default_moderation_tests(),
         default_ingestor_tests(),
         DEFAULT_MAX_FILE_SIZE,
+        PathBuf::from("/tmp/nexus-watcher-test"),
     ));
     let store: Arc<dyn RetryStore> = Arc::new(RedisRetryStore::new());
     let retry_scheduler = Arc::new(RetryScheduler::new(
@@ -42,7 +43,6 @@ async fn test_event_processor_runner_default_homeserver_excluded() -> Result<(),
     let runner = KeyBasedEventProcessorRunner {
         limit: 1000,
         monitored_hs_limit: HS_IDS.len(),
-        files_path: PathBuf::from("/tmp/nexus-watcher-test"),
         event_handler,
         event_source: Arc::new(PubkyKeyBasedEventSource),
         shutdown_rx: tokio::sync::watch::channel(false).1,
@@ -78,6 +78,7 @@ async fn test_event_processor_runner_blacklisted_homeserver_excluded() -> Result
         default_moderation_tests(),
         default_ingestor_tests(),
         DEFAULT_MAX_FILE_SIZE,
+        PathBuf::from("/tmp/nexus-watcher-test"),
     ));
     let store: Arc<dyn RetryStore> = Arc::new(RedisRetryStore::new());
     let retry_scheduler = Arc::new(RetryScheduler::new(
@@ -94,7 +95,6 @@ async fn test_event_processor_runner_blacklisted_homeserver_excluded() -> Result
     let runner = KeyBasedEventProcessorRunner {
         limit: 1000,
         monitored_hs_limit: 100,
-        files_path: PathBuf::from("/tmp/nexus-watcher-test"),
         event_handler,
         event_source: Arc::new(PubkyKeyBasedEventSource),
         shutdown_rx: tokio::sync::watch::channel(false).1,

--- a/nexus-watcher/tests/service/hs_event_processor.rs
+++ b/nexus-watcher/tests/service/hs_event_processor.rs
@@ -1,4 +1,3 @@
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -66,7 +65,6 @@ fn build_processor(
     Arc::new(HsEventProcessor {
         homeserver: Homeserver::new(hs_id),
         limit: 100,
-        files_path: PathBuf::from("/tmp/test"),
         event_handler,
         shutdown_rx,
         retry_scheduler,

--- a/nexus-watcher/tests/service/key_based_event_processor.rs
+++ b/nexus-watcher/tests/service/key_based_event_processor.rs
@@ -1,4 +1,3 @@
-use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -775,7 +774,6 @@ fn processor_with_options(
     Arc::new(KeyBasedEventProcessor {
         homeserver_id: homeserver.id,
         limit,
-        files_path: PathBuf::from("/tmp/nexus-watcher-test"),
         event_handler: handler,
         event_source: source,
         user_not_found_backoff,

--- a/nexus-watcher/tests/service/retry_processor.rs
+++ b/nexus-watcher/tests/service/retry_processor.rs
@@ -13,7 +13,6 @@ use nexus_watcher::events::EventHandler;
 use nexus_watcher::events::EventType;
 use nexus_watcher::service::TEventProcessor;
 use pubky_app_specs::post_uri_builder;
-use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::watch;
 
@@ -71,7 +70,6 @@ fn build_processor(
     shutdown_rx: watch::Receiver<bool>,
 ) -> Arc<RetryProcessor> {
     Arc::new(RetryProcessor {
-        files_path: PathBuf::from("/tmp/test"),
         event_handler,
         shutdown_rx,
         config,

--- a/nexus-watcher/tests/service/utils/processor.rs
+++ b/nexus-watcher/tests/service/utils/processor.rs
@@ -1,4 +1,3 @@
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::service::utils::common::create_mock_handler;
@@ -24,16 +23,11 @@ pub struct MockEventProcessor {
     sleep_duration: Option<Duration>,
     custom_timeout: Option<Duration>,
     shutdown_rx: Receiver<bool>,
-    files_path: PathBuf,
     event_handler: Arc<dyn EventHandler>,
 }
 
 #[async_trait::async_trait]
 impl TEventProcessor for MockEventProcessor {
-    fn files_path(&self) -> &PathBuf {
-        &self.files_path
-    }
-
     fn event_handler(&self) -> &Arc<dyn EventHandler> {
         &self.event_handler
     }
@@ -120,7 +114,6 @@ pub async fn create_random_homeservers_and_persist(
         processor_status,
         custom_timeout,
         shutdown_rx,
-        files_path: PathBuf::from("/tmp/mock"),
         event_handler: create_mock_handler(Ok(()), None),
     };
     event_processor_list.push(event_processor);
@@ -148,7 +141,6 @@ pub fn create_mock_event_processors(
             processor_status: status,
             custom_timeout,
             shutdown_rx: shutdown_rx.clone(),
-            files_path: PathBuf::from("/tmp/mock"),
             event_handler: event_handler.clone(),
         },
     )


### PR DESCRIPTION
This PR moves the Nexus static-files path out of parsed `Event` values and into `DefaultEventHandler`, where file handling context belongs.

- Removes `files_path` from `Event` parsing and stream conversion.
- Passes the configured path to file and moderation handlers as `&Path`.
- Removes now-redundant path state from indexers, runners, retry processing, and test processor fixtures.
- Preserves existing event handling, retry, size-limit, and HS blacklist behavior.

Supersedes #838 (brings that PR's proposed logic on top of the latest `main`).

---

### Pre-submission Checklist

- [x] I manually reviewed the PR
- [x] I asked one or more LLMs to review the PR
- [x] I asked one or more LLMs to check if this PR can be simplified [^1]
- [x] If appropriate, I added tests for the changes in this PR
- [ ] If appropriate, I added performance benchmarks for the APIs added in this PR [^2]

[^1]: Sample prompt: "Can this be simplified? Can the code, comments, or logic introduced by these changes be simplfied, clarified or otherwise made more terse, concise and understandable, without affecting functionality?"
[^2]: `cargo bench -p nexus-webapi`
