### PR TITLE
feat: Add a job-agnostic scheduling engine to nexusd

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,22 @@ jobs:
         with:
           tool: cargo-nextest
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Pre-build the neo4j+GDS image with the GHA layer cache: after the
+      # first run, the ~62MB GDS jar layer is restored from cache instead of
+      # downloaded from graphdatascience.ninja. `docker compose up` below
+      # finds the image under this tag and skips its own build.
+      - name: Build Neo4j image with GDS plugin (cached)
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/neo4j
+          tags: pubky-nexus/neo4j:5.26.27-gds2.13.10
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha
+
       - name: Set up Docker Compose
         working-directory: docker
         run: docker compose --profile tests --env-file .env-sample up -d
@@ -86,6 +102,12 @@ jobs:
       # This test suite uses the TEST_PUBKY_CONNECTION_STRING env variable
       - name: Run WATCHER integration tests
         run: cargo nextest run -p nexus-watcher --no-fail-fast
+
+      # Runs last: the trust recompute writes a `trust` property across all
+      # :User nodes, so keep it after the suites that assert on graph state.
+      # Requires the GDS plugin in the neo4j image (pre-built above).
+      - name: Run NEXUSD integration tests
+        run: cargo nextest run -p nexusd --no-fail-fast
 
       - name: Tear down Docker Compose
         if: always()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3144,6 +3144,7 @@ dependencies = [
 name = "nexusd"
 version = "0.4.1"
 dependencies = [
+ "anyhow",
  "async-trait",
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,6 +1096,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
+name = "cron"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5dcd6f69605c2956916ce24e8af637b754964c9a83f4662d3a2361654cdba09"
+dependencies = [
+ "chrono",
+ "once_cell",
+ "phf",
+ "winnow 0.7.15",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3135,16 +3147,22 @@ dependencies = [
  "async-trait",
  "chrono",
  "clap",
+ "cron",
  "dirs",
  "futures",
  "nexus-common",
  "nexus-watcher",
  "nexus-webapi",
+ "opentelemetry 0.32.0",
+ "opentelemetry_sdk 0.32.1",
  "redis",
  "serde",
+ "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-shared-rt",
  "tracing",
+ "tracing-test",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ hex = "0.4"
 async-trait = "0.1.89"
 chrono = { version = "0.4.45", default-features = false, features = ["clock"] }
 clap = "4.6.1"
+cron = "0.17.0"
 deadpool-redis = "0.23"
 dirs = "6.0.0"
 neo4rs = "0.8.0"

--- a/README.md
+++ b/README.md
@@ -89,6 +89,33 @@ cargo run -p nexusd -- api
      - Note: on first run, an error popup is shown and a TOS popup. After you accept the TOS, the link will work.
    - Neo4J Browser: [http://localhost:7474/browser/](http://localhost:7474/browser/)
 
+## ⏰ Scheduled Jobs
+
+Nexusd can run background jobs on a cron schedule. Jobs are configured in `config.toml` under `[jobs.<name>]` sections:
+
+```toml
+[jobs.my_job]
+cron = "0 0 3 * * *"  # every day at 03:00 (UTC)
+```
+
+The `cron` expression is SECONDS-FIRST, not the standard 5-field crontab — always include the seconds field: `sec min hour day-of-month month day-of-week [year]`. The trailing year field is optional. The same format is used for every schedule, from coarse to per-second granularity:
+
+```toml
+[jobs.reindex]
+cron = "0 * * * * *"  # every minute at second 0
+```
+
+### Available Commands
+
+- **`nexusd jobs list`** — prints the names of all available jobs
+- **`nexusd jobs run <name>`** — runs a single job immediately (on demand), bypassing the schedule
+
+### Notes
+
+- A job with no `[jobs.<name>]` section or no `cron` key is unscheduled (won't run automatically) but can still be triggered on demand.
+- The `nexusd run` daemon validates all `[jobs.*]` sections at startup — a typo'd section name fails fast rather than being silently ignored.
+- Running a job on demand with `nexusd jobs run` also validates the config, so a typo'd `[jobs.<name>]` section is caught regardless of how you invoke it.
+
 ## 📈 Observability
 
 If you want to enable observability in Nexus, you can connect it to an OpenTelemetry exporter. Follow these steps:

--- a/README.md
+++ b/README.md
@@ -190,6 +190,10 @@ cargo nextest run -p nexus-webapi --no-fail-fast
 # TEST_PUBKY_CONNECTION_STRING from docker/.env-sample
 # export TEST_PUBKY_CONNECTION_STRING=postgres://test_user:test_pass@localhost:5432/postgres?pubky-test=true
 cargo nextest run -p nexus-watcher --no-fail-fast
+
+# nexusd trust-rank tests require the GDS plugin baked into the neo4j image
+# (docker/neo4j/Dockerfile); the docker compose stack builds it automatically.
+cargo nextest run -p nexusd --no-fail-fast
 ```
 
 To test specific feature(s):

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,11 @@ name: pubky-nexus
 
 services:
   neo4j:
-    image: neo4j:5.26.27-community
+    # Locally-built neo4j with the GDS plugin baked in (see neo4j/Dockerfile);
+    # `docker compose up` builds it on first use, CI pre-builds it with a
+    # GitHub Actions layer cache.
+    build: ./neo4j
+    image: pubky-nexus/neo4j:5.26.27-gds2.13.10
     container_name: neo4j
     restart: unless-stopped
     ports:
@@ -22,7 +26,8 @@ services:
       NEO4J_AUTH: ${NEO4J_DB_USERNAME}/${NEO4J_PASSWORD}
       # https://neo4j.com/docs/operations-manual/current/docker/configuration/
       # Modify the default configuration
-      # Raise memory limits
+      # Raise memory limits.
+      # GDS projection lives in heap.
       NEO4J_server_memory_pagecache_size: 1G
       NEO4J_server_memory_heap_initial__size: 2G
       NEO4J_server_memory_heap_max__size: 2G
@@ -33,7 +38,11 @@ services:
       # https://neo4j.com/docs/operations-manual/current/configuration/configuration-settings/#config_client.allow_telemetry
       NEO4J_client_allow__telemetry: false
       # NEO4J_apoc_uuid_enabled: false
-
+      # Graph Data Science plugin (free on Community Edition), used to compute
+      # seeded PageRank trust scores over the follow graph.
+      NEO4J_PLUGINS: '["graph-data-science"]'
+      NEO4J_dbms_security_procedures_unrestricted: gds.*
+      NEO4J_dbms_security_procedures_allowlist: gds.graph.project,gds.graph.project.estimate,gds.graph.drop,gds.graph.list,gds.pageRank.write
   redis:
     image: redis:8.0.6-alpine
     container_name: redis
@@ -44,7 +53,6 @@ services:
     volumes:
       - .database/redis/data:/data:Z
     restart: always
-
   redisinsight:
     image: redis/redisinsight:3.0.3
     container_name: redisinsight
@@ -58,7 +66,6 @@ services:
     depends_on:
       - redis
     restart: always
-
   # Only used for tests that involve homeservers (requires --profile tests)
   postgres:
     profiles: ["tests"]

--- a/docker/neo4j/Dockerfile
+++ b/docker/neo4j/Dockerfile
@@ -1,0 +1,20 @@
+# Neo4j Community with the Graph Data Science plugin baked in.
+#
+# GDS ships in /var/lib/neo4j/products/ only in the *enterprise* image; on
+# community, the NEO4J_PLUGINS entrypoint handler falls back to downloading
+# ~62MB from graphdatascience.ninja on every container creation — a startup
+# latency, a CI flake source, and a hard failure on restricted networks.
+# Baking the jar into the products dir makes the stock entrypoint find it via
+# its location glob (/var/lib/neo4j/products/neo4j-graph-data-science-*.jar)
+# and install it offline, plugin default config included.
+#
+# GDS 2.13 is the only GDS series supported on Neo4j 5.26.
+FROM neo4j:5.26.27-community
+
+ARG GDS_VERSION=2.13.10
+# --checksum pins the artifact (supply-chain integrity) and gives BuildKit a
+# stable cache key, so cached builds skip the download entirely.
+ADD --chown=neo4j:neo4j \
+    --checksum=sha256:d3d842653fede3f83d6c7e2a6fafb73ac5b7dce98e2e234c18e755852e432e14 \
+    https://graphdatascience.ninja/neo4j-graph-data-science-${GDS_VERSION}.jar \
+    /var/lib/neo4j/products/neo4j-graph-data-science-${GDS_VERSION}.jar

--- a/nexus-common/default.config.toml
+++ b/nexus-common/default.config.toml
@@ -122,3 +122,34 @@ slow_query_logging_threshold_ms = 100
 #[jobs.example]
 #cron = "0 0 3 * * *"    # daily at 03:00 UTC
 #cron = "0 0 4 * * MON"  # Mondays at 04:00 UTC
+
+# Scheduling for the trust-rank recompute job. Set a cron for automatic
+# recomputes; omit it to leave the job on-demand only (`nexusd jobs run
+# trust-recompute` always works).
+[jobs.trust-recompute]
+# Example: daily at 03:00:
+#cron = "0 0 3 * * *"
+
+# Trust-rank parameters (what the recompute does; when it runs is set under
+# [jobs.trust-recompute] above).
+[trust_rank]
+# Seeds for the personalized PageRank over the follow graph, each weighted
+# equally (v = 1/N). Empty by default: the job refuses to run until set.
+# Duplicate ids are silently deduplicated, keeping first-occurrence order. Example:
+# seed = ["8um71us3fyw6h8wbcxb5ar3rwusy1a6u49956ikzojg3gcwd1dty"]
+seed = []
+# Teleport weight `alpha` in `trust = alpha*v + (1-alpha)*M*trust` (GDS dampingFactor = 1-alpha)
+alpha = 0.35
+# Cap on power-iteration rounds
+max_iterations = 200
+# Convergence tolerance; kept low to run to convergence rather than early-stop
+tolerance = 0.0000001
+# When true, each recompute also writes a CSV report of the run to report_dir
+report_enabled = false
+# Directory recompute reports are written to, created if missing.
+# Files are named trust-report-<UTC timestamp>.csv
+report_dir = "~/.pubky-nexus/trust-reports"
+# Max rows in a report (top users by score).
+report_limit = 10000
+# Hard cap on GDS projection size (bytes). Prevents projection larger than Neo4j heap.
+# max_projection_bytes = 2147483648

--- a/nexus-common/default.config.toml
+++ b/nexus-common/default.config.toml
@@ -110,3 +110,15 @@ password = "12345678"
 slow_query_logging_threshold_ms = 100
 # Include the Cypher query text in slow query log entries
 #slow_query_logging_include_cypher = false
+
+# Cron scheduling, one section per registered job (see `nexusd jobs list`),
+# keyed by job name: `[jobs.<name>]`.
+#
+# `cron` is SECONDS-FIRST, not the standard 5-field crontab — always include the
+# seconds field: sec min hour day-of-month month day-of-week [year]
+#
+# No enable flag: an absent `cron` (or section) leaves the job unscheduled, but
+# still runnable on demand with `nexusd jobs run <name>`.
+#[jobs.example]
+#cron = "0 0 3 * * *"    # daily at 03:00 UTC
+#cron = "0 0 4 * * MON"  # Mondays at 04:00 UTC

--- a/nexus-common/src/config/daemon.rs
+++ b/nexus-common/src/config/daemon.rs
@@ -6,7 +6,9 @@ use tracing::error;
 
 use crate::{file::CONFIG_FILE_NAME, types::DynError};
 
-use super::{file::ConfigLoader, ApiConfig, JobConfig, StackConfig, WatcherConfig};
+use super::{
+    file::ConfigLoader, ApiConfig, JobConfig, StackConfig, TrustRankConfig, WatcherConfig,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DaemonConfig {
@@ -18,6 +20,9 @@ pub struct DaemonConfig {
     /// Scheduling config per cron job, keyed by job name (`[jobs.<name>]`).
     #[serde(default)]
     pub jobs: HashMap<String, JobConfig>,
+    /// Trust-rank computation parameters (`[trust_rank]`).
+    #[serde(default)]
+    pub trust_rank: TrustRankConfig,
 }
 
 impl DaemonConfig {
@@ -70,7 +75,9 @@ mod tests {
 
     use crate::config::file::{reader::DEFAULT_CONFIG_TOML, ConfigLoader};
     use crate::{
-        config::watcher::DEFAULT_MODERATION_ID, file::validate_and_expand_path, DaemonConfig, Level,
+        config::watcher::DEFAULT_MODERATION_ID, default_trust_report_dir,
+        file::validate_and_expand_path, DaemonConfig, Level, DEFAULT_TRUST_ALPHA,
+        DEFAULT_TRUST_MAX_ITERATIONS, DEFAULT_TRUST_REPORT_LIMIT, DEFAULT_TRUST_TOLERANCE,
     };
 
     #[tokio_shared_rt::test(shared)]
@@ -123,8 +130,18 @@ mod tests {
         assert_eq!(c.stack.db.redis, "redis://127.0.0.1:6379");
         assert_eq!(c.stack.db.neo4j.uri, "bolt://localhost:7687");
 
-        // No jobs are registered/configured by default.
-        assert!(c.jobs.is_empty());
+        let trust_job = c
+            .jobs
+            .get("trust-recompute")
+            .expect("[jobs.trust-recompute] should be present");
+        assert!(trust_job.cron.is_none());
+        assert!(c.trust_rank.seed.is_empty());
+        assert_eq!(c.trust_rank.alpha, DEFAULT_TRUST_ALPHA);
+        assert_eq!(c.trust_rank.max_iterations, DEFAULT_TRUST_MAX_ITERATIONS);
+        assert_eq!(c.trust_rank.tolerance, DEFAULT_TRUST_TOLERANCE);
+        assert!(!c.trust_rank.report_enabled);
+        assert_eq!(c.trust_rank.report_dir, default_trust_report_dir());
+        assert_eq!(c.trust_rank.report_limit, DEFAULT_TRUST_REPORT_LIMIT);
     }
 
     /// A `[jobs.<name>]` section parses into a keyed [`JobConfig`], with its cron
@@ -147,6 +164,143 @@ mod tests {
             .expect("config with an empty job section should parse");
 
         assert!(c.jobs["example"].cron.is_none());
+    }
+
+    /// A valid `[jobs.trust-recompute] cron` expression parses and is stored verbatim.
+    #[test]
+    fn test_trust_job_cron_parsing() {
+        let toml =
+            DEFAULT_CONFIG_TOML.replace(r#"#cron = "0 0 3 * * *""#, r#"cron = "0 0 3 * * *""#);
+
+        let c = DaemonConfig::try_from_str(&toml).expect("config with a valid cron should parse");
+
+        assert_eq!(
+            c.jobs["trust-recompute"].cron.as_deref(),
+            Some("0 0 3 * * *")
+        );
+    }
+
+    /// `trust_rank.report_enabled` and `trust_rank.report_dir` parse, with `~` expanded.
+    #[test]
+    fn test_trust_report_config_parsing() {
+        let toml = DEFAULT_CONFIG_TOML
+            .replace("report_enabled = false", "report_enabled = true")
+            .replace(
+                r#"report_dir = "~/.pubky-nexus/trust-reports""#,
+                r#"report_dir = "~/custom/reports""#,
+            );
+
+        let c = DaemonConfig::try_from_str(&toml)
+            .expect("config with trust reports enabled should parse");
+
+        assert!(c.trust_rank.report_enabled);
+        assert_eq!(
+            c.trust_rank.report_dir,
+            validate_and_expand_path(PathBuf::from_str("~/custom/reports").unwrap()).unwrap()
+        );
+    }
+
+    /// A populated `trust_rank.seed` list parses into `PubkyId` entries, in order.
+    #[test]
+    fn test_trust_seed_parsing() {
+        let hs1 = "8um71us3fyw6h8wbcxb5ar3rwusy1a6u49956ikzojg3gcwd1dty";
+        let hs2 = "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo";
+
+        let toml =
+            DEFAULT_CONFIG_TOML.replace("seed = []", &format!(r#"seed = ["{hs1}", "{hs2}"]"#));
+
+        let c = DaemonConfig::try_from_str(&toml).expect("config with a trust seed should parse");
+
+        assert_eq!(
+            c.trust_rank.seed,
+            vec![
+                PubkyId::try_from(hs1).unwrap(),
+                PubkyId::try_from(hs2).unwrap(),
+            ]
+        );
+    }
+
+    /// Duplicate `trust_rank.seed` ids are silently deduplicated, preserving
+    /// first-occurrence order.
+    #[test]
+    fn test_trust_seed_dedupes_duplicates() {
+        let hs1 = "8um71us3fyw6h8wbcxb5ar3rwusy1a6u49956ikzojg3gcwd1dty";
+        let hs2 = "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo";
+
+        let toml = DEFAULT_CONFIG_TOML.replace(
+            "seed = []",
+            &format!(r#"seed = ["{hs1}", "{hs2}", "{hs1}"]"#),
+        );
+
+        let c =
+            DaemonConfig::try_from_str(&toml).expect("config with duplicated seeds should parse");
+
+        assert_eq!(
+            c.trust_rank.seed,
+            vec![
+                PubkyId::try_from(hs1).unwrap(),
+                PubkyId::try_from(hs2).unwrap(),
+            ],
+            "duplicate seed ids should be removed, keeping first-occurrence order"
+        );
+    }
+
+    /// `trust_rank.alpha` must be in `(0, 1]`; out-of-range values fail config parsing.
+    #[test]
+    fn test_trust_alpha_rejects_out_of_range() {
+        for bad_alpha in ["0.0", "1.5", "-0.1"] {
+            let toml = DEFAULT_CONFIG_TOML.replace("alpha = 0.35", &format!("alpha = {bad_alpha}"));
+            assert!(
+                DaemonConfig::try_from_str(&toml).is_err(),
+                "alpha = {bad_alpha} should be rejected"
+            );
+        }
+    }
+
+    /// An unknown key under `[trust_rank]` (e.g. a typo'd `report_enable`) must
+    /// fail config parsing rather than parse silently into no effect.
+    #[test]
+    fn test_trust_rank_rejects_unknown_key() {
+        let toml = format!("{DEFAULT_CONFIG_TOML}\nreport_enable = true\n");
+        assert!(
+            DaemonConfig::try_from_str(&toml).is_err(),
+            "an unknown [trust_rank] key must be rejected"
+        );
+    }
+
+    /// `trust_rank.max_iterations` must be at least 1; zero fails config parsing.
+    #[test]
+    fn test_trust_max_iterations_rejects_zero() {
+        let toml = DEFAULT_CONFIG_TOML.replace("max_iterations = 200", "max_iterations = 0");
+        assert!(
+            DaemonConfig::try_from_str(&toml).is_err(),
+            "max_iterations = 0 should be rejected"
+        );
+    }
+
+    /// `report_limit` must be ≥ 1; zero fails parsing.
+    #[test]
+    fn test_trust_report_limit_rejects_zero() {
+        let toml = DEFAULT_CONFIG_TOML.replace("report_limit = 10000", "report_limit = 0");
+        assert!(
+            DaemonConfig::try_from_str(&toml).is_err(),
+            "report_limit = 0 should be rejected"
+        );
+    }
+
+    /// `trust_rank.tolerance` must be finite and non-negative; bad values fail config parsing.
+    #[test]
+    fn test_trust_tolerance_rejects_invalid() {
+        for bad_tolerance in ["-0.1", "nan", "inf"] {
+            let toml = DEFAULT_CONFIG_TOML.replace(
+                "tolerance = 0.0000001",
+                &format!("tolerance = {bad_tolerance}"),
+            );
+            assert!(
+                DaemonConfig::try_from_str(&toml).is_err(),
+                "tolerance = {bad_tolerance} should be rejected"
+            );
+        }
     }
 
     /// A populated `external_hs_pk_blacklist` is parsed into the expected

--- a/nexus-common/src/config/daemon.rs
+++ b/nexus-common/src/config/daemon.rs
@@ -1,11 +1,12 @@
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::{fmt::Debug, path::PathBuf};
 use tracing::error;
 
 use crate::{file::CONFIG_FILE_NAME, types::DynError};
 
-use super::{file::ConfigLoader, ApiConfig, StackConfig, WatcherConfig};
+use super::{file::ConfigLoader, ApiConfig, JobConfig, StackConfig, WatcherConfig};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DaemonConfig {
@@ -14,6 +15,9 @@ pub struct DaemonConfig {
     #[serde(default)]
     pub watcher: WatcherConfig,
     pub stack: StackConfig,
+    /// Scheduling config per cron job, keyed by job name (`[jobs.<name>]`).
+    #[serde(default)]
+    pub jobs: HashMap<String, JobConfig>,
 }
 
 impl DaemonConfig {
@@ -118,6 +122,31 @@ mod tests {
         assert!(c.stack.otlp.endpoint.is_none());
         assert_eq!(c.stack.db.redis, "redis://127.0.0.1:6379");
         assert_eq!(c.stack.db.neo4j.uri, "bolt://localhost:7687");
+
+        // No jobs are registered/configured by default.
+        assert!(c.jobs.is_empty());
+    }
+
+    /// A `[jobs.<name>]` section parses into a keyed [`JobConfig`], with its cron
+    /// stored verbatim.
+    #[test]
+    fn test_job_config_parsing() {
+        let toml = format!("{DEFAULT_CONFIG_TOML}\n[jobs.example]\ncron = \"0 0 3 * * *\"\n");
+
+        let c = DaemonConfig::try_from_str(&toml).expect("config with a job section should parse");
+
+        assert_eq!(c.jobs["example"].cron.as_deref(), Some("0 0 3 * * *"));
+    }
+
+    /// An absent cron leaves the job unscheduled (the default).
+    #[test]
+    fn test_job_config_defaults_to_no_cron() {
+        let toml = format!("{DEFAULT_CONFIG_TOML}\n[jobs.example]\n");
+
+        let c = DaemonConfig::try_from_str(&toml)
+            .expect("config with an empty job section should parse");
+
+        assert!(c.jobs["example"].cron.is_none());
     }
 
     /// A populated `external_hs_pk_blacklist` is parsed into the expected

--- a/nexus-common/src/config/job.rs
+++ b/nexus-common/src/config/job.rs
@@ -1,0 +1,10 @@
+use serde::{Deserialize, Serialize};
+
+/// Scheduling config for a cron job, keyed under `[jobs.<name>]`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(default, deny_unknown_fields)]
+pub struct JobConfig {
+    /// 7-field cron (`sec min hour dom month dow [year]`, seconds-first).
+    /// `None` leaves the job unscheduled.
+    pub cron: Option<String>,
+}

--- a/nexus-common/src/config/job.rs
+++ b/nexus-common/src/config/job.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 #[serde(default, deny_unknown_fields)]
 pub struct JobConfig {
-    /// 7-field cron (`sec min hour dom month dow [year]`, seconds-first).
+    /// 6- or 7-field cron (`sec min hour dom month dow [year]`, seconds-first).
     /// `None` leaves the job unscheduled.
     pub cron: Option<String>,
 }

--- a/nexus-common/src/config/mod.rs
+++ b/nexus-common/src/config/mod.rs
@@ -19,12 +19,14 @@ pub fn get_files_dir_pathbuf() -> PathBuf {
 mod api;
 mod daemon;
 pub mod file;
+mod job;
 mod net;
 mod stack;
 pub mod watcher;
 
 pub use api::{ApiConfig, RateLimitBucketConfig, RateLimitConfig};
 pub use daemon::DaemonConfig;
+pub use job::JobConfig;
 pub use net::NetConfig;
 pub use stack::{default_stack, OtlpConfig, StackConfig};
 pub use watcher::{

--- a/nexus-common/src/config/mod.rs
+++ b/nexus-common/src/config/mod.rs
@@ -22,6 +22,7 @@ pub mod file;
 mod job;
 mod net;
 mod stack;
+mod trust;
 pub mod watcher;
 
 pub use api::{ApiConfig, RateLimitBucketConfig, RateLimitConfig};
@@ -29,6 +30,10 @@ pub use daemon::DaemonConfig;
 pub use job::JobConfig;
 pub use net::NetConfig;
 pub use stack::{default_stack, OtlpConfig, StackConfig};
+pub use trust::{
+    default_trust_report_dir, TrustRankConfig, DEFAULT_TRUST_ALPHA, DEFAULT_TRUST_MAX_ITERATIONS,
+    DEFAULT_TRUST_REPORT_LIMIT, DEFAULT_TRUST_TOLERANCE,
+};
 pub use watcher::{
     EventRetryConfig, WatcherConfig, DEFAULT_HS_RESOLVER_TTL, DEFAULT_INITIAL_BACKOFF_SECS,
     DEFAULT_MAX_BACKOFF_SECS, DEFAULT_MAX_FILE_SIZE, MAX_EVENTS_LIMIT, MAX_KEY_BASED_EVENTS_LIMIT,

--- a/nexus-common/src/config/trust.rs
+++ b/nexus-common/src/config/trust.rs
@@ -1,0 +1,129 @@
+use pubky_app_specs::PubkyId;
+use serde::{de::Error, Deserialize, Deserializer, Serialize};
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use super::file::{default_config_dir_path, validate_and_expand_path};
+
+/// Default teleport weight (`alpha` in `trust = alpha*v + (1-alpha)*M*trust`).
+/// GDS's `dampingFactor` is `1 - alpha`.
+pub const DEFAULT_TRUST_ALPHA: f64 = 0.35;
+/// Default cap on PageRank power-iteration rounds.
+pub const DEFAULT_TRUST_MAX_ITERATIONS: u32 = 200;
+/// Default convergence tolerance: run close to full convergence rather than early-stop.
+pub const DEFAULT_TRUST_TOLERANCE: f64 = 0.0000001;
+/// Default max rows in a recompute CSV report.
+pub const DEFAULT_TRUST_REPORT_LIMIT: usize = 10_000;
+
+/// Dedupes the seed list, keeping first-occurrence order: duplicate ids would
+/// otherwise inflate `sourceNodes` and skew the configured-vs-matched seed check.
+fn deserialize_seed<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<PubkyId>, D::Error> {
+    let seeds = Vec::<PubkyId>::deserialize(d)?;
+    let mut seen = HashSet::new();
+    Ok(seeds
+        .into_iter()
+        .filter(|id| seen.insert(id.clone()))
+        .collect())
+}
+
+fn deserialize_alpha<'de, D: Deserializer<'de>>(d: D) -> Result<f64, D::Error> {
+    let alpha = f64::deserialize(d)?;
+    if !alpha.is_finite() || alpha <= 0.0 || alpha > 1.0 {
+        return Err(D::Error::custom(format!(
+            "trust.alpha ({alpha}) must be in the range (0, 1]"
+        )));
+    }
+    Ok(alpha)
+}
+
+fn deserialize_max_iterations<'de, D: Deserializer<'de>>(d: D) -> Result<u32, D::Error> {
+    let max_iterations = u32::deserialize(d)?;
+    if max_iterations == 0 {
+        return Err(D::Error::custom("trust.max_iterations must be at least 1"));
+    }
+    Ok(max_iterations)
+}
+
+fn deserialize_report_limit<'de, D: Deserializer<'de>>(d: D) -> Result<usize, D::Error> {
+    let report_limit = usize::deserialize(d)?;
+    if report_limit == 0 {
+        return Err(D::Error::custom("trust.report_limit must be at least 1"));
+    }
+    Ok(report_limit)
+}
+
+fn deserialize_tolerance<'de, D: Deserializer<'de>>(d: D) -> Result<f64, D::Error> {
+    let tolerance = f64::deserialize(d)?;
+    if !tolerance.is_finite() || tolerance < 0.0 {
+        return Err(D::Error::custom(format!(
+            "trust.tolerance ({tolerance}) must be a finite, non-negative number"
+        )));
+    }
+    Ok(tolerance)
+}
+
+fn deserialize_report_dir<'de, D: Deserializer<'de>>(d: D) -> Result<PathBuf, D::Error> {
+    let path = PathBuf::deserialize(d)?;
+    validate_and_expand_path(path).map_err(D::Error::custom)
+}
+
+/// Default directory for scheduled-run CSV reports.
+pub fn default_trust_report_dir() -> PathBuf {
+    default_config_dir_path().join("trust-reports")
+}
+
+/// Parameters for the seeded (personalized) PageRank trust computation, run via
+/// the Neo4j GDS `pageRank` procedure over the follow graph. Covers *what* the
+/// computation does; *when* it runs is a job concern (see
+/// `[jobs.trust-recompute]` / [`super::JobConfig`]).
+///
+/// Seeds are weighted equally (`v` uniform, `1/N` over `seed`): GDS 2.13 (the
+/// only version on Neo4j 5.26) has no weighted `sourceNodes`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(default, deny_unknown_fields)]
+pub struct TrustRankConfig {
+    /// Users trust originates from, each weighted equally (`v = 1/N`). Empty
+    /// by default: an operator must configure a seed set before trust rank
+    /// can be computed. Duplicate ids are silently deduplicated, keeping
+    /// first-occurrence order.
+    #[serde(deserialize_with = "deserialize_seed")]
+    pub seed: Vec<PubkyId>,
+    /// Teleport weight `alpha` in `trust = alpha*v + (1-alpha)*M*trust`.
+    /// GDS's `dampingFactor` is derived as `1 - alpha`. Must be in (0, 1].
+    #[serde(deserialize_with = "deserialize_alpha")]
+    pub alpha: f64,
+    /// Cap on power-iteration rounds. Must be at least 1.
+    #[serde(deserialize_with = "deserialize_max_iterations")]
+    pub max_iterations: u32,
+    /// Convergence tolerance passed to GDS; kept low so the computation runs to
+    /// convergence rather than stopping early. Must be finite and non-negative.
+    #[serde(deserialize_with = "deserialize_tolerance")]
+    pub tolerance: f64,
+    /// When true, each recompute also writes a CSV report of the run to
+    /// `report_dir` (default: false).
+    pub report_enabled: bool,
+    /// Directory recompute reports are written to, created if missing.
+    /// Files are named `trust-report-<UTC timestamp>.csv`.
+    #[serde(deserialize_with = "deserialize_report_dir")]
+    pub report_dir: PathBuf,
+    /// Max rows in a recompute report (top users by score). Must be ≥ 1.
+    #[serde(deserialize_with = "deserialize_report_limit")]
+    pub report_limit: usize,
+    /// Hard cap on the GDS projection size (bytes). Default: None (no cap).
+    pub max_projection_bytes: Option<u64>,
+}
+
+impl Default for TrustRankConfig {
+    fn default() -> Self {
+        Self {
+            seed: Vec::new(),
+            alpha: DEFAULT_TRUST_ALPHA,
+            max_iterations: DEFAULT_TRUST_MAX_ITERATIONS,
+            tolerance: DEFAULT_TRUST_TOLERANCE,
+            report_enabled: false,
+            report_dir: default_trust_report_dir(),
+            report_limit: DEFAULT_TRUST_REPORT_LIMIT,
+            max_projection_bytes: None,
+        }
+    }
+}

--- a/nexus-common/src/db/graph/instrumented.rs
+++ b/nexus-common/src/db/graph/instrumented.rs
@@ -12,6 +12,7 @@ use tracing::warn;
 
 use super::ops::{Graph, GraphOps};
 use super::query::Query;
+use crate::utils::ms;
 
 /// The OpenTelemetry meter name used by all Neo4j graph metrics.
 ///
@@ -355,10 +356,6 @@ impl<G: GraphOps> GraphOps for InstrumentedGraph<G> {
         span.end();
         result
     }
-}
-
-fn ms(d: Duration) -> f64 {
-    d.as_secs_f64() * 1000.0
 }
 
 #[cfg(test)]

--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -563,35 +563,75 @@ pub fn get_viewer_trusted_network_post_tags(
         .param("limit_taggers", limit_taggers as i64)
 }
 
+/// Per-user count fields, as `(alias, COUNT {} subquery)` pairs bound to the
+/// node variable `u`. Single source of truth shared by [`user_counts`] (map
+/// form) and the trust report (column form), so their filters — especially the
+/// collection/bookmark rules — can't drift between the two queries.
+const USER_COUNT_FIELDS: &[(&str, &str)] = &[
+    ("following", "COUNT { (u)-[:FOLLOWS]->(:User) }"),
+    ("followers", "COUNT { (:User)-[:FOLLOWS]->(u) }"),
+    (
+        "friends",
+        "COUNT { (u)-[:FOLLOWS]->(friend:User) WHERE (friend)-[:FOLLOWS]->(u) }",
+    ),
+    ("posts", "COUNT { (u)-[:AUTHORED]->(:Post) }"),
+    (
+        "replies",
+        "COUNT { (u)-[:AUTHORED]->(:Post)-[:REPLIED]->(:Post) }",
+    ),
+    (
+        "collections",
+        "COUNT { (u)-[:AUTHORED]->(p:Post) WHERE p.kind = 'collection' }",
+    ),
+    // A collection-follow is stored as a bookmark; keep it out of the count.
+    (
+        "bookmarks",
+        "COUNT { (u)-[:BOOKMARKED]->(bp:Post) WHERE (bp.kind IS NULL OR bp.kind <> 'collection') }",
+    ),
+    // tagged = tags this user assigned to users + to posts
+    (
+        "tagged",
+        "COUNT { (u)-[:TAGGED]->(:User) } + COUNT { (u)-[:TAGGED]->(:Post) }",
+    ),
+    ("tags", "COUNT { (:User)-[:TAGGED]->(u) }"),
+    (
+        "unique_tags",
+        "COUNT { MATCH (u)<-[t:TAGGED]-(:User) RETURN DISTINCT t.label }",
+    ),
+];
+
+/// Renders [`USER_COUNT_FIELDS`] as `field: COUNT {…}, …` for a Cypher map literal.
+fn user_count_fields_map() -> String {
+    USER_COUNT_FIELDS
+        .iter()
+        .map(|(name, expr)| format!("{name}: {expr}"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Renders [`USER_COUNT_FIELDS`] as `COUNT {…} AS field, …` for a flat RETURN.
+pub fn user_count_fields_columns() -> String {
+    USER_COUNT_FIELDS
+        .iter()
+        .map(|(name, expr)| format!("{expr} AS {name}"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 pub fn user_counts(user_id: &str) -> Query {
-    Query::new(
-        "user_counts",
-        "
-        MATCH (u:User {id: $user_id})
-        // Each field is an independent COUNT { } subquery off the single (u) row.
-        // Do NOT precede this with a row-multiplying OPTIONAL MATCH (e.g. over
-        // received tags): that makes every subquery a per-row grouping key, so the
-        // whole block runs once per received tag, i.e. O(received_tags x authored_posts)
-        // and hangs on heavy users. See issue #935.
-        RETURN
-            u IS NOT NULL AS exists,
-            {
-                following: COUNT { (u)-[:FOLLOWS]->(:User) },
-                followers: COUNT { (:User)-[:FOLLOWS]->(u) },
-                friends: COUNT { (u)-[:FOLLOWS]->(friend:User) WHERE (friend)-[:FOLLOWS]->(u) },
-                posts: COUNT { (u)-[:AUTHORED]->(:Post) },
-                replies: COUNT { (u)-[:AUTHORED]->(:Post)-[:REPLIED]->(:Post) },
-                collections: COUNT { (u)-[:AUTHORED]->(p:Post) WHERE p.kind = 'collection' },
-                // A collection-follow is stored as a bookmark; keep it out of the count.
-                bookmarks: COUNT { (u)-[:BOOKMARKED]->(bp:Post) WHERE (bp.kind IS NULL OR bp.kind <> 'collection') },
-                // tagged = tags this user assigned to users + to posts
-                tagged: COUNT { (u)-[:TAGGED]->(:User) } + COUNT { (u)-[:TAGGED]->(:Post) },
-                tags: COUNT { (:User)-[:TAGGED]->(u) },
-                unique_tags: COUNT { MATCH (u)<-[t:TAGGED]-(:User) RETURN DISTINCT t.label }
-            } AS counts;
-        ",
-    )
-    .param("user_id", user_id)
+    // Each field is an independent COUNT { } subquery off the single (u) row.
+    // Do NOT precede this with a row-multiplying OPTIONAL MATCH (e.g. over
+    // received tags): that makes every subquery a per-row grouping key, so the
+    // whole block runs once per received tag, i.e. O(received_tags x authored_posts)
+    // and hangs on heavy users. See issue #935.
+    let cypher = format!(
+        "MATCH (u:User {{id: $user_id}})
+         RETURN
+             u IS NOT NULL AS exists,
+             {{ {fields} }} AS counts;",
+        fields = user_count_fields_map()
+    );
+    Query::new("user_counts", cypher).param("user_id", user_id)
 }
 
 pub fn get_user_followers(user_id: &str, skip: Option<usize>, limit: Option<usize>) -> Query {

--- a/nexus-common/src/db/kv/lock.rs
+++ b/nexus-common/src/db/kv/lock.rs
@@ -1,0 +1,42 @@
+//! Redis primitives for a TTL-based distributed lock. The TTL frees the lock if
+//! a holder dies without releasing it.
+
+use crate::db::get_redis_conn;
+use crate::db::kv::error::RedisResult;
+use deadpool_redis::redis::{self, Script};
+use std::sync::LazyLock;
+
+/// Compare-and-delete: release only if the token still matches, so a re-taken
+/// lease isn't dropped by the previous holder.
+static RELEASE: LazyLock<Script> = LazyLock::new(|| {
+    Script::new(
+        r"if redis.call('get', KEYS[1]) == ARGV[1] then
+            return redis.call('del', KEYS[1])
+        else
+            return 0
+        end",
+    )
+});
+
+/// Tries to claim `key` with `token` for `ttl_secs`. `Ok(false)` when another
+/// holder has it. `SET NX EX` acquires and arms the expiry atomically.
+pub async fn try_acquire_lock(key: &str, token: &str, ttl_secs: u64) -> RedisResult<bool> {
+    let mut conn = get_redis_conn().await?;
+    // SET returns Some when NX succeeds, None when the key exists.
+    let acquired: Option<String> = redis::cmd("SET")
+        .arg(key)
+        .arg(token)
+        .arg("NX")
+        .arg("EX")
+        .arg(ttl_secs)
+        .query_async(&mut conn)
+        .await?;
+    Ok(acquired.is_some())
+}
+
+/// Releases `key` only if still held by `token` (see [`RELEASE`]).
+pub async fn release_lock(key: &str, token: &str) -> RedisResult<()> {
+    let mut conn = get_redis_conn().await?;
+    let _: i64 = RELEASE.key(key).arg(token).invoke_async(&mut conn).await?;
+    Ok(())
+}

--- a/nexus-common/src/db/kv/mod.rs
+++ b/nexus-common/src/db/kv/mod.rs
@@ -2,6 +2,7 @@ mod error;
 mod flush;
 mod index;
 mod last_save;
+mod lock;
 mod traits;
 
 pub use error::{RedisError, RedisResult};
@@ -11,4 +12,5 @@ pub(crate) use index::search;
 pub use index::sets;
 pub use index::sorted_sets::{ScoreAction, SortOrder};
 pub use last_save::get_last_rdb_save_time;
+pub use lock::{release_lock, try_acquire_lock};
 pub use traits::RedisOps;

--- a/nexus-common/src/db/mod.rs
+++ b/nexus-common/src/db/mod.rs
@@ -14,4 +14,4 @@ pub use graph::exec::*;
 pub use graph::queries;
 pub use graph::setup;
 pub use graph::GraphOps;
-pub use kv::RedisOps;
+pub use kv::{release_lock, try_acquire_lock, RedisError, RedisOps, RedisResult};

--- a/nexus-common/src/models/post/metrics.rs
+++ b/nexus-common/src/models/post/metrics.rs
@@ -30,6 +30,8 @@ use std::time::Duration;
 use opentelemetry::metrics::{Counter, Histogram};
 use opentelemetry::{global, KeyValue};
 
+use crate::utils::ms;
+
 const METER_NAME: &str = "wot";
 
 struct WotStreamMetrics {
@@ -106,9 +108,7 @@ pub(super) fn record_wot_result(
         KeyValue::new("source", source),
         KeyValue::new("depth", i64::from(depth)),
     ];
-    METRICS
-        .query_duration
-        .record(elapsed.as_secs_f64() * 1000.0, attrs);
+    METRICS.query_duration.record(ms(elapsed), attrs);
     match posts {
         Some(posts) => {
             METRICS.returned_posts.record(posts as u64, attrs);

--- a/nexus-common/src/utils/mod.rs
+++ b/nexus-common/src/utils/mod.rs
@@ -1,6 +1,12 @@
 pub mod test_utils;
 
+use std::time::Duration;
 use tokio::sync::watch::Receiver;
+
+/// Duration as milliseconds, for `ms`-unit histograms.
+pub fn ms(d: Duration) -> f64 {
+    d.as_secs_f64() * 1000.0
+}
 
 // blake3 truncated to 128 bits. Shared by resource_id and IndexKey::for_uri — fine, separate keyspaces.
 pub fn hash_str_hex(input: &str) -> String {

--- a/nexus-watcher/src/events/mod.rs
+++ b/nexus-watcher/src/events/mod.rs
@@ -6,6 +6,7 @@ pub use event::{Event, EventType, ParseResult};
 use crate::errors::EventProcessorError;
 use nexus_common::WatcherConfig;
 use pubky_app_specs::{ExtendedParsedUri, PubkyAppObject, Resource};
+use std::collections::HashSet;
 use std::{
     path::{Path, PathBuf},
     sync::Arc,

--- a/nexus-watcher/src/events/mod.rs
+++ b/nexus-watcher/src/events/mod.rs
@@ -6,7 +6,6 @@ pub use event::{Event, EventType, ParseResult};
 use crate::errors::EventProcessorError;
 use nexus_common::WatcherConfig;
 use pubky_app_specs::{ExtendedParsedUri, PubkyAppObject, Resource};
-use std::collections::HashSet;
 use std::{
     path::{Path, PathBuf},
     sync::Arc,

--- a/nexusd/Cargo.toml
+++ b/nexusd/Cargo.toml
@@ -12,14 +12,21 @@ async-trait = { workspace = true }
 dirs = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
+cron = { workspace = true }
 futures = { workspace = true }
 nexus-webapi = { version = "0.4.1", path = "../nexus-webapi" }
 nexus-common = { version = "0.4.1", path = "../nexus-common" }
+opentelemetry = { workspace = true }
 redis = { workspace = true, features = ["tokio-comp"] }
 nexus-watcher = { version = "0.4.1", path = "../nexus-watcher" }
 serde = { workspace = true }
+thiserror = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
 
 [dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }
 tokio-shared-rt = { workspace = true }
+tempfile = { workspace = true }
+tracing-test = { workspace = true }
+opentelemetry_sdk = { workspace = true, features = ["testing"] }

--- a/nexusd/Cargo.toml
+++ b/nexusd/Cargo.toml
@@ -26,6 +26,7 @@ tokio = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
+anyhow = { workspace = true }
 tokio-shared-rt = { workspace = true }
 tempfile = { workspace = true }
 tracing-test = { workspace = true }

--- a/nexusd/src/cli.rs
+++ b/nexusd/src/cli.rs
@@ -40,11 +40,15 @@ pub enum NexusCommands {
     /// Run the event watcher
     Watcher(WatcherArgs),
 
+    /// Run scheduled jobs on demand
+    #[command(subcommand)]
+    Jobs(JobCommands),
+
     /// Database operations
     #[command(subcommand)]
     Db(DbCommands),
 
-    /// Run both the API and the Watcher (default when no arguments are given)
+    /// Run the API, the Watcher and the scheduled Jobs (default when no arguments are given)
     #[command(hide = true)]
     Run {
         /// Path to the configuration file
@@ -63,6 +67,26 @@ pub struct ApiArgs {
 #[derive(Args, Debug)]
 pub struct WatcherArgs {
     /// Optional configuration file for the watcher
+    #[arg(short, long, default_value_os_t = default_config_dir_path(), value_parser = validate_config_dir_path)]
+    pub config_dir: PathBuf,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum JobCommands {
+    /// Run a single job once, now
+    Run(JobRunArgs),
+
+    /// List the available jobs
+    List,
+}
+
+#[derive(Args, Debug)]
+pub struct JobRunArgs {
+    /// Name of the job to run (see `jobs list`)
+    #[arg(required = true)]
+    pub name: String,
+
+    /// Directory containing `config.toml`
     #[arg(short, long, default_value_os_t = default_config_dir_path(), value_parser = validate_config_dir_path)]
     pub config_dir: PathBuf,
 }

--- a/nexusd/src/jobs/error.rs
+++ b/nexusd/src/jobs/error.rs
@@ -1,6 +1,12 @@
-use nexus_common::db::RedisError;
 use nexus_common::types::DynError;
 use thiserror::Error;
+
+/// A run lock backend failure.
+#[derive(Debug, Error)]
+#[error("run lock backend failed: {0}")]
+pub struct LockError(#[source] pub DynError);
+
+pub type LockResult<T> = Result<T, LockError>;
 
 #[derive(Debug, Error)]
 pub enum JobError {
@@ -8,7 +14,7 @@ pub enum JobError {
     AlreadyRunning { job: &'static str },
 
     #[error("run lock error: {0}")]
-    Lock(#[source] RedisError),
+    Lock(#[source] LockError),
 
     #[error("unknown job(s) {unknown:?}; available jobs: {available}")]
     UnknownJobConfig {

--- a/nexusd/src/jobs/error.rs
+++ b/nexusd/src/jobs/error.rs
@@ -38,6 +38,12 @@ pub enum JobError {
     #[error("stack setup failed: {0}")]
     Stack(#[source] DynError),
 
+    #[error("job {job:?} exceeded its {after:?} run deadline and was abandoned")]
+    TimedOut {
+        job: &'static str,
+        after: std::time::Duration,
+    },
+
     /// Boxed: jobs are heterogeneous and the runner only logs the error.
     #[error("job {job:?} failed: {source}")]
     Run {

--- a/nexusd/src/jobs/error.rs
+++ b/nexusd/src/jobs/error.rs
@@ -1,0 +1,47 @@
+use nexus_common::db::RedisError;
+use nexus_common::types::DynError;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum JobError {
+    #[error("job {job:?} is already running")]
+    AlreadyRunning { job: &'static str },
+
+    #[error("run lock error: {0}")]
+    Lock(#[source] RedisError),
+
+    #[error("unknown job(s) {unknown:?}; available jobs: {available}")]
+    UnknownJobConfig {
+        unknown: Vec<String>,
+        available: String,
+    },
+
+    #[error("unknown job {name:?}; available jobs: {available}")]
+    UnknownJobName { name: String, available: String },
+
+    #[error("[jobs.{job}]: {source}")]
+    InvalidCron {
+        job: String,
+        #[source]
+        source: CronParseError,
+    },
+
+    /// Boxed until StackManager::setup returns a typed error instead of DynError.
+    #[error("stack setup failed: {0}")]
+    Stack(#[source] DynError),
+
+    /// Boxed: jobs are heterogeneous and the runner only logs the error.
+    #[error("job {job:?} failed: {source}")]
+    Run {
+        job: &'static str,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+}
+
+#[derive(Debug, Error)]
+#[error("cron expression ({expr:?}): {reason}")]
+pub struct CronParseError {
+    pub expr: String,
+    pub reason: String,
+}

--- a/nexusd/src/jobs/error.rs
+++ b/nexusd/src/jobs/error.rs
@@ -2,9 +2,11 @@ use nexus_common::types::DynError;
 use thiserror::Error;
 
 /// A run lock backend failure.
+///
+/// Type-erased so alternative lock backends keep their error types out of the trait.
 #[derive(Debug, Error)]
 #[error("run lock backend failed: {0}")]
-pub struct LockError(#[source] pub DynError);
+pub struct LockError(#[source] pub Box<dyn std::error::Error + Send + Sync>);
 
 pub type LockResult<T> = Result<T, LockError>;
 

--- a/nexusd/src/jobs/error.rs
+++ b/nexusd/src/jobs/error.rs
@@ -44,6 +44,9 @@ pub enum JobError {
         after: std::time::Duration,
     },
 
+    #[error("lock acquire timed out for job {job:?}")]
+    LockTimedOut { job: &'static str },
+
     /// Boxed: jobs are heterogeneous and the runner only logs the error.
     #[error("job {job:?} failed: {source}")]
     Run {

--- a/nexusd/src/jobs/lock.rs
+++ b/nexusd/src/jobs/lock.rs
@@ -87,13 +87,49 @@ fn key(job: &str) -> String {
     format!("lock:job:{job}")
 }
 
-/// RAII lock release. Call `release()` on the happy path to await unlock; on a
-/// panic the explicit call is skipped but Drop still frees the lock so it
-/// doesn't stay stuck for its TTL.
+/// The outcome of [`acquire`].
+pub(super) enum Acquired {
+    /// Taken; release through the guard.
+    Taken(LockGuard),
+    /// Another run holds it. Nothing to release.
+    Held,
+    /// The backend failed. Anything we might have taken is already released.
+    Failed(LockError),
+}
+
+/// Takes `job`'s run slot, arming the guard *before* the acquire so a lost SET
+/// reply (or a cancel mid-acquire) still releases; the compare-and-delete no-ops
+/// if our token was never stored.
 ///
-/// Drop releases fire-and-forget via `tokio::spawn` (so it must be dropped
-/// inside a runtime context), falling back to the TTL if the spawn is dropped
-/// during shutdown.
+/// One `job` feeds both the acquire and the guard, so a run can't release a key
+/// it never acquired. On backend error the guard is released inline rather than
+/// left to Drop: callers may return straight into process exit, where a
+/// Drop-spawned unlock never gets polled.
+pub(super) async fn acquire(job: &'static str, lock: &Arc<dyn RunLock>) -> Acquired {
+    let token = lock.new_token();
+    let guard = LockGuard::new(job, token.clone(), Arc::clone(lock));
+
+    match lock.acquire(job, &token).await {
+        Ok(true) => Acquired::Taken(guard),
+        Ok(false) => {
+            guard.disarm();
+            Acquired::Held
+        }
+        Err(e) => {
+            guard.release().await;
+            Acquired::Failed(e)
+        }
+    }
+}
+
+/// RAII lock release. Prefer `release()`, which awaits the unlock; Drop is the
+/// backstop for guards dropped while still armed (a panic in `run()`, or the
+/// whole future being dropped).
+///
+/// Drop releases fire-and-forget via `tokio::spawn`, so it must be dropped in a
+/// runtime context, and only frees the lock if that runtime outlives the spawn —
+/// otherwise the TTL is the fallback. Don't rely on it where the process may
+/// exit right after (see [`acquire`]).
 pub struct LockGuard {
     job: &'static str,
     token: Option<String>,
@@ -138,33 +174,72 @@ impl Drop for LockGuard {
         };
         let lock = self.lock.clone();
         let job = self.job;
-        // Fire-and-forget. Only reached on the panic path — happy path calls
-        // release() first, which sets self.token = None.
+        // Fire-and-forget: reached whenever a guard is dropped still armed, which
+        // release() and disarm() both prevent. Needs the runtime to outlive it.
         tokio::spawn(async move {
             if let Err(e) = lock.unlock(job, &token).await {
-                tracing::warn!(
-                    job,
-                    "Could not release run lock on panic path (will expire via TTL): {e}"
-                );
+                tracing::warn!(job, "Could not release run lock (will expire via TTL): {e}");
             }
         });
     }
 }
 
-/// Test [`RunLock`] that always grants the lock.
 #[cfg(test)]
-pub struct AlwaysAvailableLock;
+mod tests {
+    use super::{acquire, Acquired, RunLock};
+    use crate::jobs::test_support::{AcquireOutcome, FakeLock};
+    use std::sync::Arc;
 
-#[cfg(test)]
-#[async_trait]
-impl RunLock for AlwaysAvailableLock {
-    fn new_token(&self) -> String {
-        "test-token".to_string()
+    #[tokio::test]
+    async fn failed_acquire_releases_before_returning() {
+        let fake = FakeLock::new(AcquireOutcome::Fails);
+        let lock: Arc<dyn RunLock> = fake.clone();
+
+        let outcome = acquire("job", &lock).await;
+
+        // Asserted with no yield in between: a Drop-spawned unlock could not have
+        // run yet, so a nonzero count can only mean the release was awaited inline.
+        assert_eq!(
+            fake.releases(),
+            1,
+            "a failed acquire must release inline, not leave it to Drop's spawn"
+        );
+        assert!(matches!(outcome, Acquired::Failed(_)));
     }
-    async fn acquire(&self, _job: &str, _token: &str) -> LockResult<bool> {
-        Ok(true)
+
+    #[tokio::test]
+    async fn held_lock_is_not_released() {
+        let fake = FakeLock::new(AcquireOutcome::Denied);
+        let lock: Arc<dyn RunLock> = fake.clone();
+
+        let outcome = acquire("job", &lock).await;
+        // Yield so a stray Drop-spawned unlock would surface rather than race us.
+        tokio::task::yield_now().await;
+
+        assert_eq!(
+            fake.releases(),
+            0,
+            "we never held the lock; unlocking would free another run's lease"
+        );
+        assert!(matches!(outcome, Acquired::Held));
     }
-    async fn unlock(&self, _job: &str, _token: &str) -> LockResult<()> {
-        Ok(())
+
+    #[tokio::test]
+    async fn acquire_and_release_use_the_same_job() {
+        let fake = FakeLock::new(AcquireOutcome::Granted);
+        let lock: Arc<dyn RunLock> = fake.clone();
+
+        let Acquired::Taken(guard) = acquire("the-job", &lock).await else {
+            panic!("a granted acquire must yield a guard");
+        };
+        assert_eq!(fake.releases(), 0, "held until released");
+        guard.release().await;
+
+        assert_eq!(fake.releases(), 1);
+        assert_eq!(
+            fake.acquired_with(),
+            fake.released_with(),
+            "the release must target the key the acquire took"
+        );
     }
 }

--- a/nexusd/src/jobs/lock.rs
+++ b/nexusd/src/jobs/lock.rs
@@ -1,0 +1,153 @@
+use async_trait::async_trait;
+use nexus_common::db::{release_lock, try_acquire_lock, RedisResult};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// TTL on a job's run lock, and the crash backstop. Must exceed the longest
+/// expected run, or a run outliving its lease could overlap another.
+const LOCK_TTL_SECS: u64 = 3600;
+
+/// Cross-process mutual exclusion for a job's runs (the scheduler already
+/// serializes within one process). Injected so the scheduler is testable
+/// without Redis.
+#[async_trait]
+pub trait RunLock: Send + Sync {
+    /// Tries to claim the run slot for `job`. `Ok(None)` when another run holds
+    /// it; the returned token must be passed back to [`unlock`](Self::unlock).
+    async fn try_lock(&self, job: &str) -> RedisResult<Option<String>>;
+
+    /// Releases a slot claimed with `token` (compare-and-delete).
+    async fn unlock(&self, job: &str, token: &str) -> RedisResult<()>;
+}
+
+/// Redis-backed [`RunLock`] used in production. Construct once per process (via
+/// [`new`](Self::new)) and share the `Arc`: the token counter is per-instance,
+/// so a second instance would restart it and could mint a colliding token.
+pub struct RedisRunLock {
+    // pid can be reused after a process exits, so mix in the start time to keep
+    // tokens distinct across pid reuse (a cross-process concern).
+    seed: u128,
+    counter: AtomicU64,
+}
+
+impl RedisRunLock {
+    pub fn new() -> Self {
+        let seed = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        Self {
+            seed,
+            counter: AtomicU64::new(0),
+        }
+    }
+
+    /// A token unique per acquisition within this process: `<pid>-<seed>-<counter>`.
+    fn new_token(&self) -> String {
+        format!(
+            "{}-{}-{}",
+            std::process::id(),
+            self.seed,
+            self.counter.fetch_add(1, Ordering::Relaxed),
+        )
+    }
+}
+
+impl Default for RedisRunLock {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl RunLock for RedisRunLock {
+    async fn try_lock(&self, job: &str) -> RedisResult<Option<String>> {
+        let token = self.new_token();
+        if try_acquire_lock(&key(job), &token, LOCK_TTL_SECS).await? {
+            Ok(Some(token))
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn unlock(&self, job: &str, token: &str) -> RedisResult<()> {
+        release_lock(&key(job), token).await
+    }
+}
+
+fn key(job: &str) -> String {
+    format!("lock:job:{job}")
+}
+
+/// RAII lock release. Call `release()` on the happy path to await unlock; on a
+/// panic the explicit call is skipped but Drop still frees the lock so it
+/// doesn't stay stuck for its TTL.
+///
+/// Drop releases fire-and-forget via `tokio::spawn` (so it must be dropped
+/// inside a runtime context), falling back to the TTL if the spawn is dropped
+/// during shutdown.
+pub struct LockGuard {
+    job: &'static str,
+    token: Option<String>,
+    lock: Arc<dyn RunLock>,
+}
+
+impl LockGuard {
+    pub(super) fn new(job: &'static str, token: String, lock: Arc<dyn RunLock>) -> Self {
+        Self {
+            job,
+            token: Some(token),
+            lock,
+        }
+    }
+
+    /// Releases the lock, awaiting the result so unlock errors log
+    /// synchronously. After this, Drop is a no-op.
+    pub async fn release(mut self) {
+        let Some(token) = self.token.take() else {
+            return;
+        };
+        if let Err(e) = self.lock.unlock(self.job, &token).await {
+            tracing::warn!(
+                job = self.job,
+                "Could not release run lock (will expire via TTL): {e}"
+            );
+        }
+    }
+}
+
+impl Drop for LockGuard {
+    fn drop(&mut self) {
+        let Some(token) = self.token.take() else {
+            return;
+        };
+        let lock = self.lock.clone();
+        let job = self.job;
+        // Fire-and-forget. Only reached on the panic path — happy path calls
+        // release() first, which sets self.token = None.
+        tokio::spawn(async move {
+            if let Err(e) = lock.unlock(job, &token).await {
+                tracing::warn!(
+                    job,
+                    "Could not release run lock on panic path (will expire via TTL): {e}"
+                );
+            }
+        });
+    }
+}
+
+/// Test [`RunLock`] that always grants the lock and never touches Redis.
+#[cfg(test)]
+pub struct AlwaysAvailableLock;
+
+#[cfg(test)]
+#[async_trait]
+impl RunLock for AlwaysAvailableLock {
+    async fn try_lock(&self, _job: &str) -> RedisResult<Option<String>> {
+        Ok(Some("test-token".to_string()))
+    }
+    async fn unlock(&self, _job: &str, _token: &str) -> RedisResult<()> {
+        Ok(())
+    }
+}

--- a/nexusd/src/jobs/lock.rs
+++ b/nexusd/src/jobs/lock.rs
@@ -1,8 +1,10 @@
 use async_trait::async_trait;
-use nexus_common::db::{release_lock, try_acquire_lock, RedisResult};
+use nexus_common::db::{release_lock, try_acquire_lock, RedisError};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
+
+use super::error::{LockError, LockResult};
 
 /// TTL on a job's run lock, and the crash backstop. Must exceed the longest
 /// expected run, or a run outliving its lease could overlap another.
@@ -19,10 +21,16 @@ pub trait RunLock: Send + Sync {
 
     /// Tries to claim the run slot for `job` under `token`. `Ok(false)` when
     /// another run already holds it.
-    async fn acquire(&self, job: &str, token: &str) -> RedisResult<bool>;
+    async fn acquire(&self, job: &str, token: &str) -> LockResult<bool>;
 
     /// Releases the slot, but only if it's still held by `token`.
-    async fn unlock(&self, job: &str, token: &str) -> RedisResult<()>;
+    async fn unlock(&self, job: &str, token: &str) -> LockResult<()>;
+}
+
+impl From<RedisError> for LockError {
+    fn from(e: RedisError) -> Self {
+        Self(Box::new(e))
+    }
 }
 
 /// Redis-backed [`RunLock`] used in production. Construct once per process (via
@@ -66,12 +74,12 @@ impl RunLock for RedisRunLock {
         )
     }
 
-    async fn acquire(&self, job: &str, token: &str) -> RedisResult<bool> {
-        try_acquire_lock(&key(job), token, LOCK_TTL_SECS).await
+    async fn acquire(&self, job: &str, token: &str) -> LockResult<bool> {
+        Ok(try_acquire_lock(&key(job), token, LOCK_TTL_SECS).await?)
     }
 
-    async fn unlock(&self, job: &str, token: &str) -> RedisResult<()> {
-        release_lock(&key(job), token).await
+    async fn unlock(&self, job: &str, token: &str) -> LockResult<()> {
+        Ok(release_lock(&key(job), token).await?)
     }
 }
 
@@ -143,7 +151,7 @@ impl Drop for LockGuard {
     }
 }
 
-/// Test [`RunLock`] that always grants the lock and never touches Redis.
+/// Test [`RunLock`] that always grants the lock.
 #[cfg(test)]
 pub struct AlwaysAvailableLock;
 
@@ -153,10 +161,10 @@ impl RunLock for AlwaysAvailableLock {
     fn new_token(&self) -> String {
         "test-token".to_string()
     }
-    async fn acquire(&self, _job: &str, _token: &str) -> RedisResult<bool> {
+    async fn acquire(&self, _job: &str, _token: &str) -> LockResult<bool> {
         Ok(true)
     }
-    async fn unlock(&self, _job: &str, _token: &str) -> RedisResult<()> {
+    async fn unlock(&self, _job: &str, _token: &str) -> LockResult<()> {
         Ok(())
     }
 }

--- a/nexusd/src/jobs/lock.rs
+++ b/nexusd/src/jobs/lock.rs
@@ -2,13 +2,22 @@ use async_trait::async_trait;
 use nexus_common::db::{release_lock, try_acquire_lock, RedisError};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use super::error::{LockError, LockResult};
 
-/// TTL on a job's run lock, and the crash backstop. Must exceed the longest
-/// expected run, or a run outliving its lease could overlap another.
-const LOCK_TTL_SECS: u64 = 3600;
+/// The one knob: how long a run may take. Callers abandon `run()` at this
+/// wall-clock deadline, and the lease is sized from it, so a run can't outlive
+/// its lease and overlap another process's.
+pub(super) const MAX_RUN: Duration = Duration::from_secs(3600);
+
+/// Lease slack past [`MAX_RUN`], covering the acquire-to-run gap and the release
+/// round-trip. Also the crash backstop: after a hard kill the slot frees itself
+/// this long after the deadline.
+const LEASE_MARGIN: Duration = Duration::from_secs(60);
+
+/// Lease TTL, sized from the deadline it has to outlast.
+const LOCK_TTL_SECS: u64 = MAX_RUN.as_secs() + LEASE_MARGIN.as_secs();
 
 /// Cross-process mutual exclusion for a job's runs (the scheduler already
 /// serializes within one process). Injected so the scheduler is testable
@@ -186,9 +195,18 @@ impl Drop for LockGuard {
 
 #[cfg(test)]
 mod tests {
-    use super::{acquire, Acquired, RunLock};
+    use super::{acquire, Acquired, RunLock, LOCK_TTL_SECS, MAX_RUN};
     use crate::jobs::test_support::{AcquireOutcome, FakeLock};
     use std::sync::Arc;
+
+    #[test]
+    fn lease_outlives_the_run_deadline() {
+        assert!(
+            LOCK_TTL_SECS > MAX_RUN.as_secs(),
+            "the lease must outlast the deadline, or an abandoned run's slot could \
+             be taken before its release lands"
+        );
+    }
 
     #[tokio::test]
     async fn failed_acquire_releases_before_returning() {

--- a/nexusd/src/jobs/lock.rs
+++ b/nexusd/src/jobs/lock.rs
@@ -13,11 +13,15 @@ const LOCK_TTL_SECS: u64 = 3600;
 /// without Redis.
 #[async_trait]
 pub trait RunLock: Send + Sync {
-    /// Tries to claim the run slot for `job`. `Ok(None)` when another run holds
-    /// it; the returned token must be passed back to [`unlock`](Self::unlock).
-    async fn try_lock(&self, job: &str) -> RedisResult<Option<String>>;
+    /// Mints a fresh token (no I/O), so a [`LockGuard`] can be armed before
+    /// `acquire` — a run cancelled mid-acquire then still releases.
+    fn new_token(&self) -> String;
 
-    /// Releases a slot claimed with `token` (compare-and-delete).
+    /// Tries to claim the run slot for `job` under `token`. `Ok(false)` when
+    /// another run already holds it.
+    async fn acquire(&self, job: &str, token: &str) -> RedisResult<bool>;
+
+    /// Releases the slot, but only if it's still held by `token`.
     async fn unlock(&self, job: &str, token: &str) -> RedisResult<()>;
 }
 
@@ -42,16 +46,6 @@ impl RedisRunLock {
             counter: AtomicU64::new(0),
         }
     }
-
-    /// A token unique per acquisition within this process: `<pid>-<seed>-<counter>`.
-    fn new_token(&self) -> String {
-        format!(
-            "{}-{}-{}",
-            std::process::id(),
-            self.seed,
-            self.counter.fetch_add(1, Ordering::Relaxed),
-        )
-    }
 }
 
 impl Default for RedisRunLock {
@@ -62,13 +56,18 @@ impl Default for RedisRunLock {
 
 #[async_trait]
 impl RunLock for RedisRunLock {
-    async fn try_lock(&self, job: &str) -> RedisResult<Option<String>> {
-        let token = self.new_token();
-        if try_acquire_lock(&key(job), &token, LOCK_TTL_SECS).await? {
-            Ok(Some(token))
-        } else {
-            Ok(None)
-        }
+    /// A token unique per acquisition within this process: `<pid>-<seed>-<counter>`.
+    fn new_token(&self) -> String {
+        format!(
+            "{}-{}-{}",
+            std::process::id(),
+            self.seed,
+            self.counter.fetch_add(1, Ordering::Relaxed),
+        )
+    }
+
+    async fn acquire(&self, job: &str, token: &str) -> RedisResult<bool> {
+        try_acquire_lock(&key(job), token, LOCK_TTL_SECS).await
     }
 
     async fn unlock(&self, job: &str, token: &str) -> RedisResult<()> {
@@ -100,6 +99,13 @@ impl LockGuard {
             token: Some(token),
             lock,
         }
+    }
+
+    /// Forget the lock without releasing it — for the path where the guard was
+    /// armed before the acquire but the lock wasn't actually taken. After this,
+    /// Drop is a no-op.
+    pub(super) fn disarm(mut self) {
+        self.token = None;
     }
 
     /// Releases the lock, awaiting the result so unlock errors log
@@ -144,8 +150,11 @@ pub struct AlwaysAvailableLock;
 #[cfg(test)]
 #[async_trait]
 impl RunLock for AlwaysAvailableLock {
-    async fn try_lock(&self, _job: &str) -> RedisResult<Option<String>> {
-        Ok(Some("test-token".to_string()))
+    fn new_token(&self) -> String {
+        "test-token".to_string()
+    }
+    async fn acquire(&self, _job: &str, _token: &str) -> RedisResult<bool> {
+        Ok(true)
     }
     async fn unlock(&self, _job: &str, _token: &str) -> RedisResult<()> {
         Ok(())

--- a/nexusd/src/jobs/lock.rs
+++ b/nexusd/src/jobs/lock.rs
@@ -20,9 +20,9 @@ pub(super) const MAX_RUN: Duration = Duration::from_secs(3600);
 /// this long after the deadline.
 const LEASE_MARGIN: Duration = Duration::from_secs(60);
 
-/// Deadline for a single lock round trip (pool checkout + command). The pool
-/// has no wait timeout and redis-rs has no response timeout, so without this
-/// a blackholed connection hangs the run phase and, worse, shutdown.
+/// Deadline for a single lock round trip. A backend isn't required to bound its
+/// own calls, so without this a stalled one hangs the run phase and, worse,
+/// shutdown.
 /// Monotonic on purpose: `tokio::time::timeout`, not `sleep_wall`. The
 /// wall-clock discipline elsewhere exists so a run can't outlive its lease;
 /// a five-second I/O window is unaffected by host suspend.
@@ -33,7 +33,10 @@ const LOCK_TTL_SECS: u64 = MAX_RUN.as_secs() + LEASE_MARGIN.as_secs();
 
 /// Cross-process mutual exclusion for a job's runs (the scheduler already
 /// serializes within one process). Injected so the scheduler is testable
-/// without Redis.
+/// without a real backend.
+///
+/// A claim must expire on its own, so a crashed holder's slot frees itself; that
+/// lease has to outlast [`MAX_RUN`].
 #[async_trait]
 pub trait RunLock: Send + Sync {
     /// Mints a fresh token (no I/O), so a [`LockGuard`] can be armed before
@@ -114,11 +117,11 @@ pub(super) enum Acquired {
     Taken(LockGuard),
     /// Another run holds it. Nothing to release.
     Held,
-    /// Backend error during SET. Inline release was attempted; `released` is true
-    /// when the unlock command completed.
+    /// Backend error while acquiring. Inline release was attempted; `released` is
+    /// true when that unlock succeeded.
     Failed { error: LockError, released: bool },
-    /// I/O deadline elapsed during SET. Inline release was attempted; `released`
-    /// is true when the unlock command completed, false when it also timed out.
+    /// I/O deadline elapsed while acquiring. Inline release was attempted;
+    /// `released` is true when that unlock succeeded, false when it also timed out.
     TimedOut { released: bool },
 }
 
@@ -131,8 +134,8 @@ pub(super) enum ReleaseOutcome {
     NotHeld,
     /// Backend reported an error releasing the lock.
     Failed,
-    /// I/O deadline elapsed during the unlock command. The slot will now
-    /// stay held until its TTL expires.
+    /// I/O deadline elapsed while releasing. The slot will now stay held until
+    /// its lease expires.
     TimedOut,
 }
 
@@ -206,9 +209,9 @@ impl LockMetrics {
     }
 }
 
-/// Takes `job`'s run slot, arming the guard *before* the acquire so a lost SET
-/// reply (or a cancel mid-acquire) still releases; the compare-and-delete no-ops
-/// if our token was never stored.
+/// Takes `job`'s run slot, arming the guard *before* the acquire so a lost
+/// acquire reply (or a cancel mid-acquire) still releases; the release is
+/// token-scoped, so it no-ops if our token never took the slot.
 ///
 /// One `job` feeds both the acquire and the guard, so a run can't release a key
 /// it never acquired. On backend error the guard is released inline rather than
@@ -256,8 +259,8 @@ pub(super) async fn acquire(
 ///
 /// Drop releases fire-and-forget via `tokio::spawn`, so it must be dropped in a
 /// runtime context, and only frees the lock if that runtime outlives the spawn —
-/// otherwise the TTL is the fallback. Don't rely on it where the process may
-/// exit right after (see [`acquire`]).
+/// otherwise the lease expiry is the fallback. Don't rely on it where the
+/// process may exit right after (see [`acquire`]).
 pub struct LockGuard {
     job: &'static str,
     token: Option<String>,

--- a/nexusd/src/jobs/lock.rs
+++ b/nexusd/src/jobs/lock.rs
@@ -29,7 +29,7 @@ const LEASE_MARGIN: Duration = Duration::from_secs(60);
 const LOCK_IO_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Lease TTL, sized from the deadline it has to outlast.
-const LOCK_TTL_SECS: u64 = MAX_RUN.as_secs() + LEASE_MARGIN.as_secs();
+pub const LOCK_TTL_SECS: u64 = MAX_RUN.as_secs() + LEASE_MARGIN.as_secs();
 
 /// Cross-process mutual exclusion for a job's runs (the scheduler already
 /// serializes within one process). Injected so the scheduler is testable

--- a/nexusd/src/jobs/lock.rs
+++ b/nexusd/src/jobs/lock.rs
@@ -164,7 +164,8 @@ impl LockMetrics {
             .build();
         let duration_histogram = meter
             .f64_histogram("jobs.lock.duration")
-            .with_description("Lock acquire/release duration (seconds)")
+            .with_description("Lock acquire/release duration, in milliseconds")
+            .with_unit("ms")
             .build();
         Self {
             operations_counter,
@@ -188,7 +189,7 @@ impl LockMetrics {
         ];
         self.operations_counter.add(1, &tags);
         self.duration_histogram
-            .record(duration.as_secs_f64(), &tags);
+            .record(duration.as_secs_f64() * 1000.0, &tags);
     }
 
     fn record_acquire(&self, job: &'static str, outcome: &'static str, duration: Duration) {

--- a/nexusd/src/jobs/lock.rs
+++ b/nexusd/src/jobs/lock.rs
@@ -1,11 +1,14 @@
 use async_trait::async_trait;
 use nexus_common::db::{release_lock, try_acquire_lock, RedisError};
+use opentelemetry::metrics::{Counter, Histogram, Meter};
+use opentelemetry::{global, KeyValue};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::time::timeout;
 
 use super::error::{LockError, LockResult};
+use super::METER_NAME;
 
 /// The one knob: how long a run may take. Callers abandon `run()` at this
 /// wall-clock deadline, and the lease is sized from it, so a run can't outlive
@@ -133,6 +136,76 @@ pub(super) enum ReleaseOutcome {
     TimedOut,
 }
 
+/// Lock-level observability: counter for acquire/release outcomes and a
+/// duration histogram for both operations. Cheap to clone (all `Arc`-backed).
+/// Instruments are from the global meter (no-ops until an `SdkMeterProvider`
+/// is installed). Note: on the scheduled path, lock outcomes overlap
+/// `jobs.run.skipped{reason}` — do not sum both on dashboards.
+#[derive(Clone)]
+pub struct LockMetrics {
+    operations_counter: Counter<u64>,
+    duration_histogram: Histogram<f64>,
+}
+
+impl LockMetrics {
+    /// Build from the global meter.
+    pub fn new() -> Self {
+        Self::with_meter(global::meter(METER_NAME))
+    }
+
+    /// Explicit meter for tests.
+    pub(crate) fn with_meter(meter: Meter) -> Self {
+        let operations_counter = meter
+            .u64_counter("jobs.lock.operations")
+            .with_description("Lock acquire/release attempts")
+            .build();
+        let duration_histogram = meter
+            .f64_histogram("jobs.lock.duration")
+            .with_description("Lock acquire/release duration (seconds)")
+            .build();
+        Self {
+            operations_counter,
+            duration_histogram,
+        }
+    }
+
+    fn record(
+        &self,
+        job: &'static str,
+        operation: &'static str,
+        outcome: &'static str,
+        path: &'static str,
+        duration: Duration,
+    ) {
+        let tags = [
+            KeyValue::new("job", job),
+            KeyValue::new("operation", operation),
+            KeyValue::new("outcome", outcome),
+            KeyValue::new("path", path),
+        ];
+        self.operations_counter.add(1, &tags);
+        self.duration_histogram
+            .record(duration.as_secs_f64(), &tags);
+    }
+
+    fn record_acquire(&self, job: &'static str, outcome: &'static str, duration: Duration) {
+        self.record(job, "acquire", outcome, "inline", duration);
+    }
+
+    fn record_release(&self, job: &'static str, outcome: &'static str, duration: Duration) {
+        self.record(job, "release", outcome, "inline", duration);
+    }
+
+    fn record_release_from_drop(
+        &self,
+        job: &'static str,
+        outcome: &'static str,
+        duration: Duration,
+    ) {
+        self.record(job, "release", outcome, "drop", duration);
+    }
+}
+
 /// Takes `job`'s run slot, arming the guard *before* the acquire so a lost SET
 /// reply (or a cancel mid-acquire) still releases; the compare-and-delete no-ops
 /// if our token was never stored.
@@ -141,22 +214,37 @@ pub(super) enum ReleaseOutcome {
 /// it never acquired. On backend error the guard is released inline rather than
 /// left to Drop: callers may return straight into process exit, where a
 /// Drop-spawned unlock never gets polled.
-pub(super) async fn acquire(job: &'static str, lock: &Arc<dyn RunLock>) -> Acquired {
+// Drop-spawned release may cancel at shutdown — TTL is the backstop.
+// Acquire-timeout ownership uncertain — best-effort inline release, TTL backstop.
+pub(super) async fn acquire(
+    job: &'static str,
+    lock: &Arc<dyn RunLock>,
+    metrics: &LockMetrics,
+) -> Acquired {
     let token = lock.new_token();
-    let guard = LockGuard::new(job, token.clone(), Arc::clone(lock));
+    let guard = LockGuard::new(job, token.clone(), Arc::clone(lock), metrics.clone());
 
+    let start = Instant::now();
     match timeout(LOCK_IO_TIMEOUT, lock.acquire(job, &token)).await {
-        Ok(Ok(true)) => Acquired::Taken(guard),
+        Ok(Ok(true)) => {
+            metrics.record_acquire(job, "ok", start.elapsed());
+            Acquired::Taken(guard)
+        }
         Ok(Ok(false)) => {
+            metrics.record_acquire(job, "held", start.elapsed());
             guard.disarm();
             Acquired::Held
         }
         Ok(Err(e)) => {
+            let elapsed = start.elapsed();
             let released = matches!(guard.release().await, ReleaseOutcome::Released);
+            metrics.record_acquire(job, "error", elapsed);
             Acquired::Failed { error: e, released }
         }
         Err(_) => {
+            let elapsed = start.elapsed();
             let released = matches!(guard.release().await, ReleaseOutcome::Released);
+            metrics.record_acquire(job, "timeout", elapsed);
             Acquired::TimedOut { released }
         }
     }
@@ -174,14 +262,21 @@ pub struct LockGuard {
     job: &'static str,
     token: Option<String>,
     lock: Arc<dyn RunLock>,
+    metrics: LockMetrics,
 }
 
 impl LockGuard {
-    pub(super) fn new(job: &'static str, token: String, lock: Arc<dyn RunLock>) -> Self {
+    pub(super) fn new(
+        job: &'static str,
+        token: String,
+        lock: Arc<dyn RunLock>,
+        metrics: LockMetrics,
+    ) -> Self {
         Self {
             job,
             token: Some(token),
             lock,
+            metrics,
         }
     }
 
@@ -199,13 +294,21 @@ impl LockGuard {
             return ReleaseOutcome::NotHeld;
         };
 
+        let start = Instant::now();
         match timeout(LOCK_IO_TIMEOUT, self.lock.unlock(self.job, &token)).await {
-            Ok(Ok(())) => ReleaseOutcome::Released,
+            Ok(Ok(())) => {
+                self.metrics.record_release(self.job, "ok", start.elapsed());
+                ReleaseOutcome::Released
+            }
             Ok(Err(e)) => {
+                self.metrics
+                    .record_release(self.job, "error", start.elapsed());
                 tracing::debug!(job = self.job, "Could not release run lock: {e}");
                 ReleaseOutcome::Failed
             }
             Err(_) => {
+                self.metrics
+                    .record_release(self.job, "timeout", start.elapsed());
                 tracing::debug!(
                     job = self.job,
                     "Unlock timed out — slot may stay held until TTL expires"
@@ -222,17 +325,23 @@ impl Drop for LockGuard {
             return;
         };
         let lock = self.lock.clone();
+        let metrics = self.metrics.clone();
         let job = self.job;
         // Fire-and-forget: reached whenever a guard is dropped still armed, which
         // release() and disarm() both prevent. Needs the runtime to outlive it.
         tokio::spawn(async move {
+            let start = Instant::now();
             match timeout(LOCK_IO_TIMEOUT, lock.unlock(job, &token)).await {
-                Ok(Ok(())) => {}
+                Ok(Ok(())) => {
+                    metrics.record_release_from_drop(job, "ok", start.elapsed());
+                }
                 Ok(Err(e)) => {
+                    metrics.record_release_from_drop(job, "error", start.elapsed());
                     // Sole reporter (no caller), so stays warn unlike release()
                     tracing::warn!(job, "Could not release run lock: {e}");
                 }
                 Err(_) => {
+                    metrics.record_release_from_drop(job, "timeout", start.elapsed());
                     // Sole reporter (no caller), so stays warn unlike release()
                     tracing::warn!(
                         job,
@@ -246,10 +355,23 @@ impl Drop for LockGuard {
 
 #[cfg(test)]
 mod tests {
-    use super::{acquire, ReleaseOutcome, LOCK_IO_TIMEOUT};
+    use super::{acquire, LockMetrics, ReleaseOutcome, LOCK_IO_TIMEOUT};
     use super::{Acquired, RunLock, LEASE_MARGIN, LOCK_TTL_SECS, MAX_RUN};
-    use crate::jobs::test_support::{AcquireOutcome, FakeLock, UnlockOutcome};
+    use crate::jobs::test_support::{counter_value, AcquireOutcome, FakeLock, UnlockOutcome};
+    use opentelemetry::metrics::MeterProvider;
+    use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData};
+    use opentelemetry_sdk::metrics::{InMemoryMetricExporter, SdkMeterProvider};
     use std::sync::Arc;
+
+    /// Build a [`LockMetrics`] with an in-memory exporter.
+    fn metered_lock_metrics() -> (LockMetrics, SdkMeterProvider, InMemoryMetricExporter) {
+        let exporter = InMemoryMetricExporter::default();
+        let provider = SdkMeterProvider::builder()
+            .with_periodic_exporter(exporter.clone())
+            .build();
+        let metrics = LockMetrics::with_meter(provider.meter("test"));
+        (metrics, provider, exporter)
+    }
 
     #[test]
     fn lock_io_timeout_is_comfortably_within_lease_margin() {
@@ -277,8 +399,9 @@ mod tests {
     async fn failed_acquire_releases_before_returning() {
         let fake = FakeLock::new(AcquireOutcome::Fails, UnlockOutcome::Succeeds);
         let lock: Arc<dyn RunLock> = fake.clone();
+        let (metrics, _provider, _exporter) = metered_lock_metrics();
 
-        let outcome = acquire("job", &lock).await;
+        let outcome = acquire("job", &lock, &metrics).await;
 
         // Asserted with no yield in between: a Drop-spawned unlock could not have
         // run yet, so a nonzero count can only mean the release was awaited inline.
@@ -301,8 +424,9 @@ mod tests {
     async fn held_lock_is_not_released() {
         let fake = FakeLock::new(AcquireOutcome::Denied, UnlockOutcome::Succeeds);
         let lock: Arc<dyn RunLock> = fake.clone();
+        let (metrics, _provider, _exporter) = metered_lock_metrics();
 
-        let outcome = acquire("job", &lock).await;
+        let outcome = acquire("job", &lock, &metrics).await;
         // Yield so a stray Drop-spawned unlock would surface rather than race us.
         tokio::task::yield_now().await;
 
@@ -318,8 +442,9 @@ mod tests {
     async fn acquire_and_release_use_the_same_job() {
         let fake = FakeLock::new(AcquireOutcome::Granted, UnlockOutcome::Succeeds);
         let lock: Arc<dyn RunLock> = fake.clone();
+        let (metrics, _provider, _exporter) = metered_lock_metrics();
 
-        let Acquired::Taken(guard) = acquire("the-job", &lock).await else {
+        let Acquired::Taken(guard) = acquire("the-job", &lock, &metrics).await else {
             panic!("a granted acquire must yield a guard");
         };
         assert_eq!(fake.unlock_attempts(), 0, "held until released");
@@ -337,9 +462,10 @@ mod tests {
     async fn acquire_times_out_and_releases_inline() {
         let fake = FakeLock::new(AcquireOutcome::Hangs, UnlockOutcome::Succeeds);
         let lock: Arc<dyn RunLock> = fake.clone();
+        let (metrics, _provider, _exporter) = metered_lock_metrics();
 
         // Paused-mode auto-advance fires the timer when the runtime goes idle on pending().
-        let outcome = acquire("job", &lock).await;
+        let outcome = acquire("job", &lock, &metrics).await;
 
         let Acquired::TimedOut { released } = outcome else {
             panic!("expected Acquired::TimedOut");
@@ -356,8 +482,9 @@ mod tests {
     async fn acquire_and_release_both_time_out() {
         let fake = FakeLock::new(AcquireOutcome::Hangs, UnlockOutcome::Hangs);
         let lock: Arc<dyn RunLock> = fake.clone();
+        let (metrics, _provider, _exporter) = metered_lock_metrics();
 
-        let outcome = acquire("job", &lock).await;
+        let outcome = acquire("job", &lock, &metrics).await;
 
         let Acquired::TimedOut { released } = outcome else {
             panic!("expected Acquired::TimedOut");
@@ -372,8 +499,9 @@ mod tests {
     async fn failed_acquire_with_failed_release() {
         let fake = FakeLock::new(AcquireOutcome::Fails, UnlockOutcome::Hangs);
         let lock: Arc<dyn RunLock> = fake.clone();
+        let (metrics, _provider, _exporter) = metered_lock_metrics();
 
-        let outcome = acquire("job", &lock).await;
+        let outcome = acquire("job", &lock, &metrics).await;
 
         let Acquired::Failed { error, released } = outcome else {
             panic!("expected Acquired::Failed");
@@ -392,8 +520,9 @@ mod tests {
     async fn release_times_out_and_reports_it() {
         let fake = FakeLock::new(AcquireOutcome::Granted, UnlockOutcome::Hangs);
         let lock: Arc<dyn RunLock> = fake.clone();
+        let (metrics, _provider, _exporter) = metered_lock_metrics();
 
-        let Acquired::Taken(guard) = acquire("job", &lock).await else {
+        let Acquired::Taken(guard) = acquire("job", &lock, &metrics).await else {
             panic!("acquire should succeed");
         };
 
@@ -403,6 +532,148 @@ mod tests {
         assert!(
             matches!(outcome, ReleaseOutcome::TimedOut),
             "release should return TimedOut when the unlock I/O deadline elapses"
+        );
+    }
+
+    #[tokio::test]
+    async fn lock_metrics_record_acquire_outcomes() {
+        let fake = FakeLock::new(AcquireOutcome::Granted, UnlockOutcome::Succeeds);
+        let lock: Arc<dyn RunLock> = fake.clone();
+        let (metrics, provider, exporter) = metered_lock_metrics();
+
+        let outcome = acquire("test-job", &lock, &metrics).await;
+        assert!(matches!(outcome, Acquired::Taken(_)));
+
+        provider.force_flush().unwrap();
+        let resource_metrics = exporter.get_finished_metrics().unwrap();
+
+        assert_eq!(
+            counter_value(
+                &resource_metrics,
+                "jobs.lock.operations",
+                &[("outcome", "ok"), ("operation", "acquire")]
+            ),
+            1,
+            "acquire outcome must be recorded"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn lock_metrics_record_acquire_timeout() {
+        let fake = FakeLock::new(AcquireOutcome::Hangs, UnlockOutcome::Succeeds);
+        let lock: Arc<dyn RunLock> = fake.clone();
+        let (metrics, provider, exporter) = metered_lock_metrics();
+
+        let outcome = acquire("test-job", &lock, &metrics).await;
+        assert!(matches!(outcome, Acquired::TimedOut { .. }));
+
+        provider.force_flush().unwrap();
+        let resource_metrics = exporter.get_finished_metrics().unwrap();
+
+        assert_eq!(
+            counter_value(
+                &resource_metrics,
+                "jobs.lock.operations",
+                &[("outcome", "timeout"), ("operation", "acquire")]
+            ),
+            1,
+            "acquire timeout must be recorded"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn lock_metrics_record_acquire_error() {
+        let fake = FakeLock::new(AcquireOutcome::Fails, UnlockOutcome::Succeeds);
+        let lock: Arc<dyn RunLock> = fake.clone();
+        let (metrics, provider, exporter) = metered_lock_metrics();
+
+        let outcome = acquire("test-job", &lock, &metrics).await;
+        assert!(matches!(outcome, Acquired::Failed { .. }));
+
+        provider.force_flush().unwrap();
+        let resource_metrics = exporter.get_finished_metrics().unwrap();
+
+        assert_eq!(
+            counter_value(
+                &resource_metrics,
+                "jobs.lock.operations",
+                &[("outcome", "error"), ("operation", "acquire")]
+            ),
+            1,
+            "acquire error must be recorded"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn lock_metrics_record_release_outcomes() {
+        let fake = FakeLock::new(AcquireOutcome::Granted, UnlockOutcome::Succeeds);
+        let lock: Arc<dyn RunLock> = fake.clone();
+        let (metrics, provider, exporter) = metered_lock_metrics();
+
+        let Acquired::Taken(guard) = acquire("test-job", &lock, &metrics).await else {
+            panic!("acquire should succeed");
+        };
+        guard.release().await;
+
+        provider.force_flush().unwrap();
+        let resource_metrics = exporter.get_finished_metrics().unwrap();
+
+        assert_eq!(
+            counter_value(
+                &resource_metrics,
+                "jobs.lock.operations",
+                &[("outcome", "ok"), ("operation", "release")]
+            ),
+            1,
+            "release outcome must be recorded"
+        );
+        // Histogram has two series: one acquire + one release (each a unique attr set)
+        let mut histogram_count = 0u64;
+        for rm in &resource_metrics {
+            for sm in rm.scope_metrics() {
+                for m in sm.metrics().filter(|m| m.name() == "jobs.lock.duration") {
+                    let AggregatedMetrics::F64(MetricData::Histogram(h)) = m.data() else {
+                        continue;
+                    };
+                    histogram_count += h.data_points().count() as u64;
+                }
+            }
+        }
+        assert!(
+            histogram_count >= 2,
+            "duration histogram must have at least 2 series (acquire + release), got {histogram_count}"
+        );
+    }
+
+    #[tokio::test]
+    async fn lock_metrics_record_drop_path_release() {
+        let fake = FakeLock::new(AcquireOutcome::Granted, UnlockOutcome::Succeeds);
+        let lock: Arc<dyn RunLock> = fake.clone();
+        let (metrics, provider, exporter) = metered_lock_metrics();
+
+        let Acquired::Taken(guard) = acquire("test-job", &lock, &metrics).await else {
+            panic!("acquire should succeed");
+        };
+        // Drop the guard without calling release() — triggers the drop path.
+        std::mem::drop(guard);
+        // Yield so the spawned drop-task runs.
+        tokio::task::yield_now().await;
+
+        provider.force_flush().unwrap();
+        let resource_metrics = exporter.get_finished_metrics().unwrap();
+
+        assert_eq!(
+            counter_value(
+                &resource_metrics,
+                "jobs.lock.operations",
+                &[
+                    ("outcome", "ok"),
+                    ("operation", "release"),
+                    ("path", "drop")
+                ]
+            ),
+            1,
+            "drop-path release must be recorded with path=drop"
         );
     }
 }

--- a/nexusd/src/jobs/lock.rs
+++ b/nexusd/src/jobs/lock.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use nexus_common::db::{release_lock, try_acquire_lock, RedisError};
+use nexus_common::utils::ms;
 use opentelemetry::metrics::{Counter, Histogram, Meter};
 use opentelemetry::{global, KeyValue};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -204,8 +205,7 @@ impl LockMetrics {
                 ]
             });
         self.operations_counter.add(1, &tags);
-        self.duration_histogram
-            .record(duration.as_secs_f64() * 1000.0, &tags);
+        self.duration_histogram.record(ms(duration), &tags);
     }
 
     fn record_acquire(&self, job: &'static str, outcome: &'static str, duration: Duration) {

--- a/nexusd/src/jobs/lock.rs
+++ b/nexusd/src/jobs/lock.rs
@@ -173,31 +173,43 @@ impl LockMetrics {
         }
     }
 
+    /// Record an acquire/release outcome.
+    ///
+    /// `path` describes how an *unlock* happened and is emitted only on release
+    /// points (`inline` = explicit `release()`, `drop` = Drop backstop,
+    /// `cleanup` = acquire-failure cleanup). Acquire points carry no `path`
+    /// attribute because there is only one way to acquire.
     fn record(
         &self,
         job: &'static str,
         operation: &'static str,
         outcome: &'static str,
-        path: &'static str,
+        path: Option<&'static str>,
         duration: Duration,
     ) {
-        let tags = [
-            KeyValue::new("job", job),
-            KeyValue::new("operation", operation),
-            KeyValue::new("outcome", outcome),
-            KeyValue::new("path", path),
-        ];
+        let tags: Vec<KeyValue> = path
+            .map(|p| {
+                vec![
+                    KeyValue::new("job", job),
+                    KeyValue::new("operation", operation),
+                    KeyValue::new("outcome", outcome),
+                    KeyValue::new("path", p),
+                ]
+            })
+            .unwrap_or_else(|| {
+                vec![
+                    KeyValue::new("job", job),
+                    KeyValue::new("operation", operation),
+                    KeyValue::new("outcome", outcome),
+                ]
+            });
         self.operations_counter.add(1, &tags);
         self.duration_histogram
             .record(duration.as_secs_f64() * 1000.0, &tags);
     }
 
     fn record_acquire(&self, job: &'static str, outcome: &'static str, duration: Duration) {
-        self.record(job, "acquire", outcome, "inline", duration);
-    }
-
-    fn record_release(&self, job: &'static str, outcome: &'static str, duration: Duration) {
-        self.record(job, "release", outcome, "inline", duration);
+        self.record(job, "acquire", outcome, None, duration);
     }
 
     fn record_release_from_drop(
@@ -206,7 +218,7 @@ impl LockMetrics {
         outcome: &'static str,
         duration: Duration,
     ) {
-        self.record(job, "release", outcome, "drop", duration);
+        self.record(job, "release", outcome, Some("drop"), duration);
     }
 }
 
@@ -241,13 +253,13 @@ pub(super) async fn acquire(
         }
         Ok(Err(e)) => {
             let elapsed = start.elapsed();
-            let released = matches!(guard.release().await, ReleaseOutcome::Released);
+            let released = matches!(guard.release_as("cleanup").await, ReleaseOutcome::Released);
             metrics.record_acquire(job, "error", elapsed);
             Acquired::Failed { error: e, released }
         }
         Err(_) => {
             let elapsed = start.elapsed();
-            let released = matches!(guard.release().await, ReleaseOutcome::Released);
+            let released = matches!(guard.release_as("cleanup").await, ReleaseOutcome::Released);
             metrics.record_acquire(job, "timeout", elapsed);
             Acquired::TimedOut { released }
         }
@@ -292,8 +304,15 @@ impl LockGuard {
     }
 
     /// Releases the lock, awaiting the result so unlock errors log
-    /// synchronously. After this, Drop is a no-op.
-    pub async fn release(mut self) -> ReleaseOutcome {
+    /// synchronously. After this, Drop is a no-op. Emits metrics with
+    /// `path=inline`.
+    pub async fn release(self) -> ReleaseOutcome {
+        self.release_as("inline").await
+    }
+
+    /// Like [`release`](Self::release) but emits the given `path` label.
+    /// Used by [`acquire`] to distinguish cleanup releases from normal ones.
+    pub(super) async fn release_as(mut self, path: &'static str) -> ReleaseOutcome {
         let Some(token) = self.token.take() else {
             return ReleaseOutcome::NotHeld;
         };
@@ -301,18 +320,19 @@ impl LockGuard {
         let start = Instant::now();
         match timeout(LOCK_IO_TIMEOUT, self.lock.unlock(self.job, &token)).await {
             Ok(Ok(())) => {
-                self.metrics.record_release(self.job, "ok", start.elapsed());
+                self.metrics
+                    .record(self.job, "release", "ok", Some(path), start.elapsed());
                 ReleaseOutcome::Released
             }
             Ok(Err(e)) => {
                 self.metrics
-                    .record_release(self.job, "error", start.elapsed());
+                    .record(self.job, "release", "error", Some(path), start.elapsed());
                 tracing::debug!(job = self.job, "Could not release run lock: {e}");
                 ReleaseOutcome::Failed
             }
             Err(_) => {
                 self.metrics
-                    .record_release(self.job, "timeout", start.elapsed());
+                    .record(self.job, "release", "timeout", Some(path), start.elapsed());
                 tracing::debug!(
                     job = self.job,
                     "Unlock timed out — slot may stay held until TTL expires"
@@ -626,10 +646,14 @@ mod tests {
             counter_value(
                 &resource_metrics,
                 "jobs.lock.operations",
-                &[("outcome", "ok"), ("operation", "release")]
+                &[
+                    ("outcome", "ok"),
+                    ("operation", "release"),
+                    ("path", "inline")
+                ]
             ),
             1,
-            "release outcome must be recorded"
+            "happy-path release must be recorded with path=inline"
         );
         // Histogram has two series: one acquire + one release (each a unique attr set)
         let mut histogram_count = 0u64;
@@ -646,6 +670,58 @@ mod tests {
         assert!(
             histogram_count >= 2,
             "duration histogram must have at least 2 series (acquire + release), got {histogram_count}"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn lock_metrics_record_cleanup_release_on_failed_acquire() {
+        let fake = FakeLock::new(AcquireOutcome::Fails, UnlockOutcome::Succeeds);
+        let lock: Arc<dyn RunLock> = fake.clone();
+        let (metrics, provider, exporter) = metered_lock_metrics();
+
+        let outcome = acquire("test-job", &lock, &metrics).await;
+        assert!(matches!(outcome, Acquired::Failed { released: true, .. }));
+
+        provider.force_flush().unwrap();
+        let resource_metrics = exporter.get_finished_metrics().unwrap();
+
+        // The acquire error should have no path attribute
+        assert_eq!(
+            counter_value(
+                &resource_metrics,
+                "jobs.lock.operations",
+                &[("outcome", "error"), ("operation", "acquire")]
+            ),
+            1,
+            "acquire error must be recorded without path"
+        );
+        // The cleanup release should have path=cleanup
+        assert_eq!(
+            counter_value(
+                &resource_metrics,
+                "jobs.lock.operations",
+                &[
+                    ("outcome", "ok"),
+                    ("operation", "release"),
+                    ("path", "cleanup")
+                ]
+            ),
+            1,
+            "cleanup release after failed acquire must be recorded with path=cleanup"
+        );
+        // No inline release should exist
+        assert_eq!(
+            counter_value(
+                &resource_metrics,
+                "jobs.lock.operations",
+                &[
+                    ("outcome", "ok"),
+                    ("operation", "release"),
+                    ("path", "inline")
+                ]
+            ),
+            0,
+            "no inline release should exist when acquire failed"
         );
     }
 

--- a/nexusd/src/jobs/lock.rs
+++ b/nexusd/src/jobs/lock.rs
@@ -3,6 +3,7 @@ use nexus_common::db::{release_lock, try_acquire_lock, RedisError};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::time::timeout;
 
 use super::error::{LockError, LockResult};
 
@@ -15,6 +16,14 @@ pub(super) const MAX_RUN: Duration = Duration::from_secs(3600);
 /// round-trip. Also the crash backstop: after a hard kill the slot frees itself
 /// this long after the deadline.
 const LEASE_MARGIN: Duration = Duration::from_secs(60);
+
+/// Deadline for a single lock round trip (pool checkout + command). The pool
+/// has no wait timeout and redis-rs has no response timeout, so without this
+/// a blackholed connection hangs the run phase and, worse, shutdown.
+/// Monotonic on purpose: `tokio::time::timeout`, not `sleep_wall`. The
+/// wall-clock discipline elsewhere exists so a run can't outlive its lease;
+/// a five-second I/O window is unaffected by host suspend.
+const LOCK_IO_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Lease TTL, sized from the deadline it has to outlast.
 const LOCK_TTL_SECS: u64 = MAX_RUN.as_secs() + LEASE_MARGIN.as_secs();
@@ -102,8 +111,26 @@ pub(super) enum Acquired {
     Taken(LockGuard),
     /// Another run holds it. Nothing to release.
     Held,
-    /// The backend failed. Anything we might have taken is already released.
-    Failed(LockError),
+    /// Backend error during SET. Inline release was attempted; `released` is true
+    /// when the unlock command completed.
+    Failed { error: LockError, released: bool },
+    /// I/O deadline elapsed during SET. Inline release was attempted; `released`
+    /// is true when the unlock command completed, false when it also timed out.
+    TimedOut { released: bool },
+}
+
+/// Outcome of a [`LockGuard::release`] operation.
+#[derive(Debug)]
+pub(super) enum ReleaseOutcome {
+    /// Lock was successfully released.
+    Released,
+    /// Guard was already disarmed; nothing to release.
+    NotHeld,
+    /// Backend reported an error releasing the lock.
+    Failed,
+    /// I/O deadline elapsed during the unlock command. The slot will now
+    /// stay held until its TTL expires.
+    TimedOut,
 }
 
 /// Takes `job`'s run slot, arming the guard *before* the acquire so a lost SET
@@ -118,15 +145,19 @@ pub(super) async fn acquire(job: &'static str, lock: &Arc<dyn RunLock>) -> Acqui
     let token = lock.new_token();
     let guard = LockGuard::new(job, token.clone(), Arc::clone(lock));
 
-    match lock.acquire(job, &token).await {
-        Ok(true) => Acquired::Taken(guard),
-        Ok(false) => {
+    match timeout(LOCK_IO_TIMEOUT, lock.acquire(job, &token)).await {
+        Ok(Ok(true)) => Acquired::Taken(guard),
+        Ok(Ok(false)) => {
             guard.disarm();
             Acquired::Held
         }
-        Err(e) => {
-            guard.release().await;
-            Acquired::Failed(e)
+        Ok(Err(e)) => {
+            let released = matches!(guard.release().await, ReleaseOutcome::Released);
+            Acquired::Failed { error: e, released }
+        }
+        Err(_) => {
+            let released = matches!(guard.release().await, ReleaseOutcome::Released);
+            Acquired::TimedOut { released }
         }
     }
 }
@@ -163,15 +194,24 @@ impl LockGuard {
 
     /// Releases the lock, awaiting the result so unlock errors log
     /// synchronously. After this, Drop is a no-op.
-    pub async fn release(mut self) {
+    pub async fn release(mut self) -> ReleaseOutcome {
         let Some(token) = self.token.take() else {
-            return;
+            return ReleaseOutcome::NotHeld;
         };
-        if let Err(e) = self.lock.unlock(self.job, &token).await {
-            tracing::warn!(
-                job = self.job,
-                "Could not release run lock (will expire via TTL): {e}"
-            );
+
+        match timeout(LOCK_IO_TIMEOUT, self.lock.unlock(self.job, &token)).await {
+            Ok(Ok(())) => ReleaseOutcome::Released,
+            Ok(Err(e)) => {
+                tracing::debug!(job = self.job, "Could not release run lock: {e}");
+                ReleaseOutcome::Failed
+            }
+            Err(_) => {
+                tracing::debug!(
+                    job = self.job,
+                    "Unlock timed out — slot may stay held until TTL expires"
+                );
+                ReleaseOutcome::TimedOut
+            }
         }
     }
 }
@@ -186,8 +226,19 @@ impl Drop for LockGuard {
         // Fire-and-forget: reached whenever a guard is dropped still armed, which
         // release() and disarm() both prevent. Needs the runtime to outlive it.
         tokio::spawn(async move {
-            if let Err(e) = lock.unlock(job, &token).await {
-                tracing::warn!(job, "Could not release run lock (will expire via TTL): {e}");
+            match timeout(LOCK_IO_TIMEOUT, lock.unlock(job, &token)).await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => {
+                    // Sole reporter (no caller), so stays warn unlike release()
+                    tracing::warn!(job, "Could not release run lock: {e}");
+                }
+                Err(_) => {
+                    // Sole reporter (no caller), so stays warn unlike release()
+                    tracing::warn!(
+                        job,
+                        "Drop-path unlock timed out — slot may stay held until TTL expires"
+                    );
+                }
             }
         });
     }
@@ -195,9 +246,23 @@ impl Drop for LockGuard {
 
 #[cfg(test)]
 mod tests {
-    use super::{acquire, Acquired, RunLock, LOCK_TTL_SECS, MAX_RUN};
-    use crate::jobs::test_support::{AcquireOutcome, FakeLock};
+    use super::{acquire, ReleaseOutcome, LOCK_IO_TIMEOUT};
+    use super::{Acquired, RunLock, LEASE_MARGIN, LOCK_TTL_SECS, MAX_RUN};
+    use crate::jobs::test_support::{AcquireOutcome, FakeLock, UnlockOutcome};
     use std::sync::Arc;
+
+    #[test]
+    fn lock_io_timeout_is_comfortably_within_lease_margin() {
+        // The margin covers the acquire-to-run gap plus the release round trip.
+        // 2 * LOCK_IO_TIMEOUT is harmless slack for both I/O operations.
+        assert!(
+            2 * LOCK_IO_TIMEOUT < LEASE_MARGIN,
+            "2 * LOCK_IO_TIMEOUT ({:?}) must be < LEASE_MARGIN ({:?}) so that the \
+             acquire-to-run gap + release round trip fit within the margin",
+            2 * LOCK_IO_TIMEOUT,
+            LEASE_MARGIN,
+        );
+    }
 
     #[test]
     fn lease_outlives_the_run_deadline() {
@@ -210,7 +275,7 @@ mod tests {
 
     #[tokio::test]
     async fn failed_acquire_releases_before_returning() {
-        let fake = FakeLock::new(AcquireOutcome::Fails);
+        let fake = FakeLock::new(AcquireOutcome::Fails, UnlockOutcome::Succeeds);
         let lock: Arc<dyn RunLock> = fake.clone();
 
         let outcome = acquire("job", &lock).await;
@@ -218,16 +283,23 @@ mod tests {
         // Asserted with no yield in between: a Drop-spawned unlock could not have
         // run yet, so a nonzero count can only mean the release was awaited inline.
         assert_eq!(
-            fake.releases(),
+            fake.unlock_attempts(),
             1,
             "a failed acquire must release inline, not leave it to Drop's spawn"
         );
-        assert!(matches!(outcome, Acquired::Failed(_)));
+        let Acquired::Failed { error, released } = outcome else {
+            panic!("expected Acquired::Failed");
+        };
+        assert!(released, "inline release should succeed when unlock works");
+        assert!(
+            error.to_string().contains("backend down"),
+            "the original backend error should be preserved"
+        );
     }
 
     #[tokio::test]
     async fn held_lock_is_not_released() {
-        let fake = FakeLock::new(AcquireOutcome::Denied);
+        let fake = FakeLock::new(AcquireOutcome::Denied, UnlockOutcome::Succeeds);
         let lock: Arc<dyn RunLock> = fake.clone();
 
         let outcome = acquire("job", &lock).await;
@@ -235,7 +307,7 @@ mod tests {
         tokio::task::yield_now().await;
 
         assert_eq!(
-            fake.releases(),
+            fake.unlock_attempts(),
             0,
             "we never held the lock; unlocking would free another run's lease"
         );
@@ -244,20 +316,93 @@ mod tests {
 
     #[tokio::test]
     async fn acquire_and_release_use_the_same_job() {
-        let fake = FakeLock::new(AcquireOutcome::Granted);
+        let fake = FakeLock::new(AcquireOutcome::Granted, UnlockOutcome::Succeeds);
         let lock: Arc<dyn RunLock> = fake.clone();
 
         let Acquired::Taken(guard) = acquire("the-job", &lock).await else {
             panic!("a granted acquire must yield a guard");
         };
-        assert_eq!(fake.releases(), 0, "held until released");
+        assert_eq!(fake.unlock_attempts(), 0, "held until released");
         guard.release().await;
 
-        assert_eq!(fake.releases(), 1);
+        assert_eq!(fake.unlock_attempts(), 1);
         assert_eq!(
             fake.acquired_with(),
             fake.released_with(),
             "the release must target the key the acquire took"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn acquire_times_out_and_releases_inline() {
+        let fake = FakeLock::new(AcquireOutcome::Hangs, UnlockOutcome::Succeeds);
+        let lock: Arc<dyn RunLock> = fake.clone();
+
+        // Paused-mode auto-advance fires the timer when the runtime goes idle on pending().
+        let outcome = acquire("job", &lock).await;
+
+        let Acquired::TimedOut { released } = outcome else {
+            panic!("expected Acquired::TimedOut");
+        };
+        assert!(released, "inline release should succeed when unlock works");
+        assert_eq!(
+            fake.unlock_attempts(),
+            1,
+            "the timeout path must release inline, not leave it to Drop"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn acquire_and_release_both_time_out() {
+        let fake = FakeLock::new(AcquireOutcome::Hangs, UnlockOutcome::Hangs);
+        let lock: Arc<dyn RunLock> = fake.clone();
+
+        let outcome = acquire("job", &lock).await;
+
+        let Acquired::TimedOut { released } = outcome else {
+            panic!("expected Acquired::TimedOut");
+        };
+        assert!(
+            !released,
+            "inline release must time out when unlock hangs, so released is false"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn failed_acquire_with_failed_release() {
+        let fake = FakeLock::new(AcquireOutcome::Fails, UnlockOutcome::Hangs);
+        let lock: Arc<dyn RunLock> = fake.clone();
+
+        let outcome = acquire("job", &lock).await;
+
+        let Acquired::Failed { error, released } = outcome else {
+            panic!("expected Acquired::Failed");
+        };
+        assert!(
+            !released,
+            "inline release must time out when unlock hangs, so released is false"
+        );
+        assert!(
+            error.to_string().contains("backend down"),
+            "the original backend error should be preserved"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn release_times_out_and_reports_it() {
+        let fake = FakeLock::new(AcquireOutcome::Granted, UnlockOutcome::Hangs);
+        let lock: Arc<dyn RunLock> = fake.clone();
+
+        let Acquired::Taken(guard) = acquire("job", &lock).await else {
+            panic!("acquire should succeed");
+        };
+
+        // Paused-mode auto-advance fires the timer when the runtime goes idle on pending().
+        let outcome = guard.release().await;
+
+        assert!(
+            matches!(outcome, ReleaseOutcome::TimedOut),
+            "release should return TimedOut when the unlock I/O deadline elapses"
         );
     }
 }

--- a/nexusd/src/jobs/mod.rs
+++ b/nexusd/src/jobs/mod.rs
@@ -32,8 +32,10 @@ pub fn job_cron(config: &JobConfig) -> Result<Option<Schedule>, CronParseError> 
 /// any concrete job; both set up the stack first, so `run` can assume it's up.
 ///
 /// The runner takes a cross-process run lock around every run, so a job's runs
-/// never overlap — implementors don't manage concurrency. It imposes no timeout,
-/// though, so jobs hitting external services should apply their own.
+/// never overlap — implementors don't manage concurrency. A run is abandoned at
+/// the runner's one-hour deadline, so a job needing finer granularity should
+/// apply its own timeouts. Abandonment only drops `run`'s future: work the job
+/// spawned onto its own task keeps going, outside the lock's protection.
 #[async_trait]
 pub trait Job: Send + Sync {
     /// Stable unique identifier: used in logs, on-demand selection, and as the
@@ -107,7 +109,8 @@ impl JobRegistry {
             .map_err(JobError::Stack)?;
 
         let lock: Arc<dyn lock::RunLock> = Arc::new(RedisRunLock::new());
-        run_once_locked(job.as_ref(), &lock).await
+        let now_fn = Arc::new(Utc::now) as scheduler::NowFn;
+        run_once_locked(job.as_ref(), &lock, &now_fn).await
     }
 
     /// The scheduled jobs, resolved from config. Each job's schedule is validated
@@ -154,22 +157,43 @@ impl JobRegistry {
 }
 
 /// Runs `job` once under `lock`, mapping lock state to [`JobError`]. Split from
-/// [`JobRegistry::run_on_demand`] so it's testable without a stack; `lock` is
-/// injected for the same reason.
-async fn run_once_locked(job: &dyn Job, lock: &Arc<dyn lock::RunLock>) -> Result<(), JobError> {
+/// [`JobRegistry::run_on_demand`] so it's testable without a stack; `lock` and
+/// `now_fn` are injected for the same reason.
+///
+/// Abandoned at [`lock::MAX_RUN`] like a scheduled run, so an on-demand run can't
+/// outlive its lease either.
+async fn run_once_locked(
+    job: &dyn Job,
+    lock: &Arc<dyn lock::RunLock>,
+    now_fn: &scheduler::NowFn,
+) -> Result<(), JobError> {
     let guard = match lock::acquire(job.name(), lock).await {
         lock::Acquired::Taken(guard) => guard,
         lock::Acquired::Held => return Err(JobError::AlreadyRunning { job: job.name() }),
         lock::Acquired::Failed(e) => return Err(JobError::Lock(e)),
     };
 
-    let result = job.run().await;
+    // Wall-clock deadline, not `tokio::time::timeout` — see `scheduler::sleep_wall`.
+    let result = tokio::select! {
+        biased;
+
+        // Polled first, so a run finishing on the deadline still counts as finished.
+        result = job.run() => Some(result),
+        _ = scheduler::sleep_wall(lock::MAX_RUN, now_fn, scheduler::MAX_SLEEP) => None,
+    };
     guard.release().await;
 
-    result.map_err(|source| JobError::Run {
-        job: job.name(),
-        source,
-    })
+    match result {
+        Some(Ok(())) => Ok(()),
+        Some(Err(source)) => Err(JobError::Run {
+            job: job.name(),
+            source,
+        }),
+        None => Err(JobError::TimedOut {
+            job: job.name(),
+            after: lock::MAX_RUN,
+        }),
+    }
 }
 
 /// Runs every scheduled job until shutdown, one supervised task per job. A panic
@@ -264,7 +288,7 @@ mod tests {
     async fn run_once_locked_reports_a_held_lock_as_already_running() {
         let lock: Arc<dyn lock::RunLock> = FakeLock::new(AcquireOutcome::Denied);
         let job = CountingJob::new("stub");
-        let err = run_once_locked(&job, &lock).await.err().unwrap();
+        let err = run_once_locked(&job, &lock, &virtual_now()).await.err().unwrap();
 
         assert!(
             matches!(err, JobError::AlreadyRunning { job } if job == "stub"),
@@ -272,11 +296,30 @@ mod tests {
         );
     }
 
+    #[tokio::test(start_paused = true)]
+    async fn run_once_locked_abandons_a_run_past_the_deadline() {
+        let job = crate::jobs::test_support::BlockingJob::new();
+        let lock: Arc<dyn lock::RunLock> = FakeLock::new(AcquireOutcome::Granted);
+
+        // Paused time auto-advances while the run hangs, so the hour costs nothing.
+        let err = run_once_locked(&job, &lock, &virtual_now()).await.err().unwrap();
+
+        assert!(
+            matches!(err, JobError::TimedOut { job, .. } if job == "blocking"),
+            "a run past the deadline must surface as TimedOut, got: {err:?}"
+        );
+        assert_eq!(
+            job.completed(),
+            0,
+            "the abandoned run must not have completed"
+        );
+    }
+
     #[tokio::test]
     async fn run_once_locked_surfaces_lock_errors() {
         let job = CountingJob::new("counter");
         let lock: Arc<dyn lock::RunLock> = FakeLock::new(AcquireOutcome::Fails);
-        let err = run_once_locked(&job, &lock).await.err().unwrap();
+        let err = run_once_locked(&job, &lock, &virtual_now()).await.err().unwrap();
 
         assert!(
             matches!(err, JobError::Lock(_)),

--- a/nexusd/src/jobs/mod.rs
+++ b/nexusd/src/jobs/mod.rs
@@ -288,7 +288,10 @@ mod tests {
     async fn run_once_locked_reports_a_held_lock_as_already_running() {
         let lock: Arc<dyn lock::RunLock> = FakeLock::new(AcquireOutcome::Denied);
         let job = CountingJob::new("stub");
-        let err = run_once_locked(&job, &lock, &virtual_now()).await.err().unwrap();
+        let err = run_once_locked(&job, &lock, &virtual_now())
+            .await
+            .err()
+            .unwrap();
 
         assert!(
             matches!(err, JobError::AlreadyRunning { job } if job == "stub"),
@@ -302,7 +305,10 @@ mod tests {
         let lock: Arc<dyn lock::RunLock> = FakeLock::new(AcquireOutcome::Granted);
 
         // Paused time auto-advances while the run hangs, so the hour costs nothing.
-        let err = run_once_locked(&job, &lock, &virtual_now()).await.err().unwrap();
+        let err = run_once_locked(&job, &lock, &virtual_now())
+            .await
+            .err()
+            .unwrap();
 
         assert!(
             matches!(err, JobError::TimedOut { job, .. } if job == "blocking"),
@@ -319,7 +325,10 @@ mod tests {
     async fn run_once_locked_surfaces_lock_errors() {
         let job = CountingJob::new("counter");
         let lock: Arc<dyn lock::RunLock> = FakeLock::new(AcquireOutcome::Fails);
-        let err = run_once_locked(&job, &lock, &virtual_now()).await.err().unwrap();
+        let err = run_once_locked(&job, &lock, &virtual_now())
+            .await
+            .err()
+            .unwrap();
 
         assert!(
             matches!(err, JobError::Lock(_)),

--- a/nexusd/src/jobs/mod.rs
+++ b/nexusd/src/jobs/mod.rs
@@ -1,0 +1,551 @@
+mod error;
+mod lock;
+mod scheduler;
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use cron::Schedule;
+use nexus_common::{DaemonConfig, JobConfig};
+use tokio::sync::watch::Receiver;
+use tracing::error;
+
+pub use error::{CronParseError, JobError};
+use lock::RedisRunLock;
+pub use scheduler::validate_cron;
+
+/// Resolves and validates a job's cron: `None` when unscheduled, else the
+/// parsed [`Schedule`] so callers don't re-parse.
+pub fn job_cron(config: &JobConfig) -> Result<Option<Schedule>, CronParseError> {
+    let Some(cron) = &config.cron else {
+        return Ok(None);
+    };
+    Ok(Some(validate_cron(cron)?))
+}
+
+/// A unit of work, runnable on demand or on a schedule. Its name matches the
+/// `[jobs.<name>]` config section. The runner and scheduler know nothing about
+/// any concrete job; both set up the stack first, so `run` can assume it's up.
+///
+/// The runner takes a cross-process run lock around every run, so a job's runs
+/// never overlap — implementors don't manage concurrency. It imposes no timeout,
+/// though, so jobs hitting external services should apply their own.
+#[async_trait]
+pub trait Job: Send + Sync {
+    /// Stable unique identifier: used in logs, on-demand selection, and as the
+    /// `[jobs.<name>]` config key.
+    fn name(&self) -> &'static str;
+
+    /// Executes a single run. A returned error is logged but doesn't stop future
+    /// scheduled runs.
+    async fn run(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>>;
+}
+
+/// A [`Job`] bound to its cron schedule, with the [`Schedule`] pre-parsed. `Arc`
+/// shares one instance between the registry and the scheduler.
+pub struct ScheduledJob {
+    schedule: Schedule,
+    job: Arc<dyn Job>,
+}
+
+/// The single source of truth for what jobs exist — listing, on-demand runs, and
+/// scheduling all read from here.
+pub struct JobRegistry {
+    jobs: Vec<Arc<dyn Job>>,
+}
+
+impl JobRegistry {
+    /// Builds a registry from pre-built jobs. Panics on duplicate names, since
+    /// lookups match first-by-name and the second entry would be dead code.
+    pub fn new(jobs: Vec<Arc<dyn Job>>) -> Self {
+        let mut seen = HashSet::new();
+        assert!(
+            jobs.iter().all(|j| seen.insert(j.name())),
+            "registry contains jobs with duplicate names"
+        );
+        Self { jobs }
+    }
+
+    /// Names of all available jobs; used for `jobs list` and error messages.
+    pub fn job_names(&self) -> Vec<&'static str> {
+        self.jobs.iter().map(|job| job.name()).collect()
+    }
+
+    /// Job list for error hints; `(none)` when empty.
+    fn available_jobs_hint(&self) -> String {
+        let names = self.job_names();
+        if names.is_empty() {
+            "(none)".to_string()
+        } else {
+            names.join(", ")
+        }
+    }
+
+    /// Runs a single job once, even when unscheduled. Validates the full
+    /// `[jobs.*]` config up front (parity with `nexusd run`) and sets up the
+    /// stack before running.
+    ///
+    /// Takes the scheduler's cross-process run lock, so it can't overlap a
+    /// scheduled run. Unlike the scheduler (which skips), a held lock is an error
+    /// here: the operator asked to run *now*.
+    pub async fn run_on_demand(&self, name: &str, config: &DaemonConfig) -> Result<(), JobError> {
+        self.scheduled_jobs(config)?;
+        let job = self
+            .jobs
+            .iter()
+            .find(|job| job.name() == name)
+            .ok_or_else(|| JobError::UnknownJobName {
+                name: name.into(),
+                available: self.available_jobs_hint(),
+            })?;
+        nexus_common::StackManager::setup(&config.stack)
+            .await
+            .map_err(JobError::Stack)?;
+
+        let lock: Arc<dyn lock::RunLock> = Arc::new(RedisRunLock::new());
+        let token = lock
+            .try_lock(job.name())
+            .await
+            .map_err(JobError::Lock)?
+            .ok_or_else(|| JobError::AlreadyRunning { job: job.name() })?;
+
+        let guard = lock::LockGuard::new(job.name(), token, Arc::clone(&lock));
+
+        let result = job.run().await;
+        guard.release().await;
+
+        result.map_err(|source| JobError::Run {
+            job: job.name(),
+            source,
+        })
+    }
+
+    /// The scheduled jobs, resolved from config. Each job's schedule is validated
+    /// here, so a misconfigured job fails fast rather than at its first fire.
+    pub fn scheduled_jobs(&self, config: &DaemonConfig) -> Result<Vec<ScheduledJob>, JobError> {
+        let job_names = self.job_names();
+
+        // Fail fast on a `[jobs.<name>]` section matching no registered job (typo).
+        let mut unknown: Vec<&str> = config
+            .jobs
+            .keys()
+            .map(String::as_str)
+            .filter(|name| !job_names.contains(name))
+            .collect();
+        if !unknown.is_empty() {
+            unknown.sort_unstable();
+            return Err(JobError::UnknownJobConfig {
+                unknown: unknown.into_iter().map(String::from).collect(),
+                available: self.available_jobs_hint(),
+            });
+        }
+
+        let mut jobs = Vec::new();
+
+        for job in &self.jobs {
+            let name = job.name();
+            // An absent `[jobs.<name>]` section means the job is unscheduled.
+            let job_config = config.jobs.get(name).cloned().unwrap_or_default();
+            // Tag the error with the section naming the malformed cron.
+            let cron = job_cron(&job_config).map_err(|source| JobError::InvalidCron {
+                job: name.into(),
+                source,
+            })?;
+            if let Some(schedule) = cron {
+                jobs.push(ScheduledJob {
+                    schedule,
+                    job: Arc::clone(job),
+                });
+            }
+        }
+
+        Ok(jobs)
+    }
+}
+
+/// Runs every scheduled job until shutdown, one supervised task per job. A panic
+/// in one job is caught and logged, leaving siblings up until restart. Returns
+/// once all jobs stop (immediately when there are none). Sets up the stack
+/// before spawning, so a fast cron can't outrace it to `StackManager::setup`.
+pub async fn run(
+    jobs: Vec<ScheduledJob>,
+    stack: &nexus_common::StackConfig,
+    shutdown_rx: Receiver<bool>,
+) -> Result<(), JobError> {
+    if jobs.is_empty() {
+        return Ok(());
+    }
+    nexus_common::StackManager::setup(stack)
+        .await
+        .map_err(JobError::Stack)?;
+    let scheduler = scheduler::Scheduler::new(
+        Arc::new(Utc::now) as scheduler::NowFn,
+        Arc::new(RedisRunLock::new()),
+    );
+    supervise(scheduler, jobs, shutdown_rx).await;
+    Ok(())
+}
+
+/// Spawns and supervises one task per job until shutdown, catching and logging a
+/// per-job panic (see [`run`]). Split from `run` so supervision is testable
+/// without the stack; `scheduler` (clock + lock) is injected for the same reason.
+async fn supervise(
+    scheduler: scheduler::Scheduler,
+    jobs: Vec<ScheduledJob>,
+    shutdown_rx: Receiver<bool>,
+) {
+    let mut set = tokio::task::JoinSet::new();
+    // Map task id -> job name so we can recover the name on panic.
+    let mut names: HashMap<tokio::task::Id, &'static str> = HashMap::new();
+
+    for ScheduledJob { schedule, job } in jobs {
+        let name = job.name();
+        let job_shutdown_rx = shutdown_rx.clone();
+        let scheduler = scheduler.clone();
+        let handle = set.spawn(async move {
+            scheduler
+                .run_job(name, &schedule, job.as_ref(), job_shutdown_rx)
+                .await;
+        });
+        names.insert(handle.id(), name);
+    }
+
+    while let Some(result) = set.join_next_with_id().await {
+        match result {
+            Ok((id, ())) => {
+                names.remove(&id);
+            }
+            Err(e) => {
+                let name = names.remove(&e.id()).unwrap_or("<unknown>");
+                scheduler.record_stopped(name, "panic");
+                error!(
+                    job = name,
+                    "Job scheduler panicked; disabled until restart: {e}"
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use scheduler::virtual_now;
+    use std::error::Error;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+    use tokio::sync::watch;
+    use tracing_test::traced_test;
+
+    /// Builds a [`DaemonConfig`] from the canonical default config with `extra`
+    /// TOML appended (e.g. a `[jobs.<name>]` section).
+    async fn default_config_with(extra: &str) -> DaemonConfig {
+        use nexus_common::file::{ConfigLoader, CONFIG_FILE_NAME};
+
+        let dir = tempfile::TempDir::new().unwrap();
+        DaemonConfig::read_or_create_config_file(dir.path().to_path_buf())
+            .await
+            .unwrap();
+        let default_toml = std::fs::read_to_string(dir.path().join(CONFIG_FILE_NAME)).unwrap();
+        DaemonConfig::try_from_str(&format!("{default_toml}\n{extra}"))
+            .expect("config with the appended section should parse")
+    }
+
+    /// Stub job for testing schedule resolution.
+    struct StubJob;
+    #[async_trait]
+    impl Job for StubJob {
+        fn name(&self) -> &'static str {
+            "stub"
+        }
+        async fn run(&self) -> Result<(), Box<dyn Error + Send + Sync>> {
+            Ok(())
+        }
+    }
+
+    /// Duplicate job names must fail registry construction: lookups match
+    /// first-by-name, so the second entry would be dead code.
+    #[test]
+    #[should_panic(expected = "duplicate names")]
+    fn new_panics_on_duplicate_job_names() {
+        JobRegistry::new(vec![Arc::new(StubJob), Arc::new(StubJob)]);
+    }
+
+    /// An empty registry renders the unknown-job hint as `(none)` rather than a
+    /// dangling "available jobs:".
+    #[tokio::test]
+    async fn unknown_job_error_shows_none_when_registry_empty() {
+        let registry = JobRegistry::new(Vec::new());
+        let config = default_config_with("").await;
+
+        // The name lookup fails before stack setup, so this needs no stack.
+        let err = match registry.run_on_demand("whatever", &config).await {
+            Ok(()) => panic!("running against an empty registry must error"),
+            Err(e) => e.to_string(),
+        };
+
+        assert!(
+            err.contains("available jobs: (none)"),
+            "empty registry must render `(none)`, got: {err}"
+        );
+    }
+
+    /// run_on_demand validates the `[jobs.*]` config itself: a malformed cron
+    /// fails before the stack is touched, giving parity with `nexusd run`.
+    #[tokio::test]
+    async fn run_on_demand_validates_jobs_config() {
+        let registry = JobRegistry::new(vec![Arc::new(StubJob)]);
+        let config = default_config_with("[jobs.stub]\ncron = \"not a cron\"\n").await;
+
+        // The bad cron is caught before StackManager::setup, so no stack is needed.
+        let err = match registry.run_on_demand("stub", &config).await {
+            Ok(()) => panic!("a malformed cron must fail run_on_demand"),
+            Err(e) => e.to_string(),
+        };
+        assert!(
+            err.contains("[jobs.stub]"),
+            "run_on_demand must surface the config error naming the section, got: {err}"
+        );
+    }
+
+    /// A `[jobs.<name>]` section that matches no registered job fails startup
+    /// rather than being silently ignored.
+    #[tokio::test]
+    async fn scheduled_jobs_rejects_unknown_job_config_key() {
+        let registry = JobRegistry::new(vec![Arc::new(StubJob)]);
+        let config = default_config_with("[jobs.does_not_exist]\n").await;
+
+        let err = registry.scheduled_jobs(&config).err().unwrap();
+        assert!(
+            matches!(err, JobError::UnknownJobConfig { .. }),
+            "an unknown [jobs.<name>] key must fail startup, got: {err:?}"
+        );
+    }
+
+    /// A malformed `[jobs.<name>]` cron is caught at startup rather than at first
+    /// fire, and the error names the offending job.
+    #[tokio::test]
+    async fn scheduled_jobs_fails_fast_on_malformed_cron() {
+        let registry = JobRegistry::new(vec![Arc::new(StubJob)]);
+
+        let config = default_config_with("[jobs.stub]\ncron = \"not a cron\"\n").await;
+
+        // scheduled_jobs only resolves; it never spawns. The error must name the
+        // offending job so the operator needn't grep the config.
+        let err = registry.scheduled_jobs(&config).err().unwrap();
+        assert!(
+            matches!(err, JobError::InvalidCron { ref job, .. } if job == "stub"),
+            "malformed-cron error must name the section, got: {err:?}"
+        );
+    }
+
+    /// A panicking job is contained: its sibling keeps running, supervise returns
+    /// (no propagation or hang), and the panic is logged.
+    #[tokio::test(start_paused = true)]
+    #[traced_test]
+    async fn panic_in_one_job_does_not_stop_siblings() {
+        /// Panics on every fire.
+        struct PanicJob;
+        #[async_trait]
+        impl Job for PanicJob {
+            fn name(&self) -> &'static str {
+                "panicky"
+            }
+            async fn run(&self) -> Result<(), Box<dyn Error + Send + Sync>> {
+                panic!("boom");
+            }
+        }
+
+        let count = Arc::new(AtomicU32::new(0));
+        let cron = validate_cron("* * * * * *").unwrap();
+        let jobs = vec![
+            ScheduledJob {
+                schedule: cron.clone(),
+                job: Arc::new(PanicJob),
+            },
+            ScheduledJob {
+                schedule: cron,
+                job: Arc::new(CountingJob {
+                    name: "counter",
+                    count: count.clone(),
+                }),
+            },
+        ];
+
+        let (tx, rx) = watch::channel(false);
+        let scheduler =
+            scheduler::Scheduler::new(virtual_now(), Arc::new(lock::AlwaysAvailableLock));
+        let supervisor = supervise(scheduler, jobs, rx);
+        let stopper = async {
+            tokio::time::sleep(Duration::from_millis(1500)).await;
+            let _ = tx.send(true);
+        };
+        // Reaching this line proves the panic was caught (supervise returned).
+        let ((), ()) = tokio::join!(supervisor, stopper);
+
+        assert!(
+            count.load(Ordering::SeqCst) >= 1,
+            "the sibling job must keep firing despite the panicking job"
+        );
+        assert!(
+            logs_contain("Job scheduler panicked"),
+            "the caught panic must be logged"
+        );
+    }
+
+    /// A panicking job still releases its run lock via `LockGuard`'s Drop, so it
+    /// doesn't stay stuck for its TTL. The panic itself still surfaces.
+    #[tokio::test(start_paused = true)]
+    #[traced_test]
+    async fn panic_in_run_still_releases_lock() {
+        use nexus_common::db::RedisResult;
+
+        struct PanicJob;
+        #[async_trait]
+        impl Job for PanicJob {
+            fn name(&self) -> &'static str {
+                "panicky"
+            }
+            async fn run(&self) -> Result<(), Box<dyn Error + Send + Sync>> {
+                panic!("boom");
+            }
+        }
+
+        struct RecordingLock {
+            acquired: Arc<AtomicU32>,
+            released: Arc<AtomicU32>,
+        }
+        #[async_trait]
+        impl lock::RunLock for RecordingLock {
+            async fn try_lock(&self, _job: &str) -> RedisResult<Option<String>> {
+                self.acquired.fetch_add(1, Ordering::SeqCst);
+                Ok(Some("t".to_string()))
+            }
+            async fn unlock(&self, _job: &str, _token: &str) -> RedisResult<()> {
+                self.released.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+        }
+
+        let acquired = Arc::new(AtomicU32::new(0));
+        let released = Arc::new(AtomicU32::new(0));
+        let cron = validate_cron("* * * * * *").unwrap();
+        let jobs = vec![ScheduledJob {
+            schedule: cron,
+            job: Arc::new(PanicJob),
+        }];
+
+        let (tx, rx) = watch::channel(false);
+        let scheduler = scheduler::Scheduler::new(
+            virtual_now(),
+            Arc::new(RecordingLock {
+                acquired: acquired.clone(),
+                released: released.clone(),
+            }),
+        );
+        let supervisor = supervise(scheduler, jobs, rx);
+        let stopper = async {
+            tokio::time::sleep(Duration::from_millis(1500)).await;
+            // Yield after shutdown so any Drop-spawned unlock tasks get a chance to run.
+            let _ = tx.send(true);
+        };
+        let ((), ()) = tokio::join!(supervisor, stopper);
+
+        // Let detached Drop-spawn tasks complete before asserting.
+        tokio::task::yield_now().await;
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        assert_eq!(
+            acquired.load(Ordering::SeqCst),
+            1,
+            "PanicJob dies after one fire (JoinSet catches, task ends)"
+        );
+        assert_eq!(
+            released.load(Ordering::SeqCst),
+            1,
+            "the panicked run's lock must still be released via Drop"
+        );
+        // Existing supervise contract still holds: the panic is logged.
+        assert!(
+            logs_contain("Job scheduler panicked"),
+            "the panic must still surface as a scheduler-internal panic"
+        );
+    }
+
+    /// Minimal stub job that just counts how many times it ran.
+    struct CountingJob {
+        name: &'static str,
+        count: Arc<AtomicU32>,
+    }
+
+    #[async_trait]
+    impl Job for CountingJob {
+        fn name(&self) -> &'static str {
+            self.name
+        }
+        async fn run(&self) -> Result<(), Box<dyn Error + Send + Sync>> {
+            self.count.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    /// No cron configured → the job is unscheduled.
+    #[test]
+    fn job_cron_none_when_unscheduled() {
+        assert!(job_cron(&JobConfig { cron: None }).unwrap().is_none());
+    }
+
+    /// A valid cron is parsed into a Schedule that round-trips to the same string.
+    #[test]
+    fn job_cron_returns_valid_cron() {
+        let config = JobConfig {
+            cron: Some("0 0 3 * * *".to_string()),
+        };
+        let schedule = job_cron(&config).unwrap().unwrap();
+        // The Schedule retains its source expression verbatim.
+        assert_eq!(
+            schedule.to_string(),
+            "0 0 3 * * *",
+            "parsed schedule must round-trip the input cron expression"
+        );
+    }
+
+    /// A malformed cron fails fast rather than silently going unscheduled.
+    #[test]
+    fn job_cron_rejects_malformed_cron() {
+        let config = JobConfig {
+            cron: Some("not a cron".to_string()),
+        };
+        assert!(job_cron(&config).is_err());
+    }
+
+    /// The scheduler fires the job on its cron. Virtual clock keeps it instant.
+    #[tokio::test(start_paused = true)]
+    async fn run_job_fires_on_schedule() {
+        let count = Arc::new(AtomicU32::new(0));
+        let job = CountingJob {
+            name: "mock",
+            count: count.clone(),
+        };
+        let (tx, rx) = watch::channel(false);
+
+        // Fires every second; stop after ~1.5s (virtual) so it fires at least once.
+        let schedule = validate_cron("* * * * * *").unwrap();
+        let scheduler =
+            scheduler::Scheduler::new(virtual_now(), Arc::new(lock::AlwaysAvailableLock));
+        let runner = scheduler.run_job("mock", &schedule, &job, rx);
+        let stopper = async {
+            tokio::time::sleep(Duration::from_millis(1500)).await;
+            let _ = tx.send(true);
+        };
+        tokio::join!(runner, stopper);
+
+        assert!(
+            count.load(Ordering::SeqCst) >= 1,
+            "a per-second cron should fire at least once"
+        );
+    }
+}

--- a/nexusd/src/jobs/mod.rs
+++ b/nexusd/src/jobs/mod.rs
@@ -105,13 +105,22 @@ impl JobRegistry {
             .map_err(JobError::Stack)?;
 
         let lock: Arc<dyn lock::RunLock> = Arc::new(RedisRunLock::new());
-        let token = lock
-            .try_lock(job.name())
-            .await
-            .map_err(JobError::Lock)?
-            .ok_or_else(|| JobError::AlreadyRunning { job: job.name() })?;
+        let token = lock.new_token();
+        // Arm the guard before acquiring so a cancel mid-acquire still releases
+        // (see `scheduler::run_locked`).
+        let guard = lock::LockGuard::new(job.name(), token.clone(), Arc::clone(&lock));
 
-        let guard = lock::LockGuard::new(job.name(), token, Arc::clone(&lock));
+        match lock.acquire(job.name(), &token).await {
+            Ok(true) => {}
+            Ok(false) => {
+                guard.disarm();
+                return Err(JobError::AlreadyRunning { job: job.name() });
+            }
+            Err(e) => {
+                guard.disarm();
+                return Err(JobError::Lock(e));
+            }
+        }
 
         let result = job.run().await;
         guard.release().await;
@@ -420,9 +429,12 @@ mod tests {
         }
         #[async_trait]
         impl lock::RunLock for RecordingLock {
-            async fn try_lock(&self, _job: &str) -> RedisResult<Option<String>> {
+            fn new_token(&self) -> String {
+                "t".to_string()
+            }
+            async fn acquire(&self, _job: &str, _token: &str) -> RedisResult<bool> {
                 self.acquired.fetch_add(1, Ordering::SeqCst);
-                Ok(Some("t".to_string()))
+                Ok(true)
             }
             async fn unlock(&self, _job: &str, _token: &str) -> RedisResult<()> {
                 self.released.fetch_add(1, Ordering::SeqCst);

--- a/nexusd/src/jobs/mod.rs
+++ b/nexusd/src/jobs/mod.rs
@@ -410,7 +410,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     #[traced_test]
     async fn panic_in_run_still_releases_lock() {
-        use nexus_common::db::RedisResult;
+        use crate::jobs::error::LockResult;
 
         struct PanicJob;
         #[async_trait]
@@ -432,11 +432,11 @@ mod tests {
             fn new_token(&self) -> String {
                 "t".to_string()
             }
-            async fn acquire(&self, _job: &str, _token: &str) -> RedisResult<bool> {
+            async fn acquire(&self, _job: &str, _token: &str) -> LockResult<bool> {
                 self.acquired.fetch_add(1, Ordering::SeqCst);
                 Ok(true)
             }
-            async fn unlock(&self, _job: &str, _token: &str) -> RedisResult<()> {
+            async fn unlock(&self, _job: &str, _token: &str) -> LockResult<()> {
                 self.released.fetch_add(1, Ordering::SeqCst);
                 Ok(())
             }

--- a/nexusd/src/jobs/mod.rs
+++ b/nexusd/src/jobs/mod.rs
@@ -1,6 +1,8 @@
 mod error;
 mod lock;
 mod scheduler;
+#[cfg(test)]
+mod test_support;
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -105,30 +107,7 @@ impl JobRegistry {
             .map_err(JobError::Stack)?;
 
         let lock: Arc<dyn lock::RunLock> = Arc::new(RedisRunLock::new());
-        let token = lock.new_token();
-        // Arm the guard before acquiring so a cancel mid-acquire still releases
-        // (see `scheduler::run_locked`).
-        let guard = lock::LockGuard::new(job.name(), token.clone(), Arc::clone(&lock));
-
-        match lock.acquire(job.name(), &token).await {
-            Ok(true) => {}
-            Ok(false) => {
-                guard.disarm();
-                return Err(JobError::AlreadyRunning { job: job.name() });
-            }
-            Err(e) => {
-                guard.disarm();
-                return Err(JobError::Lock(e));
-            }
-        }
-
-        let result = job.run().await;
-        guard.release().await;
-
-        result.map_err(|source| JobError::Run {
-            job: job.name(),
-            source,
-        })
+        run_once_locked(job.as_ref(), &lock).await
     }
 
     /// The scheduled jobs, resolved from config. Each job's schedule is validated
@@ -174,6 +153,25 @@ impl JobRegistry {
     }
 }
 
+/// Runs `job` once under `lock`, mapping lock state to [`JobError`]. Split from
+/// [`JobRegistry::run_on_demand`] so it's testable without a stack; `lock` is
+/// injected for the same reason.
+async fn run_once_locked(job: &dyn Job, lock: &Arc<dyn lock::RunLock>) -> Result<(), JobError> {
+    let guard = match lock::acquire(job.name(), lock).await {
+        lock::Acquired::Taken(guard) => guard,
+        lock::Acquired::Held => return Err(JobError::AlreadyRunning { job: job.name() }),
+        lock::Acquired::Failed(e) => return Err(JobError::Lock(e)),
+    };
+
+    let result = job.run().await;
+    guard.release().await;
+
+    result.map_err(|source| JobError::Run {
+        job: job.name(),
+        source,
+    })
+}
+
 /// Runs every scheduled job until shutdown, one supervised task per job. A panic
 /// in one job is caught and logged, leaving siblings up until restart. Returns
 /// once all jobs stop (immediately when there are none). Sets up the stack
@@ -215,7 +213,7 @@ async fn supervise(
         let scheduler = scheduler.clone();
         let handle = set.spawn(async move {
             scheduler
-                .run_job(name, &schedule, job.as_ref(), job_shutdown_rx)
+                .run_job(&schedule, job.as_ref(), job_shutdown_rx)
                 .await;
         });
         names.insert(handle.id(), name);
@@ -241,9 +239,8 @@ async fn supervise(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::jobs::test_support::{AcquireOutcome, CountingJob, FakeLock, PanicJob};
     use scheduler::virtual_now;
-    use std::error::Error;
-    use std::sync::atomic::{AtomicU32, Ordering};
     use std::sync::Arc;
     use std::time::Duration;
     use tokio::sync::watch;
@@ -263,28 +260,44 @@ mod tests {
             .expect("config with the appended section should parse")
     }
 
-    /// Stub job for testing schedule resolution.
-    struct StubJob;
-    #[async_trait]
-    impl Job for StubJob {
-        fn name(&self) -> &'static str {
-            "stub"
-        }
-        async fn run(&self) -> Result<(), Box<dyn Error + Send + Sync>> {
-            Ok(())
-        }
+    #[tokio::test]
+    async fn run_once_locked_reports_a_held_lock_as_already_running() {
+        let lock: Arc<dyn lock::RunLock> = FakeLock::new(AcquireOutcome::Denied);
+        let job = CountingJob::new("stub");
+        let err = run_once_locked(&job, &lock).await.err().unwrap();
+
+        assert!(
+            matches!(err, JobError::AlreadyRunning { job } if job == "stub"),
+            "a held lock must surface as AlreadyRunning, got: {err:?}"
+        );
     }
 
-    /// Duplicate job names must fail registry construction: lookups match
-    /// first-by-name, so the second entry would be dead code.
+    #[tokio::test]
+    async fn run_once_locked_surfaces_lock_errors() {
+        let job = CountingJob::new("counter");
+        let lock: Arc<dyn lock::RunLock> = FakeLock::new(AcquireOutcome::Fails);
+        let err = run_once_locked(&job, &lock).await.err().unwrap();
+
+        assert!(
+            matches!(err, JobError::Lock(_)),
+            "an unreachable backend must surface as JobError::Lock, got: {err:?}"
+        );
+        assert_eq!(
+            job.runs(),
+            0,
+            "the job must not run when the lock could not be taken"
+        );
+    }
+
     #[test]
     #[should_panic(expected = "duplicate names")]
     fn new_panics_on_duplicate_job_names() {
-        JobRegistry::new(vec![Arc::new(StubJob), Arc::new(StubJob)]);
+        JobRegistry::new(vec![
+            Arc::new(CountingJob::new("stub")),
+            Arc::new(CountingJob::new("stub")),
+        ]);
     }
 
-    /// An empty registry renders the unknown-job hint as `(none)` rather than a
-    /// dangling "available jobs:".
     #[tokio::test]
     async fn unknown_job_error_shows_none_when_registry_empty() {
         let registry = JobRegistry::new(Vec::new());
@@ -302,11 +315,9 @@ mod tests {
         );
     }
 
-    /// run_on_demand validates the `[jobs.*]` config itself: a malformed cron
-    /// fails before the stack is touched, giving parity with `nexusd run`.
     #[tokio::test]
     async fn run_on_demand_validates_jobs_config() {
-        let registry = JobRegistry::new(vec![Arc::new(StubJob)]);
+        let registry = JobRegistry::new(vec![Arc::new(CountingJob::new("stub"))]);
         let config = default_config_with("[jobs.stub]\ncron = \"not a cron\"\n").await;
 
         // The bad cron is caught before StackManager::setup, so no stack is needed.
@@ -320,11 +331,9 @@ mod tests {
         );
     }
 
-    /// A `[jobs.<name>]` section that matches no registered job fails startup
-    /// rather than being silently ignored.
     #[tokio::test]
     async fn scheduled_jobs_rejects_unknown_job_config_key() {
-        let registry = JobRegistry::new(vec![Arc::new(StubJob)]);
+        let registry = JobRegistry::new(vec![Arc::new(CountingJob::new("stub"))]);
         let config = default_config_with("[jobs.does_not_exist]\n").await;
 
         let err = registry.scheduled_jobs(&config).err().unwrap();
@@ -334,11 +343,9 @@ mod tests {
         );
     }
 
-    /// A malformed `[jobs.<name>]` cron is caught at startup rather than at first
-    /// fire, and the error names the offending job.
     #[tokio::test]
     async fn scheduled_jobs_fails_fast_on_malformed_cron() {
-        let registry = JobRegistry::new(vec![Arc::new(StubJob)]);
+        let registry = JobRegistry::new(vec![Arc::new(CountingJob::new("stub"))]);
 
         let config = default_config_with("[jobs.stub]\ncron = \"not a cron\"\n").await;
 
@@ -351,24 +358,10 @@ mod tests {
         );
     }
 
-    /// A panicking job is contained: its sibling keeps running, supervise returns
-    /// (no propagation or hang), and the panic is logged.
     #[tokio::test(start_paused = true)]
     #[traced_test]
     async fn panic_in_one_job_does_not_stop_siblings() {
-        /// Panics on every fire.
-        struct PanicJob;
-        #[async_trait]
-        impl Job for PanicJob {
-            fn name(&self) -> &'static str {
-                "panicky"
-            }
-            async fn run(&self) -> Result<(), Box<dyn Error + Send + Sync>> {
-                panic!("boom");
-            }
-        }
-
-        let count = Arc::new(AtomicU32::new(0));
+        let counter = Arc::new(CountingJob::new("counter"));
         let cron = validate_cron("* * * * * *").unwrap();
         let jobs = vec![
             ScheduledJob {
@@ -377,16 +370,13 @@ mod tests {
             },
             ScheduledJob {
                 schedule: cron,
-                job: Arc::new(CountingJob {
-                    name: "counter",
-                    count: count.clone(),
-                }),
+                job: counter.clone(),
             },
         ];
 
         let (tx, rx) = watch::channel(false);
         let scheduler =
-            scheduler::Scheduler::new(virtual_now(), Arc::new(lock::AlwaysAvailableLock));
+            scheduler::Scheduler::new(virtual_now(), FakeLock::new(AcquireOutcome::Granted));
         let supervisor = supervise(scheduler, jobs, rx);
         let stopper = async {
             tokio::time::sleep(Duration::from_millis(1500)).await;
@@ -396,7 +386,7 @@ mod tests {
         let ((), ()) = tokio::join!(supervisor, stopper);
 
         assert!(
-            count.load(Ordering::SeqCst) >= 1,
+            counter.runs() >= 1,
             "the sibling job must keep firing despite the panicking job"
         );
         assert!(
@@ -405,45 +395,9 @@ mod tests {
         );
     }
 
-    /// A panicking job still releases its run lock via `LockGuard`'s Drop, so it
-    /// doesn't stay stuck for its TTL. The panic itself still surfaces.
     #[tokio::test(start_paused = true)]
     #[traced_test]
     async fn panic_in_run_still_releases_lock() {
-        use crate::jobs::error::LockResult;
-
-        struct PanicJob;
-        #[async_trait]
-        impl Job for PanicJob {
-            fn name(&self) -> &'static str {
-                "panicky"
-            }
-            async fn run(&self) -> Result<(), Box<dyn Error + Send + Sync>> {
-                panic!("boom");
-            }
-        }
-
-        struct RecordingLock {
-            acquired: Arc<AtomicU32>,
-            released: Arc<AtomicU32>,
-        }
-        #[async_trait]
-        impl lock::RunLock for RecordingLock {
-            fn new_token(&self) -> String {
-                "t".to_string()
-            }
-            async fn acquire(&self, _job: &str, _token: &str) -> LockResult<bool> {
-                self.acquired.fetch_add(1, Ordering::SeqCst);
-                Ok(true)
-            }
-            async fn unlock(&self, _job: &str, _token: &str) -> LockResult<()> {
-                self.released.fetch_add(1, Ordering::SeqCst);
-                Ok(())
-            }
-        }
-
-        let acquired = Arc::new(AtomicU32::new(0));
-        let released = Arc::new(AtomicU32::new(0));
         let cron = validate_cron("* * * * * *").unwrap();
         let jobs = vec![ScheduledJob {
             schedule: cron,
@@ -451,13 +405,8 @@ mod tests {
         }];
 
         let (tx, rx) = watch::channel(false);
-        let scheduler = scheduler::Scheduler::new(
-            virtual_now(),
-            Arc::new(RecordingLock {
-                acquired: acquired.clone(),
-                released: released.clone(),
-            }),
-        );
+        let lock = FakeLock::new(AcquireOutcome::Granted);
+        let scheduler = scheduler::Scheduler::new(virtual_now(), lock.clone());
         let supervisor = supervise(scheduler, jobs, rx);
         let stopper = async {
             tokio::time::sleep(Duration::from_millis(1500)).await;
@@ -471,12 +420,12 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(10)).await;
 
         assert_eq!(
-            acquired.load(Ordering::SeqCst),
+            lock.acquires(),
             1,
             "PanicJob dies after one fire (JoinSet catches, task ends)"
         );
         assert_eq!(
-            released.load(Ordering::SeqCst),
+            lock.releases(),
             1,
             "the panicked run's lock must still be released via Drop"
         );
@@ -487,30 +436,11 @@ mod tests {
         );
     }
 
-    /// Minimal stub job that just counts how many times it ran.
-    struct CountingJob {
-        name: &'static str,
-        count: Arc<AtomicU32>,
-    }
-
-    #[async_trait]
-    impl Job for CountingJob {
-        fn name(&self) -> &'static str {
-            self.name
-        }
-        async fn run(&self) -> Result<(), Box<dyn Error + Send + Sync>> {
-            self.count.fetch_add(1, Ordering::SeqCst);
-            Ok(())
-        }
-    }
-
-    /// No cron configured → the job is unscheduled.
     #[test]
     fn job_cron_none_when_unscheduled() {
         assert!(job_cron(&JobConfig { cron: None }).unwrap().is_none());
     }
 
-    /// A valid cron is parsed into a Schedule that round-trips to the same string.
     #[test]
     fn job_cron_returns_valid_cron() {
         let config = JobConfig {
@@ -525,7 +455,6 @@ mod tests {
         );
     }
 
-    /// A malformed cron fails fast rather than silently going unscheduled.
     #[test]
     fn job_cron_rejects_malformed_cron() {
         let config = JobConfig {
@@ -534,21 +463,16 @@ mod tests {
         assert!(job_cron(&config).is_err());
     }
 
-    /// The scheduler fires the job on its cron. Virtual clock keeps it instant.
     #[tokio::test(start_paused = true)]
     async fn run_job_fires_on_schedule() {
-        let count = Arc::new(AtomicU32::new(0));
-        let job = CountingJob {
-            name: "mock",
-            count: count.clone(),
-        };
+        let job = CountingJob::new("mock");
         let (tx, rx) = watch::channel(false);
 
         // Fires every second; stop after ~1.5s (virtual) so it fires at least once.
         let schedule = validate_cron("* * * * * *").unwrap();
         let scheduler =
-            scheduler::Scheduler::new(virtual_now(), Arc::new(lock::AlwaysAvailableLock));
-        let runner = scheduler.run_job("mock", &schedule, &job, rx);
+            scheduler::Scheduler::new(virtual_now(), FakeLock::new(AcquireOutcome::Granted));
+        let runner = scheduler.run_job(&schedule, &job, rx);
         let stopper = async {
             tokio::time::sleep(Duration::from_millis(1500)).await;
             let _ = tx.send(true);
@@ -556,7 +480,7 @@ mod tests {
         tokio::join!(runner, stopper);
 
         assert!(
-            count.load(Ordering::SeqCst) >= 1,
+            job.runs() >= 1,
             "a per-second cron should fire at least once"
         );
     }

--- a/nexusd/src/jobs/mod.rs
+++ b/nexusd/src/jobs/mod.rs
@@ -15,8 +15,11 @@ use tokio::sync::watch::Receiver;
 use tracing::{error, warn};
 
 pub use error::{CronParseError, JobError};
-use lock::RedisRunLock;
+use lock::{LockMetrics, RedisRunLock};
 pub use scheduler::validate_cron;
+
+/// OpenTelemetry meter name for all job metrics.
+const METER_NAME: &str = "nexus.jobs";
 
 /// Resolves and validates a job's cron: `None` when unscheduled, else the
 /// parsed [`Schedule`] so callers don't re-parse.
@@ -110,7 +113,8 @@ impl JobRegistry {
 
         let lock: Arc<dyn lock::RunLock> = Arc::new(RedisRunLock::new());
         let now_fn = Arc::new(Utc::now) as scheduler::NowFn;
-        run_once_locked(job.as_ref(), &lock, &now_fn).await
+        let metrics = LockMetrics::new();
+        run_once_locked(job.as_ref(), &lock, &now_fn, &metrics).await
     }
 
     /// The scheduled jobs, resolved from config. Each job's schedule is validated
@@ -157,8 +161,8 @@ impl JobRegistry {
 }
 
 /// Runs `job` once under `lock`, mapping lock state to [`JobError`]. Split from
-/// [`JobRegistry::run_on_demand`] so it's testable without a stack; `lock` and
-/// `now_fn` are injected for the same reason.
+/// [`JobRegistry::run_on_demand`] so it's testable without a stack; `lock`,
+/// `now_fn`, and `metrics` are injected for the same reason.
 ///
 /// Abandoned at [`lock::MAX_RUN`] like a scheduled run, so an on-demand run can't
 /// outlive its lease either.
@@ -166,8 +170,9 @@ async fn run_once_locked(
     job: &dyn Job,
     lock: &Arc<dyn lock::RunLock>,
     now_fn: &scheduler::NowFn,
+    metrics: &LockMetrics,
 ) -> Result<(), JobError> {
-    let guard = match lock::acquire(job.name(), lock).await {
+    let guard = match lock::acquire(job.name(), lock, metrics).await {
         lock::Acquired::Taken(guard) => guard,
         lock::Acquired::Held => return Err(JobError::AlreadyRunning { job: job.name() }),
         lock::Acquired::Failed { error, released } => {
@@ -293,6 +298,7 @@ mod tests {
     use crate::jobs::test_support::{
         AcquireOutcome, CountingJob, FakeLock, PanicJob, UnlockOutcome,
     };
+    use lock::LockMetrics;
     use scheduler::virtual_now;
     use std::sync::Arc;
     use std::time::Duration;
@@ -318,7 +324,7 @@ mod tests {
         let lock: Arc<dyn lock::RunLock> =
             FakeLock::new(AcquireOutcome::Denied, UnlockOutcome::Succeeds);
         let job = CountingJob::new("stub");
-        let err = run_once_locked(&job, &lock, &virtual_now())
+        let err = run_once_locked(&job, &lock, &virtual_now(), &LockMetrics::new())
             .await
             .err()
             .unwrap();
@@ -336,7 +342,7 @@ mod tests {
             FakeLock::new(AcquireOutcome::Granted, UnlockOutcome::Succeeds);
 
         // Paused time auto-advances while the run hangs, so the hour costs nothing.
-        let err = run_once_locked(&job, &lock, &virtual_now())
+        let err = run_once_locked(&job, &lock, &virtual_now(), &LockMetrics::new())
             .await
             .err()
             .unwrap();
@@ -357,7 +363,7 @@ mod tests {
         let job = CountingJob::new("counter");
         let lock: Arc<dyn lock::RunLock> =
             FakeLock::new(AcquireOutcome::Fails, UnlockOutcome::Succeeds);
-        let err = run_once_locked(&job, &lock, &virtual_now())
+        let err = run_once_locked(&job, &lock, &virtual_now(), &LockMetrics::new())
             .await
             .err()
             .unwrap();
@@ -581,7 +587,7 @@ mod tests {
         let lock: Arc<dyn lock::RunLock> =
             FakeLock::new(AcquireOutcome::Hangs, UnlockOutcome::Hangs);
 
-        let err = run_once_locked(&job, &lock, &virtual_now())
+        let err = run_once_locked(&job, &lock, &virtual_now(), &LockMetrics::new())
             .await
             .err()
             .unwrap();
@@ -604,7 +610,7 @@ mod tests {
         let lock: Arc<dyn lock::RunLock> =
             FakeLock::new(AcquireOutcome::Fails, UnlockOutcome::Hangs);
 
-        let err = run_once_locked(&job, &lock, &virtual_now())
+        let err = run_once_locked(&job, &lock, &virtual_now(), &LockMetrics::new())
             .await
             .err()
             .unwrap();
@@ -624,7 +630,7 @@ mod tests {
         let lock: Arc<dyn lock::RunLock> =
             FakeLock::new(AcquireOutcome::Granted, UnlockOutcome::Hangs);
 
-        let result = run_once_locked(&job, &lock, &virtual_now()).await;
+        let result = run_once_locked(&job, &lock, &virtual_now(), &LockMetrics::new()).await;
         assert!(
             result.is_ok(),
             "the run itself must succeed; only the phase-3 release hangs, got: {result:?}"

--- a/nexusd/src/jobs/mod.rs
+++ b/nexusd/src/jobs/mod.rs
@@ -15,6 +15,7 @@ use tokio::sync::watch::Receiver;
 use tracing::{error, warn};
 
 pub use error::{CronParseError, JobError};
+pub use lock::LOCK_TTL_SECS;
 use lock::{LockMetrics, RedisRunLock};
 pub use scheduler::validate_cron;
 
@@ -319,6 +320,21 @@ mod tests {
             .expect("config with the appended section should parse")
     }
 
+    /// A registry with `extra` plus a stub for every other `[jobs.<name>]`
+    /// section `config` carries, so validation against the full default config
+    /// sees a known job per shipped section without this generic test naming a
+    /// specific one.
+    fn registry_covering(config: &DaemonConfig, extra: &'static str) -> JobRegistry {
+        let mut jobs: Vec<Arc<dyn Job>> = vec![Arc::new(CountingJob::new(extra))];
+        for name in config.jobs.keys() {
+            if name != extra {
+                let name: &'static str = Box::leak(name.clone().into_boxed_str());
+                jobs.push(Arc::new(CountingJob::new(name)));
+            }
+        }
+        JobRegistry::new(jobs)
+    }
+
     #[tokio::test]
     async fn run_once_locked_reports_a_held_lock_as_already_running() {
         let lock: Arc<dyn lock::RunLock> =
@@ -407,8 +423,8 @@ mod tests {
 
     #[tokio::test]
     async fn run_on_demand_validates_jobs_config() {
-        let registry = JobRegistry::new(vec![Arc::new(CountingJob::new("stub"))]);
         let config = default_config_with("[jobs.stub]\ncron = \"not a cron\"\n").await;
+        let registry = registry_covering(&config, "stub");
 
         // The bad cron is caught before StackManager::setup, so no stack is needed.
         let err = match registry.run_on_demand("stub", &config).await {
@@ -435,9 +451,8 @@ mod tests {
 
     #[tokio::test]
     async fn scheduled_jobs_fails_fast_on_malformed_cron() {
-        let registry = JobRegistry::new(vec![Arc::new(CountingJob::new("stub"))]);
-
         let config = default_config_with("[jobs.stub]\ncron = \"not a cron\"\n").await;
+        let registry = registry_covering(&config, "stub");
 
         // scheduled_jobs only resolves; it never spawns. The error must name the
         // offending job so the operator needn't grep the config.

--- a/nexusd/src/jobs/mod.rs
+++ b/nexusd/src/jobs/mod.rs
@@ -12,7 +12,7 @@ use chrono::Utc;
 use cron::Schedule;
 use nexus_common::{DaemonConfig, JobConfig};
 use tokio::sync::watch::Receiver;
-use tracing::error;
+use tracing::{error, warn};
 
 pub use error::{CronParseError, JobError};
 use lock::RedisRunLock;
@@ -170,7 +170,24 @@ async fn run_once_locked(
     let guard = match lock::acquire(job.name(), lock).await {
         lock::Acquired::Taken(guard) => guard,
         lock::Acquired::Held => return Err(JobError::AlreadyRunning { job: job.name() }),
-        lock::Acquired::Failed(e) => return Err(JobError::Lock(e)),
+        lock::Acquired::Failed { error, released } => {
+            if !released {
+                warn!(
+                    job = job.name(),
+                    "Lock acquire failed and inline release also failed — slot may stay held until TTL expires"
+                );
+            }
+            return Err(JobError::Lock(error));
+        }
+        lock::Acquired::TimedOut { released } => {
+            if !released {
+                warn!(
+                    job = job.name(),
+                    "Lock acquire timed out and inline release also failed — slot may stay held until TTL expires"
+                );
+            }
+            return Err(JobError::LockTimedOut { job: job.name() });
+        }
     };
 
     // Wall-clock deadline, not `tokio::time::timeout` — see `scheduler::sleep_wall`.
@@ -181,7 +198,17 @@ async fn run_once_locked(
         result = job.run() => Some(result),
         _ = scheduler::sleep_wall(lock::MAX_RUN, now_fn, scheduler::MAX_SLEEP) => None,
     };
-    guard.release().await;
+    let release_outcome = guard.release().await;
+    if !matches!(
+        release_outcome,
+        lock::ReleaseOutcome::Released | lock::ReleaseOutcome::NotHeld
+    ) {
+        warn!(
+            job = job.name(),
+            ?release_outcome,
+            "Lock release failed after run — slot may stay held until TTL expires"
+        );
+    }
 
     match result {
         Some(Ok(())) => Ok(()),
@@ -263,7 +290,9 @@ async fn supervise(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::jobs::test_support::{AcquireOutcome, CountingJob, FakeLock, PanicJob};
+    use crate::jobs::test_support::{
+        AcquireOutcome, CountingJob, FakeLock, PanicJob, UnlockOutcome,
+    };
     use scheduler::virtual_now;
     use std::sync::Arc;
     use std::time::Duration;
@@ -286,7 +315,8 @@ mod tests {
 
     #[tokio::test]
     async fn run_once_locked_reports_a_held_lock_as_already_running() {
-        let lock: Arc<dyn lock::RunLock> = FakeLock::new(AcquireOutcome::Denied);
+        let lock: Arc<dyn lock::RunLock> =
+            FakeLock::new(AcquireOutcome::Denied, UnlockOutcome::Succeeds);
         let job = CountingJob::new("stub");
         let err = run_once_locked(&job, &lock, &virtual_now())
             .await
@@ -302,7 +332,8 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn run_once_locked_abandons_a_run_past_the_deadline() {
         let job = crate::jobs::test_support::BlockingJob::new();
-        let lock: Arc<dyn lock::RunLock> = FakeLock::new(AcquireOutcome::Granted);
+        let lock: Arc<dyn lock::RunLock> =
+            FakeLock::new(AcquireOutcome::Granted, UnlockOutcome::Succeeds);
 
         // Paused time auto-advances while the run hangs, so the hour costs nothing.
         let err = run_once_locked(&job, &lock, &virtual_now())
@@ -324,7 +355,8 @@ mod tests {
     #[tokio::test]
     async fn run_once_locked_surfaces_lock_errors() {
         let job = CountingJob::new("counter");
-        let lock: Arc<dyn lock::RunLock> = FakeLock::new(AcquireOutcome::Fails);
+        let lock: Arc<dyn lock::RunLock> =
+            FakeLock::new(AcquireOutcome::Fails, UnlockOutcome::Succeeds);
         let err = run_once_locked(&job, &lock, &virtual_now())
             .await
             .err()
@@ -427,8 +459,10 @@ mod tests {
         ];
 
         let (tx, rx) = watch::channel(false);
-        let scheduler =
-            scheduler::Scheduler::new(virtual_now(), FakeLock::new(AcquireOutcome::Granted));
+        let scheduler = scheduler::Scheduler::new(
+            virtual_now(),
+            FakeLock::new(AcquireOutcome::Granted, UnlockOutcome::Succeeds),
+        );
         let supervisor = supervise(scheduler, jobs, rx);
         let stopper = async {
             tokio::time::sleep(Duration::from_millis(1500)).await;
@@ -457,7 +491,7 @@ mod tests {
         }];
 
         let (tx, rx) = watch::channel(false);
-        let lock = FakeLock::new(AcquireOutcome::Granted);
+        let lock = FakeLock::new(AcquireOutcome::Granted, UnlockOutcome::Succeeds);
         let scheduler = scheduler::Scheduler::new(virtual_now(), lock.clone());
         let supervisor = supervise(scheduler, jobs, rx);
         let stopper = async {
@@ -477,7 +511,7 @@ mod tests {
             "PanicJob dies after one fire (JoinSet catches, task ends)"
         );
         assert_eq!(
-            lock.releases(),
+            lock.unlock_attempts(),
             1,
             "the panicked run's lock must still be released via Drop"
         );
@@ -522,8 +556,10 @@ mod tests {
 
         // Fires every second; stop after ~1.5s (virtual) so it fires at least once.
         let schedule = validate_cron("* * * * * *").unwrap();
-        let scheduler =
-            scheduler::Scheduler::new(virtual_now(), FakeLock::new(AcquireOutcome::Granted));
+        let scheduler = scheduler::Scheduler::new(
+            virtual_now(),
+            FakeLock::new(AcquireOutcome::Granted, UnlockOutcome::Succeeds),
+        );
         let runner = scheduler.run_job(&schedule, &job, rx);
         let stopper = async {
             tokio::time::sleep(Duration::from_millis(1500)).await;
@@ -534,6 +570,69 @@ mod tests {
         assert!(
             job.runs() >= 1,
             "a per-second cron should fire at least once"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    #[traced_test]
+    async fn run_once_locked_warns_when_acquire_times_out_and_release_fails() {
+        let job = CountingJob::new("stub");
+        // Hangs + Hangs => acquire times out, inline release also times out (released == false)
+        let lock: Arc<dyn lock::RunLock> =
+            FakeLock::new(AcquireOutcome::Hangs, UnlockOutcome::Hangs);
+
+        let err = run_once_locked(&job, &lock, &virtual_now())
+            .await
+            .err()
+            .unwrap();
+
+        assert!(
+            matches!(err, JobError::LockTimedOut { job } if job == "stub"),
+            "got: {err:?}"
+        );
+        assert!(
+            logs_contain("Lock acquire timed out and inline release also failed"),
+            "should warn when both acquire timeout and inline release fail"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    #[traced_test]
+    async fn run_once_locked_warns_when_acquire_fails_and_release_fails() {
+        let job = CountingJob::new("stub");
+        // Fails + Hangs => acquire errors, inline release times out (released == false)
+        let lock: Arc<dyn lock::RunLock> =
+            FakeLock::new(AcquireOutcome::Fails, UnlockOutcome::Hangs);
+
+        let err = run_once_locked(&job, &lock, &virtual_now())
+            .await
+            .err()
+            .unwrap();
+
+        assert!(matches!(err, JobError::Lock(_)), "got: {err:?}");
+        assert!(
+            logs_contain("Lock acquire failed and inline release also failed"),
+            "should warn when both acquire error and inline release fail"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    #[traced_test]
+    async fn run_once_locked_warns_when_phase_three_release_fails() {
+        let job = CountingJob::new("stub");
+        // Granted + Hangs => acquire succeeds, phase-3 release times out
+        let lock: Arc<dyn lock::RunLock> =
+            FakeLock::new(AcquireOutcome::Granted, UnlockOutcome::Hangs);
+
+        let result = run_once_locked(&job, &lock, &virtual_now()).await;
+        assert!(
+            result.is_ok(),
+            "the run itself must succeed; only the phase-3 release hangs, got: {result:?}"
+        );
+
+        assert!(
+            logs_contain("Lock release failed after run"),
+            "should warn when phase-3 release fails"
         );
     }
 }

--- a/nexusd/src/jobs/scheduler.rs
+++ b/nexusd/src/jobs/scheduler.rs
@@ -196,9 +196,17 @@ impl Scheduler {
         self.run_attempts
             .add(1, &[KeyValue::new("job", name.to_string())]);
 
-        let token = match self.lock.try_lock(name).await {
-            Ok(Some(token)) => token,
-            Ok(None) => {
+        let token = self.lock.new_token();
+        // Arm the guard *before* acquiring. If this future is dropped mid-acquire
+        // on shutdown, Drop releases the lock iff it was actually taken (else it's
+        // a no-op), so the acquire can't orphan it. `name` isn't &'static; use
+        // `job.name()`, which the trait guarantees is.
+        let guard = super::lock::LockGuard::new(job.name(), token.clone(), self.lock.clone());
+
+        match self.lock.acquire(name, &token).await {
+            Ok(true) => {}
+            Ok(false) => {
+                guard.disarm();
                 self.run_skipped.add(
                     1,
                     &[
@@ -213,6 +221,7 @@ impl Scheduler {
                 return;
             }
             Err(e) => {
+                guard.disarm();
                 self.run_skipped.add(
                     1,
                     &[
@@ -226,10 +235,7 @@ impl Scheduler {
                 );
                 return;
             }
-        };
-
-        // `name` isn't &'static; use `job.name()`, which the trait guarantees is.
-        let guard = super::lock::LockGuard::new(job.name(), token, self.lock.clone());
+        }
 
         let result = job.run().await;
 
@@ -540,15 +546,18 @@ mod tests {
         );
     }
 
-    /// A lock held elsewhere (`try_lock` → `None`) makes the scheduler skip every
+    /// A lock held elsewhere (`acquire` → `false`) makes the scheduler skip every
     /// fire — the job never runs — while it keeps ticking and exits on shutdown.
     #[tokio::test(start_paused = true)]
     async fn run_job_skips_run_when_lock_held() {
         struct HeldLock;
         #[async_trait]
         impl RunLock for HeldLock {
-            async fn try_lock(&self, _job: &str) -> RedisResult<Option<String>> {
-                Ok(None)
+            fn new_token(&self) -> String {
+                "token".to_string()
+            }
+            async fn acquire(&self, _job: &str, _token: &str) -> RedisResult<bool> {
+                Ok(false)
             }
             async fn unlock(&self, _job: &str, _token: &str) -> RedisResult<()> {
                 Ok(())
@@ -588,9 +597,12 @@ mod tests {
         }
         #[async_trait]
         impl RunLock for RecordingLock {
-            async fn try_lock(&self, _job: &str) -> RedisResult<Option<String>> {
+            fn new_token(&self) -> String {
+                "token".to_string()
+            }
+            async fn acquire(&self, _job: &str, _token: &str) -> RedisResult<bool> {
                 self.acquired.fetch_add(1, Ordering::SeqCst);
-                Ok(Some("token".to_string()))
+                Ok(true)
             }
             async fn unlock(&self, _job: &str, _token: &str) -> RedisResult<()> {
                 self.released.fetch_add(1, Ordering::SeqCst);
@@ -633,6 +645,64 @@ mod tests {
         );
     }
 
+    /// Cancelling a run while its acquire is still in flight (shutdown dropping
+    /// the future between the lock being taken and the token reaching us) must
+    /// not orphan the lock: the guard is armed before the acquire, so its Drop
+    /// releases it. Modelled with an `acquire` that never resolves.
+    #[tokio::test(start_paused = true)]
+    async fn cancel_during_acquire_releases_lock() {
+        struct StalledLock {
+            released: Arc<AtomicU32>,
+        }
+        #[async_trait]
+        impl RunLock for StalledLock {
+            fn new_token(&self) -> String {
+                "token".to_string()
+            }
+            async fn acquire(&self, _job: &str, _token: &str) -> RedisResult<bool> {
+                // Never resolves: the acquire's response never reaches us before
+                // the task is cancelled.
+                std::future::pending::<()>().await;
+                unreachable!()
+            }
+            async fn unlock(&self, _job: &str, _token: &str) -> RedisResult<()> {
+                self.released.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+        }
+
+        let released = Arc::new(AtomicU32::new(0));
+        let scheduler = Scheduler::new(
+            virtual_now(),
+            Arc::new(StalledLock {
+                released: released.clone(),
+            }),
+        );
+        let job = CountingJob {
+            count: Arc::new(AtomicU32::new(0)),
+        };
+
+        // Poll run_locked so it reaches (and stalls on) the acquire, then drop it.
+        {
+            let fut = scheduler.run_locked("counting", &job);
+            tokio::pin!(fut);
+            tokio::select! {
+                _ = &mut fut => panic!("acquire stalls; run_locked cannot complete"),
+                _ = tokio::time::sleep(Duration::from_millis(1)) => {}
+            }
+        } // fut dropped here → the pre-armed guard's Drop spawns the unlock.
+
+        // Let the detached Drop-spawn unlock run.
+        tokio::task::yield_now().await;
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        assert_eq!(
+            released.load(Ordering::SeqCst),
+            1,
+            "a run dropped mid-acquire must still release via the pre-armed guard"
+        );
+    }
+
     /// Every fire is one attempt that partitions into completed or skipped,
     /// never both — asserted by reading the real `jobs.run.*` OTel counters back
     /// through an in-memory exporter.
@@ -645,12 +715,11 @@ mod tests {
         }
         #[async_trait]
         impl RunLock for AlternatingLock {
-            async fn try_lock(&self, _job: &str) -> RedisResult<Option<String>> {
-                if self.calls.fetch_add(1, Ordering::SeqCst).is_multiple_of(2) {
-                    Ok(Some("token".to_string()))
-                } else {
-                    Ok(None)
-                }
+            fn new_token(&self) -> String {
+                "token".to_string()
+            }
+            async fn acquire(&self, _job: &str, _token: &str) -> RedisResult<bool> {
+                Ok(self.calls.fetch_add(1, Ordering::SeqCst).is_multiple_of(2))
             }
             async fn unlock(&self, _job: &str, _token: &str) -> RedisResult<()> {
                 Ok(())

--- a/nexusd/src/jobs/scheduler.rs
+++ b/nexusd/src/jobs/scheduler.rs
@@ -8,14 +8,14 @@ use std::time::Duration;
 use tokio::sync::watch::Receiver;
 use tracing::{debug, error, info, warn};
 
-use super::lock::RunLock;
+use super::lock::{self, RunLock};
 use super::{CronParseError, Job};
 
 /// OpenTelemetry meter name for all job metrics.
 const METER_NAME: &str = "nexus.jobs";
 
 /// Wall-clock re-check interval while waiting for a fire time (see [`Scheduler::sleep_until`]).
-const MAX_SLEEP: Duration = Duration::from_secs(30);
+pub(super) const MAX_SLEEP: Duration = Duration::from_secs(30);
 
 /// Shared clock source. Production passes `Arc::new(Utc::now)`; tests pass a
 /// virtual clock tied to tokio's paused time.
@@ -30,9 +30,11 @@ pub struct Scheduler {
     lock: Arc<dyn RunLock>,
     /// Wall-clock re-check interval while sleeping toward a fire time (see [`MAX_SLEEP`]).
     max_sleep: Duration,
+    /// Deadline for a single run, past which it's abandoned (see [`lock::MAX_RUN`]).
+    max_run: Duration,
     /// Every fire attempt, before the lock is tried.
     run_attempts: Counter<u64>,
-    /// Fires where the job ran, labelled by `outcome` in {ok, error, abandoned}.
+    /// Fires where the job ran, labelled by `outcome` in {ok, error, abandoned, timed_out}.
     run_completed: Counter<u64>,
     /// Fires that didn't run the job, labelled by `reason` in
     /// {in_progress, lock_error, shutdown_before_acquire}.
@@ -76,6 +78,7 @@ impl Scheduler {
             now_fn,
             lock,
             max_sleep: MAX_SLEEP,
+            max_run: lock::MAX_RUN,
             run_attempts,
             run_completed,
             run_skipped,
@@ -92,6 +95,14 @@ impl Scheduler {
         self
     }
 
+    /// Overrides the per-run deadline, so tests can hit it without burning the
+    /// production hour of virtual time.
+    #[cfg(test)]
+    pub(crate) fn with_max_run(mut self, max_run: Duration) -> Self {
+        self.max_run = max_run;
+        self
+    }
+
     /// Records that a job's scheduler stopped and won't run again until restart
     /// (a caught panic or an exhausted schedule — never a clean shutdown).
     pub(super) fn record_stopped(&self, job: &str, reason: &'static str) {
@@ -102,6 +113,28 @@ impl Scheduler {
                 KeyValue::new("reason", reason),
             ],
         );
+    }
+}
+
+/// Sleeps for `dur` of *wall-clock* time, re-reading `now_fn` after each chunk of
+/// at most `max_sleep`.
+///
+/// Same reason as [`Scheduler::sleep_until`]: `tokio::time::sleep` counts
+/// monotonic time, which stalls across a host suspend. The run lock's lease is a
+/// wall-clock TTL, so a monotonic deadline would let a suspend push a run past
+/// its expired lease and alongside another process's run.
+pub(super) async fn sleep_wall(dur: Duration, now_fn: &NowFn, max_sleep: Duration) {
+    let started = now_fn();
+    loop {
+        // A backward clock step reads as no elapsed time rather than as overshoot.
+        let elapsed = (now_fn() - started).to_std().unwrap_or(Duration::ZERO);
+        let Some(remaining) = dur.checked_sub(elapsed) else {
+            return;
+        };
+        if remaining.is_zero() {
+            return;
+        }
+        tokio::time::sleep(remaining.min(max_sleep)).await;
     }
 }
 
@@ -288,8 +321,11 @@ impl Scheduler {
             }
         };
 
-        // Phase 2: the job — cancellable via the shutdown signal (drops job.run()'s
-        // future, never the acquire or release around it).
+        // Phase 2: the job — cancellable via the shutdown signal or the deadline
+        // (both drop job.run()'s future, never the acquire or release around it).
+        // This loop already serializes fires within the process; the deadline is
+        // what bounds a hung run and keeps it from outliving its lease, which
+        // would let *another* process acquire alongside it.
         let outcome = tokio::select! {
             biased;
 
@@ -307,6 +343,16 @@ impl Scheduler {
                     "error"
                 }
             },
+            // Polled after the run, so a run finishing on the deadline still counts
+            // as finished.
+            _ = sleep_wall(self.max_run, &self.now_fn, self.max_sleep) => {
+                error!(
+                    job = name,
+                    "Run exceeded the {:?} deadline; abandoning to keep runs from overlapping",
+                    self.max_run
+                );
+                "timed_out"
+            }
         };
 
         // Phase 3: release — uncancellable. Runs even after abandonment; awaiting
@@ -538,6 +584,52 @@ mod tests {
             attempts,
             completed + skipped,
             "abandonment folds into completed, keeping attempts = completed + skipped"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn overlong_run_is_abandoned_at_the_deadline() {
+        let job = BlockingJob::new();
+        let (tx, rx) = watch::channel(false);
+
+        let schedule = validate_cron("* * * * * *").unwrap();
+        let lock = FakeLock::new(AcquireOutcome::Granted);
+        let (scheduler, provider, exporter) = metered_scheduler(virtual_now(), lock.clone());
+        let scheduler = scheduler.with_max_run(Duration::from_secs(2));
+        let runner = scheduler.run_job(&schedule, &job, rx);
+        let driver = async {
+            // Two deadlines' worth: enough for the hung run to be abandoned and the
+            // next fire to take the lock again.
+            tokio::time::sleep(Duration::from_millis(4500)).await;
+            let _ = tx.send(true);
+        };
+        tokio::join!(runner, driver);
+
+        assert!(
+            job.started() >= 2,
+            "the deadline must free the slot so a later fire runs; started={}",
+            job.started()
+        );
+        assert_eq!(
+            job.completed(),
+            0,
+            "the hung runs must never have completed"
+        );
+        assert_eq!(
+            lock.acquires(),
+            lock.releases(),
+            "an abandoned run must still release its lease"
+        );
+
+        provider.force_flush().unwrap();
+        let metrics = exporter.get_finished_metrics().unwrap();
+        assert!(
+            counter_value(
+                &metrics,
+                "jobs.run.completed",
+                &[("job", "blocking"), ("outcome", "timed_out")],
+            ) >= 1,
+            "an abandoned-at-deadline run must record completed{{timed_out}}"
         );
     }
 

--- a/nexusd/src/jobs/scheduler.rs
+++ b/nexusd/src/jobs/scheduler.rs
@@ -14,6 +14,9 @@ use super::{CronParseError, Job};
 /// OpenTelemetry meter name for all job metrics.
 const METER_NAME: &str = "nexus.jobs";
 
+/// Wall-clock re-check interval while waiting for a fire time (see [`Scheduler::sleep_until`]).
+const MAX_SLEEP: Duration = Duration::from_secs(30);
+
 /// Shared clock source. Production passes `Arc::new(Utc::now)`; tests pass a
 /// virtual clock tied to tokio's paused time.
 pub type NowFn = Arc<dyn Fn() -> DateTime<Utc> + Send + Sync>;
@@ -25,6 +28,8 @@ pub type NowFn = Arc<dyn Fn() -> DateTime<Utc> + Send + Sync>;
 pub struct Scheduler {
     now_fn: NowFn,
     lock: Arc<dyn RunLock>,
+    /// Wall-clock re-check interval while sleeping toward a fire time (see [`MAX_SLEEP`]).
+    max_sleep: Duration,
     /// Every fire attempt, before the lock is tried.
     run_attempts: Counter<u64>,
     /// Fires where the job ran, labelled by `outcome` in {ok, error, abandoned}.
@@ -70,11 +75,21 @@ impl Scheduler {
         Self {
             now_fn,
             lock,
+            max_sleep: MAX_SLEEP,
             run_attempts,
             run_completed,
             run_skipped,
             scheduler_stopped,
         }
+    }
+
+    /// Overrides the wall-clock re-check interval. Only for tests pinning a
+    /// far-future fire time, where the default would grind through millions of
+    /// chunks under a paused clock.
+    #[cfg(test)]
+    pub(crate) fn with_max_sleep(mut self, max_sleep: Duration) -> Self {
+        self.max_sleep = max_sleep;
+        self
     }
 
     /// Records that a job's scheduler stopped and won't run again until restart
@@ -133,17 +148,21 @@ pub fn validate_cron(cron_expr: &str) -> Result<Schedule, CronParseError> {
 
 impl Scheduler {
     /// Drives a single [`Job`] on its pre-parsed `schedule` until shutdown. A
-    /// failing run is logged but doesn't stop later runs. Each iteration
-    /// re-anchors to wall-clock via `schedule.after()`, so a forward clock jump
-    /// (NTP, resume) is O(1) with no catch-up per missed tick.
+    /// failing run is logged but doesn't stop later runs. Wall-clock jumps in
+    /// either direction are handled at the anchor and in [`sleep_until`](Self::sleep_until).
     pub async fn run_job(
         &self,
-        name: &str,
         schedule: &Schedule,
         job: &dyn Job,
         mut shutdown_rx: Receiver<bool>,
     ) {
+        // Single source of truth for the name: the lock key and the metric labels
+        // must agree, or a run releases a key it never acquired.
+        let name = job.name();
         info!(job = name, cron = %schedule, "Job scheduler started");
+
+        // The last tick fired, so a backward clock step can't hand it back.
+        let mut last_fired: Option<DateTime<Utc>> = None;
 
         loop {
             // `wait_for_shutdown` only fires on the false→true transition, and
@@ -155,8 +174,12 @@ impl Scheduler {
             }
 
             // Re-anchor to wall-clock each iteration: O(1) skip of all missed ticks.
+            // Anchor past `last_fired` too — a backward step (NTP, snapshot restore)
+            // leaves `now` before a tick we already ran, and `after()` would return
+            // that same tick for a second run.
             let now = (self.now_fn)();
-            let Some(next) = schedule.after(&now).next() else {
+            let anchor = last_fired.map_or(now, |last| last.max(now));
+            let Some(next) = schedule.after(&anchor).next() else {
                 // Bounded schedule (e.g. fixed past year) ran out of fire times.
                 warn!(
                     job = name,
@@ -167,49 +190,65 @@ impl Scheduler {
                 break;
             };
 
-            // `after(&now)` returns times strictly after `now`, so the sleep is
-            // always positive — no overrun check needed.
-            let remaining = (next - now).to_std().unwrap_or(Duration::ZERO);
             // Sleep phase: shutdown can drop this safely — no lock I/O here.
-            tokio::select! {
-                biased;
-
-                _ = wait_for_shutdown(&mut shutdown_rx) => {
-                    info!(job = name, "Shutdown received, exiting job scheduler");
-                    return;
-                }
-                _ = tokio::time::sleep(remaining) => {}
+            if !self.sleep_until(next, &mut shutdown_rx).await {
+                info!(job = name, "Shutdown received, exiting job scheduler");
+                return;
             }
+
+            // Consumed whether or not the run below is skipped: this tick is spent
+            // either way, and retrying it would double-run the job.
+            last_fired = Some(next);
 
             debug!(job = name, fire_time = %next, "Running scheduled job");
             // Run phase: no select! around run_locked — that would drop it (and its
             // in-flight lock I/O) on shutdown. run_locked observes shutdown itself,
             // as a signal that leaves acquire and release uncancellable.
-            self.run_locked(name, job, &mut shutdown_rx).await;
+            self.run_locked(job, &mut shutdown_rx).await;
         }
     }
 
-    /// Acquires the run lock, runs the job once, then releases it. Skips (no
-    /// error) when the lock is held or unreachable — the next tick retries
-    /// rather than piling up a backlog.
+    /// Sleeps until the wall clock reaches `deadline`, re-reading it after each
+    /// chunk of at most `max_sleep`. Returns `false` if shutdown was signaled
+    /// instead.
     ///
-    /// Structured in three phases around `shutdown`: acquire and release are
-    /// uncancellable (they read the backend's reply before returning, so a
-    /// mid-flight drop can't orphan the lock or poison a pooled connection); only
-    /// `job.run()` is raced against shutdown, via `select!` on the watch receiver.
-    ///
-    /// A panic in `run()` propagates via `JoinSet` (see `supervise`); the lock
-    /// still releases through `LockGuard`'s Drop.
-    async fn run_locked(&self, name: &str, job: &dyn Job, shutdown: &mut Receiver<bool>) {
-        self.run_attempts
-            .add(1, &[KeyValue::new("job", name.to_string())]);
+    /// Chunking is what makes the deadline wall-clock-based: `tokio::time::sleep`
+    /// counts monotonic time, which doesn't advance across a host suspend, so one
+    /// `sleep(deadline - now)` would fire late by the suspend's full duration.
+    async fn sleep_until(&self, deadline: DateTime<Utc>, shutdown: &mut Receiver<bool>) -> bool {
+        loop {
+            // Negative (deadline already passed) converts to ZERO — fire now.
+            let remaining = (deadline - (self.now_fn)())
+                .to_std()
+                .unwrap_or(Duration::ZERO);
+            if remaining.is_zero() {
+                return true;
+            }
+            tokio::select! {
+                biased;
+
+                _ = wait_for_shutdown(shutdown) => return false,
+                _ = tokio::time::sleep(remaining.min(self.max_sleep)) => {}
+            }
+        }
+    }
+
+    // Acquires the run lock, runs the job once, releases it; skips (no error) when
+    // the lock is held or unreachable, so a backlog can't pile up. Three phases
+    // around `shutdown`: acquire and release are uncancellable (they read the
+    // backend reply first, so a mid-flight drop can't orphan the lock or poison a
+    // pooled connection); only `job.run()` races shutdown. A panic in `run()`
+    // propagates via `JoinSet` (see `supervise`); the lock still releases via Drop.
+    async fn run_locked(&self, job: &dyn Job, shutdown: &mut Receiver<bool>) {
+        let name = job.name();
+        self.run_attempts.add(1, &[KeyValue::new("job", name)]);
 
         // Shutdown already signaled before we touched the lock: skip without acquiring.
         if *shutdown.borrow() {
             self.run_skipped.add(
                 1,
                 &[
-                    KeyValue::new("job", name.to_string()),
+                    KeyValue::new("job", name),
                     KeyValue::new("reason", "shutdown_before_acquire"),
                 ],
             );
@@ -217,21 +256,13 @@ impl Scheduler {
         }
 
         // Phase 1: acquire — uncancellable. Reads the SET reply before returning.
-        let token = self.lock.new_token();
-        // Arm the guard *before* acquiring. If the acquire errors after the SET
-        // committed but its reply was lost, Drop releases the lock; the
-        // compare-and-delete is a no-op if our token wasn't stored. `name` isn't
-        // &'static; use `job.name()`, which the trait guarantees is.
-        let guard = super::lock::LockGuard::new(job.name(), token.clone(), self.lock.clone());
-
-        match self.lock.acquire(name, &token).await {
-            Ok(true) => {}
-            Ok(false) => {
-                guard.disarm();
+        let guard = match super::lock::acquire(name, &self.lock).await {
+            super::lock::Acquired::Taken(guard) => guard,
+            super::lock::Acquired::Held => {
                 self.run_skipped.add(
                     1,
                     &[
-                        KeyValue::new("job", name.to_string()),
+                        KeyValue::new("job", name),
                         KeyValue::new("reason", "in_progress"),
                     ],
                 );
@@ -241,11 +272,11 @@ impl Scheduler {
                 );
                 return;
             }
-            Err(e) => {
+            super::lock::Acquired::Failed(e) => {
                 self.run_skipped.add(
                     1,
                     &[
-                        KeyValue::new("job", name.to_string()),
+                        KeyValue::new("job", name),
                         KeyValue::new("reason", "lock_error"),
                     ],
                 );
@@ -255,7 +286,7 @@ impl Scheduler {
                 );
                 return;
             }
-        }
+        };
 
         // Phase 2: the job — cancellable via the shutdown signal (drops job.run()'s
         // future, never the acquire or release around it).
@@ -285,7 +316,7 @@ impl Scheduler {
         self.run_completed.add(
             1,
             &[
-                KeyValue::new("job", name.to_string()),
+                KeyValue::new("job", name),
                 KeyValue::new("outcome", outcome),
             ],
         );
@@ -307,16 +338,25 @@ pub(crate) fn virtual_now() -> NowFn {
 
 #[cfg(test)]
 mod tests {
-    use super::super::error::LockResult;
-    use super::super::lock::{AlwaysAvailableLock, RunLock};
-    use super::{validate_cron, virtual_now, NowFn, Scheduler};
+    use super::super::lock::RunLock;
+    use super::{validate_cron, virtual_now, DateTime, NowFn, Scheduler, Utc};
+
+    /// Parses an RFC-3339 instant for pinning a test clock's epoch.
+    fn at(rfc3339: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(rfc3339)
+            .expect("test epoch must be valid RFC-3339")
+            .with_timezone(&Utc)
+    }
+    use crate::jobs::test_support::{
+        steppable_clock, AcquireOutcome, BlockingJob, CountingJob, FakeLock,
+    };
     use crate::jobs::Job;
     use async_trait::async_trait;
     use opentelemetry::metrics::MeterProvider;
     use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData, ResourceMetrics};
     use opentelemetry_sdk::metrics::{InMemoryMetricExporter, SdkMeterProvider};
     use std::error::Error;
-    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::atomic::{AtomicI64, AtomicU32, Ordering};
     use std::sync::Arc;
     use std::sync::Mutex;
     use std::time::Duration;
@@ -363,36 +403,27 @@ mod tests {
         total
     }
 
-    /// A valid cron expression is accepted.
     #[test]
     fn validate_cron_accepts_valid_expression() {
         assert!(validate_cron("0 0 3 * * *").is_ok());
     }
 
-    /// A malformed cron expression is rejected.
     #[test]
     fn validate_cron_rejects_invalid_expression() {
         assert!(validate_cron("not a cron expression").is_err());
     }
 
-    /// A syntactically valid cron that can never fire (fixed past year) is rejected.
     #[test]
     fn validate_cron_rejects_never_firing() {
         assert!(validate_cron("0 0 3 * * * 2020").is_err());
     }
 
-    /// The `cron` crate is seconds-first (6-7 fields). A standard 5-field
-    /// expression is rejected outright, not silently reinterpreted as a
-    /// seconds-first schedule — so `0 3 * * *` can't sneak in as ":03 every
-    /// hour". Pins that guarantee against a crate bump loosening parsing.
     #[test]
     fn validate_cron_rejects_five_field_expressions() {
         assert!(validate_cron("0 3 * * *").is_err());
         assert!(validate_cron("* * * * *").is_err());
     }
 
-    /// A run overrunning several fire times gets no back-to-back catch-up runs:
-    /// the scheduler skips missed ticks and fires exactly once more.
     #[tokio::test(start_paused = true)]
     async fn overrunning_run_skips_missed_ticks_and_fires_once_more() {
         /// Sleeps past several per-second ticks on its first run only.
@@ -422,8 +453,8 @@ mod tests {
         let (tx, rx) = watch::channel(false);
 
         let schedule = validate_cron("* * * * * *").unwrap();
-        let scheduler = Scheduler::new(virtual_now(), Arc::new(AlwaysAvailableLock));
-        let runner = scheduler.run_job("overrun", &schedule, &job, rx);
+        let scheduler = Scheduler::new(virtual_now(), FakeLock::new(AcquireOutcome::Granted));
+        let runner = scheduler.run_job(&schedule, &job, rx);
         let driver = async {
             // Anchor to the first fire so timing doesn't depend on the start
             // offset within the second.
@@ -444,45 +475,19 @@ mod tests {
         );
     }
 
-    /// Shutdown mid-run abandons the (here never-completing) run and returns
-    /// promptly.
     #[tokio::test(start_paused = true)]
     async fn shutdown_during_running_job_returns_promptly() {
-        /// Starts, then blocks forever on a `Notify` that is never signaled.
-        struct BlockingJob {
-            started: Arc<AtomicU32>,
-            completed: Arc<AtomicU32>,
-            gate: Arc<tokio::sync::Notify>,
-        }
-        #[async_trait]
-        impl Job for BlockingJob {
-            fn name(&self) -> &'static str {
-                "blocking"
-            }
-            async fn run(&self) -> Result<(), Box<dyn Error + Send + Sync>> {
-                self.started.fetch_add(1, Ordering::SeqCst);
-                self.gate.notified().await; // never signaled
-                self.completed.fetch_add(1, Ordering::SeqCst);
-                Ok(())
-            }
-        }
-
-        let started = Arc::new(AtomicU32::new(0));
-        let completed = Arc::new(AtomicU32::new(0));
-        let job = BlockingJob {
-            started: started.clone(),
-            completed: completed.clone(),
-            gate: Arc::new(tokio::sync::Notify::new()),
-        };
+        let job = BlockingJob::new();
         let (tx, rx) = watch::channel(false);
 
         let shutdown_at: Mutex<Option<tokio::time::Instant>> = Mutex::new(None);
         let schedule = validate_cron("* * * * * *").unwrap();
-        let scheduler = Scheduler::new(virtual_now(), Arc::new(AlwaysAvailableLock));
-        let runner = scheduler.run_job("blocking", &schedule, &job, rx);
+        let (scheduler, provider, exporter) =
+            metered_scheduler(virtual_now(), FakeLock::new(AcquireOutcome::Granted));
+        let runner = scheduler.run_job(&schedule, &job, rx);
         let driver = async {
             // Wait until the job has actually started running.
-            while started.load(Ordering::SeqCst) == 0 {
+            while job.started() == 0 {
                 tokio::time::sleep(Duration::from_millis(5)).await;
             }
             *shutdown_at.lock().unwrap() = Some(tokio::time::Instant::now());
@@ -490,6 +495,8 @@ mod tests {
         };
         tokio::join!(runner, driver);
 
+        // Behaviour: the run started, never completed, and run_job returned in zero
+        // virtual time.
         let elapsed = shutdown_at
             .lock()
             .unwrap()
@@ -501,48 +508,50 @@ mod tests {
             "run_job must return promptly after shutdown mid-run (zero virtual time elapsed); took {elapsed:?}"
         );
         assert_eq!(
-            started.load(Ordering::SeqCst),
+            job.started(),
             1,
             "the job must have started before shutdown"
         );
         assert_eq!(
-            completed.load(Ordering::SeqCst),
+            job.completed(),
             0,
             "the abandoned run must not have completed"
         );
+
+        // Metrics: abandonment records completed{abandoned} (not a skip), so the
+        // attempts partition still holds.
+        provider.force_flush().unwrap();
+        let metrics = exporter.get_finished_metrics().unwrap();
+        assert_eq!(
+            counter_value(
+                &metrics,
+                "jobs.run.completed",
+                &[("job", "blocking"), ("outcome", "abandoned")],
+            ),
+            1,
+            "a run abandoned on shutdown must record exactly one completed{{abandoned}}"
+        );
+        let attempts = counter_value(&metrics, "jobs.run.attempts", &[("job", "blocking")]);
+        let completed = counter_value(&metrics, "jobs.run.completed", &[("job", "blocking")]);
+        let skipped = counter_value(&metrics, "jobs.run.skipped", &[("job", "blocking")]);
+        assert_eq!(
+            attempts,
+            completed + skipped,
+            "abandonment folds into completed, keeping attempts = completed + skipped"
+        );
     }
 
-    /// A minimal job that just counts how many times it ran.
-    struct CountingJob {
-        count: Arc<AtomicU32>,
-    }
-    #[async_trait]
-    impl Job for CountingJob {
-        fn name(&self) -> &'static str {
-            "counting"
-        }
-        async fn run(&self) -> Result<(), Box<dyn Error + Send + Sync>> {
-            self.count.fetch_add(1, Ordering::SeqCst);
-            Ok(())
-        }
-    }
-
-    /// Shutdown during the sleep phase (first select!) exits without firing. Uses
-    /// a far-future cron so the job never fires on its own.
     #[tokio::test(start_paused = true)]
     async fn run_job_exits_on_shutdown_without_firing() {
-        let count = Arc::new(AtomicU32::new(0));
-        let job = CountingJob {
-            count: count.clone(),
-        };
+        let job = CountingJob::new("counting");
         let (tx, rx) = watch::channel(false);
 
         // Year-pinned cron (2100, the crate's max) fixes one fire far outside any
         // test run. The pin is what guarantees no fire: an unpinned "0 0 0 1 1 *"
         // recurs yearly and could fire if the paused clock lands near Jan 1 UTC.
         let schedule = validate_cron("0 0 0 1 1 * 2100").unwrap();
-        let scheduler = Scheduler::new(virtual_now(), Arc::new(AlwaysAvailableLock));
-        let runner = scheduler.run_job("counting", &schedule, &job, rx);
+        let scheduler = Scheduler::new(virtual_now(), FakeLock::new(AcquireOutcome::Granted));
+        let runner = scheduler.run_job(&schedule, &job, rx);
         let stopper = async {
             tokio::time::sleep(Duration::from_millis(100)).await;
             let _ = tx.send(true);
@@ -550,28 +559,23 @@ mod tests {
         tokio::join!(runner, stopper);
 
         assert_eq!(
-            count.load(Ordering::SeqCst),
+            job.runs(),
             0,
             "shutdown during sleep must exit without firing the job"
         );
     }
 
-    /// A `false` send must not stop the scheduler; it exits only on `true` (or
-    /// dropped senders).
     #[tokio::test(start_paused = true)]
     async fn false_shutdown_signal_does_not_stop_scheduler() {
-        let count = Arc::new(AtomicU32::new(0));
-        let job = CountingJob {
-            count: count.clone(),
-        };
+        let job = CountingJob::new("counting");
         let (tx, rx) = watch::channel(false);
 
         let schedule = validate_cron("* * * * * *").unwrap();
-        let scheduler = Scheduler::new(virtual_now(), Arc::new(AlwaysAvailableLock));
-        let runner = scheduler.run_job("counting", &schedule, &job, rx);
+        let scheduler = Scheduler::new(virtual_now(), FakeLock::new(AcquireOutcome::Granted));
+        let runner = scheduler.run_job(&schedule, &job, rx);
         let driver = async {
             // Wait for the first fire, then send false (a no-op).
-            while count.load(Ordering::SeqCst) == 0 {
+            while job.runs() == 0 {
                 tokio::time::sleep(Duration::from_millis(10)).await;
             }
             let _ = tx.send(false);
@@ -582,38 +586,19 @@ mod tests {
         tokio::join!(runner, driver);
 
         assert!(
-            count.load(Ordering::SeqCst) >= 2,
+            job.runs() >= 2,
             "a false send must not stop the scheduler; it should keep firing"
         );
     }
 
-    /// A lock held elsewhere (`acquire` → `false`) makes the scheduler skip every
-    /// fire — the job never runs — while it keeps ticking and exits on shutdown.
     #[tokio::test(start_paused = true)]
     async fn run_job_skips_run_when_lock_held() {
-        struct HeldLock;
-        #[async_trait]
-        impl RunLock for HeldLock {
-            fn new_token(&self) -> String {
-                "token".to_string()
-            }
-            async fn acquire(&self, _job: &str, _token: &str) -> LockResult<bool> {
-                Ok(false)
-            }
-            async fn unlock(&self, _job: &str, _token: &str) -> LockResult<()> {
-                Ok(())
-            }
-        }
-
-        let count = Arc::new(AtomicU32::new(0));
-        let job = CountingJob {
-            count: count.clone(),
-        };
+        let job = CountingJob::new("counting");
         let (tx, rx) = watch::channel(false);
 
         let schedule = validate_cron("* * * * * *").unwrap();
-        let scheduler = Scheduler::new(virtual_now(), Arc::new(HeldLock));
-        let runner = scheduler.run_job("counting", &schedule, &job, rx);
+        let scheduler = Scheduler::new(virtual_now(), FakeLock::new(AcquireOutcome::Denied));
+        let runner = scheduler.run_job(&schedule, &job, rx);
         let stopper = async {
             // Several ticks pass; every fire should be skipped.
             tokio::time::sleep(Duration::from_millis(3500)).await;
@@ -622,166 +607,52 @@ mod tests {
         tokio::join!(runner, stopper);
 
         assert_eq!(
-            count.load(Ordering::SeqCst),
+            job.runs(),
             0,
             "a held lock must prevent the job from running"
         );
     }
 
-    /// Every fire pairs one lock acquire with one release, so the lock is never
-    /// leaked between runs.
     #[tokio::test(start_paused = true)]
     async fn run_job_acquires_and_releases_lock_around_run() {
-        struct RecordingLock {
-            acquired: Arc<AtomicU32>,
-            released: Arc<AtomicU32>,
-        }
-        #[async_trait]
-        impl RunLock for RecordingLock {
-            fn new_token(&self) -> String {
-                "token".to_string()
-            }
-            async fn acquire(&self, _job: &str, _token: &str) -> LockResult<bool> {
-                self.acquired.fetch_add(1, Ordering::SeqCst);
-                Ok(true)
-            }
-            async fn unlock(&self, _job: &str, _token: &str) -> LockResult<()> {
-                self.released.fetch_add(1, Ordering::SeqCst);
-                Ok(())
-            }
-        }
-
-        let acquired = Arc::new(AtomicU32::new(0));
-        let released = Arc::new(AtomicU32::new(0));
-        let count = Arc::new(AtomicU32::new(0));
-        let job = CountingJob {
-            count: count.clone(),
-        };
+        let job = CountingJob::new("counting");
         let (tx, rx) = watch::channel(false);
 
         let schedule = validate_cron("* * * * * *").unwrap();
-        let lock = RecordingLock {
-            acquired: acquired.clone(),
-            released: released.clone(),
-        };
-        let scheduler = Scheduler::new(virtual_now(), Arc::new(lock));
-        let runner = scheduler.run_job("counting", &schedule, &job, rx);
+        let lock = FakeLock::new(AcquireOutcome::Granted);
+        let scheduler = Scheduler::new(virtual_now(), lock.clone());
+        let runner = scheduler.run_job(&schedule, &job, rx);
         let stopper = async {
             tokio::time::sleep(Duration::from_millis(2500)).await;
             let _ = tx.send(true);
         };
         tokio::join!(runner, stopper);
 
-        let runs = count.load(Ordering::SeqCst);
+        let runs = job.runs();
         assert!(runs >= 2, "the job should have fired at least twice");
         assert_eq!(
-            acquired.load(Ordering::SeqCst),
-            released.load(Ordering::SeqCst),
+            lock.acquires(),
+            lock.releases(),
             "every acquire must be paired with a release"
         );
         assert_eq!(
-            released.load(Ordering::SeqCst),
+            lock.releases(),
             runs,
             "the lock must be released once per run"
         );
     }
 
-    /// Cancelling a run while its acquire is still in flight (shutdown dropping
-    /// the future between the lock being taken and the token reaching us) must
-    /// not orphan the lock: the guard is armed before the acquire, so its Drop
-    /// releases it. Modelled with an `acquire` that never resolves.
-    #[tokio::test(start_paused = true)]
-    async fn cancel_during_acquire_releases_lock() {
-        struct StalledLock {
-            released: Arc<AtomicU32>,
-        }
-        #[async_trait]
-        impl RunLock for StalledLock {
-            fn new_token(&self) -> String {
-                "token".to_string()
-            }
-            async fn acquire(&self, _job: &str, _token: &str) -> LockResult<bool> {
-                // Never resolves: the acquire's response never reaches us before
-                // the task is cancelled.
-                std::future::pending::<()>().await;
-                unreachable!()
-            }
-            async fn unlock(&self, _job: &str, _token: &str) -> LockResult<()> {
-                self.released.fetch_add(1, Ordering::SeqCst);
-                Ok(())
-            }
-        }
-
-        let released = Arc::new(AtomicU32::new(0));
-        let scheduler = Scheduler::new(
-            virtual_now(),
-            Arc::new(StalledLock {
-                released: released.clone(),
-            }),
-        );
-        let job = CountingJob {
-            count: Arc::new(AtomicU32::new(0)),
-        };
-        let (_tx, mut rx) = watch::channel(false);
-
-        // Poll run_locked so it reaches (and stalls on) the acquire, then drop it.
-        {
-            let fut = scheduler.run_locked("counting", &job, &mut rx);
-            tokio::pin!(fut);
-            tokio::select! {
-                _ = &mut fut => panic!("acquire stalls; run_locked cannot complete"),
-                _ = tokio::time::sleep(Duration::from_millis(1)) => {}
-            }
-        } // fut dropped here → the pre-armed guard's Drop spawns the unlock.
-
-        // Let the detached Drop-spawn unlock run.
-        tokio::task::yield_now().await;
-        tokio::time::sleep(Duration::from_millis(10)).await;
-
-        assert_eq!(
-            released.load(Ordering::SeqCst),
-            1,
-            "a run dropped mid-acquire must still release via the pre-armed guard"
-        );
-    }
-
-    /// Every fire is one attempt that partitions into completed or skipped,
-    /// never both — asserted by reading the real `jobs.run.*` OTel counters back
-    /// through an in-memory exporter.
     #[tokio::test(start_paused = true)]
     async fn attempts_partition_between_completed_and_skipped() {
-        /// Grants then denies the lock on alternate fires: even fires run the job
-        /// (completed{ok}), odd fires are denied (skipped{in_progress}).
-        struct AlternatingLock {
-            calls: AtomicU32,
-        }
-        #[async_trait]
-        impl RunLock for AlternatingLock {
-            fn new_token(&self) -> String {
-                "token".to_string()
-            }
-            async fn acquire(&self, _job: &str, _token: &str) -> LockResult<bool> {
-                Ok(self.calls.fetch_add(1, Ordering::SeqCst).is_multiple_of(2))
-            }
-            async fn unlock(&self, _job: &str, _token: &str) -> LockResult<()> {
-                Ok(())
-            }
-        }
-
-        let count = Arc::new(AtomicU32::new(0));
-        let job = CountingJob {
-            count: count.clone(),
-        };
+        let job = CountingJob::new("counting");
         let (tx, rx) = watch::channel(false);
 
         let schedule = validate_cron("* * * * * *").unwrap();
-        let (scheduler, provider, exporter) = metered_scheduler(
-            virtual_now(),
-            Arc::new(AlternatingLock {
-                calls: AtomicU32::new(0),
-            }),
-        );
-        let runner = scheduler.run_job("counting", &schedule, &job, rx);
+        // Alternating: even fires run the job (completed{ok}), odd fires are
+        // denied (skipped{in_progress}), so one run exercises both branches.
+        let (scheduler, provider, exporter) =
+            metered_scheduler(virtual_now(), FakeLock::new(AcquireOutcome::Alternating));
+        let runner = scheduler.run_job(&schedule, &job, rx);
         let stopper = async {
             tokio::time::sleep(Duration::from_millis(4500)).await;
             let _ = tx.send(true);
@@ -815,113 +686,22 @@ mod tests {
         );
     }
 
-    /// A run abandoned mid-flight on shutdown records `completed{outcome=abandoned}`
-    /// (not a skip), so the attempts partition still holds and abandonment is
-    /// observable.
-    #[tokio::test(start_paused = true)]
-    async fn abandoned_run_records_completed_outcome() {
-        /// Marks itself started, then blocks forever on a never-signaled `Notify`.
-        struct BlockingJob {
-            started: Arc<AtomicU32>,
-            gate: Arc<tokio::sync::Notify>,
-        }
-        #[async_trait]
-        impl Job for BlockingJob {
-            fn name(&self) -> &'static str {
-                "blocking"
-            }
-            async fn run(&self) -> Result<(), Box<dyn Error + Send + Sync>> {
-                self.started.fetch_add(1, Ordering::SeqCst);
-                self.gate.notified().await; // never signaled
-                Ok(())
-            }
-        }
-
-        let started = Arc::new(AtomicU32::new(0));
-        let job = BlockingJob {
-            started: started.clone(),
-            gate: Arc::new(tokio::sync::Notify::new()),
-        };
-        let (tx, rx) = watch::channel(false);
-
-        let schedule = validate_cron("* * * * * *").unwrap();
-        let (scheduler, provider, exporter) =
-            metered_scheduler(virtual_now(), Arc::new(AlwaysAvailableLock));
-        let runner = scheduler.run_job("blocking", &schedule, &job, rx);
-        let driver = async {
-            while started.load(Ordering::SeqCst) == 0 {
-                tokio::time::sleep(Duration::from_millis(5)).await;
-            }
-            let _ = tx.send(true);
-        };
-        tokio::join!(runner, driver);
-
-        provider.force_flush().unwrap();
-        let metrics = exporter.get_finished_metrics().unwrap();
-
-        let abandoned = counter_value(
-            &metrics,
-            "jobs.run.completed",
-            &[("job", "blocking"), ("outcome", "abandoned")],
-        );
-        assert_eq!(
-            abandoned, 1,
-            "a run abandoned on shutdown must record exactly one completed{{abandoned}}"
-        );
-
-        // The partition still holds across all outcomes/reasons.
-        let attempts = counter_value(&metrics, "jobs.run.attempts", &[("job", "blocking")]);
-        let completed = counter_value(&metrics, "jobs.run.completed", &[("job", "blocking")]);
-        let skipped = counter_value(&metrics, "jobs.run.skipped", &[("job", "blocking")]);
-        assert_eq!(
-            attempts,
-            completed + skipped,
-            "abandonment folds into completed, keeping attempts = completed + skipped"
-        );
-    }
-
-    /// Shutdown already signaled before we touch the lock: `run_locked` fast-exits,
-    /// recording `skipped{shutdown_before_acquire}` and never calling `acquire`.
     #[tokio::test(start_paused = true)]
     async fn run_locked_fast_exits_when_already_shutdown() {
-        struct AcquireCountingLock {
-            acquired: Arc<AtomicU32>,
-        }
-        #[async_trait]
-        impl RunLock for AcquireCountingLock {
-            fn new_token(&self) -> String {
-                "token".to_string()
-            }
-            async fn acquire(&self, _job: &str, _token: &str) -> LockResult<bool> {
-                self.acquired.fetch_add(1, Ordering::SeqCst);
-                Ok(true)
-            }
-            async fn unlock(&self, _job: &str, _token: &str) -> LockResult<()> {
-                Ok(())
-            }
-        }
-
-        let acquired = Arc::new(AtomicU32::new(0));
-        let job = CountingJob {
-            count: Arc::new(AtomicU32::new(0)),
-        };
-        let (scheduler, provider, exporter) = metered_scheduler(
-            virtual_now(),
-            Arc::new(AcquireCountingLock {
-                acquired: acquired.clone(),
-            }),
-        );
+        let job = CountingJob::new("counting");
+        let lock = FakeLock::new(AcquireOutcome::Granted);
+        let (scheduler, provider, exporter) = metered_scheduler(virtual_now(), lock.clone());
 
         // Shutdown is already true when run_locked is entered.
         let (tx, mut rx) = watch::channel(false);
         tx.send(true).unwrap();
-        scheduler.run_locked("counting", &job, &mut rx).await;
+        scheduler.run_locked(&job, &mut rx).await;
 
         provider.force_flush().unwrap();
         let metrics = exporter.get_finished_metrics().unwrap();
 
         assert_eq!(
-            acquired.load(Ordering::SeqCst),
+            lock.acquires(),
             0,
             "a fast-exit on shutdown must not reach acquire"
         );
@@ -941,28 +721,107 @@ mod tests {
         );
     }
 
-    /// A bounded schedule that runs out of fire times records one
-    /// `jobs.scheduler.stopped{reason=schedule_exhausted}` and returns on its own.
+    #[tokio::test(start_paused = true)]
+    async fn wall_clock_jump_forward_fires_within_max_sleep() {
+        let job = CountingJob::new("counting");
+        let (tx, rx) = watch::channel(false);
+
+        // Epoch pinned on the hour, so the next hourly fire is exactly 1h out.
+        let (now_fn, skew) = steppable_clock(at("2030-01-01T00:00:00Z"));
+        let schedule = validate_cron("0 0 * * * *").unwrap();
+        let scheduler = Scheduler::new(now_fn, FakeLock::new(AcquireOutcome::Granted))
+            .with_max_sleep(Duration::from_secs(30));
+        let runner = scheduler.run_job(&schedule, &job, rx);
+        let driver = async {
+            // Let the scheduler settle into its wait toward 01:00.
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            assert_eq!(job.runs(), 0, "the hourly job must not fire an hour early");
+            // Suspend: the wall clock lands past the fire time, tokio's does not.
+            skew.store(2 * 3600, Ordering::SeqCst);
+            // Two max_sleep chunks — one is enough to re-anchor and notice.
+            tokio::time::sleep(Duration::from_secs(60)).await;
+            let _ = tx.send(true);
+        };
+        tokio::join!(runner, driver);
+
+        assert!(
+            job.runs() >= 1,
+            "the fire time passed during the jump; the scheduler must re-anchor to the \
+             wall clock within max_sleep instead of sleeping out the monotonic delay"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wall_clock_step_backward_does_not_refire_the_same_tick() {
+        /// Steps the clock back on its first run. The step has to land between the
+        /// run finishing and the scheduler re-anchoring for the next tick, and the
+        /// job body *is* that window — which is also how it happens for real: NTP
+        /// corrects while the job is executing.
+        struct SteppingJob {
+            runs: AtomicU32,
+            skew: Arc<AtomicI64>,
+        }
+        #[async_trait]
+        impl Job for SteppingJob {
+            fn name(&self) -> &'static str {
+                "stepping"
+            }
+            async fn run(&self) -> Result<(), Box<dyn Error + Send + Sync>> {
+                if self.runs.fetch_add(1, Ordering::SeqCst) == 0 {
+                    // Back 2s: `now` now sits before the 01:00:00 tick we just fired.
+                    self.skew.store(-2, Ordering::SeqCst);
+                }
+                Ok(())
+            }
+        }
+
+        // Epoch 1s before the hourly fire, so 01:00:00 lands almost immediately.
+        let (now_fn, skew) = steppable_clock(at("2030-01-01T00:59:59Z"));
+        let job = SteppingJob {
+            runs: AtomicU32::new(0),
+            skew,
+        };
+        let (tx, rx) = watch::channel(false);
+
+        let schedule = validate_cron("0 0 * * * *").unwrap();
+        let scheduler = Scheduler::new(now_fn, FakeLock::new(AcquireOutcome::Granted));
+        let runner = scheduler.run_job(&schedule, &job, rx);
+        let stopper = async {
+            // Far longer than the ~2s a re-fire of 01:00:00 would take, and far
+            // short of the next real fire at 02:00.
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            let _ = tx.send(true);
+        };
+        tokio::join!(runner, stopper);
+
+        assert_eq!(
+            job.runs.load(Ordering::SeqCst),
+            1,
+            "a backward clock step must not re-fire the 01:00:00 tick; the anchor \
+             must never move behind the last tick fired"
+        );
+    }
+
     #[tokio::test(start_paused = true)]
     async fn exhausted_schedule_records_stopped_metric() {
-        let count = Arc::new(AtomicU32::new(0));
-        let job = CountingJob {
-            count: count.clone(),
-        };
+        let job = CountingJob::new("counting");
         // No shutdown is sent: run_job returns once the schedule is exhausted.
         let (_tx, rx) = watch::channel(false);
 
         // Year-pinned single fire: fires once, then `after()` yields no more times.
         let schedule = validate_cron("0 0 0 1 1 * 2099").unwrap();
         let (scheduler, provider, exporter) =
-            metered_scheduler(virtual_now(), Arc::new(AlwaysAvailableLock));
-        scheduler.run_job("counting", &schedule, &job, rx).await;
+            metered_scheduler(virtual_now(), FakeLock::new(AcquireOutcome::Granted));
+        // Unbounded chunks: the fire is decades out, and the default 30s re-check
+        // would need millions of iterations to reach it under the paused clock.
+        let scheduler = scheduler.with_max_sleep(Duration::MAX);
+        scheduler.run_job(&schedule, &job, rx).await;
 
         provider.force_flush().unwrap();
         let metrics = exporter.get_finished_metrics().unwrap();
 
         assert!(
-            count.load(Ordering::SeqCst) >= 1,
+            job.runs() >= 1,
             "the single-fire schedule must fire before exhausting"
         );
         assert_eq!(

--- a/nexusd/src/jobs/scheduler.rs
+++ b/nexusd/src/jobs/scheduler.rs
@@ -350,6 +350,16 @@ mod tests {
         assert!(validate_cron("0 0 3 * * * 2020").is_err());
     }
 
+    /// The `cron` crate is seconds-first (6-7 fields). A standard 5-field
+    /// expression is rejected outright, not silently reinterpreted as a
+    /// seconds-first schedule — so `0 3 * * *` can't sneak in as ":03 every
+    /// hour". Pins that guarantee against a crate bump loosening parsing.
+    #[test]
+    fn validate_cron_rejects_five_field_expressions() {
+        assert!(validate_cron("0 3 * * *").is_err());
+        assert!(validate_cron("* * * * *").is_err());
+    }
+
     /// A run overrunning several fire times gets no back-to-back catch-up runs:
     /// the scheduler skips missed ticks and fires exactly once more.
     #[tokio::test(start_paused = true)]

--- a/nexusd/src/jobs/scheduler.rs
+++ b/nexusd/src/jobs/scheduler.rs
@@ -1,0 +1,741 @@
+use chrono::{DateTime, Utc};
+use cron::Schedule;
+use opentelemetry::metrics::{Counter, Meter};
+use opentelemetry::{global, KeyValue};
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::watch::Receiver;
+use tracing::{debug, error, info, warn};
+
+use super::lock::RunLock;
+use super::{CronParseError, Job};
+
+/// OpenTelemetry meter name for all job metrics.
+const METER_NAME: &str = "nexus.jobs";
+
+/// Shared clock source. Production passes `Arc::new(Utc::now)`; tests pass a
+/// virtual clock tied to tokio's paused time.
+pub type NowFn = Arc<dyn Fn() -> DateTime<Utc> + Send + Sync>;
+
+/// Drives scheduled jobs, owning the clock, run lock, and metrics. Cheap to
+/// clone (all `Arc`-backed), so [`supervise`](super::supervise) hands one clone
+/// to each per-job task.
+#[derive(Clone)]
+pub struct Scheduler {
+    now_fn: NowFn,
+    lock: Arc<dyn RunLock>,
+    /// Every fire attempt, before the lock is tried.
+    run_attempts: Counter<u64>,
+    /// Fires where the job ran, labelled by `outcome` in {ok, error}.
+    run_completed: Counter<u64>,
+    /// Fires that didn't run the job, labelled by `reason` in
+    /// {in_progress, lock_error}.
+    run_skipped: Counter<u64>,
+    /// Schedulers that stopped and won't run again until restart, labelled by
+    /// `reason` in {panic, schedule_exhausted}. Excludes clean shutdown. A
+    /// nonzero rate should alert.
+    scheduler_stopped: Counter<u64>,
+}
+
+impl Scheduler {
+    /// Builds a scheduler with `now_fn` as its clock and `lock` guarding runs.
+    /// Instruments come from the global meter (no-ops until an
+    /// `SdkMeterProvider` is installed).
+    pub fn new(now_fn: NowFn, lock: Arc<dyn RunLock>) -> Self {
+        Self::with_meter(now_fn, lock, global::meter(METER_NAME))
+    }
+
+    /// [`new`](Self::new) with an explicit `meter`, so tests can install a local
+    /// `SdkMeterProvider` and read the counters back.
+    pub(crate) fn with_meter(now_fn: NowFn, lock: Arc<dyn RunLock>, meter: Meter) -> Self {
+        let run_attempts = meter
+            .u64_counter("jobs.run.attempts")
+            .with_description("Scheduled fire attempts (before lock acquisition)")
+            .build();
+        let run_completed = meter
+            .u64_counter("jobs.run.completed")
+            .with_description("Scheduled fires where the job's run() was invoked")
+            .build();
+        let run_skipped = meter
+            .u64_counter("jobs.run.skipped")
+            .with_description("Scheduled fires skipped without running the job")
+            .build();
+        let scheduler_stopped = meter
+            .u64_counter("jobs.scheduler.stopped")
+            .with_description(
+                "Schedulers that stopped and won't run until restart (excludes shutdown)",
+            )
+            .build();
+        Self {
+            now_fn,
+            lock,
+            run_attempts,
+            run_completed,
+            run_skipped,
+            scheduler_stopped,
+        }
+    }
+
+    /// Records that a job's scheduler stopped and won't run again until restart
+    /// (a caught panic or an exhausted schedule — never a clean shutdown).
+    pub(super) fn record_stopped(&self, job: &str, reason: &'static str) {
+        self.scheduler_stopped.add(
+            1,
+            &[
+                KeyValue::new("job", job.to_string()),
+                KeyValue::new("reason", reason),
+            ],
+        );
+    }
+}
+
+/// Waits until `shutdown_rx` carries `true` or all senders drop; `false` sends
+/// are ignored.
+///
+/// Cancel-safe: the only await is `Receiver::changed()`, and there's no await
+/// between wake and `borrow_and_update()`, so a `select!` drop can't swallow a
+/// shutdown. Keep it that way.
+async fn wait_for_shutdown(rx: &mut Receiver<bool>) {
+    loop {
+        match rx.changed().await {
+            Ok(()) => {
+                if *rx.borrow_and_update() {
+                    return;
+                }
+                // false — not a shutdown, keep waiting.
+            }
+            Err(_) => {
+                // All senders dropped — treat as shutdown.
+                return;
+            }
+        }
+    }
+}
+
+/// Parses `cron_expr` and checks it has at least one upcoming fire time,
+/// returning the [`Schedule`] or an error. Used to fail fast when building a job.
+pub fn validate_cron(cron_expr: &str) -> Result<Schedule, CronParseError> {
+    let schedule = Schedule::from_str(cron_expr).map_err(|e| CronParseError {
+        expr: cron_expr.into(),
+        reason: format!("parse failed: {e}"),
+    })?;
+    // A valid expression can still never fire (e.g. a fixed past year): the
+    // scheduler would start and immediately exit.
+    if schedule.upcoming(Utc).next().is_none() {
+        return Err(CronParseError {
+            expr: cron_expr.into(),
+            reason: "has no upcoming fire times".to_string(),
+        });
+    }
+    Ok(schedule)
+}
+
+impl Scheduler {
+    /// Drives a single [`Job`] on its pre-parsed `schedule` until shutdown. A
+    /// failing run is logged but doesn't stop later runs. Each iteration
+    /// re-anchors to wall-clock via `schedule.after()`, so a forward clock jump
+    /// (NTP, resume) is O(1) with no catch-up per missed tick.
+    pub async fn run_job(
+        &self,
+        name: &str,
+        schedule: &Schedule,
+        job: &dyn Job,
+        mut shutdown_rx: Receiver<bool>,
+    ) {
+        info!(job = name, cron = %schedule, "Job scheduler started");
+
+        loop {
+            // Re-anchor to wall-clock each iteration: O(1) skip of all missed ticks.
+            let now = (self.now_fn)();
+            let Some(next) = schedule.after(&now).next() else {
+                // Bounded schedule (e.g. fixed past year) ran out of fire times.
+                warn!(
+                    job = name,
+                    cron = %schedule,
+                    "Cron schedule has no more fire times; scheduled job stopped"
+                );
+                self.record_stopped(name, "schedule_exhausted");
+                break;
+            };
+
+            // `after(&now)` returns times strictly after `now`, so the sleep is
+            // always positive — no overrun check needed.
+            let remaining = (next - now).to_std().unwrap_or(Duration::ZERO);
+            tokio::select! {
+                biased;
+
+                _ = wait_for_shutdown(&mut shutdown_rx) => {
+                    info!(job = name, "Shutdown received, exiting job scheduler");
+                    return;
+                }
+                _ = tokio::time::sleep(remaining) => {}
+            }
+
+            debug!(job = name, fire_time = %next, "Running scheduled job");
+            tokio::select! {
+                biased;
+
+                // Dropping the future leaves the lock to its TTL, but we're exiting anyway.
+                _ = wait_for_shutdown(&mut shutdown_rx) => {
+                    info!(job = name, "Shutdown received during run; abandoning it");
+                    return;
+                }
+                () = self.run_locked(name, job) => {}
+            }
+        }
+    }
+
+    /// Acquires the run lock, runs the job once, then releases it. Skips (no
+    /// error) when the lock is held or unreachable — the next tick retries
+    /// rather than piling up a backlog.
+    ///
+    /// A panic in `run()` propagates via `JoinSet` (see `supervise`); the lock
+    /// still releases through `LockGuard`'s Drop.
+    async fn run_locked(&self, name: &str, job: &dyn Job) {
+        self.run_attempts
+            .add(1, &[KeyValue::new("job", name.to_string())]);
+
+        let token = match self.lock.try_lock(name).await {
+            Ok(Some(token)) => token,
+            Ok(None) => {
+                self.run_skipped.add(
+                    1,
+                    &[
+                        KeyValue::new("job", name.to_string()),
+                        KeyValue::new("reason", "in_progress"),
+                    ],
+                );
+                warn!(
+                    job = name,
+                    "Previous run still in progress; skipping this fire"
+                );
+                return;
+            }
+            Err(e) => {
+                self.run_skipped.add(
+                    1,
+                    &[
+                        KeyValue::new("job", name.to_string()),
+                        KeyValue::new("reason", "lock_error"),
+                    ],
+                );
+                error!(
+                    job = name,
+                    "Could not acquire run lock; skipping this fire: {e}"
+                );
+                return;
+            }
+        };
+
+        // `name` isn't &'static; use `job.name()`, which the trait guarantees is.
+        let guard = super::lock::LockGuard::new(job.name(), token, self.lock.clone());
+
+        let result = job.run().await;
+
+        // Await the release so unlock errors log synchronously. A panic in run()
+        // skips this line — Drop releases instead.
+        guard.release().await;
+
+        let outcome = match &result {
+            Ok(()) => "ok",
+            Err(_) => "error",
+        };
+        self.run_completed.add(
+            1,
+            &[
+                KeyValue::new("job", name.to_string()),
+                KeyValue::new("outcome", outcome),
+            ],
+        );
+        match result {
+            Ok(()) => debug!(job = name, "Scheduled job completed"),
+            Err(e) => error!(job = name, "Scheduled job failed: {e:?}"),
+        }
+    }
+}
+
+/// A `now_fn` mapping tokio's virtual clock (under `start_paused`) back to
+/// wall-clock `DateTime<Utc>`.
+#[cfg(test)]
+pub(crate) fn virtual_now() -> NowFn {
+    let wall0 = Utc::now();
+    let virt0 = tokio::time::Instant::now();
+    Arc::new(move || {
+        wall0
+            + chrono::Duration::from_std(virt0.elapsed())
+                .expect("virtual elapsed time must fit in chrono::Duration")
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::lock::{AlwaysAvailableLock, RunLock};
+    use super::{validate_cron, virtual_now, NowFn, Scheduler};
+    use crate::jobs::Job;
+    use async_trait::async_trait;
+    use nexus_common::db::RedisResult;
+    use opentelemetry::metrics::MeterProvider;
+    use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData, ResourceMetrics};
+    use opentelemetry_sdk::metrics::{InMemoryMetricExporter, SdkMeterProvider};
+    use std::error::Error;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Arc;
+    use std::sync::Mutex;
+    use std::time::Duration;
+    use tokio::sync::watch;
+
+    /// A [`Scheduler`] whose counters feed an in-memory exporter. Call
+    /// `provider.force_flush()` before reading `exporter.get_finished_metrics()`.
+    fn metered_scheduler(
+        now_fn: NowFn,
+        lock: Arc<dyn RunLock>,
+    ) -> (Scheduler, SdkMeterProvider, InMemoryMetricExporter) {
+        let exporter = InMemoryMetricExporter::default();
+        let provider = SdkMeterProvider::builder()
+            .with_periodic_exporter(exporter.clone())
+            .build();
+        let scheduler = Scheduler::with_meter(now_fn, lock, provider.meter("test"));
+        (scheduler, provider, exporter)
+    }
+
+    /// Sum of a `u64` counter's data points whose attributes contain every
+    /// (key, value) pair in `filters`.
+    fn counter_value(metrics: &[ResourceMetrics], name: &str, filters: &[(&str, &str)]) -> u64 {
+        let mut total = 0;
+        for rm in metrics {
+            for sm in rm.scope_metrics() {
+                for m in sm.metrics().filter(|m| m.name() == name) {
+                    let AggregatedMetrics::U64(MetricData::Sum(sum)) = m.data() else {
+                        continue;
+                    };
+                    for dp in sum.data_points() {
+                        let matches = filters.iter().all(|(k, v)| {
+                            dp.attributes().any(|kv| {
+                                kv.key.as_str() == *k
+                                    && kv.value.as_str() == std::borrow::Cow::Borrowed(*v)
+                            })
+                        });
+                        if matches {
+                            total += dp.value();
+                        }
+                    }
+                }
+            }
+        }
+        total
+    }
+
+    /// A valid cron expression is accepted.
+    #[test]
+    fn validate_cron_accepts_valid_expression() {
+        assert!(validate_cron("0 0 3 * * *").is_ok());
+    }
+
+    /// A malformed cron expression is rejected.
+    #[test]
+    fn validate_cron_rejects_invalid_expression() {
+        assert!(validate_cron("not a cron expression").is_err());
+    }
+
+    /// A syntactically valid cron that can never fire (fixed past year) is rejected.
+    #[test]
+    fn validate_cron_rejects_never_firing() {
+        assert!(validate_cron("0 0 3 * * * 2020").is_err());
+    }
+
+    /// A run overrunning several fire times gets no back-to-back catch-up runs:
+    /// the scheduler skips missed ticks and fires exactly once more.
+    #[tokio::test(start_paused = true)]
+    async fn overrunning_run_skips_missed_ticks_and_fires_once_more() {
+        /// Sleeps past several per-second ticks on its first run only.
+        struct OverrunJob {
+            fires: Arc<AtomicU32>,
+            first_run_sleep: Duration,
+        }
+        #[async_trait]
+        impl Job for OverrunJob {
+            fn name(&self) -> &'static str {
+                "overrun"
+            }
+            async fn run(&self) -> Result<(), Box<dyn Error + Send + Sync>> {
+                let prior = self.fires.fetch_add(1, Ordering::SeqCst);
+                if prior == 0 {
+                    tokio::time::sleep(self.first_run_sleep).await;
+                }
+                Ok(())
+            }
+        }
+
+        let fires = Arc::new(AtomicU32::new(0));
+        let job = OverrunJob {
+            fires: fires.clone(),
+            first_run_sleep: Duration::from_secs(3),
+        };
+        let (tx, rx) = watch::channel(false);
+
+        let schedule = validate_cron("* * * * * *").unwrap();
+        let scheduler = Scheduler::new(virtual_now(), Arc::new(AlwaysAvailableLock));
+        let runner = scheduler.run_job("overrun", &schedule, &job, rx);
+        let driver = async {
+            // Anchor to the first fire so timing doesn't depend on the start
+            // offset within the second.
+            while fires.load(Ordering::SeqCst) == 0 {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+            // Wait past the ~3s run and its single catch-up fire, but before the
+            // next tick.
+            tokio::time::sleep(Duration::from_millis(4200)).await;
+            let _ = tx.send(true);
+        };
+        tokio::join!(runner, driver);
+
+        assert_eq!(
+            fires.load(Ordering::SeqCst),
+            2,
+            "overrun must skip missed ticks: the first fire plus exactly one catch-up"
+        );
+    }
+
+    /// Shutdown mid-run abandons the (here never-completing) run and returns
+    /// promptly.
+    #[tokio::test(start_paused = true)]
+    async fn shutdown_during_running_job_returns_promptly() {
+        /// Starts, then blocks forever on a `Notify` that is never signaled.
+        struct BlockingJob {
+            started: Arc<AtomicU32>,
+            completed: Arc<AtomicU32>,
+            gate: Arc<tokio::sync::Notify>,
+        }
+        #[async_trait]
+        impl Job for BlockingJob {
+            fn name(&self) -> &'static str {
+                "blocking"
+            }
+            async fn run(&self) -> Result<(), Box<dyn Error + Send + Sync>> {
+                self.started.fetch_add(1, Ordering::SeqCst);
+                self.gate.notified().await; // never signaled
+                self.completed.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+        }
+
+        let started = Arc::new(AtomicU32::new(0));
+        let completed = Arc::new(AtomicU32::new(0));
+        let job = BlockingJob {
+            started: started.clone(),
+            completed: completed.clone(),
+            gate: Arc::new(tokio::sync::Notify::new()),
+        };
+        let (tx, rx) = watch::channel(false);
+
+        let shutdown_at: Mutex<Option<tokio::time::Instant>> = Mutex::new(None);
+        let schedule = validate_cron("* * * * * *").unwrap();
+        let scheduler = Scheduler::new(virtual_now(), Arc::new(AlwaysAvailableLock));
+        let runner = scheduler.run_job("blocking", &schedule, &job, rx);
+        let driver = async {
+            // Wait until the job has actually started running.
+            while started.load(Ordering::SeqCst) == 0 {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+            *shutdown_at.lock().unwrap() = Some(tokio::time::Instant::now());
+            let _ = tx.send(true);
+        };
+        tokio::join!(runner, driver);
+
+        let elapsed = shutdown_at
+            .lock()
+            .unwrap()
+            .expect("the job should have started")
+            .elapsed();
+        assert_eq!(
+            elapsed,
+            Duration::ZERO,
+            "run_job must return promptly after shutdown mid-run (zero virtual time elapsed); took {elapsed:?}"
+        );
+        assert_eq!(
+            started.load(Ordering::SeqCst),
+            1,
+            "the job must have started before shutdown"
+        );
+        assert_eq!(
+            completed.load(Ordering::SeqCst),
+            0,
+            "the abandoned run must not have completed"
+        );
+    }
+
+    /// A minimal job that just counts how many times it ran.
+    struct CountingJob {
+        count: Arc<AtomicU32>,
+    }
+    #[async_trait]
+    impl Job for CountingJob {
+        fn name(&self) -> &'static str {
+            "counting"
+        }
+        async fn run(&self) -> Result<(), Box<dyn Error + Send + Sync>> {
+            self.count.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    /// Shutdown during the sleep phase (first select!) exits without firing. Uses
+    /// a far-future cron so the job never fires on its own.
+    #[tokio::test(start_paused = true)]
+    async fn run_job_exits_on_shutdown_without_firing() {
+        let count = Arc::new(AtomicU32::new(0));
+        let job = CountingJob {
+            count: count.clone(),
+        };
+        let (tx, rx) = watch::channel(false);
+
+        // Year-pinned cron (2100, the crate's max) fixes one fire far outside any
+        // test run. The pin is what guarantees no fire: an unpinned "0 0 0 1 1 *"
+        // recurs yearly and could fire if the paused clock lands near Jan 1 UTC.
+        let schedule = validate_cron("0 0 0 1 1 * 2100").unwrap();
+        let scheduler = Scheduler::new(virtual_now(), Arc::new(AlwaysAvailableLock));
+        let runner = scheduler.run_job("counting", &schedule, &job, rx);
+        let stopper = async {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            let _ = tx.send(true);
+        };
+        tokio::join!(runner, stopper);
+
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            0,
+            "shutdown during sleep must exit without firing the job"
+        );
+    }
+
+    /// A `false` send must not stop the scheduler; it exits only on `true` (or
+    /// dropped senders).
+    #[tokio::test(start_paused = true)]
+    async fn false_shutdown_signal_does_not_stop_scheduler() {
+        let count = Arc::new(AtomicU32::new(0));
+        let job = CountingJob {
+            count: count.clone(),
+        };
+        let (tx, rx) = watch::channel(false);
+
+        let schedule = validate_cron("* * * * * *").unwrap();
+        let scheduler = Scheduler::new(virtual_now(), Arc::new(AlwaysAvailableLock));
+        let runner = scheduler.run_job("counting", &schedule, &job, rx);
+        let driver = async {
+            // Wait for the first fire, then send false (a no-op).
+            while count.load(Ordering::SeqCst) == 0 {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+            let _ = tx.send(false);
+            // Let the scheduler run for a couple more ticks.
+            tokio::time::sleep(Duration::from_millis(2500)).await;
+            let _ = tx.send(true);
+        };
+        tokio::join!(runner, driver);
+
+        assert!(
+            count.load(Ordering::SeqCst) >= 2,
+            "a false send must not stop the scheduler; it should keep firing"
+        );
+    }
+
+    /// A lock held elsewhere (`try_lock` → `None`) makes the scheduler skip every
+    /// fire — the job never runs — while it keeps ticking and exits on shutdown.
+    #[tokio::test(start_paused = true)]
+    async fn run_job_skips_run_when_lock_held() {
+        struct HeldLock;
+        #[async_trait]
+        impl RunLock for HeldLock {
+            async fn try_lock(&self, _job: &str) -> RedisResult<Option<String>> {
+                Ok(None)
+            }
+            async fn unlock(&self, _job: &str, _token: &str) -> RedisResult<()> {
+                Ok(())
+            }
+        }
+
+        let count = Arc::new(AtomicU32::new(0));
+        let job = CountingJob {
+            count: count.clone(),
+        };
+        let (tx, rx) = watch::channel(false);
+
+        let schedule = validate_cron("* * * * * *").unwrap();
+        let scheduler = Scheduler::new(virtual_now(), Arc::new(HeldLock));
+        let runner = scheduler.run_job("counting", &schedule, &job, rx);
+        let stopper = async {
+            // Several ticks pass; every fire should be skipped.
+            tokio::time::sleep(Duration::from_millis(3500)).await;
+            let _ = tx.send(true);
+        };
+        tokio::join!(runner, stopper);
+
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            0,
+            "a held lock must prevent the job from running"
+        );
+    }
+
+    /// Every fire pairs one lock acquire with one release, so the lock is never
+    /// leaked between runs.
+    #[tokio::test(start_paused = true)]
+    async fn run_job_acquires_and_releases_lock_around_run() {
+        struct RecordingLock {
+            acquired: Arc<AtomicU32>,
+            released: Arc<AtomicU32>,
+        }
+        #[async_trait]
+        impl RunLock for RecordingLock {
+            async fn try_lock(&self, _job: &str) -> RedisResult<Option<String>> {
+                self.acquired.fetch_add(1, Ordering::SeqCst);
+                Ok(Some("token".to_string()))
+            }
+            async fn unlock(&self, _job: &str, _token: &str) -> RedisResult<()> {
+                self.released.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+        }
+
+        let acquired = Arc::new(AtomicU32::new(0));
+        let released = Arc::new(AtomicU32::new(0));
+        let count = Arc::new(AtomicU32::new(0));
+        let job = CountingJob {
+            count: count.clone(),
+        };
+        let (tx, rx) = watch::channel(false);
+
+        let schedule = validate_cron("* * * * * *").unwrap();
+        let lock = RecordingLock {
+            acquired: acquired.clone(),
+            released: released.clone(),
+        };
+        let scheduler = Scheduler::new(virtual_now(), Arc::new(lock));
+        let runner = scheduler.run_job("counting", &schedule, &job, rx);
+        let stopper = async {
+            tokio::time::sleep(Duration::from_millis(2500)).await;
+            let _ = tx.send(true);
+        };
+        tokio::join!(runner, stopper);
+
+        let runs = count.load(Ordering::SeqCst);
+        assert!(runs >= 2, "the job should have fired at least twice");
+        assert_eq!(
+            acquired.load(Ordering::SeqCst),
+            released.load(Ordering::SeqCst),
+            "every acquire must be paired with a release"
+        );
+        assert_eq!(
+            released.load(Ordering::SeqCst),
+            runs,
+            "the lock must be released once per run"
+        );
+    }
+
+    /// Every fire is one attempt that partitions into completed or skipped,
+    /// never both — asserted by reading the real `jobs.run.*` OTel counters back
+    /// through an in-memory exporter.
+    #[tokio::test(start_paused = true)]
+    async fn attempts_partition_between_completed_and_skipped() {
+        /// Grants then denies the lock on alternate fires: even fires run the job
+        /// (completed{ok}), odd fires are denied (skipped{in_progress}).
+        struct AlternatingLock {
+            calls: AtomicU32,
+        }
+        #[async_trait]
+        impl RunLock for AlternatingLock {
+            async fn try_lock(&self, _job: &str) -> RedisResult<Option<String>> {
+                if self.calls.fetch_add(1, Ordering::SeqCst).is_multiple_of(2) {
+                    Ok(Some("token".to_string()))
+                } else {
+                    Ok(None)
+                }
+            }
+            async fn unlock(&self, _job: &str, _token: &str) -> RedisResult<()> {
+                Ok(())
+            }
+        }
+
+        let count = Arc::new(AtomicU32::new(0));
+        let job = CountingJob {
+            count: count.clone(),
+        };
+        let (tx, rx) = watch::channel(false);
+
+        let schedule = validate_cron("* * * * * *").unwrap();
+        let (scheduler, provider, exporter) = metered_scheduler(
+            virtual_now(),
+            Arc::new(AlternatingLock {
+                calls: AtomicU32::new(0),
+            }),
+        );
+        let runner = scheduler.run_job("counting", &schedule, &job, rx);
+        let stopper = async {
+            tokio::time::sleep(Duration::from_millis(4500)).await;
+            let _ = tx.send(true);
+        };
+        tokio::join!(runner, stopper);
+
+        provider.force_flush().unwrap();
+        let metrics = exporter.get_finished_metrics().unwrap();
+
+        let attempts = counter_value(&metrics, "jobs.run.attempts", &[("job", "counting")]);
+        let completed = counter_value(
+            &metrics,
+            "jobs.run.completed",
+            &[("job", "counting"), ("outcome", "ok")],
+        );
+        let skipped = counter_value(
+            &metrics,
+            "jobs.run.skipped",
+            &[("job", "counting"), ("reason", "in_progress")],
+        );
+
+        assert!(attempts >= 3, "the alternating lock needs several fires");
+        assert!(
+            completed >= 1 && skipped >= 1,
+            "both the completed and skipped branches must be exercised (completed={completed}, skipped={skipped})"
+        );
+        assert_eq!(
+            attempts,
+            completed + skipped,
+            "every fire attempt must partition into exactly one of completed or skipped"
+        );
+    }
+
+    /// A bounded schedule that runs out of fire times records one
+    /// `jobs.scheduler.stopped{reason=schedule_exhausted}` and returns on its own.
+    #[tokio::test(start_paused = true)]
+    async fn exhausted_schedule_records_stopped_metric() {
+        let count = Arc::new(AtomicU32::new(0));
+        let job = CountingJob {
+            count: count.clone(),
+        };
+        // No shutdown is sent: run_job returns once the schedule is exhausted.
+        let (_tx, rx) = watch::channel(false);
+
+        // Year-pinned single fire: fires once, then `after()` yields no more times.
+        let schedule = validate_cron("0 0 0 1 1 * 2099").unwrap();
+        let (scheduler, provider, exporter) =
+            metered_scheduler(virtual_now(), Arc::new(AlwaysAvailableLock));
+        scheduler.run_job("counting", &schedule, &job, rx).await;
+
+        provider.force_flush().unwrap();
+        let metrics = exporter.get_finished_metrics().unwrap();
+
+        assert!(
+            count.load(Ordering::SeqCst) >= 1,
+            "the single-fire schedule must fire before exhausting"
+        );
+        assert_eq!(
+            counter_value(
+                &metrics,
+                "jobs.scheduler.stopped",
+                &[("job", "counting"), ("reason", "schedule_exhausted")],
+            ),
+            1,
+            "an exhausted schedule must record exactly one stopped{{schedule_exhausted}}"
+        );
+    }
+}

--- a/nexusd/src/jobs/scheduler.rs
+++ b/nexusd/src/jobs/scheduler.rs
@@ -27,10 +27,10 @@ pub struct Scheduler {
     lock: Arc<dyn RunLock>,
     /// Every fire attempt, before the lock is tried.
     run_attempts: Counter<u64>,
-    /// Fires where the job ran, labelled by `outcome` in {ok, error}.
+    /// Fires where the job ran, labelled by `outcome` in {ok, error, abandoned}.
     run_completed: Counter<u64>,
     /// Fires that didn't run the job, labelled by `reason` in
-    /// {in_progress, lock_error}.
+    /// {in_progress, lock_error, shutdown_before_acquire}.
     run_skipped: Counter<u64>,
     /// Schedulers that stopped and won't run again until restart, labelled by
     /// `reason` in {panic, schedule_exhausted}. Excludes clean shutdown. A
@@ -91,7 +91,7 @@ impl Scheduler {
 }
 
 /// Waits until `shutdown_rx` carries `true` or all senders drop; `false` sends
-/// are ignored.
+/// are ignored. Edge-triggered: an already-seen `true` won't wake it.
 ///
 /// Cancel-safe: the only await is `Receiver::changed()`, and there's no await
 /// between wake and `borrow_and_update()`, so a `select!` drop can't swallow a
@@ -146,6 +146,14 @@ impl Scheduler {
         info!(job = name, cron = %schedule, "Job scheduler started");
 
         loop {
+            // `wait_for_shutdown` only fires on the false→true transition, and
+            // run_locked may already have consumed it while abandoning a run. Read
+            // the current value directly so an already-signaled shutdown still exits.
+            if *shutdown_rx.borrow() {
+                info!(job = name, "Shutdown received, exiting job scheduler");
+                return;
+            }
+
             // Re-anchor to wall-clock each iteration: O(1) skip of all missed ticks.
             let now = (self.now_fn)();
             let Some(next) = schedule.after(&now).next() else {
@@ -162,6 +170,7 @@ impl Scheduler {
             // `after(&now)` returns times strictly after `now`, so the sleep is
             // always positive — no overrun check needed.
             let remaining = (next - now).to_std().unwrap_or(Duration::ZERO);
+            // Sleep phase: shutdown can drop this safely — no lock I/O here.
             tokio::select! {
                 biased;
 
@@ -173,16 +182,10 @@ impl Scheduler {
             }
 
             debug!(job = name, fire_time = %next, "Running scheduled job");
-            tokio::select! {
-                biased;
-
-                // Dropping the future leaves the lock to its TTL, but we're exiting anyway.
-                _ = wait_for_shutdown(&mut shutdown_rx) => {
-                    info!(job = name, "Shutdown received during run; abandoning it");
-                    return;
-                }
-                () = self.run_locked(name, job) => {}
-            }
+            // Run phase: no select! around run_locked — that would drop it (and its
+            // in-flight lock I/O) on shutdown. run_locked observes shutdown itself,
+            // as a signal that leaves acquire and release uncancellable.
+            self.run_locked(name, job, &mut shutdown_rx).await;
         }
     }
 
@@ -190,17 +193,35 @@ impl Scheduler {
     /// error) when the lock is held or unreachable — the next tick retries
     /// rather than piling up a backlog.
     ///
+    /// Structured in three phases around `shutdown`: acquire and release are
+    /// uncancellable (they read the backend's reply before returning, so a
+    /// mid-flight drop can't orphan the lock or poison a pooled connection); only
+    /// `job.run()` is raced against shutdown, via `select!` on the watch receiver.
+    ///
     /// A panic in `run()` propagates via `JoinSet` (see `supervise`); the lock
     /// still releases through `LockGuard`'s Drop.
-    async fn run_locked(&self, name: &str, job: &dyn Job) {
+    async fn run_locked(&self, name: &str, job: &dyn Job, shutdown: &mut Receiver<bool>) {
         self.run_attempts
             .add(1, &[KeyValue::new("job", name.to_string())]);
 
+        // Shutdown already signaled before we touched the lock: skip without acquiring.
+        if *shutdown.borrow() {
+            self.run_skipped.add(
+                1,
+                &[
+                    KeyValue::new("job", name.to_string()),
+                    KeyValue::new("reason", "shutdown_before_acquire"),
+                ],
+            );
+            return;
+        }
+
+        // Phase 1: acquire — uncancellable. Reads the SET reply before returning.
         let token = self.lock.new_token();
-        // Arm the guard *before* acquiring. If this future is dropped mid-acquire
-        // on shutdown, Drop releases the lock iff it was actually taken (else it's
-        // a no-op), so the acquire can't orphan it. `name` isn't &'static; use
-        // `job.name()`, which the trait guarantees is.
+        // Arm the guard *before* acquiring. If the acquire errors after the SET
+        // committed but its reply was lost, Drop releases the lock; the
+        // compare-and-delete is a no-op if our token wasn't stored. `name` isn't
+        // &'static; use `job.name()`, which the trait guarantees is.
         let guard = super::lock::LockGuard::new(job.name(), token.clone(), self.lock.clone());
 
         match self.lock.acquire(name, &token).await {
@@ -221,7 +242,6 @@ impl Scheduler {
                 return;
             }
             Err(e) => {
-                guard.disarm();
                 self.run_skipped.add(
                     1,
                     &[
@@ -237,16 +257,31 @@ impl Scheduler {
             }
         }
 
-        let result = job.run().await;
+        // Phase 2: the job — cancellable via the shutdown signal (drops job.run()'s
+        // future, never the acquire or release around it).
+        let outcome = tokio::select! {
+            biased;
 
-        // Await the release so unlock errors log synchronously. A panic in run()
-        // skips this line — Drop releases instead.
+            _ = wait_for_shutdown(shutdown) => {
+                info!(job = name, "Shutdown during run; abandoning");
+                "abandoned"
+            }
+            result = job.run() => match result {
+                Ok(()) => {
+                    debug!(job = name, "Scheduled job completed");
+                    "ok"
+                }
+                Err(e) => {
+                    error!(job = name, "Scheduled job failed: {e:?}");
+                    "error"
+                }
+            },
+        };
+
+        // Phase 3: release — uncancellable. Runs even after abandonment; awaiting
+        // the EVAL reply costs a few ms at shutdown but leaves the lock known-free.
         guard.release().await;
 
-        let outcome = match &result {
-            Ok(()) => "ok",
-            Err(_) => "error",
-        };
         self.run_completed.add(
             1,
             &[
@@ -254,10 +289,6 @@ impl Scheduler {
                 KeyValue::new("outcome", outcome),
             ],
         );
-        match result {
-            Ok(()) => debug!(job = name, "Scheduled job completed"),
-            Err(e) => error!(job = name, "Scheduled job failed: {e:?}"),
-        }
     }
 }
 
@@ -276,11 +307,11 @@ pub(crate) fn virtual_now() -> NowFn {
 
 #[cfg(test)]
 mod tests {
+    use super::super::error::LockResult;
     use super::super::lock::{AlwaysAvailableLock, RunLock};
     use super::{validate_cron, virtual_now, NowFn, Scheduler};
     use crate::jobs::Job;
     use async_trait::async_trait;
-    use nexus_common::db::RedisResult;
     use opentelemetry::metrics::MeterProvider;
     use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData, ResourceMetrics};
     use opentelemetry_sdk::metrics::{InMemoryMetricExporter, SdkMeterProvider};
@@ -566,10 +597,10 @@ mod tests {
             fn new_token(&self) -> String {
                 "token".to_string()
             }
-            async fn acquire(&self, _job: &str, _token: &str) -> RedisResult<bool> {
+            async fn acquire(&self, _job: &str, _token: &str) -> LockResult<bool> {
                 Ok(false)
             }
-            async fn unlock(&self, _job: &str, _token: &str) -> RedisResult<()> {
+            async fn unlock(&self, _job: &str, _token: &str) -> LockResult<()> {
                 Ok(())
             }
         }
@@ -610,11 +641,11 @@ mod tests {
             fn new_token(&self) -> String {
                 "token".to_string()
             }
-            async fn acquire(&self, _job: &str, _token: &str) -> RedisResult<bool> {
+            async fn acquire(&self, _job: &str, _token: &str) -> LockResult<bool> {
                 self.acquired.fetch_add(1, Ordering::SeqCst);
                 Ok(true)
             }
-            async fn unlock(&self, _job: &str, _token: &str) -> RedisResult<()> {
+            async fn unlock(&self, _job: &str, _token: &str) -> LockResult<()> {
                 self.released.fetch_add(1, Ordering::SeqCst);
                 Ok(())
             }
@@ -669,13 +700,13 @@ mod tests {
             fn new_token(&self) -> String {
                 "token".to_string()
             }
-            async fn acquire(&self, _job: &str, _token: &str) -> RedisResult<bool> {
+            async fn acquire(&self, _job: &str, _token: &str) -> LockResult<bool> {
                 // Never resolves: the acquire's response never reaches us before
                 // the task is cancelled.
                 std::future::pending::<()>().await;
                 unreachable!()
             }
-            async fn unlock(&self, _job: &str, _token: &str) -> RedisResult<()> {
+            async fn unlock(&self, _job: &str, _token: &str) -> LockResult<()> {
                 self.released.fetch_add(1, Ordering::SeqCst);
                 Ok(())
             }
@@ -691,10 +722,11 @@ mod tests {
         let job = CountingJob {
             count: Arc::new(AtomicU32::new(0)),
         };
+        let (_tx, mut rx) = watch::channel(false);
 
         // Poll run_locked so it reaches (and stalls on) the acquire, then drop it.
         {
-            let fut = scheduler.run_locked("counting", &job);
+            let fut = scheduler.run_locked("counting", &job, &mut rx);
             tokio::pin!(fut);
             tokio::select! {
                 _ = &mut fut => panic!("acquire stalls; run_locked cannot complete"),
@@ -728,10 +760,10 @@ mod tests {
             fn new_token(&self) -> String {
                 "token".to_string()
             }
-            async fn acquire(&self, _job: &str, _token: &str) -> RedisResult<bool> {
+            async fn acquire(&self, _job: &str, _token: &str) -> LockResult<bool> {
                 Ok(self.calls.fetch_add(1, Ordering::SeqCst).is_multiple_of(2))
             }
-            async fn unlock(&self, _job: &str, _token: &str) -> RedisResult<()> {
+            async fn unlock(&self, _job: &str, _token: &str) -> LockResult<()> {
                 Ok(())
             }
         }
@@ -780,6 +812,132 @@ mod tests {
             attempts,
             completed + skipped,
             "every fire attempt must partition into exactly one of completed or skipped"
+        );
+    }
+
+    /// A run abandoned mid-flight on shutdown records `completed{outcome=abandoned}`
+    /// (not a skip), so the attempts partition still holds and abandonment is
+    /// observable.
+    #[tokio::test(start_paused = true)]
+    async fn abandoned_run_records_completed_outcome() {
+        /// Marks itself started, then blocks forever on a never-signaled `Notify`.
+        struct BlockingJob {
+            started: Arc<AtomicU32>,
+            gate: Arc<tokio::sync::Notify>,
+        }
+        #[async_trait]
+        impl Job for BlockingJob {
+            fn name(&self) -> &'static str {
+                "blocking"
+            }
+            async fn run(&self) -> Result<(), Box<dyn Error + Send + Sync>> {
+                self.started.fetch_add(1, Ordering::SeqCst);
+                self.gate.notified().await; // never signaled
+                Ok(())
+            }
+        }
+
+        let started = Arc::new(AtomicU32::new(0));
+        let job = BlockingJob {
+            started: started.clone(),
+            gate: Arc::new(tokio::sync::Notify::new()),
+        };
+        let (tx, rx) = watch::channel(false);
+
+        let schedule = validate_cron("* * * * * *").unwrap();
+        let (scheduler, provider, exporter) =
+            metered_scheduler(virtual_now(), Arc::new(AlwaysAvailableLock));
+        let runner = scheduler.run_job("blocking", &schedule, &job, rx);
+        let driver = async {
+            while started.load(Ordering::SeqCst) == 0 {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+            let _ = tx.send(true);
+        };
+        tokio::join!(runner, driver);
+
+        provider.force_flush().unwrap();
+        let metrics = exporter.get_finished_metrics().unwrap();
+
+        let abandoned = counter_value(
+            &metrics,
+            "jobs.run.completed",
+            &[("job", "blocking"), ("outcome", "abandoned")],
+        );
+        assert_eq!(
+            abandoned, 1,
+            "a run abandoned on shutdown must record exactly one completed{{abandoned}}"
+        );
+
+        // The partition still holds across all outcomes/reasons.
+        let attempts = counter_value(&metrics, "jobs.run.attempts", &[("job", "blocking")]);
+        let completed = counter_value(&metrics, "jobs.run.completed", &[("job", "blocking")]);
+        let skipped = counter_value(&metrics, "jobs.run.skipped", &[("job", "blocking")]);
+        assert_eq!(
+            attempts,
+            completed + skipped,
+            "abandonment folds into completed, keeping attempts = completed + skipped"
+        );
+    }
+
+    /// Shutdown already signaled before we touch the lock: `run_locked` fast-exits,
+    /// recording `skipped{shutdown_before_acquire}` and never calling `acquire`.
+    #[tokio::test(start_paused = true)]
+    async fn run_locked_fast_exits_when_already_shutdown() {
+        struct AcquireCountingLock {
+            acquired: Arc<AtomicU32>,
+        }
+        #[async_trait]
+        impl RunLock for AcquireCountingLock {
+            fn new_token(&self) -> String {
+                "token".to_string()
+            }
+            async fn acquire(&self, _job: &str, _token: &str) -> LockResult<bool> {
+                self.acquired.fetch_add(1, Ordering::SeqCst);
+                Ok(true)
+            }
+            async fn unlock(&self, _job: &str, _token: &str) -> LockResult<()> {
+                Ok(())
+            }
+        }
+
+        let acquired = Arc::new(AtomicU32::new(0));
+        let job = CountingJob {
+            count: Arc::new(AtomicU32::new(0)),
+        };
+        let (scheduler, provider, exporter) = metered_scheduler(
+            virtual_now(),
+            Arc::new(AcquireCountingLock {
+                acquired: acquired.clone(),
+            }),
+        );
+
+        // Shutdown is already true when run_locked is entered.
+        let (tx, mut rx) = watch::channel(false);
+        tx.send(true).unwrap();
+        scheduler.run_locked("counting", &job, &mut rx).await;
+
+        provider.force_flush().unwrap();
+        let metrics = exporter.get_finished_metrics().unwrap();
+
+        assert_eq!(
+            acquired.load(Ordering::SeqCst),
+            0,
+            "a fast-exit on shutdown must not reach acquire"
+        );
+        assert_eq!(
+            counter_value(
+                &metrics,
+                "jobs.run.skipped",
+                &[("job", "counting"), ("reason", "shutdown_before_acquire")],
+            ),
+            1,
+            "the fast-exit must record one skipped{{shutdown_before_acquire}}"
+        );
+        assert_eq!(
+            counter_value(&metrics, "jobs.run.completed", &[("job", "counting")]),
+            0,
+            "the fast-exit must not record a completed run"
         );
     }
 

--- a/nexusd/src/jobs/scheduler.rs
+++ b/nexusd/src/jobs/scheduler.rs
@@ -269,8 +269,8 @@ impl Scheduler {
     // Acquires the run lock, runs the job once, releases it; skips (no error) when
     // the lock is held or unreachable, so a backlog can't pile up. Three phases
     // around `shutdown`: acquire and release are uncancellable (they read the
-    // backend reply first, so a mid-flight drop can't orphan the lock or poison a
-    // pooled connection); only `job.run()` races shutdown. A panic in `run()`
+    // backend reply first, so a mid-flight drop can't orphan the lock or leave the
+    // backend mid-request); only `job.run()` races shutdown. A panic in `run()`
     // propagates via `JoinSet` (see `supervise`); the lock still releases via Drop.
     async fn run_locked(&self, job: &dyn Job, shutdown: &mut Receiver<bool>) {
         let name = job.name();
@@ -288,7 +288,7 @@ impl Scheduler {
             return;
         }
 
-        // Phase 1: acquire — uncancellable. Reads the SET reply before returning.
+        // Phase 1: acquire — uncancellable. Reads the backend's reply before returning.
         let guard = match super::lock::acquire(name, &self.lock, &self.lock_metrics).await {
             super::lock::Acquired::Taken(guard) => guard,
             super::lock::Acquired::Held => {
@@ -381,7 +381,7 @@ impl Scheduler {
         };
 
         // Phase 3: release — uncancellable. Runs even after abandonment; awaiting
-        // the EVAL reply costs a few ms at shutdown but leaves the lock known-free.
+        // the unlock reply costs a few ms at shutdown but leaves the lock known-free.
         let release_outcome = guard.release().await;
         if !matches!(
             release_outcome,

--- a/nexusd/src/jobs/scheduler.rs
+++ b/nexusd/src/jobs/scheduler.rs
@@ -8,11 +8,8 @@ use std::time::Duration;
 use tokio::sync::watch::Receiver;
 use tracing::{debug, error, info, warn};
 
-use super::lock::{self, RunLock};
-use super::{CronParseError, Job};
-
-/// OpenTelemetry meter name for all job metrics.
-const METER_NAME: &str = "nexus.jobs";
+use super::lock::{self, LockMetrics, RunLock};
+use super::{CronParseError, Job, METER_NAME};
 
 /// Wall-clock re-check interval while waiting for a fire time (see [`Scheduler::sleep_until`]).
 pub(super) const MAX_SLEEP: Duration = Duration::from_secs(30);
@@ -28,6 +25,7 @@ pub type NowFn = Arc<dyn Fn() -> DateTime<Utc> + Send + Sync>;
 pub struct Scheduler {
     now_fn: NowFn,
     lock: Arc<dyn RunLock>,
+    lock_metrics: LockMetrics,
     /// Wall-clock re-check interval while sleeping toward a fire time (see [`MAX_SLEEP`]).
     max_sleep: Duration,
     /// Deadline for a single run, past which it's abandoned (see [`lock::MAX_RUN`]).
@@ -56,6 +54,7 @@ impl Scheduler {
     /// [`new`](Self::new) with an explicit `meter`, so tests can install a local
     /// `SdkMeterProvider` and read the counters back.
     pub(crate) fn with_meter(now_fn: NowFn, lock: Arc<dyn RunLock>, meter: Meter) -> Self {
+        let lock_metrics = LockMetrics::with_meter(meter.clone());
         let run_attempts = meter
             .u64_counter("jobs.run.attempts")
             .with_description("Scheduled fire attempts (before lock acquisition)")
@@ -77,6 +76,7 @@ impl Scheduler {
         Self {
             now_fn,
             lock,
+            lock_metrics,
             max_sleep: MAX_SLEEP,
             max_run: lock::MAX_RUN,
             run_attempts,
@@ -289,7 +289,7 @@ impl Scheduler {
         }
 
         // Phase 1: acquire — uncancellable. Reads the SET reply before returning.
-        let guard = match super::lock::acquire(name, &self.lock).await {
+        let guard = match super::lock::acquire(name, &self.lock, &self.lock_metrics).await {
             super::lock::Acquired::Taken(guard) => guard,
             super::lock::Acquired::Held => {
                 self.run_skipped.add(
@@ -429,12 +429,12 @@ mod tests {
             .with_timezone(&Utc)
     }
     use crate::jobs::test_support::{
-        steppable_clock, AcquireOutcome, BlockingJob, CountingJob, FakeLock, UnlockOutcome,
+        counter_value, steppable_clock, AcquireOutcome, BlockingJob, CountingJob, FakeLock,
+        UnlockOutcome,
     };
     use crate::jobs::Job;
     use async_trait::async_trait;
     use opentelemetry::metrics::MeterProvider;
-    use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData, ResourceMetrics};
     use opentelemetry_sdk::metrics::{InMemoryMetricExporter, SdkMeterProvider};
     use std::error::Error;
     use std::sync::atomic::{AtomicI64, AtomicU32, Ordering};
@@ -455,33 +455,6 @@ mod tests {
             .build();
         let scheduler = Scheduler::with_meter(now_fn, lock, provider.meter("test"));
         (scheduler, provider, exporter)
-    }
-
-    /// Sum of a `u64` counter's data points whose attributes contain every
-    /// (key, value) pair in `filters`.
-    fn counter_value(metrics: &[ResourceMetrics], name: &str, filters: &[(&str, &str)]) -> u64 {
-        let mut total = 0;
-        for rm in metrics {
-            for sm in rm.scope_metrics() {
-                for m in sm.metrics().filter(|m| m.name() == name) {
-                    let AggregatedMetrics::U64(MetricData::Sum(sum)) = m.data() else {
-                        continue;
-                    };
-                    for dp in sum.data_points() {
-                        let matches = filters.iter().all(|(k, v)| {
-                            dp.attributes().any(|kv| {
-                                kv.key.as_str() == *k
-                                    && kv.value.as_str() == std::borrow::Cow::Borrowed(*v)
-                            })
-                        });
-                        if matches {
-                            total += dp.value();
-                        }
-                    }
-                }
-            }
-        }
-        total
     }
 
     #[test]

--- a/nexusd/src/jobs/scheduler.rs
+++ b/nexusd/src/jobs/scheduler.rs
@@ -37,7 +37,7 @@ pub struct Scheduler {
     /// Fires where the job ran, labelled by `outcome` in {ok, error, abandoned, timed_out}.
     run_completed: Counter<u64>,
     /// Fires that didn't run the job, labelled by `reason` in
-    /// {in_progress, lock_error, shutdown_before_acquire}.
+    /// {in_progress, lock_error, acquire_timed_out, shutdown_before_acquire}.
     run_skipped: Counter<u64>,
     /// Schedulers that stopped and won't run again until restart, labelled by
     /// `reason` in {panic, schedule_exhausted}. Excludes clean shutdown. A
@@ -305,7 +305,7 @@ impl Scheduler {
                 );
                 return;
             }
-            super::lock::Acquired::Failed(e) => {
+            super::lock::Acquired::Failed { error, released } => {
                 self.run_skipped.add(
                     1,
                     &[
@@ -313,10 +313,35 @@ impl Scheduler {
                         KeyValue::new("reason", "lock_error"),
                     ],
                 );
-                error!(
-                    job = name,
-                    "Could not acquire run lock; skipping this fire: {e}"
+                if released {
+                    warn!(
+                        job = name,
+                        "Could not acquire run lock; skipping this fire: {error}"
+                    );
+                } else {
+                    warn!(
+                        job = name,
+                        "Could not acquire run lock and inline release also failed — slot may stay held until TTL expires; skipping this fire: {error}"
+                    );
+                }
+                return;
+            }
+            super::lock::Acquired::TimedOut { released } => {
+                self.run_skipped.add(
+                    1,
+                    &[
+                        KeyValue::new("job", name),
+                        KeyValue::new("reason", "acquire_timed_out"),
+                    ],
                 );
+                if released {
+                    warn!(job = name, "Lock acquire timed out; skipping this fire");
+                } else {
+                    warn!(
+                        job = name,
+                        "Lock acquire timed out and inline release also failed — slot may stay held until TTL expires; skipping this fire"
+                    );
+                }
                 return;
             }
         };
@@ -357,7 +382,17 @@ impl Scheduler {
 
         // Phase 3: release — uncancellable. Runs even after abandonment; awaiting
         // the EVAL reply costs a few ms at shutdown but leaves the lock known-free.
-        guard.release().await;
+        let release_outcome = guard.release().await;
+        if !matches!(
+            release_outcome,
+            super::lock::ReleaseOutcome::Released | super::lock::ReleaseOutcome::NotHeld
+        ) {
+            warn!(
+                job = name,
+                ?release_outcome,
+                "Lock release failed after run — slot may stay held until TTL expires"
+            );
+        }
 
         self.run_completed.add(
             1,
@@ -394,7 +429,7 @@ mod tests {
             .with_timezone(&Utc)
     }
     use crate::jobs::test_support::{
-        steppable_clock, AcquireOutcome, BlockingJob, CountingJob, FakeLock,
+        steppable_clock, AcquireOutcome, BlockingJob, CountingJob, FakeLock, UnlockOutcome,
     };
     use crate::jobs::Job;
     use async_trait::async_trait;
@@ -499,7 +534,10 @@ mod tests {
         let (tx, rx) = watch::channel(false);
 
         let schedule = validate_cron("* * * * * *").unwrap();
-        let scheduler = Scheduler::new(virtual_now(), FakeLock::new(AcquireOutcome::Granted));
+        let scheduler = Scheduler::new(
+            virtual_now(),
+            FakeLock::new(AcquireOutcome::Granted, UnlockOutcome::Succeeds),
+        );
         let runner = scheduler.run_job(&schedule, &job, rx);
         let driver = async {
             // Anchor to the first fire so timing doesn't depend on the start
@@ -528,8 +566,10 @@ mod tests {
 
         let shutdown_at: Mutex<Option<tokio::time::Instant>> = Mutex::new(None);
         let schedule = validate_cron("* * * * * *").unwrap();
-        let (scheduler, provider, exporter) =
-            metered_scheduler(virtual_now(), FakeLock::new(AcquireOutcome::Granted));
+        let (scheduler, provider, exporter) = metered_scheduler(
+            virtual_now(),
+            FakeLock::new(AcquireOutcome::Granted, UnlockOutcome::Succeeds),
+        );
         let runner = scheduler.run_job(&schedule, &job, rx);
         let driver = async {
             // Wait until the job has actually started running.
@@ -593,7 +633,7 @@ mod tests {
         let (tx, rx) = watch::channel(false);
 
         let schedule = validate_cron("* * * * * *").unwrap();
-        let lock = FakeLock::new(AcquireOutcome::Granted);
+        let lock = FakeLock::new(AcquireOutcome::Granted, UnlockOutcome::Succeeds);
         let (scheduler, provider, exporter) = metered_scheduler(virtual_now(), lock.clone());
         let scheduler = scheduler.with_max_run(Duration::from_secs(2));
         let runner = scheduler.run_job(&schedule, &job, rx);
@@ -617,7 +657,7 @@ mod tests {
         );
         assert_eq!(
             lock.acquires(),
-            lock.releases(),
+            lock.unlock_attempts(),
             "an abandoned run must still release its lease"
         );
 
@@ -642,7 +682,10 @@ mod tests {
         // test run. The pin is what guarantees no fire: an unpinned "0 0 0 1 1 *"
         // recurs yearly and could fire if the paused clock lands near Jan 1 UTC.
         let schedule = validate_cron("0 0 0 1 1 * 2100").unwrap();
-        let scheduler = Scheduler::new(virtual_now(), FakeLock::new(AcquireOutcome::Granted));
+        let scheduler = Scheduler::new(
+            virtual_now(),
+            FakeLock::new(AcquireOutcome::Granted, UnlockOutcome::Succeeds),
+        );
         let runner = scheduler.run_job(&schedule, &job, rx);
         let stopper = async {
             tokio::time::sleep(Duration::from_millis(100)).await;
@@ -663,7 +706,10 @@ mod tests {
         let (tx, rx) = watch::channel(false);
 
         let schedule = validate_cron("* * * * * *").unwrap();
-        let scheduler = Scheduler::new(virtual_now(), FakeLock::new(AcquireOutcome::Granted));
+        let scheduler = Scheduler::new(
+            virtual_now(),
+            FakeLock::new(AcquireOutcome::Granted, UnlockOutcome::Succeeds),
+        );
         let runner = scheduler.run_job(&schedule, &job, rx);
         let driver = async {
             // Wait for the first fire, then send false (a no-op).
@@ -689,7 +735,10 @@ mod tests {
         let (tx, rx) = watch::channel(false);
 
         let schedule = validate_cron("* * * * * *").unwrap();
-        let scheduler = Scheduler::new(virtual_now(), FakeLock::new(AcquireOutcome::Denied));
+        let scheduler = Scheduler::new(
+            virtual_now(),
+            FakeLock::new(AcquireOutcome::Denied, UnlockOutcome::Succeeds),
+        );
         let runner = scheduler.run_job(&schedule, &job, rx);
         let stopper = async {
             // Several ticks pass; every fire should be skipped.
@@ -711,7 +760,7 @@ mod tests {
         let (tx, rx) = watch::channel(false);
 
         let schedule = validate_cron("* * * * * *").unwrap();
-        let lock = FakeLock::new(AcquireOutcome::Granted);
+        let lock = FakeLock::new(AcquireOutcome::Granted, UnlockOutcome::Succeeds);
         let scheduler = Scheduler::new(virtual_now(), lock.clone());
         let runner = scheduler.run_job(&schedule, &job, rx);
         let stopper = async {
@@ -724,11 +773,11 @@ mod tests {
         assert!(runs >= 2, "the job should have fired at least twice");
         assert_eq!(
             lock.acquires(),
-            lock.releases(),
+            lock.unlock_attempts(),
             "every acquire must be paired with a release"
         );
         assert_eq!(
-            lock.releases(),
+            lock.unlock_attempts(),
             runs,
             "the lock must be released once per run"
         );
@@ -742,8 +791,10 @@ mod tests {
         let schedule = validate_cron("* * * * * *").unwrap();
         // Alternating: even fires run the job (completed{ok}), odd fires are
         // denied (skipped{in_progress}), so one run exercises both branches.
-        let (scheduler, provider, exporter) =
-            metered_scheduler(virtual_now(), FakeLock::new(AcquireOutcome::Alternating));
+        let (scheduler, provider, exporter) = metered_scheduler(
+            virtual_now(),
+            FakeLock::new(AcquireOutcome::Alternating, UnlockOutcome::Succeeds),
+        );
         let runner = scheduler.run_job(&schedule, &job, rx);
         let stopper = async {
             tokio::time::sleep(Duration::from_millis(4500)).await;
@@ -781,7 +832,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn run_locked_fast_exits_when_already_shutdown() {
         let job = CountingJob::new("counting");
-        let lock = FakeLock::new(AcquireOutcome::Granted);
+        let lock = FakeLock::new(AcquireOutcome::Granted, UnlockOutcome::Succeeds);
         let (scheduler, provider, exporter) = metered_scheduler(virtual_now(), lock.clone());
 
         // Shutdown is already true when run_locked is entered.
@@ -821,8 +872,11 @@ mod tests {
         // Epoch pinned on the hour, so the next hourly fire is exactly 1h out.
         let (now_fn, skew) = steppable_clock(at("2030-01-01T00:00:00Z"));
         let schedule = validate_cron("0 0 * * * *").unwrap();
-        let scheduler = Scheduler::new(now_fn, FakeLock::new(AcquireOutcome::Granted))
-            .with_max_sleep(Duration::from_secs(30));
+        let scheduler = Scheduler::new(
+            now_fn,
+            FakeLock::new(AcquireOutcome::Granted, UnlockOutcome::Succeeds),
+        )
+        .with_max_sleep(Duration::from_secs(30));
         let runner = scheduler.run_job(&schedule, &job, rx);
         let driver = async {
             // Let the scheduler settle into its wait toward 01:00.
@@ -876,7 +930,10 @@ mod tests {
         let (tx, rx) = watch::channel(false);
 
         let schedule = validate_cron("0 0 * * * *").unwrap();
-        let scheduler = Scheduler::new(now_fn, FakeLock::new(AcquireOutcome::Granted));
+        let scheduler = Scheduler::new(
+            now_fn,
+            FakeLock::new(AcquireOutcome::Granted, UnlockOutcome::Succeeds),
+        );
         let runner = scheduler.run_job(&schedule, &job, rx);
         let stopper = async {
             // Far longer than the ~2s a re-fire of 01:00:00 would take, and far
@@ -902,8 +959,10 @@ mod tests {
 
         // Year-pinned single fire: fires once, then `after()` yields no more times.
         let schedule = validate_cron("0 0 0 1 1 * 2099").unwrap();
-        let (scheduler, provider, exporter) =
-            metered_scheduler(virtual_now(), FakeLock::new(AcquireOutcome::Granted));
+        let (scheduler, provider, exporter) = metered_scheduler(
+            virtual_now(),
+            FakeLock::new(AcquireOutcome::Granted, UnlockOutcome::Succeeds),
+        );
         // Unbounded chunks: the fire is decades out, and the default 30s re-check
         // would need millions of iterations to reach it under the paused clock.
         let scheduler = scheduler.with_max_sleep(Duration::MAX);

--- a/nexusd/src/jobs/test_support.rs
+++ b/nexusd/src/jobs/test_support.rs
@@ -1,0 +1,199 @@
+//! Stubs shared by the `jobs` unit tests. Each is a dumb canned responder: the
+//! behaviour under test lives in the scheduler, never in here.
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use std::error::Error;
+use std::sync::atomic::{AtomicI64, AtomicU32, Ordering};
+use std::sync::{Arc, Mutex};
+use tokio::sync::Notify;
+
+use super::error::{LockError, LockResult};
+use super::lock::RunLock;
+use super::scheduler::NowFn;
+use super::Job;
+
+/// A wall clock anchored at `epoch` that tracks tokio's virtual time, paired
+/// with a step handle. Storing seconds into the handle moves the wall clock
+/// *without* advancing tokio's monotonic clock: forward is a host suspend,
+/// backward is an NTP correction or a snapshot restore.
+///
+/// `epoch` is pinned by the caller so a fire time sits a known distance away,
+/// rather than wherever the real `Utc::now()` happens to fall.
+pub(super) fn steppable_clock(epoch: DateTime<Utc>) -> (NowFn, Arc<AtomicI64>) {
+    let virt0 = tokio::time::Instant::now();
+    let skew = Arc::new(AtomicI64::new(0));
+    let handle = Arc::clone(&skew);
+    let now_fn: NowFn = Arc::new(move || {
+        epoch
+            + chrono::Duration::from_std(virt0.elapsed()).expect("virtual elapsed must fit")
+            + chrono::Duration::seconds(skew.load(Ordering::SeqCst))
+    });
+    (now_fn, handle)
+}
+
+/// What [`FakeLock`]'s `acquire` reports, fixed per instance.
+pub(super) enum AcquireOutcome {
+    /// Always granted.
+    Granted,
+    /// Always denied — another run holds the lease.
+    Denied,
+    /// Always a backend failure.
+    Fails,
+    /// Granted on even calls, denied on odd, so one run exercises both branches.
+    Alternating,
+}
+
+/// The [`RunLock`] stub: a canned `acquire` outcome plus counters and the last
+/// job name seen on each call.
+pub(super) struct FakeLock {
+    outcome: AcquireOutcome,
+    acquires: AtomicU32,
+    releases: AtomicU32,
+    acquired_with: Mutex<Option<String>>,
+    released_with: Mutex<Option<String>>,
+}
+
+impl FakeLock {
+    pub(super) fn new(outcome: AcquireOutcome) -> Arc<Self> {
+        Arc::new(Self {
+            outcome,
+            acquires: AtomicU32::new(0),
+            releases: AtomicU32::new(0),
+            acquired_with: Mutex::new(None),
+            released_with: Mutex::new(None),
+        })
+    }
+
+    /// Calls to `acquire`, including denied and failed ones.
+    pub(super) fn acquires(&self) -> u32 {
+        self.acquires.load(Ordering::SeqCst)
+    }
+
+    /// Calls to `unlock`.
+    pub(super) fn releases(&self) -> u32 {
+        self.releases.load(Ordering::SeqCst)
+    }
+
+    /// Job name the last `acquire` was handed.
+    pub(super) fn acquired_with(&self) -> Option<String> {
+        self.acquired_with.lock().unwrap().clone()
+    }
+
+    /// Job name the last `unlock` was handed.
+    pub(super) fn released_with(&self) -> Option<String> {
+        self.released_with.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl RunLock for FakeLock {
+    fn new_token(&self) -> String {
+        "token".to_string()
+    }
+
+    async fn acquire(&self, job: &str, _token: &str) -> LockResult<bool> {
+        *self.acquired_with.lock().unwrap() = Some(job.to_string());
+        let call = self.acquires.fetch_add(1, Ordering::SeqCst);
+        match self.outcome {
+            AcquireOutcome::Granted => Ok(true),
+            AcquireOutcome::Denied => Ok(false),
+            AcquireOutcome::Fails => Err(LockError("backend down".into())),
+            AcquireOutcome::Alternating => Ok(call.is_multiple_of(2)),
+        }
+    }
+
+    async fn unlock(&self, job: &str, _token: &str) -> LockResult<()> {
+        *self.released_with.lock().unwrap() = Some(job.to_string());
+        self.releases.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+/// Counts its runs. The default [`Job`] stub, for tests where the body doesn't
+/// matter; `name` is a parameter because it keys the lock and the metric labels.
+pub(super) struct CountingJob {
+    name: &'static str,
+    runs: AtomicU32,
+}
+
+impl CountingJob {
+    pub(super) fn new(name: &'static str) -> Self {
+        Self {
+            name,
+            runs: AtomicU32::new(0),
+        }
+    }
+
+    /// Completed runs.
+    pub(super) fn runs(&self) -> u32 {
+        self.runs.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl Job for CountingJob {
+    fn name(&self) -> &'static str {
+        self.name
+    }
+
+    async fn run(&self) -> Result<(), Box<dyn Error + Send + Sync>> {
+        self.runs.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+/// Panics on every fire.
+pub(super) struct PanicJob;
+
+#[async_trait]
+impl Job for PanicJob {
+    fn name(&self) -> &'static str {
+        "panicky"
+    }
+
+    async fn run(&self) -> Result<(), Box<dyn Error + Send + Sync>> {
+        panic!("boom");
+    }
+}
+
+/// Marks itself started, then blocks forever on a gate nothing signals.
+pub(super) struct BlockingJob {
+    started: AtomicU32,
+    completed: AtomicU32,
+    gate: Notify,
+}
+
+impl BlockingJob {
+    pub(super) fn new() -> Self {
+        Self {
+            started: AtomicU32::new(0),
+            completed: AtomicU32::new(0),
+            gate: Notify::new(),
+        }
+    }
+
+    /// Runs that reached the gate.
+    pub(super) fn started(&self) -> u32 {
+        self.started.load(Ordering::SeqCst)
+    }
+
+    /// Runs that got past the gate — stays 0 unless the run is left to hang.
+    pub(super) fn completed(&self) -> u32 {
+        self.completed.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl Job for BlockingJob {
+    fn name(&self) -> &'static str {
+        "blocking"
+    }
+
+    async fn run(&self) -> Result<(), Box<dyn Error + Send + Sync>> {
+        self.started.fetch_add(1, Ordering::SeqCst);
+        self.gate.notified().await; // never signaled
+        self.completed.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+}

--- a/nexusd/src/jobs/test_support.rs
+++ b/nexusd/src/jobs/test_support.rs
@@ -3,6 +3,8 @@
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData, ResourceMetrics};
+use std::borrow::Cow;
 use std::error::Error;
 use std::sync::atomic::{AtomicI64, AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
@@ -212,4 +214,34 @@ impl Job for BlockingJob {
         self.completed.fetch_add(1, Ordering::SeqCst);
         Ok(())
     }
+}
+
+/// Sum of a `u64` counter's data points whose attributes contain every
+/// (key, value) pair in `filters`.
+pub(super) fn counter_value(
+    metrics: &[ResourceMetrics],
+    name: &str,
+    filters: &[(&str, &str)],
+) -> u64 {
+    let mut total = 0;
+    for rm in metrics {
+        for sm in rm.scope_metrics() {
+            for m in sm.metrics().filter(|m| m.name() == name) {
+                let AggregatedMetrics::U64(MetricData::Sum(sum)) = m.data() else {
+                    continue;
+                };
+                for dp in sum.data_points() {
+                    let matches = filters.iter().all(|(k, v)| {
+                        dp.attributes().any(|kv| {
+                            kv.key.as_str() == *k && kv.value.as_str() == Cow::Borrowed(*v)
+                        })
+                    });
+                    if matches {
+                        total += dp.value();
+                    }
+                }
+            }
+        }
+    }
+    total
 }

--- a/nexusd/src/jobs/test_support.rs
+++ b/nexusd/src/jobs/test_support.rs
@@ -42,12 +42,23 @@ pub(super) enum AcquireOutcome {
     Fails,
     /// Granted on even calls, denied on odd, so one run exercises both branches.
     Alternating,
+    /// Hangs indefinitely (awaits a future that never resolves).
+    Hangs,
+}
+
+/// What [`FakeLock`]'s `unlock` does, fixed per instance.
+pub(super) enum UnlockOutcome {
+    /// Succeeds immediately.
+    Succeeds,
+    /// Hangs indefinitely (awaits a future that never resolves).
+    Hangs,
 }
 
 /// The [`RunLock`] stub: a canned `acquire` outcome plus counters and the last
 /// job name seen on each call.
 pub(super) struct FakeLock {
-    outcome: AcquireOutcome,
+    acquire_outcome: AcquireOutcome,
+    unlock_outcome: UnlockOutcome,
     acquires: AtomicU32,
     releases: AtomicU32,
     acquired_with: Mutex<Option<String>>,
@@ -55,9 +66,10 @@ pub(super) struct FakeLock {
 }
 
 impl FakeLock {
-    pub(super) fn new(outcome: AcquireOutcome) -> Arc<Self> {
+    pub(super) fn new(acquire_outcome: AcquireOutcome, unlock_outcome: UnlockOutcome) -> Arc<Self> {
         Arc::new(Self {
-            outcome,
+            acquire_outcome,
+            unlock_outcome,
             acquires: AtomicU32::new(0),
             releases: AtomicU32::new(0),
             acquired_with: Mutex::new(None),
@@ -70,8 +82,8 @@ impl FakeLock {
         self.acquires.load(Ordering::SeqCst)
     }
 
-    /// Calls to `unlock`.
-    pub(super) fn releases(&self) -> u32 {
+    /// Calls to `unlock` (tracks attempts, including ones that hang).
+    pub(super) fn unlock_attempts(&self) -> u32 {
         self.releases.load(Ordering::SeqCst)
     }
 
@@ -95,18 +107,22 @@ impl RunLock for FakeLock {
     async fn acquire(&self, job: &str, _token: &str) -> LockResult<bool> {
         *self.acquired_with.lock().unwrap() = Some(job.to_string());
         let call = self.acquires.fetch_add(1, Ordering::SeqCst);
-        match self.outcome {
+        match self.acquire_outcome {
             AcquireOutcome::Granted => Ok(true),
             AcquireOutcome::Denied => Ok(false),
             AcquireOutcome::Fails => Err(LockError("backend down".into())),
             AcquireOutcome::Alternating => Ok(call.is_multiple_of(2)),
+            AcquireOutcome::Hangs => std::future::pending().await,
         }
     }
 
     async fn unlock(&self, job: &str, _token: &str) -> LockResult<()> {
         *self.released_with.lock().unwrap() = Some(job.to_string());
         self.releases.fetch_add(1, Ordering::SeqCst);
-        Ok(())
+        match self.unlock_outcome {
+            UnlockOutcome::Succeeds => Ok(()),
+            UnlockOutcome::Hangs => std::future::pending().await,
+        }
     }
 }
 

--- a/nexusd/src/launcher.rs
+++ b/nexusd/src/launcher.rs
@@ -7,27 +7,36 @@ use nexus_webapi::{api_context::ApiContextBuilder, NexusApiBuilder};
 use serde::{Deserialize, Serialize};
 use tokio::{sync::watch::Receiver, try_join};
 
+use crate::jobs::JobRegistry;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DaemonLauncher {}
 
 impl DaemonLauncher {
-    /// Starts a daemon, with separate threads for a [NexusApi] and a [NexusWatcher] instances.
+    /// Starts a daemon, with separate threads for a [NexusApi], a [NexusWatcher]
+    /// and the scheduled [jobs](crate::jobs).
     ///
     /// This is a blocking method. It only returns:
     /// - either when one of these services throws an error, or
-    /// - when the shutdown signal is received and both services shut down
+    /// - when the shutdown signal is received and all services shut down
     ///
     /// ### Arguments
     ///
     /// - `config_dir`: the directory where the config file is expected to be
+    /// - `job_registry`: the registry of available jobs
     /// - `shutdown_rx`: optional shutdown signal. If none is provided, a default one will be created, listening for Ctrl-C.
     pub async fn start(
         config_dir: PathBuf,
+        job_registry: &JobRegistry,
         shutdown_rx: Option<Receiver<bool>>,
     ) -> Result<(), DynError> {
         let shutdown_rx = shutdown_rx.unwrap_or_else(create_shutdown_rx);
 
         let config = DaemonConfig::read_or_create_config_file(config_dir.clone()).await?;
+
+        // Resolve + validate scheduled jobs before starting any service, so a
+        // bad cron fails fast at startup.
+        let jobs = job_registry.scheduled_jobs(&config)?;
 
         let api_context = ApiContextBuilder::from_config_dir(config_dir)
             .try_build()
@@ -38,7 +47,14 @@ impl DaemonLauncher {
 
         try_join!(
             nexus_webapi_builder.start(Some(shutdown_rx.clone())),
-            nexus_watcher_builder.start(Some(shutdown_rx))
+            nexus_watcher_builder.start(Some(shutdown_rx.clone())),
+            // Erase JobError to DynError so it unifies with the webapi/watcher
+            // arms (try_join! needs one error type).
+            async {
+                crate::jobs::run(jobs, &config.stack, shutdown_rx)
+                    .await
+                    .map_err(DynError::from)
+            },
         )?;
         Ok(())
     }

--- a/nexusd/src/lib.rs
+++ b/nexusd/src/lib.rs
@@ -2,5 +2,6 @@ pub mod cli;
 pub mod jobs;
 mod launcher;
 pub mod migrations;
+pub mod trust;
 
 pub use launcher::DaemonLauncher;

--- a/nexusd/src/lib.rs
+++ b/nexusd/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod cli;
+pub mod jobs;
 mod launcher;
 pub mod migrations;
 

--- a/nexusd/src/main.rs
+++ b/nexusd/src/main.rs
@@ -1,6 +1,8 @@
+use std::sync::Arc;
+
 use clap::Parser;
 use nexus_common::types::DynError;
-use nexus_common::{DaemonConfig, StackManager};
+use nexus_common::{DaemonConfig, StackManager, TrustRankConfig};
 use nexus_watcher::service::NexusWatcher;
 use nexus_webapi::mock::MockDb;
 use nexus_webapi::NexusApi;
@@ -10,13 +12,23 @@ use nexusd::cli::{
 };
 use nexusd::jobs::JobRegistry;
 use nexusd::migrations::{import_migrations, MigrationBuilder, MigrationManager};
+use nexusd::trust::TrustRecomputeJob;
 use nexusd::DaemonLauncher;
+
+/// The registry of jobs available to the daemon, built from config. Config-free
+/// callers (e.g. `jobs list`) can pass `TrustRankConfig::default()`.
+fn job_registry(trust_rank: &TrustRankConfig, lock_ttl_secs: u64) -> JobRegistry {
+    JobRegistry::new(vec![Arc::new(TrustRecomputeJob::build(
+        trust_rank,
+        lock_ttl_secs,
+    ))])
+}
 
 #[tokio::main]
 async fn main() -> Result<(), DynError> {
     let cli = Cli::parse();
     let command = Cli::receive_command(cli);
-    let job_registry = JobRegistry::new(Vec::new());
+    let lock_ttl_secs = nexusd::jobs::LOCK_TTL_SECS;
 
     match command {
         NexusCommands::Db(db_command) => match db_command {
@@ -60,16 +72,25 @@ async fn main() -> Result<(), DynError> {
                 let config = DaemonConfig::read_or_create_config_file(config_dir).await?;
                 // run_on_demand validates [jobs.*], so a typo'd section fails here
                 // just like `nexusd run`.
-                job_registry.run_on_demand(&name, &config).await?;
+                job_registry(&config.trust_rank, lock_ttl_secs)
+                    .run_on_demand(&name, &config)
+                    .await?;
             }
             JobCommands::List => {
-                for name in job_registry.job_names() {
+                // Listing needs only job names, so a default config suffices.
+                for name in job_registry(&TrustRankConfig::default(), lock_ttl_secs).job_names() {
                     println!("{name}");
                 }
             }
         },
         NexusCommands::Run { config_dir } => {
-            DaemonLauncher::start(config_dir, &job_registry, None).await?;
+            let config = DaemonConfig::read_or_create_config_file(config_dir.clone()).await?;
+            DaemonLauncher::start(
+                config_dir,
+                &job_registry(&config.trust_rank, lock_ttl_secs),
+                None,
+            )
+            .await?;
         }
     }
 

--- a/nexusd/src/main.rs
+++ b/nexusd/src/main.rs
@@ -1,10 +1,14 @@
 use clap::Parser;
 use nexus_common::types::DynError;
-use nexus_common::StackManager;
+use nexus_common::{DaemonConfig, StackManager};
 use nexus_watcher::service::NexusWatcher;
 use nexus_webapi::mock::MockDb;
 use nexus_webapi::NexusApi;
-use nexusd::cli::{ApiArgs, Cli, DbCommands, MigrationCommands, NexusCommands, WatcherArgs};
+use nexusd::cli::{
+    ApiArgs, Cli, DbCommands, JobCommands, JobRunArgs, MigrationCommands, NexusCommands,
+    WatcherArgs,
+};
+use nexusd::jobs::JobRegistry;
 use nexusd::migrations::{import_migrations, MigrationBuilder, MigrationManager};
 use nexusd::DaemonLauncher;
 
@@ -12,6 +16,8 @@ use nexusd::DaemonLauncher;
 async fn main() -> Result<(), DynError> {
     let cli = Cli::parse();
     let command = Cli::receive_command(cli);
+    let job_registry = JobRegistry::new(Vec::new());
+
     match command {
         NexusCommands::Db(db_command) => match db_command {
             DbCommands::Clear => MockDb::clear_database().await,
@@ -49,8 +55,21 @@ async fn main() -> Result<(), DynError> {
         NexusCommands::Watcher(WatcherArgs { config_dir }) => {
             NexusWatcher::start_from_daemon(config_dir, None).await?;
         }
+        NexusCommands::Jobs(job_command) => match job_command {
+            JobCommands::Run(JobRunArgs { name, config_dir }) => {
+                let config = DaemonConfig::read_or_create_config_file(config_dir).await?;
+                // run_on_demand validates [jobs.*], so a typo'd section fails here
+                // just like `nexusd run`.
+                job_registry.run_on_demand(&name, &config).await?;
+            }
+            JobCommands::List => {
+                for name in job_registry.job_names() {
+                    println!("{name}");
+                }
+            }
+        },
         NexusCommands::Run { config_dir } => {
-            DaemonLauncher::start(config_dir, None).await?;
+            DaemonLauncher::start(config_dir, &job_registry, None).await?;
         }
     }
 

--- a/nexusd/src/trust/engine.rs
+++ b/nexusd/src/trust/engine.rs
@@ -1,0 +1,52 @@
+use async_trait::async_trait;
+use nexus_common::types::DynError;
+use nexus_common::TrustRankConfig;
+
+/// Inputs for a seeded PageRank computation, decoupling [`TrustRankEngine`]
+/// from [`TrustRankConfig`] so implementations ignore config fields they don't
+/// use (e.g. `report_dir`).
+#[derive(Debug, Clone)]
+pub struct TrustRankParams {
+    /// Users trust originates from, each weighted equally (`v = 1/N`).
+    pub seed_ids: Vec<String>,
+    /// Teleport weight `alpha` in `trust = alpha*v + (1-alpha)*M*trust`.
+    pub alpha: f64,
+    /// Cap on power-iteration rounds.
+    pub max_iterations: u32,
+    /// Convergence tolerance.
+    pub tolerance: f64,
+    /// Optional hard cap on the GDS projection size (bytes).
+    pub max_projection_bytes: Option<u64>,
+}
+
+impl From<&TrustRankConfig> for TrustRankParams {
+    fn from(config: &TrustRankConfig) -> Self {
+        Self {
+            seed_ids: config.seed.iter().map(|id| id.to_string()).collect(),
+            alpha: config.alpha,
+            max_iterations: config.max_iterations,
+            tolerance: config.tolerance,
+            max_projection_bytes: config.max_projection_bytes,
+        }
+    }
+}
+
+/// Summary of a completed trust-rank run.
+#[derive(Debug, Clone)]
+pub struct TrustRankStats {
+    /// Number of users a score was written for.
+    pub users_written: u64,
+    /// Power-iteration rounds actually run.
+    pub ran_iterations: u64,
+    /// Whether the computation converged within `max_iterations`.
+    pub did_converge: bool,
+}
+
+/// Computes seeded (personalized) PageRank trust, persisting each user's
+/// score as a side effect and returning only run stats.
+#[async_trait]
+pub trait TrustRankEngine: Send + Sync {
+    /// Runs the computation for `params` and returns run stats. Input
+    /// validation (seed set, empty graph) is the implementation's job.
+    async fn compute(&self, params: &TrustRankParams) -> Result<TrustRankStats, DynError>;
+}

--- a/nexusd/src/trust/export.rs
+++ b/nexusd/src/trust/export.rs
@@ -1,0 +1,198 @@
+use chrono::{DateTime, Utc};
+use nexus_common::db::fetch_all_rows_from_graph;
+use nexus_common::models::error::ModelResult;
+use nexus_common::types::DynError;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use super::neo4j::queries::{read_trust_scores, trust_report_user_details};
+
+// Per-process counter so two reports in the same second get distinct names.
+static REPORT_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// Reads the top `limit` trust scores from the last recompute, highest first.
+pub async fn read_scores(limit: usize) -> ModelResult<Vec<(String, f64)>> {
+    let rows = fetch_all_rows_from_graph(read_trust_scores(limit)).await?;
+    let mut scores = Vec::with_capacity(rows.len());
+    for row in rows {
+        let user_id: String = row.get("user_id")?;
+        let score: f64 = row.get("score")?;
+        scores.push((user_id, score));
+    }
+    Ok(scores)
+}
+
+#[derive(Default)]
+struct UserReportRow {
+    name: String,
+    following: i64,
+    followers: i64,
+    friends: i64,
+    posts: i64,
+    replies: i64,
+    collections: i64,
+    bookmarks: i64,
+    tagged: i64,
+    tags: i64,
+    unique_tags: i64,
+}
+
+/// Writes a CSV report joining trust scores with user details and counts, for
+/// investigating who ranked where and why. Read straight from the graph (not
+/// Redis), so it reflects current state even where the cache is stale or empty.
+///
+/// Columns: id, name, score, followers, following, friends, posts, replies,
+/// tagged, tags, unique_tags, bookmarks, collections. `scores` must be
+/// highest-first (as [`super::read_scores`] returns); rows preserve that order.
+async fn write_csv(path: &Path, scores: &[(String, f64)]) -> Result<(), DynError> {
+    let ids: Vec<String> = scores.iter().map(|(id, _)| id.clone()).collect();
+
+    let rows = fetch_all_rows_from_graph(trust_report_user_details(&ids)).await?;
+
+    let mut details: HashMap<String, UserReportRow> = HashMap::with_capacity(rows.len());
+    for row in rows {
+        let id: String = row.get("id")?;
+        let name: Option<String> = row.get("name").unwrap_or(None);
+        details.insert(
+            id,
+            UserReportRow {
+                name: name.unwrap_or_default(),
+                following: row.get("following").unwrap_or_default(),
+                followers: row.get("followers").unwrap_or_default(),
+                friends: row.get("friends").unwrap_or_default(),
+                posts: row.get("posts").unwrap_or_default(),
+                replies: row.get("replies").unwrap_or_default(),
+                collections: row.get("collections").unwrap_or_default(),
+                bookmarks: row.get("bookmarks").unwrap_or_default(),
+                tagged: row.get("tagged").unwrap_or_default(),
+                tags: row.get("tags").unwrap_or_default(),
+                unique_tags: row.get("unique_tags").unwrap_or_default(),
+            },
+        );
+    }
+
+    let mut csv = String::from(
+        "id,name,score,followers,following,friends,posts,replies,tagged,tags,unique_tags,bookmarks,collections\n",
+    );
+    // Shared default for missing ids; avoids cloning per row.
+    let missing = UserReportRow::default();
+    for (id, score) in scores {
+        // Every requested id yields a row (OPTIONAL MATCH), but default missing.
+        let d = details.get(id).unwrap_or(&missing);
+
+        csv.push_str(&csv_field(id));
+        csv.push(',');
+        csv.push_str(&csv_field(&d.name));
+        csv.push(',');
+        csv.push_str(&format!(
+            "{score},{},{},{},{},{},{},{},{},{},{}\n",
+            d.followers,
+            d.following,
+            d.friends,
+            d.posts,
+            d.replies,
+            d.tagged,
+            d.tags,
+            d.unique_tags,
+            d.bookmarks,
+            d.collections,
+        ));
+    }
+
+    // Create the target dir so a write into a missing dir doesn't fail.
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+    }
+    tokio::fs::write(path, csv).await?;
+    Ok(())
+}
+
+/// Writes a scheduled-run report into `dir` as `trust-report-<UTC timestamp>.csv`
+/// (columns per [`write_csv`]), creating `dir` if missing. Returns the path.
+pub(super) async fn write_timestamped_csv(
+    dir: &Path,
+    scores: &[(String, f64)],
+) -> Result<PathBuf, DynError> {
+    tokio::fs::create_dir_all(dir).await?;
+    let path = dir.join(report_file_name(Utc::now()));
+    write_csv(&path, scores).await?;
+    Ok(path)
+}
+
+// Second-precision timestamp stays readable/sortable; the per-process counter
+// makes the name unique so two runs in the same second can't overwrite it.
+fn report_file_name(now: DateTime<Utc>) -> String {
+    format!(
+        "trust-report-{}-{:06}.csv",
+        now.format("%Y%m%dT%H%M%SZ"),
+        REPORT_SEQ.fetch_add(1, Ordering::Relaxed)
+    )
+}
+
+/// Quotes a CSV field per RFC 4180 and neutralizes spreadsheet formula
+/// injection: a leading trigger char (`= + - @` etc.) gets an `'` prefix.
+/// Tradeoff: a legit name starting with `-` gains an apostrophe — fine here.
+fn csv_field(s: &str) -> String {
+    let s = if s.starts_with(['=', '+', '-', '@', '\t', '\r']) {
+        format!("'{s}")
+    } else {
+        s.to_string()
+    };
+    if s.contains([',', '"', '\n', '\r']) {
+        format!("\"{}\"", s.replace('"', "\"\""))
+    } else {
+        s
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Filenames are timestamped, filesystem-safe (no `:` or spaces), and the
+    /// per-process counter makes two same-second runs distinct.
+    #[test]
+    fn test_report_file_name() {
+        let ts = DateTime::parse_from_rfc3339("2026-07-08T03:00:05Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        let first = report_file_name(ts);
+        assert!(first.starts_with("trust-report-20260708T030005Z-"));
+        assert!(first.ends_with(".csv"));
+
+        // The counter segment is numeric.
+        let seq = first
+            .strip_prefix("trust-report-20260708T030005Z-")
+            .and_then(|s| s.strip_suffix(".csv"))
+            .expect("name has the expected prefix/suffix");
+        assert!(seq.chars().all(|c| c.is_ascii_digit()));
+
+        // Same timestamp, second run → different name (no overwrite).
+        assert_ne!(first, report_file_name(ts));
+    }
+
+    /// Formula trigger chars get a leading `'` so they don't execute on open.
+    #[test]
+    fn csv_field_neutralizes_formula_triggers() {
+        assert_eq!(csv_field("=SUM(A1)"), "'=SUM(A1)");
+        assert_eq!(csv_field("+1"), "'+1");
+        assert_eq!(csv_field("@foo"), "'@foo");
+    }
+
+    /// Neutralization composes with RFC 4180 quoting.
+    #[test]
+    fn csv_field_neutralization_composes_with_quoting() {
+        assert_eq!(csv_field("=a,b"), "\"'=a,b\"");
+    }
+
+    /// Fields without a trigger char are unchanged.
+    #[test]
+    fn csv_field_leaves_safe_fields_untouched() {
+        assert_eq!(csv_field("plain"), "plain");
+        assert_eq!(csv_field("a\"b"), "\"a\"\"b\"");
+    }
+}

--- a/nexusd/src/trust/job.rs
+++ b/nexusd/src/trust/job.rs
@@ -1,0 +1,280 @@
+use std::path::PathBuf;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use nexus_common::types::DynError;
+use nexus_common::TrustRankConfig;
+use opentelemetry::global;
+use opentelemetry::metrics::{Counter, Meter};
+use tracing::{debug, error, info, warn};
+
+use super::engine::{TrustRankEngine, TrustRankParams};
+use super::export::{read_scores, write_timestamped_csv};
+use super::neo4j::GdsNeo4j;
+use crate::jobs::Job;
+
+/// OpenTelemetry meter name for all trust-rank metrics.
+const METER_NAME: &str = "nexus.trust";
+
+/// The trust-rank recompute as a runnable [`Job`]: runs the seeded PageRank
+/// computation and, when a report dir is set, writes a CSV report of the run.
+/// Build from resolved inputs with [`TrustRecomputeJob::new`] or from config
+/// with [`TrustRecomputeJob::build`]; the job runner resolves its schedule from
+/// the `[jobs.trust-recompute]` cron.
+pub struct TrustRecomputeJob {
+    params: TrustRankParams,
+    engine: Box<dyn TrustRankEngine>,
+    report_dir: Option<PathBuf>,
+    report_limit: usize,
+    /// Runs that exhausted `max_iterations` without converging, so the written
+    /// scores are the last (unconverged) iterate. A sustained nonzero rate means
+    /// `max_iterations` or `tolerance` needs raising.
+    max_iterations_reached: Counter<u64>,
+}
+
+impl TrustRecomputeJob {
+    /// Builds the job from inputs. `report_dir` is `Some` to write a CSV, `None` to skip;
+    /// `report_limit` caps rows in the report. Instruments come from the global
+    /// meter (no-ops until an `SdkMeterProvider` is installed).
+    pub fn new(
+        params: TrustRankParams,
+        engine: Box<dyn TrustRankEngine>,
+        report_dir: Option<PathBuf>,
+        report_limit: usize,
+    ) -> Self {
+        Self::with_meter(
+            params,
+            engine,
+            report_dir,
+            report_limit,
+            global::meter(METER_NAME),
+        )
+    }
+
+    /// [`new`](Self::new) with an explicit `meter`, so tests can install a local
+    /// `SdkMeterProvider` and read the counter back.
+    pub(crate) fn with_meter(
+        params: TrustRankParams,
+        engine: Box<dyn TrustRankEngine>,
+        report_dir: Option<PathBuf>,
+        report_limit: usize,
+        meter: Meter,
+    ) -> Self {
+        let max_iterations_reached = meter
+            .u64_counter("trust.recompute.max_iterations_reached")
+            .with_description("Trust rank runs that hit max_iterations without converging")
+            .build();
+        Self {
+            params,
+            engine,
+            report_dir,
+            report_limit,
+            max_iterations_reached,
+        }
+    }
+
+    /// Builds the job from its trust-rank config and the run lease TTL.
+    pub fn build(config: &TrustRankConfig, lock_ttl_secs: u64) -> Self {
+        // Sweep age = 2× the lease TTL (which already includes LEASE_MARGIN), so
+        // it sits well past lease expiry and the sweep can never race a live run.
+        Self::new(
+            TrustRankParams::from(config),
+            Box::new(GdsNeo4j::new(true, Duration::from_secs(2 * lock_ttl_secs))),
+            config.report_enabled.then(|| config.report_dir.clone()),
+            config.report_limit,
+        )
+    }
+}
+
+#[async_trait]
+impl Job for TrustRecomputeJob {
+    fn name(&self) -> &'static str {
+        "trust-recompute"
+    }
+
+    async fn run(&self) -> Result<(), DynError> {
+        let stats = self.engine.compute(&self.params).await?;
+        debug!(
+            users_written = stats.users_written,
+            ran_iterations = stats.ran_iterations,
+            did_converge = stats.did_converge,
+            "Trust rank run stats"
+        );
+        if !stats.did_converge {
+            self.max_iterations_reached.add(1, &[]);
+            warn!(
+                max_iterations = self.params.max_iterations,
+                tolerance = self.params.tolerance,
+                "Trust rank hit max_iterations without converging"
+            );
+        }
+
+        // Report failures are logged, not fatal: scores are already persisted.
+        if let Some(dir) = &self.report_dir {
+            match read_scores(self.report_limit).await {
+                Ok(scores) => match write_timestamped_csv(dir, &scores).await {
+                    Ok(path) => info!(path = %path.display(), "Trust rank report written"),
+                    Err(e) => error!("Failed to write trust rank report: {e:?}"),
+                },
+                Err(e) => error!("Failed to read trust scores for report: {e:?}"),
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Arc;
+
+    use opentelemetry::metrics::MeterProvider;
+    use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData, ResourceMetrics};
+    use opentelemetry_sdk::metrics::{InMemoryMetricExporter, SdkMeterProvider};
+
+    use super::super::engine::{TrustRankEngine, TrustRankParams, TrustRankStats};
+    use super::*;
+
+    // Dumb stub: bumps a shared counter and replays a canned result. The counter
+    // is shared so the test can inspect it after the engine moves into the job.
+    struct MockEngine {
+        calls: Arc<AtomicU32>,
+        fail: bool,
+        did_converge: bool,
+    }
+
+    impl MockEngine {
+        fn new(calls: &Arc<AtomicU32>, fail: bool) -> Self {
+            Self {
+                calls: Arc::clone(calls),
+                fail,
+                did_converge: true,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl TrustRankEngine for MockEngine {
+        async fn compute(&self, _params: &TrustRankParams) -> Result<TrustRankStats, DynError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            if self.fail {
+                return Err("compute failed".into());
+            }
+            Ok(TrustRankStats {
+                users_written: 1,
+                ran_iterations: 1,
+                did_converge: self.did_converge,
+            })
+        }
+    }
+
+    /// A job whose counters feed an in-memory exporter. Call
+    /// `provider.force_flush()` before reading `exporter.get_finished_metrics()`.
+    fn metered_job(
+        engine: Box<dyn TrustRankEngine>,
+    ) -> (TrustRecomputeJob, SdkMeterProvider, InMemoryMetricExporter) {
+        let exporter = InMemoryMetricExporter::default();
+        let provider = SdkMeterProvider::builder()
+            .with_periodic_exporter(exporter.clone())
+            .build();
+        let job = TrustRecomputeJob::with_meter(params(), engine, None, 10, provider.meter("test"));
+        (job, provider, exporter)
+    }
+
+    /// Sum of a `u64` counter's data points across all exported metrics.
+    fn counter_value(metrics: &[ResourceMetrics], name: &str) -> u64 {
+        let mut total = 0;
+        for rm in metrics {
+            for sm in rm.scope_metrics() {
+                for m in sm.metrics().filter(|m| m.name() == name) {
+                    let AggregatedMetrics::U64(MetricData::Sum(sum)) = m.data() else {
+                        continue;
+                    };
+                    total += sum.data_points().map(|dp| dp.value()).sum::<u64>();
+                }
+            }
+        }
+        total
+    }
+
+    fn params() -> TrustRankParams {
+        TrustRankParams {
+            seed_ids: vec!["seed".to_string()],
+            alpha: 0.85,
+            max_iterations: 20,
+            tolerance: 1e-6,
+            max_projection_bytes: None,
+        }
+    }
+
+    // No report_dir: run() computes and returns without touching the store.
+    #[tokio::test]
+    async fn run_without_report_computes_and_skips_report() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let engine = MockEngine::new(&calls, false);
+        let job = TrustRecomputeJob::new(params(), Box::new(engine), None, 10);
+
+        job.run().await.expect("run should succeed");
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    // A compute error propagates and short-circuits before the report block,
+    // so run() fails without ever reaching the store (report_dir is Some here).
+    #[tokio::test]
+    async fn run_propagates_compute_error_before_report() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let engine = MockEngine::new(&calls, true);
+        let job = TrustRecomputeJob::new(
+            params(),
+            Box::new(engine),
+            Some(PathBuf::from("/does-not-matter")),
+            10,
+        );
+
+        let err = job.run().await.expect_err("run should fail");
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(err.to_string(), "compute failed");
+    }
+
+    // A run that exhausted max_iterations bumps the counter.
+    #[tokio::test]
+    async fn run_counts_max_iterations_reached_when_not_converged() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let engine = MockEngine {
+            did_converge: false,
+            ..MockEngine::new(&calls, false)
+        };
+        let (job, provider, exporter) = metered_job(Box::new(engine));
+
+        job.run().await.expect("run should succeed");
+        provider.force_flush().expect("flush should succeed");
+
+        let metrics = exporter
+            .get_finished_metrics()
+            .expect("metrics should be exported");
+        assert_eq!(
+            counter_value(&metrics, "trust.recompute.max_iterations_reached"),
+            1
+        );
+    }
+
+    // A converged run leaves the counter untouched.
+    #[tokio::test]
+    async fn run_does_not_count_max_iterations_reached_when_converged() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let (job, provider, exporter) = metered_job(Box::new(MockEngine::new(&calls, false)));
+
+        job.run().await.expect("run should succeed");
+        provider.force_flush().expect("flush should succeed");
+
+        let metrics = exporter
+            .get_finished_metrics()
+            .expect("metrics should be exported");
+        assert_eq!(
+            counter_value(&metrics, "trust.recompute.max_iterations_reached"),
+            0
+        );
+    }
+}

--- a/nexusd/src/trust/mod.rs
+++ b/nexusd/src/trust/mod.rs
@@ -1,0 +1,9 @@
+mod engine;
+mod export;
+mod job;
+mod neo4j;
+
+pub use engine::{TrustRankEngine, TrustRankParams, TrustRankStats};
+pub use export::read_scores;
+pub use job::TrustRecomputeJob;
+pub use neo4j::GdsNeo4j;

--- a/nexusd/src/trust/neo4j/mod.rs
+++ b/nexusd/src/trust/neo4j/mod.rs
@@ -1,0 +1,195 @@
+//! Neo4j/GDS-backed implementation of [`TrustRankEngine`], plus its Cypher
+//! queries. All Neo4j specifics live here; the abstraction is in `super::engine`.
+
+pub mod queries;
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use nexus_common::db::fetch_row_from_graph;
+use nexus_common::types::DynError;
+use tracing::{info, warn};
+
+use super::engine::{TrustRankEngine, TrustRankParams, TrustRankStats};
+use queries::{
+    count_matching_seeds, drop_stale_trust_graphs, drop_trust_graph, estimate_trust_graph,
+    project_trust_graph, trust_rank_pagerank_write, TRUST_GRAPH_PREFIX,
+};
+
+/// Computes trust rank via the Neo4j GDS `pageRank` procedure in write mode,
+/// storing the result on each `:User` node as the `trust` property.
+///
+/// Seeds are weighted equally (`v` uniform, `1/N` over `params.seed_ids`): GDS
+/// 2.13 (the only version on Neo4j 5.26) has no weighted `sourceNodes`. The GDS
+/// projection is rebuilt each run — Neo4j Community has no incremental update.
+#[derive(Debug, Clone, Copy)]
+pub struct GdsNeo4j {
+    /// L1-normalize the written scores into a distribution (summing to 1). On in
+    /// production; tests turn it off to observe the raw scores, which expose the
+    /// mass a reachable dangling node leaks (that L1Norm otherwise rescales away).
+    use_l1norm: bool,
+    /// GDS projections older than this are swept as crash leftovers.
+    stale_graph_age: Duration,
+}
+
+impl GdsNeo4j {
+    /// Engine with an explicit scaling choice (`use_l1norm`: `L1Norm` in
+    /// production, `false` in tests to observe raw scores) and the stale-graph
+    /// sweep age (see [`GdsNeo4j::stale_graph_age`]).
+    pub fn new(use_l1norm: bool, stale_graph_age: Duration) -> Self {
+        Self {
+            use_l1norm,
+            stale_graph_age,
+        }
+    }
+}
+
+#[async_trait]
+impl TrustRankEngine for GdsNeo4j {
+    async fn compute(&self, params: &TrustRankParams) -> Result<TrustRankStats, DynError> {
+        if params.seed_ids.is_empty() {
+            return Err(
+                "trust_rank.seed is empty; refusing to compute trust rank without a seed set"
+                    .into(),
+            );
+        }
+
+        let damping_factor = 1.0 - params.alpha;
+
+        // No matching seed → GDS gets an empty sourceNodes list, treats it as
+        // unset, and computes non-personalized (Sybil-vulnerable) PageRank.
+        // Fail fast instead.
+        let matched: i64 = fetch_row_from_graph(count_matching_seeds(&params.seed_ids))
+            .await?
+            .map(|row| row.get("matched"))
+            .transpose()?
+            .unwrap_or(0);
+        let configured = params.seed_ids.len() as i64;
+        if matched == 0 {
+            return Err(format!(
+                "none of the {configured} configured trust seeds exist as users in the graph; refusing to compute trust rank"
+            )
+            .into());
+        }
+        if matched < configured {
+            warn!(
+                matched,
+                configured, "Some configured trust seeds do not exist in the graph"
+            );
+        }
+
+        // Per-run unique name so a concurrent run can't clobber this
+        // run's in-flight projection.
+        let graph_name = format!(
+            "{TRUST_GRAPH_PREFIX}-{}-{}",
+            std::process::id(),
+            chrono::Utc::now().timestamp_millis()
+        );
+
+        // Sweep projections leaked by crashed runs (age-gated, can't race a live
+        // run). Catalog calls use fetch_row_from_graph (PULL): GDS runs the side
+        // effect only when the row is pulled.
+        let stale_secs = self.stale_graph_age.as_secs() as i64;
+        if let Some(row) = fetch_row_from_graph(drop_stale_trust_graphs(stale_secs)).await? {
+            let dropped: Vec<String> = row.get("dropped").unwrap_or_default();
+            if !dropped.is_empty() {
+                warn!(
+                    ?dropped,
+                    "Dropped stale trust graph projections left by crashed runs"
+                );
+            }
+        }
+
+        // Estimate projection size (dry-run, allocates nothing). When no cap is
+        // configured the estimate is a log-only breadcrumb — failures (e.g. the
+        // procedure missing from the allowlist) warn and continue. When a cap is
+        // set the estimate is load-bearing and errors propagate.
+        let estimate_ok = match fetch_row_from_graph(estimate_trust_graph()).await {
+            Ok(row) => {
+                if let Some(row) = &row {
+                    let required_memory: String = row.get("requiredMemory").unwrap_or_default();
+                    let bytes_max: u64 = row.get("bytesMax").unwrap_or_default();
+                    let est_nodes: i64 = row.get("nodeCount").unwrap_or_default();
+                    let est_rels: i64 = row.get("relationshipCount").unwrap_or_default();
+                    info!(
+                        required_memory = %required_memory,
+                        bytes_max, estimate_nodes = est_nodes, estimate_rels = est_rels,
+                        "GDS projection estimate"
+                    );
+                    if let Some(cap) = params.max_projection_bytes {
+                        if bytes_max > cap {
+                            return Err(format!(
+                                "GDS projection estimate ({bytes_max} bytes / {required_memory}) exceeds configured cap ({cap} bytes); increase NEO4J_server_memory_heap_max__size or raise trust_rank.max_projection_bytes"
+                            ).into());
+                        }
+                    }
+                }
+                true
+            }
+            Err(e) => {
+                if params.max_projection_bytes.is_some() {
+                    return Err(e.into());
+                }
+                warn!("GDS projection estimate failed (continuing without cap check): {e:?}");
+                false
+            }
+        };
+        let _ = estimate_ok;
+
+        // GDS work below runs server-side. A run abandoned at the job's MAX_RUN
+        // drops this future but can't cancel the in-flight projection/pageRank:
+        // it keeps grinding and its projection stays resident, so the next tick
+        // can project a second graph on top (double memory). We can't bound it
+        // per-query yet — neo4rs 0.8 exposes no RUN tx_timeout metadata (needs
+        // 0.9's Query::extra, currently only an RC). The age-gated stale sweep
+        // above is the backstop until then.
+        let projected = fetch_row_from_graph(project_trust_graph(&graph_name)).await?;
+        if let Some(row) = &projected {
+            let node_count: i64 = row.get("nodeCount").unwrap_or_default();
+            let relationship_count: i64 = row.get("relationshipCount").unwrap_or_default();
+            info!(
+                node_count,
+                relationship_count, "Projected trust graph for GDS PageRank"
+            );
+        }
+
+        let write_result = fetch_row_from_graph(trust_rank_pagerank_write(
+            &graph_name,
+            &params.seed_ids,
+            damping_factor,
+            params.max_iterations,
+            params.tolerance,
+            if self.use_l1norm { "L1Norm" } else { "NONE" },
+        ))
+        .await;
+
+        // Always drop the projection so a failed run doesn't leak GDS memory.
+        // Log-and-continue: a `?` would shadow the pagerank error; the stale
+        // sweep reclaims any leak on a later run.
+        if let Err(e) = fetch_row_from_graph(drop_trust_graph(&graph_name)).await {
+            warn!(
+                graph_name,
+                "Failed to drop trust graph projection after run: {e:?}"
+            );
+        }
+
+        let row = write_result?
+            .ok_or_else(|| -> DynError { "GDS pageRank.write returned no summary row".into() })?;
+        let users_written: i64 = row.get("nodePropertiesWritten").unwrap_or_default();
+        let ran_iterations: i64 = row.get("ranIterations").unwrap_or_default();
+        let did_converge: bool = row.get("didConverge").unwrap_or_default();
+
+        if users_written == 0 {
+            return Err(
+                "trust rank computation wrote no scores; check the seed set and follow graph"
+                    .into(),
+            );
+        }
+
+        Ok(TrustRankStats {
+            users_written: users_written as u64,
+            ran_iterations: ran_iterations as u64,
+            did_converge,
+        })
+    }
+}

--- a/nexusd/src/trust/neo4j/queries.rs
+++ b/nexusd/src/trust/neo4j/queries.rs
@@ -1,0 +1,198 @@
+use nexus_common::db::graph::queries::get::user_count_fields_columns;
+use nexus_common::db::graph::Query;
+
+/// Name prefix of the per-run GDS graph projections. Each run projects under a
+/// unique `{prefix}-{pid}-{millis}` name so concurrent runs can't clobber each
+/// other; crash leftovers are swept by [`drop_stale_trust_graphs`].
+pub const TRUST_GRAPH_PREFIX: &str = "nexusTrustGraph";
+
+/// Drops the named GDS graph projection if it exists; a no-op otherwise (`failIfMissing: false`).
+pub fn drop_trust_graph(graph_name: &str) -> Query {
+    Query::new(
+        "drop_trust_graph",
+        "CALL gds.graph.drop($graph_name, false) YIELD graphName RETURN graphName",
+    )
+    .param("graph_name", graph_name.to_string())
+}
+
+/// Reclaims GDS projections left by a run that died before dropping its own:
+/// prefix-matched entries older than `stale_seconds`. A run drops its projection
+/// on success and on error, so a leak means a hard crash (SIGKILL/OOM) or a
+/// shutdown-cancelled run.
+///
+/// Age proxies for "the owner is dead". The caller sizes `stale_seconds` past a
+/// run's lease expiry so a projection old enough to sweep cannot belong to a run
+/// still holding (or able to hold) the lock.
+pub fn drop_stale_trust_graphs(stale_seconds: i64) -> Query {
+    Query::new(
+        "drop_stale_trust_graphs",
+        "CALL gds.graph.list() YIELD graphName, creationTime
+         WHERE graphName STARTS WITH $prefix AND creationTime < datetime() - duration({seconds: $stale_seconds})
+         CALL gds.graph.drop(graphName, false) YIELD graphName AS dropped
+         RETURN collect(dropped) AS dropped",
+    )
+    .param("prefix", TRUST_GRAPH_PREFIX)
+    .param("stale_seconds", stale_seconds)
+}
+
+/// Projects the follow graph (`User` nodes, `FOLLOWS` edges) into the GDS in-memory catalog.
+pub fn project_trust_graph(graph_name: &str) -> Query {
+    Query::new(
+        "project_trust_graph",
+        "CALL gds.graph.project($graph_name, 'User', 'FOLLOWS')
+         YIELD graphName, nodeCount, relationshipCount
+         RETURN graphName, nodeCount, relationshipCount",
+    )
+    .param("graph_name", graph_name.to_string())
+}
+
+/// Dry-run estimate for the User+FOLLOWS GDS projection (allocates nothing).
+/// Returns `requiredMemory`, `bytesMax`, `nodeCount`, and `relationshipCount`.
+pub fn estimate_trust_graph() -> Query {
+    Query::new(
+        "estimate_trust_graph",
+        "CALL gds.graph.project.estimate('User', 'FOLLOWS')
+         YIELD requiredMemory, bytesMax, nodeCount, relationshipCount
+         RETURN requiredMemory, bytesMax, nodeCount, relationshipCount",
+    )
+}
+
+/// Counts how many of the configured seed ids exist as `:User` nodes.
+///
+/// Run before the PageRank query: if zero seeds match, GDS gets an empty
+/// `sourceNodes`, treats it as unset, and computes non-personalized PageRank
+/// instead of the seeded trust ranking.
+pub fn count_matching_seeds(seed_ids: &[String]) -> Query {
+    Query::new(
+        "count_matching_seeds",
+        "MATCH (seed:User) WHERE seed.id IN $seed_ids RETURN count(seed) AS matched",
+    )
+    .param("seed_ids", seed_ids.to_vec())
+}
+
+/// Runs personalized PageRank over the projected follow graph in GDS **write
+/// mode**, storing each score on its `:User` node as the `trust` property.
+/// Teleports uniformly across `seed_ids` (`v = 1/N`); GDS 2.13 (the only
+/// version on Neo4j 5.26) has no weighted `sourceNodes`.
+///
+/// `scaler` picks the GDS output scaling: `L1Norm` (production) writes an
+/// L1-normalized distribution (summing to 1); `NONE` writes raw rank values.
+/// GDS drops — never teleport-redistributes — the mass of reachable dangling
+/// nodes, so raw single-seed scores sum to < 1; `L1Norm` rescales that back to a
+/// distribution, hiding the leak. Write mode overwrites `trust` on every
+/// projected `:User` each run; the projection is a snapshot, so users created
+/// after it carry no score until the next run picks them up (normal for a batch
+/// job).
+///
+/// The `size(sourceNodes) > 0` guard makes the query produce no rows when no
+/// seed matches, so a raced seed deletion can never fall back to
+/// non-personalized PageRank — the caller's "no summary row" path fires instead.
+pub fn trust_rank_pagerank_write(
+    graph_name: &str,
+    seed_ids: &[String],
+    damping_factor: f64,
+    max_iterations: u32,
+    tolerance: f64,
+    scaler: &str,
+) -> Query {
+    Query::new(
+        "trust_rank_pagerank_write",
+        "MATCH (seed:User) WHERE seed.id IN $seed_ids
+         WITH collect(seed) AS sourceNodes
+         WHERE size(sourceNodes) > 0
+         CALL gds.pageRank.write($graph_name, {
+             writeProperty: 'trust',
+             sourceNodes: sourceNodes,
+             dampingFactor: $damping_factor,
+             maxIterations: $max_iterations,
+             tolerance: $tolerance,
+             scaler: $scaler
+         })
+         YIELD nodePropertiesWritten, ranIterations, didConverge
+         RETURN nodePropertiesWritten, ranIterations, didConverge",
+    )
+    .param("graph_name", graph_name.to_string())
+    .param("seed_ids", seed_ids.to_vec())
+    .param("damping_factor", damping_factor)
+    .param("max_iterations", max_iterations as i64)
+    .param("tolerance", tolerance)
+    .param("scaler", scaler.to_string())
+}
+
+/// Reads the top `limit` trust scores, highest first. `LIMIT` prevents scanning the entire user base.
+pub fn read_trust_scores(limit: usize) -> Query {
+    Query::new(
+        "read_trust_scores",
+        "MATCH (u:User) WHERE u.trust IS NOT NULL
+         RETURN u.id AS user_id, u.trust AS score
+         ORDER BY score DESC
+         LIMIT $limit",
+    )
+    .param("limit", limit as i64)
+}
+
+/// Batched name + counts for a list of user ids, read straight from the graph
+/// (no Redis) so the report's numbers reflect current state, not a stale cache.
+///
+/// The count columns come from `nexus_common`'s shared `USER_COUNT_FIELDS` (via
+/// [`user_count_fields_columns`]), so the filters can't drift from `user_counts`.
+/// `OPTIONAL MATCH` keeps one row per requested id even if a user is missing;
+/// that match is single-row per id (not row-multiplying), so each `COUNT {}`
+/// stays O(1) per field.
+pub fn trust_report_user_details(user_ids: &[String]) -> Query {
+    let cypher = format!(
+        "UNWIND $user_ids AS user_id
+         OPTIONAL MATCH (u:User {{id: user_id}})
+         RETURN
+             user_id AS id,
+             u.name AS name,
+             {fields}",
+        fields = user_count_fields_columns()
+    );
+    Query::new("trust_report_user_details", cypher).param("user_ids", user_ids.to_vec())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trust_rank_pagerank_write_populates_seed_ids() {
+        let seed_ids = vec!["alice".to_string(), "bob".to_string()];
+        let q = trust_rank_pagerank_write(
+            "nexusTrustGraph-1-2",
+            &seed_ids,
+            0.65,
+            200,
+            0.0000001,
+            "L1Norm",
+        );
+        let populated = q.to_cypher_populated();
+        assert!(populated.contains("['alice', 'bob']"));
+        assert!(populated.contains("0.65"));
+        assert!(populated.contains("'nexusTrustGraph-1-2'"));
+        assert!(populated.contains("writeProperty: 'trust'"));
+        // Scaler is parameterized (toggled between L1Norm and NONE), not hardcoded.
+        assert!(populated.contains("'L1Norm'"));
+        // Guard closing the seed-deletion race; empty match → no rows, not global PageRank.
+        assert!(populated.contains("size(sourceNodes) > 0"));
+    }
+
+    #[test]
+    fn count_matching_seeds_populates_seed_ids() {
+        let seed_ids = vec!["alice".to_string(), "bob".to_string()];
+        let populated = count_matching_seeds(&seed_ids).to_cypher_populated();
+        assert!(populated.contains("['alice', 'bob']"));
+        assert!(populated.contains("count(seed) AS matched"));
+    }
+
+    // Smoke test: the trust report has no integration coverage (nexusd-side),
+    // so just check the composed Cypher is well-formed off the OPTIONAL MATCH.
+    #[test]
+    fn trust_report_user_details_is_well_formed() {
+        let cypher = trust_report_user_details(&["alice".to_string()]).to_cypher_populated();
+        assert!(cypher.contains("OPTIONAL MATCH (u:User {id: user_id})"));
+        assert!(cypher.contains("AS following"));
+        assert!(cypher.contains("bp.kind <> 'collection'"));
+    }
+}

--- a/nexusd/tests/trust/main.rs
+++ b/nexusd/tests/trust/main.rs
@@ -1,0 +1,3 @@
+//! Integration tests for trust-rank computation, one module per engine backend.
+
+mod neo4j;

--- a/nexusd/tests/trust/neo4j.rs
+++ b/nexusd/tests/trust/neo4j.rs
@@ -1,0 +1,312 @@
+//! Integration test for the Neo4j/GDS [`GdsNeo4j`] trust-rank engine.
+//!
+//! Builds a tiny, self-contained follow graph (so it doesn't depend on any
+//! seeded fixtures), runs a real GDS PageRank recompute against the Neo4j
+//! stack, and asserts the `trust` property is written back onto the `:User`
+//! nodes with the shape a seeded/personalized ranking must have.
+//!
+//! Requires the docker stack (Neo4j with the GDS plugin + Redis) to be up.
+
+use anyhow::{Context, Result};
+use nexus_common::db::graph::Query;
+use nexus_common::db::{exec_single_row, fetch_all_rows_from_graph};
+use nexus_common::{StackConfig, StackManager};
+use nexusd::trust::{read_scores, GdsNeo4j, TrustRankEngine, TrustRankParams};
+use std::collections::HashMap;
+use std::time::Duration;
+
+/// Creates four `:User` nodes and the follow chain `seed -> a -> b`, leaving
+/// `c` isolated (followed by no one, following no one).
+async fn create_follow_graph(seed: &str, a: &str, b: &str, c: &str) -> Result<()> {
+    let query = Query::new(
+        "trusttest_create_follow_graph",
+        "CREATE (s:User {id: $seed, name: 'trusttest seed'})
+         CREATE (a:User {id: $a, name: 'trusttest a'})
+         CREATE (b:User {id: $b, name: 'trusttest b'})
+         CREATE (c:User {id: $c, name: 'trusttest c'})
+         CREATE (s)-[:FOLLOWS]->(a)
+         CREATE (a)-[:FOLLOWS]->(b)",
+    )
+    .param("seed", seed.to_string())
+    .param("a", a.to_string())
+    .param("b", b.to_string())
+    .param("c", c.to_string());
+    exec_single_row(query).await?;
+    Ok(())
+}
+
+/// `max_projection_bytes` cap aborts compute when the estimate exceeds the limit.
+#[tokio_shared_rt::test(shared)]
+async fn test_compute_aborts_when_estimate_exceeds_cap() -> Result<()> {
+    StackManager::setup(&StackConfig::default())
+        .await
+        .map_err(|e| anyhow::anyhow!("could not initialise the stack: {e:?}"))?;
+
+    let tag = format!(
+        "{}-{}",
+        std::process::id(),
+        chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+    );
+    let seed = format!("cap-{tag}-seed");
+    let a = format!("cap-{tag}-a");
+    let b = format!("cap-{tag}-b");
+    let c = format!("cap-{tag}-c");
+
+    create_follow_graph(&seed, &a, &b, &c).await?;
+
+    let params = TrustRankParams {
+        seed_ids: vec![seed.clone()],
+        alpha: 0.35,
+        max_iterations: 200,
+        tolerance: 1e-7,
+        max_projection_bytes: Some(1), // Deliberately tiny cap
+    };
+
+    let sweep_age = Duration::from_secs(3600);
+    let compute_result = GdsNeo4j::new(true, sweep_age).compute(&params).await;
+
+    delete_users(&[&seed, &a, &b, &c]).await?;
+
+    let err = compute_result.expect_err("compute should fail with a tiny cap");
+    let err_msg = format!("{err}");
+    assert!(
+        err_msg.contains("exceeds configured cap"),
+        "error should mention cap violation, got: {err_msg}"
+    );
+    assert!(
+        err_msg.contains("cap (1 bytes)"),
+        "error should name the cap value, got: {err_msg}"
+    );
+
+    Ok(())
+}
+
+/// Removes the test nodes (and their edges) so the shared graph is left clean.
+async fn delete_users(ids: &[&str]) -> Result<()> {
+    let query = Query::new(
+        "trusttest_delete_users",
+        "MATCH (u:User) WHERE u.id IN $ids DETACH DELETE u",
+    )
+    .param("ids", ids.iter().map(|s| s.to_string()).collect::<Vec<_>>());
+    exec_single_row(query).await?;
+    Ok(())
+}
+
+/// Creates `n` scored users (`trust: 1.0..=n`) without GDS.
+async fn create_scored_users(prefix: &str, n: usize) -> Result<()> {
+    let query = Query::new(
+        "trusttest_create_scored_users",
+        "UNWIND range(1, $n) AS i
+         CREATE (:User {id: $prefix + toString(i), trust: toFloat(i)})",
+    )
+    .param("prefix", prefix.to_string())
+    .param("n", n as i64);
+    exec_single_row(query).await?;
+    Ok(())
+}
+
+/// Removes users by id prefix.
+async fn delete_users_by_prefix(prefix: &str) -> Result<()> {
+    let query = Query::new(
+        "trusttest_delete_by_prefix",
+        "MATCH (u:User) WHERE u.id STARTS WITH $prefix DETACH DELETE u",
+    )
+    .param("prefix", prefix.to_string());
+    exec_single_row(query).await?;
+    Ok(())
+}
+
+/// Reads a single user's `trust` property straight from the graph.
+async fn trust_of(id: &str) -> Result<Option<f64>> {
+    let query = Query::new(
+        "trusttest_read_trust",
+        "MATCH (u:User {id: $id}) RETURN u.trust AS trust",
+    )
+    .param("id", id.to_string());
+    let rows = fetch_all_rows_from_graph(query).await?;
+    match rows.first() {
+        Some(row) => Ok(row.get("trust").ok()),
+        None => Ok(None),
+    }
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_trust_recompute_assigns_scores_to_graph_nodes() -> Result<()> {
+    StackManager::setup(&StackConfig::default())
+        .await
+        .map_err(|e| anyhow::anyhow!("could not initialise the stack: {e:?}"))?;
+
+    // Unique ids per run so parallel/repeat runs never collide with each other
+    // or with any existing user in the shared graph.
+    let tag = format!(
+        "{}-{}",
+        std::process::id(),
+        chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+    );
+    let seed = format!("trusttest-{tag}-seed");
+    let a = format!("trusttest-{tag}-a");
+    let b = format!("trusttest-{tag}-b");
+    let c = format!("trusttest-{tag}-c");
+
+    create_follow_graph(&seed, &a, &b, &c).await?;
+
+    let params = TrustRankParams {
+        seed_ids: vec![seed.clone()],
+        alpha: 0.35,
+        max_iterations: 200,
+        tolerance: 1e-7,
+        max_projection_bytes: None,
+    };
+
+    // Read every score written onto the nodes before tearing them down, so the
+    // assertions below run against a clean graph regardless of pass/panic. Both
+    // scalings run in one test: `gds.pageRank.write` writes `trust` on *every*
+    // projected user, so splitting them into two tests would let concurrent runs
+    // clobber each other's nodes (production serializes via the job lock).
+    // This test never asserts on the stale-projection sweep; a long age keeps it
+    // from touching any live projection so the value is otherwise irrelevant.
+    let sweep_age = Duration::from_secs(3600);
+    let read_result = async {
+        // L1Norm (production scaling): the shape a seeded ranking must have.
+        let stats = GdsNeo4j::new(true, sweep_age)
+            .compute(&params)
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let seed_score = trust_of(&seed).await?.context("seed has no trust score")?;
+        let a_score = trust_of(&a)
+            .await?
+            .context("followee `a` has no trust score")?;
+        let b_score = trust_of(&b)
+            .await?
+            .context("followee `b` has no trust score")?;
+        // An unreachable node scores exactly 0; GDS may write 0.0 or leave the
+        // property unset — both mean "no trust".
+        let c_score = trust_of(&c).await?.unwrap_or(0.0);
+        // Read-back path must surface all scores (limit > graph size).
+        let all_scores: HashMap<String, f64> = read_scores(1000).await?.into_iter().collect();
+
+        // Raw (L1Norm off): same run un-normalized, to observe the mass leak.
+        GdsNeo4j::new(false, sweep_age)
+            .compute(&params)
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let raw_seed = trust_of(&seed).await?.context("raw seed score")?;
+        let raw_a = trust_of(&a).await?.context("raw a score")?;
+        let raw_b = trust_of(&b).await?.context("raw b score")?;
+
+        anyhow::Ok((
+            stats, seed_score, a_score, b_score, c_score, all_scores, raw_seed, raw_a, raw_b,
+        ))
+    }
+    .await;
+
+    delete_users(&[&seed, &a, &b, &c]).await?;
+
+    let (stats, seed_score, a_score, b_score, c_score, all_scores, raw_seed, raw_a, raw_b) =
+        read_result?;
+
+    // Scores were actually written to the graph.
+    assert!(
+        stats.users_written > 0,
+        "recompute should report writing at least one user"
+    );
+
+    // Seed and everything reachable from it along FOLLOWS gets positive trust.
+    assert!(
+        seed_score > 0.0,
+        "seed should have positive trust, got {seed_score}"
+    );
+    assert!(
+        a_score > 0.0,
+        "directly-followed node `a` should inherit trust, got {a_score}"
+    );
+    assert!(
+        b_score > 0.0,
+        "transitively-followed node `b` should inherit trust, got {b_score}"
+    );
+
+    // A node unreachable from the seed set gets zero trust — the whole point of
+    // a *seeded* (Sybil-resistant) ranking versus plain global PageRank.
+    assert_eq!(
+        c_score, 0.0,
+        "isolated node `c` should have zero trust, got {c_score}"
+    );
+
+    // Trust decays as it flows along the follow chain: seed > a > b.
+    assert!(
+        seed_score > a_score,
+        "seed ({seed_score}) should outrank its followee `a` ({a_score})"
+    );
+    assert!(
+        a_score > b_score,
+        "`a` ({a_score}) should outrank the node it follows, `b` ({b_score})"
+    );
+
+    // The read-back helper returns the same scores it wrote.
+    assert_eq!(all_scores.get(&seed).copied(), Some(seed_score));
+    assert_eq!(all_scores.get(&a).copied(), Some(a_score));
+
+    // Scaler toggle. `b` is a dangling node (reachable, but follows nobody). GDS
+    // drops — never teleport-redistributes — its mass, so with a single seed the
+    // raw scores leak below 1; L1Norm rescales the same vector back to a
+    // distribution summing to 1, hiding the leak.
+    let raw_sum = raw_seed + raw_a + raw_b;
+    assert!(
+        raw_sum < 1.0 - 1e-6,
+        "raw scores should leak below 1 at the dangling node, summed to {raw_sum}"
+    );
+    let l1_sum = seed_score + a_score + b_score;
+    assert!(
+        (l1_sum - 1.0).abs() < 1e-6,
+        "l1norm scores should sum to 1, summed to {l1_sum}"
+    );
+
+    // The rescale is uniform: node ratios are unchanged, so L1Norm only hides the
+    // leak — it does not re-flow the leaked mass to other nodes.
+    let raw_ratio = raw_a / raw_seed;
+    let l1_ratio = a_score / seed_score;
+    assert!(
+        (raw_ratio - l1_ratio).abs() < 1e-6,
+        "a/seed ratio should survive scaling: raw {raw_ratio} vs l1norm {l1_ratio}"
+    );
+
+    Ok(())
+}
+
+/// `read_scores(limit)` bounds results to `limit` rows, highest-first.
+#[tokio_shared_rt::test(shared)]
+async fn test_read_scores_respects_limit() -> Result<()> {
+    StackManager::setup(&StackConfig::default())
+        .await
+        .map_err(|e| anyhow::anyhow!("could not initialise the stack: {e:?}"))?;
+
+    let prefix = format!(
+        "trusttest-cap-{}-{}-",
+        std::process::id(),
+        chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+    );
+
+    // More users than limit to force row trimming.
+    let limit = 5;
+    create_scored_users(&prefix, limit + 3).await?;
+
+    let read_result = read_scores(limit).await.map_err(|e| anyhow::anyhow!("{e}"));
+
+    delete_users_by_prefix(&prefix).await?;
+
+    let scores = read_result?;
+
+    // LIMIT trims to exactly `limit` rows.
+    assert_eq!(
+        scores.len(),
+        limit,
+        "read_scores must return exactly `limit` rows when more scored users exist"
+    );
+    // Rows remain highest-first.
+    assert!(
+        scores.windows(2).all(|w| w[0].1 >= w[1].1),
+        "capped scores must remain sorted highest-first, got {scores:?}"
+    );
+
+    Ok(())
+}

--- a/scripts/inject_sybil_community.py
+++ b/scripts/inject_sybil_community.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Generate a Cypher script that injects a synthetic Sybil community into the
+follow graph, for validating TrustRank's Sybil resistance (does a dense cluster
+of fake accounts gain outsized trust despite few/no genuine incoming follows?).
+
+Every injected node gets label `:Sybil` and property `sybil_cluster: <name>`
+(in addition to `:User`, so it participates in the GDS projection like a real
+account) — this makes cleanup a single query:
+
+    MATCH (s:Sybil {sybil_cluster: "<name>"}) DETACH DELETE s;
+
+Run the generated script with cypher-shell, e.g.:
+
+    python3 scripts/inject_sybil_community.py --count 50 --pattern clique \\
+        --infiltrate-from <real_user_id> > sybil_wave1.cypher
+    docker exec -i neo4j cypher-shell -u neo4j -p <password> < sybil_wave1.cypher
+
+Then re-run `nexusd jobs run trust-recompute` (with `[trust] report_enabled = true`
+to get a CSV in report_dir) and check whether the cluster's members show up with
+non-negligible trust scores.
+"""
+
+import argparse
+import random
+import sys
+
+# z-base32 alphabet used by real pubky ids (opaque here - no crypto validity needed,
+# trust-rank code reads ids as plain strings, not the validated PubkyId type).
+Z32_ALPHABET = "ybndrfg8ejkmcpqxot1uwisza345h769"
+ID_LENGTH = 52
+
+
+def fake_id(rng: random.Random) -> str:
+    return "".join(rng.choices(Z32_ALPHABET, k=ID_LENGTH))
+
+
+def build_edges(ids: list[str], pattern: str, density: float, rng: random.Random) -> list[tuple[str, str]]:
+    edges = []
+    n = len(ids)
+    if pattern == "clique":
+        edges = [(a, b) for a in ids for b in ids if a != b]
+    elif pattern == "ring":
+        edges = [(ids[i], ids[(i + 1) % n]) for i in range(n)]
+    elif pattern == "random":
+        edges = [(a, b) for a in ids for b in ids if a != b and rng.random() < density]
+    return edges
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--count", type=int, default=20, help="Number of Sybil accounts to create (default: 20)")
+    parser.add_argument("--cluster", default="wave1", help="Cluster name, tags nodes for later cleanup (default: wave1)")
+    parser.add_argument(
+        "--pattern",
+        choices=["clique", "ring", "random"],
+        default="clique",
+        help="Internal follow topology: clique = everyone follows everyone (classic naive attack), "
+        "ring = each follows the next, random = each pair connected with --density probability",
+    )
+    parser.add_argument("--density", type=float, default=0.3, help="Edge probability for --pattern random (default: 0.3)")
+    parser.add_argument(
+        "--infiltrate-from",
+        nargs="*",
+        default=[],
+        metavar="REAL_USER_ID",
+        help="Real user ids that will each follow every Sybil node (simulates the cluster tricking "
+        "genuine users into following it - this is the only path trust can actually reach the cluster through)",
+    )
+    parser.add_argument(
+        "--target-follows",
+        nargs="*",
+        default=[],
+        metavar="REAL_USER_ID",
+        help="Real user ids that every Sybil node will follow (simulates follower-count inflation "
+        "of a target account; doesn't help the Sybils' own trust score, but stress-tests any "
+        "follower-count-based metric alongside TrustRank)",
+    )
+    parser.add_argument("--seed", type=int, default=None, help="Random seed, for reproducible generation")
+    args = parser.parse_args()
+
+    rng = random.Random(args.seed)
+    ids = [fake_id(rng) for _ in range(args.count)]
+    internal_edges = build_edges(ids, args.pattern, args.density, rng)
+
+    print(f"// Sybil community injection: cluster={args.cluster!r} count={args.count} pattern={args.pattern}")
+    print(f"// Cleanup: MATCH (s:Sybil {{sybil_cluster: {args.cluster!r}}}) DETACH DELETE s;")
+    print()
+    print("// ── Sybil nodes ──")
+    for i, uid in enumerate(ids):
+        print(
+            f'MERGE (u:User:Sybil {{id: "{uid}"}}) '
+            f'SET u.name = "SYBIL_{args.cluster}_{i}", u.bio = "", u.status = "undefined", '
+            f'u.links = "[]", u.indexed_at = timestamp(), u.sybil_cluster = "{args.cluster}";'
+        )
+
+    print()
+    print(f"// ── Internal follows ({args.pattern}, {len(internal_edges)} edges) ──")
+    for a, b in internal_edges:
+        print(
+            f'MATCH (u1:User {{id: "{a}"}}), (u2:User {{id: "{b}"}}) '
+            f'MERGE (u1)-[:FOLLOWS {{indexed_at: timestamp()}}]->(u2);'
+        )
+
+    if args.infiltrate_from:
+        print()
+        print(f"// ── Infiltration follows: real users -> every Sybil ({len(args.infiltrate_from)} x {args.count}) ──")
+        for real_id in args.infiltrate_from:
+            for uid in ids:
+                print(
+                    f'MATCH (u1:User {{id: "{real_id}"}}), (u2:User {{id: "{uid}"}}) '
+                    f'MERGE (u1)-[:FOLLOWS {{indexed_at: timestamp()}}]->(u2);'
+                )
+
+    if args.target_follows:
+        print()
+        print(f"// ── Target inflation: every Sybil -> real target ({args.count} x {len(args.target_follows)}) ──")
+        for target_id in args.target_follows:
+            for uid in ids:
+                print(
+                    f'MATCH (u1:User {{id: "{uid}"}}), (u2:User {{id: "{target_id}"}}) '
+                    f'MERGE (u1)-[:FOLLOWS {{indexed_at: timestamp()}}]->(u2);'
+                )
+
+    total_edges = len(internal_edges) + len(args.infiltrate_from) * args.count + args.count * len(args.target_follows)
+    print(
+        f"// {args.count} Sybil nodes, {total_edges} follow edges generated. "
+        f"Cleanup: MATCH (s:Sybil {{sybil_cluster: {args.cluster!r}}}) DETACH DELETE s;",
+        file=sys.stderr,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- `Job` trait + `run_job` scheduler loop (overrun-skip, MAX_SLEEP chunking, shutdown-responsive) backed by a `JobSpec` registry.
- `job_cron` gate + `JobConfig` (`[jobs.<name>]`, cron-only).
- `nexusd jobs run <name>` / `jobs list` CLI; the default daemon also drives scheduled jobs alongside webapi + watcher.
- Unit tests for the scheduler and `job_cron` validation.
- TrustRank job from #984 