### PR TITLE
chore: rename Default HS -> Primary HS

### DIFF
--- a/docs/decentralization.md
+++ b/docs/decentralization.md
@@ -6,8 +6,8 @@ These are technical notes describing configuration fields related to Decentraliz
 
 ## 1. Background
 
-Originally the watcher pointed at one default HS and bulk-ingested all of
-its events. With decentralization, Nexus still bulk-indexes the default HS but
+Originally the watcher pointed at one primary HS and bulk-ingested all of
+its events. With decentralization, Nexus still bulk-indexes the primary HS but
 *also* indexes users hosted on other ("third-party") HSs on a per-user
 basis, using each HS's user-events endpoint. A separate task resolves each user's
 currently-published HS from PKDNS/DHT and records it as a
@@ -17,7 +17,7 @@ pull from which HS.
 These run as parallel tasks started in `NexusWatcher::start`, each driving one
 runner; the sections below group each config field under the runner it drives:
 
-- [Section 2: Bulk indexing of default HS](#2-indexing-the-default-hs-bulk)
+- [Section 2: Bulk indexing of primary HS](#2-indexing-the-primary-hs-bulk)
 - [Section 3: Key-based indexing of externally-hosted users](#3-indexing-externally-hosted-users-key-based)
 - [Section 4: User → HS resolution](#4-user--hs-resolution)
 - [Section 5: Event retry & backoff](#5-event-retry--backoff--watcherretry)
@@ -25,25 +25,25 @@ runner; the sections below group each config field under the runner it drives:
 
 ---
 
-## 2. Indexing the default HS (bulk)
+## 2. Indexing the primary HS (bulk)
 
-The baseline, pre-decentralization path: the default HS is indexed in *bulk* — all
+The baseline, pre-decentralization path: the primary HS is indexed in *bulk* — all
 of its events are pulled from the HS `/events` endpoint. Driven by `HsEventProcessorRunner`.
 
-The default HS is trusted, which implies a different event validation model.
+The primary HS is trusted, which implies a different event validation model.
 
 ### `homeserver`
 
-> The single default, prioritized HS. Its events are bulk-ingested.
+> The single primary, prioritized HS. Its events are bulk-ingested.
 
 It is explicitly *excluded* from the third-party (`KeyBasedEventProcessorRunner`)
 list so it is never double-indexed (`hs_by_priority`). Changing this re-points
-the entire default-HS pipeline; the HS is persisted to the graph on startup
+the entire primary-HS pipeline; the HS is persisted to the graph on startup
 (`Homeserver::persist_if_unknown`).
 
 ### `events_limit`
 
-> Maximum number of events fetched **per run** from the default HS.
+> Maximum number of events fetched **per run** from the primary HS.
 
 Validated at deserialize time (`deserialize_events_limit`): `0` is rejected, and
 values above the max are rejected rather than clamped.
@@ -51,9 +51,9 @@ values above the max are rejected rather than clamped.
 *Tuning:* higher → more throughput per tick but larger batches and longer
 per-run latency. Lower → smoother but slower to drain a backlog.
 
-### `default_hs_monitoring_interval_ms`
+### `primary_hs_monitoring_interval_ms`
 
-> Scheduling interval[^1] for triggering runs of the **default-HS** indexing runner
+> Scheduling interval[^1] for triggering runs of the **primary-HS** indexing runner
 > (`HsEventProcessorRunner`).
 
 *Tuning:* lower → fresher data, more load on HSs and DBs. Higher → less load,
@@ -64,9 +64,9 @@ more lag between an event being published and indexed.
 ## 3. Indexing externally-hosted users (key-based)
 
 The core of decentralization. Driven by `KeyBasedEventProcessorRunner`, which
-indexes users hosted on **third-party** HSs — any HS other than the default
-(also called "external" or "non-default"). For every monitored HS *except* the
-default, it pulls each hosted user's events per user from the HS `/events-stream`
+indexes users hosted on **third-party** HSs — any HS other than the primary
+(also called "external" or "secondary"). For every monitored HS *except* the
+primary, it pulls each hosted user's events per user from the HS `/events-stream`
 endpoint (hence "key-based" — keyed on each user's pubky). Configured in
 `KeyBasedEventProcessorRunner::from_config`.
 
@@ -82,12 +82,12 @@ resolutions) per tick. Raise deliberately as the network of indexed HSs grows.
 ### `external_hs_monitoring_interval_ms`
 
 > Scheduling interval[^1] for this `KeyBasedEventProcessorRunner` (the external-HS
-> monitoring task). Independent of `default_hs_monitoring_interval_ms` so the two
+> monitoring task). Independent of `primary_hs_monitoring_interval_ms` so the two
 > cadences can be tuned separately.
 
 *Tuning:* lower → fresher data from external HSs, more load on them and the DBs.
 Higher → less load, more lag. External-HS runs typically touch many users across
-many HSs, so this is often set larger than `default_hs_monitoring_interval_ms`.
+many HSs, so this is often set larger than `primary_hs_monitoring_interval_ms`.
 
 ### `key_based_events_limit`
 
@@ -153,7 +153,7 @@ belong to which HS.
 
 > Scheduling interval[^1] for triggering runs of the resolver task.
 
-**Independent** of `default_hs_monitoring_interval_ms` and
+**Independent** of `primary_hs_monitoring_interval_ms` and
 `external_hs_monitoring_interval_ms` — resolution and indexing tick on separate clocks.
 
 *Tuning:* lower → mappings react faster to users migrating HSs, more PKDNS/DHT
@@ -223,7 +223,7 @@ avoid hammering an HS for content that may not exist yet.
 |---|---|---|---|
 | `homeserver` | `[watcher]` | `PubkyId` | Synonym HS |
 | `events_limit` | `[watcher]` | `u16` | `50` (max `1000`; code default `1000`) |
-| `default_hs_monitoring_interval_ms` | `[watcher]` | `u64` ms | `5000` |
+| `primary_hs_monitoring_interval_ms` | `[watcher]` | `u64` ms | `5000` |
 | `external_hs_monitoring_interval_ms` | `[watcher]` | `u64` ms | `5000` |
 | `monitored_homeservers_limit` | `[watcher]` | `usize` | `50` |
 | `key_based_events_limit` | `[watcher]` | `u16` | `50` (max `100`) |

--- a/examples/watcher/watcher-config.toml
+++ b/examples/watcher/watcher-config.toml
@@ -1,7 +1,7 @@
 homeserver = "8um71us3fyw6h8wbcxb5ar3rwusy1a6u49956ikzojg3gcwd1dty"
 events_limit = 50
 key_based_events_limit = 50
-default_hs_monitoring_interval_ms = 5000
+primary_hs_monitoring_interval_ms = 5000
 external_hs_monitoring_interval_ms = 5000
 hs_resolver_interval_ms = 10000
 # Initial backoff duration (in seconds) after the first failure of a homeserver

--- a/nexus-common/default.config.toml
+++ b/nexus-common/default.config.toml
@@ -29,13 +29,13 @@ burst = 5
 [watcher]
 # Synonym homeserver pubky
 homeserver = "8um71us3fyw6h8wbcxb5ar3rwusy1a6u49956ikzojg3gcwd1dty"
-# Maximum number of events to fetch per run from the default homeserver (max: 1000)
+# Maximum number of events to fetch per run from the primary homeserver (max: 1000)
 events_limit = 50
-# Maximum events per user per run for key-based (non-default) homeservers (max: 100)
+# Maximum events per user per run for key-based (third-party) homeservers (max: 100)
 key_based_events_limit = 50
 # Maximum number of monitored external homeservers.
 monitored_homeservers_limit = 50
-default_hs_monitoring_interval_ms = 5000
+primary_hs_monitoring_interval_ms = 5000
 external_hs_monitoring_interval_ms = 5000
 hs_resolver_interval_ms = 10000
 # Minimum time (ms) before a user's homeserver mapping is considered stale and therefore eligible to be re-resolved (default: 1 hour)

--- a/nexus-common/src/config/daemon.rs
+++ b/nexus-common/src/config/daemon.rs
@@ -87,7 +87,7 @@ mod tests {
         );
         assert_eq!(c.watcher.events_limit, 50);
         assert_eq!(c.watcher.key_based_events_limit, 50);
-        assert_eq!(c.watcher.default_hs_monitoring_interval_ms, 5_000);
+        assert_eq!(c.watcher.primary_hs_monitoring_interval_ms, 5_000);
         assert_eq!(c.watcher.external_hs_monitoring_interval_ms, 5_000);
         assert_eq!(c.watcher.hs_resolver_interval_ms, 10_000);
         assert_eq!(
@@ -166,7 +166,7 @@ mod tests {
     fn test_legacy_watcher_interval_aliases_still_parse() {
         let toml = DEFAULT_CONFIG_TOML
             .replace(
-                "default_hs_monitoring_interval_ms = 5000",
+                "primary_hs_monitoring_interval_ms = 5000",
                 "watcher_sleep = 7000",
             )
             .replace(
@@ -178,7 +178,7 @@ mod tests {
             "legacy watcher_sleep / hs_resolver_sleep field names must still parse via aliases",
         );
 
-        assert_eq!(c.watcher.default_hs_monitoring_interval_ms, 7_000);
+        assert_eq!(c.watcher.primary_hs_monitoring_interval_ms, 7_000);
         assert_eq!(c.watcher.hs_resolver_interval_ms, 20_000);
     }
 }

--- a/nexus-common/src/config/watcher.rs
+++ b/nexus-common/src/config/watcher.rs
@@ -13,8 +13,8 @@ pub const DEFAULT_EVENTS_LIMIT: u16 = 1_000;
 pub const DEFAULT_KEY_BASED_EVENTS_LIMIT: u16 = 50;
 /// Default for [WatcherConfig::monitored_homeservers_limit]
 pub const DEFAULT_MONITORED_HOMESERVERS_LIMIT: usize = 50;
-/// Default for [WatcherConfig::default_hs_monitoring_interval_ms]
-pub const DEFAULT_DEFAULT_HS_MONITORING_INTERVAL_MS: u64 = 5_000;
+/// Default for [WatcherConfig::primary_hs_monitoring_interval_ms]
+pub const DEFAULT_PRIMARY_HS_MONITORING_INTERVAL_MS: u64 = 5_000;
 /// Default for [WatcherConfig::external_hs_monitoring_interval_ms]
 pub const DEFAULT_EXTERNAL_HS_MONITORING_INTERVAL_MS: u64 = 5_000;
 /// Default for [WatcherConfig::hs_resolver_interval_ms]
@@ -96,12 +96,12 @@ pub struct WatcherConfig {
     /// Default, prioritized homeserver
     pub homeserver: PubkyId,
 
-    /// Maximum number of events to fetch per run from the default homeserver.
+    /// Maximum number of events to fetch per run from the primary homeserver.
     /// Must not exceed [MAX_EVENTS_LIMIT].
     #[serde(deserialize_with = "deserialize_events_limit")]
     pub events_limit: u16,
 
-    /// Maximum events per user per run for key-based (non-default) homeservers.
+    /// Maximum events per user per run for key-based (external) homeservers.
     /// Must not exceed [MAX_KEY_BASED_EVENTS_LIMIT].
     #[serde(
         default = "default_key_based_events_limit",
@@ -112,10 +112,10 @@ pub struct WatcherConfig {
     /// Maximum number of monitored homeservers
     pub monitored_homeservers_limit: usize,
 
-    /// Scheduling interval (ms) at which the default-HS monitoring task is triggered.
+    /// Scheduling interval (ms) at which the primary-HS monitoring task is triggered.
     /// The alias `watcher_sleep` is kept for backward compatibility.
     #[serde(alias = "watcher_sleep")]
-    pub default_hs_monitoring_interval_ms: u64,
+    pub primary_hs_monitoring_interval_ms: u64,
 
     /// Scheduling interval (ms) at which the key-based (external HS) monitoring task is triggered.
     #[serde(default = "default_external_hs_monitoring_interval_ms")]
@@ -173,7 +173,7 @@ impl Default for WatcherConfig {
             events_limit: DEFAULT_EVENTS_LIMIT,
             key_based_events_limit: DEFAULT_KEY_BASED_EVENTS_LIMIT,
             monitored_homeservers_limit: DEFAULT_MONITORED_HOMESERVERS_LIMIT,
-            default_hs_monitoring_interval_ms: DEFAULT_DEFAULT_HS_MONITORING_INTERVAL_MS,
+            primary_hs_monitoring_interval_ms: DEFAULT_PRIMARY_HS_MONITORING_INTERVAL_MS,
             external_hs_monitoring_interval_ms: DEFAULT_EXTERNAL_HS_MONITORING_INTERVAL_MS,
             hs_resolver_interval_ms: DEFAULT_HS_RESOLVER_INTERVAL_MS,
             hs_resolver_ttl: DEFAULT_HS_RESOLVER_TTL,

--- a/nexus-watcher/src/service/indexer/homeserver.rs
+++ b/nexus-watcher/src/service/indexer/homeserver.rs
@@ -41,9 +41,9 @@ pub enum HsMapping {
     Other { hs_id: String },
 }
 
-/// Event processor for the default homeserver
+/// Event processor for the primary homeserver
 pub struct HsEventProcessor {
-    /// The default HS endpoint this processor fetches events from
+    /// The primary HS endpoint this processor fetches events from
     pub homeserver: Homeserver,
 
     /// See [WatcherConfig::events_limit]

--- a/nexus-watcher/src/service/indexer/key_based.rs
+++ b/nexus-watcher/src/service/indexer/key_based.rs
@@ -73,7 +73,8 @@ impl KeyBasedEventSource for PubkyKeyBasedEventSource {
     }
 }
 
-/// Event processor for non-default HSs, where the user-specific `/events-stream` endpoint is used
+/// Event processor for third-party (external) HSs, where the user-specific `/events-stream`
+/// endpoint is used
 pub struct KeyBasedEventProcessor {
     /// The HS endpoint this processor fetches events from
     pub homeserver_id: PubkyId,

--- a/nexus-watcher/src/service/mod.rs
+++ b/nexus-watcher/src/service/mod.rs
@@ -76,7 +76,7 @@ impl NexusWatcher {
     /// Starts the Nexus Watcher with parallel periodic task loops.
     ///
     /// Currently runs four tasks, each on its own tick interval:
-    /// 1. **Default homeserver** ([`WatcherConfig::default_hs_monitoring_interval_ms`]).
+    /// 1. **Primary homeserver** ([`WatcherConfig::primary_hs_monitoring_interval_ms`]).
     /// 2. **External homeservers** ([`WatcherConfig::external_hs_monitoring_interval_ms`]).
     /// 3. **User HS resolver** ([`WatcherConfig::hs_resolver_interval_ms`]).
     /// 4. **Retry processor** (see `RETRY_PROCESSOR_SLEEP`).
@@ -89,7 +89,7 @@ impl NexusWatcher {
 
         Homeserver::persist_if_unknown(config.homeserver.clone()).await?;
 
-        let default_hs_monitoring_interval_ms = config.default_hs_monitoring_interval_ms;
+        let primary_hs_monitoring_interval_ms = config.primary_hs_monitoring_interval_ms;
         let external_hs_monitoring_interval_ms = config.external_hs_monitoring_interval_ms;
         let hs_resolver_interval_ms = config.hs_resolver_interval_ms;
 
@@ -112,8 +112,8 @@ impl NexusWatcher {
 
         let tasks = vec![
             PeriodicTask::new(
-                "default-homeserver",
-                default_hs_monitoring_interval_ms,
+                "primary-homeserver",
+                primary_hs_monitoring_interval_ms,
                 move || {
                     let runner = hs_runner.clone();
                     async move { runner.run().await.map(|_| ()) }

--- a/nexus-watcher/src/service/runner/homeserver.rs
+++ b/nexus-watcher/src/service/runner/homeserver.rs
@@ -19,7 +19,7 @@ pub struct HsEventProcessorRunner {
     pub shutdown_rx: Receiver<bool>,
 
     /// See [WatcherConfig::homeserver]
-    pub default_homeserver: PubkyId,
+    pub primary_homeserver: PubkyId,
 
     /// Scheduler shared with every processor this runner builds
     pub retry_scheduler: Arc<RetryScheduler>,
@@ -33,13 +33,13 @@ impl HsEventProcessorRunner {
             files_path: config.stack.files_path.clone(),
             event_handler: Arc::new(DefaultEventHandler::from_config(config)),
             shutdown_rx,
-            default_homeserver: config.homeserver.clone(),
+            primary_homeserver: config.homeserver.clone(),
             retry_scheduler: Arc::new(RetryScheduler::from_config(config)),
         }
     }
 
-    pub fn default_homeserver(&self) -> &str {
-        &self.default_homeserver
+    pub fn primary_homeserver(&self) -> &str {
+        &self.primary_homeserver
     }
 }
 
@@ -68,6 +68,6 @@ impl TEventProcessorRunner for HsEventProcessorRunner {
     }
 
     async fn pre_run(&self) -> Result<Vec<String>, DynError> {
-        Ok(vec![self.default_homeserver.to_string()])
+        Ok(vec![self.primary_homeserver.to_string()])
     }
 }

--- a/nexus-watcher/src/service/runner/key_based.rs
+++ b/nexus-watcher/src/service/runner/key_based.rs
@@ -28,8 +28,8 @@ pub struct KeyBasedEventProcessorRunner {
     pub event_source: Arc<dyn KeyBasedEventSource>,
     pub shutdown_rx: Receiver<bool>,
 
-    /// Default homeserver ID, excluded from the external targets list
-    pub default_homeserver: PubkyId,
+    /// Primary homeserver ID, excluded from the external targets list
+    pub primary_homeserver: PubkyId,
 
     /// HS PKs that must never be indexed. Excluded from `pre_run` and re-checked
     /// by each [`KeyBasedEventProcessor`] this runner builds.
@@ -54,7 +54,7 @@ impl KeyBasedEventProcessorRunner {
             event_handler: Arc::new(DefaultEventHandler::from_config(config)),
             event_source: Arc::new(PubkyKeyBasedEventSource),
             shutdown_rx,
-            default_homeserver: config.homeserver.clone(),
+            primary_homeserver: config.homeserver.clone(),
             hs_blacklist: HsBlacklist::from_config(&config.stack),
             backoff: Mutex::new(HomeserverBackoff::new(
                 config.initial_backoff_secs,
@@ -71,8 +71,8 @@ impl KeyBasedEventProcessorRunner {
 
         let result_hs_ids: Vec<String> = active_hs_ids
             .into_iter()
-            // Exclude the default HS, as it is processed separately
-            .filter(|hs_id| hs_id != self.default_homeserver.as_ref())
+            // Exclude the primary HS, as it is processed separately
+            .filter(|hs_id| hs_id != self.primary_homeserver.as_ref())
             // Exclude any blacklisted HS
             .filter(|hs_id| !self.hs_blacklist.is_blacklisted(hs_id))
             .collect();

--- a/nexus-watcher/tests/event_processor/utils/watcher.rs
+++ b/nexus-watcher/tests/event_processor/utils/watcher.rs
@@ -83,7 +83,7 @@ impl WatcherTest {
     /// # Returns
     /// Returns a fully configured `HsEventProcessorRunner` ready for use in tests.
     fn create_test_event_processor_runner(
-        default_homeserver: PubkyId,
+        primary_homeserver: PubkyId,
         files_path: PathBuf,
         max_file_size: u64,
     ) -> HsEventProcessorRunner {
@@ -109,7 +109,7 @@ impl WatcherTest {
             files_path,
             event_handler,
             shutdown_rx,
-            default_homeserver,
+            primary_homeserver,
             retry_scheduler,
         }
     }

--- a/nexus-watcher/tests/service/event_processing_multiple_homeservers.rs
+++ b/nexus-watcher/tests/service/event_processing_multiple_homeservers.rs
@@ -40,7 +40,7 @@ async fn test_multiple_homeserver_event_processing() -> Result<()> {
 
     let runner = MockEventProcessorRunner::new(event_processor_list, 4, shutdown_rx);
 
-    // run excludes the default homeserver (the first one), so only 3 are processed
+    // run excludes the primary homeserver (the first one), so only 3 are processed
     let stats = runner.run().await.unwrap().0;
     assert_eq!(stats.count_ok(), 2);
     assert_eq!(stats.count_error(), 1);
@@ -73,7 +73,7 @@ async fn test_multi_hs_event_processing_with_homeserver_limit() -> Result<()> {
     assert_eq!(event_processor_list.len(), 5); // Ensure 5 HSs are available
     let hs_limit = 3;
     let runner = MockEventProcessorRunner::new(event_processor_list, hs_limit, shutdown_rx);
-    // run excludes the default HS, so 4 non-default HSs available, limited to 3
+    // run excludes the primary HS, so 4 external HSs available, limited to 3
     let stats = runner.run().await.unwrap().0;
 
     assert_eq!(stats.count_ok(), 3); // 3 successful ones, due to the limit
@@ -106,14 +106,14 @@ async fn test_multi_hs_event_processing_with_homeserver_limit_one() -> Result<()
 
     assert_eq!(event_processor_list.len(), 5); // Ensure 5 HSs are available
 
-    // Check that, when the limit is 1, only one non-default homeserver is considered
+    // Check that, when the limit is 1, only one external homeserver is considered
     let runner_one = MockEventProcessorRunner::new(event_processor_list, 1, shutdown_rx);
     let hs_list = runner_one.pre_run().await.unwrap();
     assert_eq!(hs_list.len(), 1);
     assert_ne!(
         hs_list.first().unwrap(),
-        &runner_one.default_homeserver(),
-        "Default homeserver should be excluded from pre_run"
+        &runner_one.primary_homeserver(),
+        "Primary homeserver should be excluded from pre_run"
     );
 
     let stats_one = runner_one.run().await.unwrap().0;
@@ -133,7 +133,7 @@ async fn test_multi_hs_event_processing_with_timeout() -> Result<()> {
     let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
 
     // Create 3 random homeservers with timeout limit
-    // Index 0: 0s sleep (default, excluded from run)
+    // Index 0: 0s sleep (primary, excluded from run)
     // Index 1: 2s sleep
     // Index 2: 4s sleep
     for index in 0..3 {
@@ -151,7 +151,7 @@ async fn test_multi_hs_event_processing_with_timeout() -> Result<()> {
 
     let runner = MockEventProcessorRunner::new(event_processor_list, 3, shutdown_rx);
 
-    // run excludes the default HS (0s sleep), so only index 1 and 2 are processed.
+    // run excludes the primary HS (0s sleep), so only index 1 and 2 are processed.
     // Both have sleep durations exceeding the 1s timeout.
     let stats = runner.run().await.unwrap().0;
     assert_eq!(stats.count_ok(), 0); // no successes
@@ -198,9 +198,9 @@ async fn test_multi_hs_event_processing_with_panic() -> Result<()> {
 
     let runner = MockEventProcessorRunner::new(event_processor_list, 5, shutdown_rx);
 
-    // run excludes the default HS (first success), so 2 success + 2 panic are processed
+    // run excludes the primary HS (first success), so 2 success + 2 panic are processed
     let stats = runner.run().await.unwrap().0;
-    assert_eq!(stats.count_ok(), 2); // 2 expected to succeed (3 - 1 default)
+    assert_eq!(stats.count_ok(), 2); // 2 expected to succeed (3 - 1 primary)
     assert_eq!(stats.count_timeout(), 0);
     assert_eq!(stats.count_error(), 0);
     assert_eq!(stats.count_panic(), 2); // 2 expected to panic

--- a/nexus-watcher/tests/service/event_processor_prioritization.rs
+++ b/nexus-watcher/tests/service/event_processor_prioritization.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 
 #[tokio_shared_rt::test(shared)]
-async fn test_event_processor_runner_default_homeserver_excluded() -> Result<(), DynError> {
+async fn test_event_processor_runner_primary_homeserver_excluded() -> Result<(), DynError> {
     // Initialize the test
     setup().await?;
 
@@ -46,7 +46,7 @@ async fn test_event_processor_runner_default_homeserver_excluded() -> Result<(),
         event_handler,
         event_source: Arc::new(PubkyKeyBasedEventSource),
         shutdown_rx: tokio::sync::watch::channel(false).1,
-        default_homeserver: PubkyId::try_from(HS_IDS[3]).unwrap(),
+        primary_homeserver: PubkyId::try_from(HS_IDS[3]).unwrap(),
         hs_blacklist: HsBlacklist::default(),
         backoff: Mutex::new(HomeserverBackoff::default()),
         user_not_found_backoff: Arc::new(UserNotFoundBackoff::default()),
@@ -59,11 +59,11 @@ async fn test_event_processor_runner_default_homeserver_excluded() -> Result<(),
         hs.put_to_graph().await.unwrap();
     }
 
-    // The default homeserver should be excluded from the list
+    // The primary homeserver should be excluded from the list
     let hs_ids = runner.pre_run().await?;
     assert!(
         !hs_ids.contains(&HS_IDS[3].to_string()),
-        "Default homeserver should be excluded from pre_run"
+        "Primary homeserver should be excluded from pre_run"
     );
 
     Ok(())
@@ -98,7 +98,7 @@ async fn test_event_processor_runner_blacklisted_homeserver_excluded() -> Result
         event_handler,
         event_source: Arc::new(PubkyKeyBasedEventSource),
         shutdown_rx: tokio::sync::watch::channel(false).1,
-        default_homeserver: PubkyId::try_from(HS_IDS[3]).unwrap(),
+        primary_homeserver: PubkyId::try_from(HS_IDS[3]).unwrap(),
         hs_blacklist: HsBlacklist::new([blacklisted_hs.clone()]),
         backoff: Mutex::new(HomeserverBackoff::default()),
         user_not_found_backoff: Arc::new(UserNotFoundBackoff::default()),
@@ -129,7 +129,7 @@ async fn test_event_processor_runner_blacklisted_homeserver_excluded() -> Result
 }
 
 #[tokio_shared_rt::test(shared)]
-async fn test_mock_event_processor_runner_default_homeserver_excluded() -> Result<(), DynError> {
+async fn test_mock_event_processor_runner_primary_homeserver_excluded() -> Result<(), DynError> {
     // Initialize the test
     setup().await?;
 
@@ -150,11 +150,11 @@ async fn test_mock_event_processor_runner_default_homeserver_excluded() -> Resul
         hs.put_to_graph().await.unwrap();
     }
 
-    // The default homeserver (HS_IDS[0]) should be excluded from the list
+    // The primary homeserver (HS_IDS[0]) should be excluded from the list
     let hs_ids = runner.hs_by_priority().await?;
     assert!(
         !hs_ids.contains(&HS_IDS[0].to_string()),
-        "Default homeserver should be excluded from hs_by_priority"
+        "Primary homeserver should be excluded from hs_by_priority"
     );
 
     Ok(())

--- a/nexus-watcher/tests/service/signal.rs
+++ b/nexus-watcher/tests/service/signal.rs
@@ -14,7 +14,7 @@ async fn test_shutdown_signal() -> Result<()> {
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
 
     // Create 3 random homeservers with timeout limit
-    // Index 0: 0s sleep (default, excluded from run)
+    // Index 0: 0s sleep (primary, excluded from run)
     // Index 1: 2s sleep
     // Index 2: 4s sleep
     for index in 0..3 {
@@ -43,7 +43,7 @@ async fn test_shutdown_signal() -> Result<()> {
 
     let stats = runner.run().await.unwrap().0;
 
-    // run excludes the default HS (0s sleep).
+    // run excludes the primary HS (0s sleep).
     // Of the remaining 2 (2s, 4s sleep), the shutdown signal fires after 1s.
     // The 2s HS starts running, detects shutdown and exits early with Ok.
     // The 4s HS doesn't start because shutdown is detected before it begins.

--- a/nexus-watcher/tests/service/utils/processor_runner.rs
+++ b/nexus-watcher/tests/service/utils/processor_runner.rs
@@ -37,7 +37,7 @@ impl MockEventProcessorRunner {
 
         for mock_event_processor in self.event_processors.iter() {
             let hs_id = mock_event_processor.homeserver_id.to_string();
-            if persisted_hs_ids.contains(&hs_id) && hs_id != self.default_homeserver() {
+            if persisted_hs_ids.contains(&hs_id) && hs_id != self.primary_homeserver() {
                 hs_ids.push(hs_id);
             }
         }
@@ -45,7 +45,7 @@ impl MockEventProcessorRunner {
         Ok(hs_ids)
     }
 
-    pub fn default_homeserver(&self) -> String {
+    pub fn primary_homeserver(&self) -> String {
         // Use first mock homeserver ID if available, otherwise fallback to mock constant
         self.event_processors
             .first()


### PR DESCRIPTION
This PR renames "Default HS" to "Primary HS" to address https://github.com/pubky/pubky-nexus/pull/988#discussion_r3555930043 .

The main reason is to avoid confusing variable names like `DEFAULT_DEFAULT_HS_MONITORING_INTERVAL_MS`.

Another reason is that its easier to distinguish HSs on "primary vs secondary" axis, compared to "default vs non-default".

---
### Pre-submission Checklist

- [x] I manually reviewed the PR
- [x] I asked one or more LLMs to review the PR
- [ ] I asked one or more LLMs to check if this PR can be simplified [^1]
- [ ] If appropriate, I added tests for the changes in this PR
- [ ] If appropriate, I added performance benchmarks for the APIs added in this PR [^2]

[^1]: Sample prompt: "Can this be simplified? Can the code, comments, or logic introduced by these changes be simplfied, clarified or otherwise made more terse, concise and understandable, without affecting functionality?"
[^2]: `cargo bench -p nexus-webapi`
