### PR TITLE
fix: prevent HS reindexing, only allow cursor to increment

### DIFF
--- a/nexus-common/src/db/kv/error.rs
+++ b/nexus-common/src/db/kv/error.rs
@@ -38,6 +38,18 @@ impl RedisError {
     }
 }
 
+/// Shared monotonicity rule for Primary HS global cursors and External HS user cursors:
+/// a cursor may hold or advance, but never rewind. Equal is allowed so an
+/// idempotent re-persist of a boundary event is not treated as an error.
+pub fn ensure_cursor_not_backwards(new_cursor: u64, stored_cursor: u64) -> RedisResult<()> {
+    if new_cursor < stored_cursor {
+        return Err(RedisError::InvalidInput(
+            "Cursor cannot move backwards".into(),
+        ));
+    }
+    Ok(())
+}
+
 impl From<redis::RedisError> for RedisError {
     fn from(e: redis::RedisError) -> Self {
         if e.is_connection_refusal() || e.is_timeout() || e.is_io_error() {

--- a/nexus-common/src/db/kv/index/sorted_sets.rs
+++ b/nexus-common/src/db/kv/index/sorted_sets.rs
@@ -111,7 +111,12 @@ pub async fn put(
 ///
 /// `ZADD NX` makes the check and the write one atomic operation, so an existing
 /// member keeps its score whatever concurrent writers are doing.
-pub async fn put_if_absent(prefix: &str, key: &str, score: f64, member: &str) -> RedisResult<()> {
+pub async fn add_member_if_absent(
+    prefix: &str,
+    key: &str,
+    score: f64,
+    member: &str,
+) -> RedisResult<()> {
     let index_key = format!("{prefix}:{key}");
     let mut redis_conn = get_redis_conn().await?;
     let _: () = redis::cmd("ZADD")

--- a/nexus-common/src/db/kv/index/sorted_sets.rs
+++ b/nexus-common/src/db/kv/index/sorted_sets.rs
@@ -107,6 +107,23 @@ pub async fn put(
     Ok(())
 }
 
+/// Seeds `member` with `score` only if it is not already in the sorted set.
+///
+/// `ZADD NX` makes the check and the write one atomic operation, so an existing
+/// member keeps its score whatever concurrent writers are doing.
+pub async fn put_if_absent(prefix: &str, key: &str, score: f64, member: &str) -> RedisResult<()> {
+    let index_key = format!("{prefix}:{key}");
+    let mut redis_conn = get_redis_conn().await?;
+    let _: () = redis::cmd("ZADD")
+        .arg(index_key)
+        .arg("NX")
+        .arg(score)
+        .arg(member)
+        .query_async(&mut redis_conn)
+        .await?;
+    Ok(())
+}
+
 /// Updates the score of a member in a Redis sorted set.
 ///
 /// This function modifies the score of a member in the specified Redis sorted set by incrementing or decrementing it

--- a/nexus-common/src/db/kv/mod.rs
+++ b/nexus-common/src/db/kv/mod.rs
@@ -4,7 +4,7 @@ mod index;
 mod last_save;
 mod traits;
 
-pub use error::{RedisError, RedisResult};
+pub use error::{ensure_cursor_not_backwards, RedisError, RedisResult};
 pub use flush::clear_redis;
 pub use index::json::JsonAction;
 pub(crate) use index::search;

--- a/nexus-common/src/db/kv/traits.rs
+++ b/nexus-common/src/db/kv/traits.rs
@@ -602,7 +602,7 @@ pub trait RedisOps: Serialize + DeserializeOwned + Send + Sync {
     /// Atomic (`ZADD NX`), unlike a `check_sorted_set_member` read followed by
     /// [`Self::put_index_sorted_set`], which would clobber a member written
     /// between the two calls.
-    async fn put_index_sorted_set_if_absent(
+    async fn add_index_sorted_set_if_absent(
         key_parts: &[&str],
         score: f64,
         member: &str,
@@ -610,7 +610,7 @@ pub trait RedisOps: Serialize + DeserializeOwned + Send + Sync {
     ) -> RedisResult<()> {
         let prefix = prefix.unwrap_or(SORTED_PREFIX);
         let key = key_parts.join(":");
-        sorted_sets::put_if_absent(prefix, &key, score, member).await
+        sorted_sets::add_member_if_absent(prefix, &key, score, member).await
     }
 
     /// Updates the score of a member in a Redis sorted set.

--- a/nexus-common/src/db/kv/traits.rs
+++ b/nexus-common/src/db/kv/traits.rs
@@ -597,6 +597,22 @@ pub trait RedisOps: Serialize + DeserializeOwned + Send + Sync {
         sorted_sets::put(prefix, &key, elements, expiration).await
     }
 
+    /// Seeds a member of a Redis sorted set, leaving an already-present one untouched.
+    ///
+    /// Atomic (`ZADD NX`), unlike a `check_sorted_set_member` read followed by
+    /// [`Self::put_index_sorted_set`], which would clobber a member written
+    /// between the two calls.
+    async fn put_index_sorted_set_if_absent(
+        key_parts: &[&str],
+        score: f64,
+        member: &str,
+        prefix: Option<&str>,
+    ) -> RedisResult<()> {
+        let prefix = prefix.unwrap_or(SORTED_PREFIX);
+        let key = key_parts.join(":");
+        sorted_sets::put_if_absent(prefix, &key, score, member).await
+    }
+
     /// Updates the score of a member in a Redis sorted set.
     ///
     /// This method updates the score associated with a specific member in a Redis sorted set

--- a/nexus-common/src/models/homeserver.rs
+++ b/nexus-common/src/models/homeserver.rs
@@ -1,6 +1,6 @@
 use crate::db::exec_single_row;
 use crate::db::fetch_key_from_graph;
-use crate::db::kv::RedisError;
+use crate::db::kv::ensure_cursor_not_backwards;
 use crate::db::kv::RedisResult;
 use crate::db::queries;
 use crate::db::GraphResult;
@@ -115,11 +115,7 @@ impl Homeserver {
 
     async fn validate_cursor_change(id: &PubkyId, new_cursor: u64) -> RedisResult<()> {
         if let Some(existing) = Self::get_from_index(id).await? {
-            if new_cursor < existing.cursor {
-                return Err(RedisError::InvalidInput(
-                    "Cursor cannot move backwards".into(),
-                ));
-            }
+            ensure_cursor_not_backwards(new_cursor, existing.cursor)?;
         }
 
         Ok(())
@@ -197,6 +193,7 @@ mod tests {
     use pubky::Keypair;
     use pubky_app_specs::PubkyId;
 
+    use crate::db::kv::RedisError;
     use crate::{types::DynError, StackConfig, StackManager};
 
     use super::*;

--- a/nexus-common/src/models/homeserver.rs
+++ b/nexus-common/src/models/homeserver.rs
@@ -114,6 +114,7 @@ impl Homeserver {
     }
 
     async fn validate_cursor_change(id: &PubkyId, new_cursor: u64) -> RedisResult<()> {
+        // Read-then-write is non-atomic but race-free: a given HS is only ever written by one processor run at a time.
         if let Some(existing) = Self::get_from_index(id).await? {
             ensure_cursor_not_backwards(new_cursor, existing.cursor)?;
         }

--- a/nexus-common/src/models/homeserver.rs
+++ b/nexus-common/src/models/homeserver.rs
@@ -8,7 +8,7 @@ use crate::db::RedisOps;
 use crate::models::error::ModelError;
 use crate::models::error::ModelResult;
 use pubky_app_specs::PubkyId;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use tracing::{info, warn};
 
 /// A set of homeserver public keys forbidden from indexing and ingestion.
@@ -41,7 +41,25 @@ pub struct Homeserver {
     // loss; `persist_if_unknown` only re-seeds cursor=0 when the
     // Homeserver key is missing from Redis entirely (e.g. wiped volume),
     // never on a routine crash.
-    pub cursor: String,
+    #[serde(deserialize_with = "deserialize_cursor")]
+    pub cursor: u64,
+}
+
+fn deserialize_cursor<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Cursor {
+        Number(u64),
+        String(String),
+    }
+
+    match Cursor::deserialize(deserializer)? {
+        Cursor::Number(cursor) => Ok(cursor),
+        Cursor::String(cursor) => cursor.parse().map_err(serde::de::Error::custom),
+    }
 }
 
 impl RedisOps for Homeserver {}
@@ -49,20 +67,19 @@ impl RedisOps for Homeserver {}
 impl Homeserver {
     /// Instantiates a new homeserver with default cursor
     pub fn new(id: PubkyId) -> Self {
-        Homeserver {
-            id,
-            cursor: "0000000000000".to_string(),
-        }
+        Homeserver { id, cursor: 0 }
     }
 
     /// Creates a new homeserver instance with the specified cursor
-    pub fn try_from_cursor<T: Into<String>>(id: PubkyId, cursor: T) -> ModelResult<Self> {
+    pub async fn try_from_cursor<T: Into<String>>(id: PubkyId, cursor: T) -> ModelResult<Self> {
         let cursor = cursor.into();
-        if cursor.is_empty() {
-            return Err(ModelError::from_generic(
-                "Cannot create a homeserver from an empty cursor",
-            ));
-        }
+        let cursor = cursor.parse().map_err(|_| {
+            ModelError::from_generic(format!(
+                "Cannot create a homeserver from a non-numeric cursor: {cursor}"
+            ))
+        })?;
+
+        Self::validate_cursor_change(&id, cursor).await?;
 
         Ok(Homeserver { id, cursor })
     }
@@ -92,12 +109,20 @@ impl Homeserver {
 
     /// Stores this homeserver in Redis.
     pub async fn put_to_index(&self) -> RedisResult<()> {
-        if self.cursor.is_empty() {
-            return Err(RedisError::InvalidInput(
-                "Cannot save to index a homeserver with an empty cursor".into(),
-            ));
-        }
+        Self::validate_cursor_change(&self.id, self.cursor).await?;
         self.put_index_json(&[&self.id], None, None).await
+    }
+
+    async fn validate_cursor_change(id: &PubkyId, new_cursor: u64) -> RedisResult<()> {
+        if let Some(existing) = Self::get_from_index(id).await? {
+            if new_cursor < existing.cursor {
+                return Err(RedisError::InvalidInput(
+                    "Cursor cannot move backwards".into(),
+                ));
+            }
+        }
+
+        Ok(())
     }
 
     pub async fn get_by_id(homeserver_id: PubkyId) -> ModelResult<Option<Homeserver>> {
@@ -176,6 +201,28 @@ mod tests {
 
     use super::*;
 
+    #[test]
+    fn test_deserialize_cursor_from_string() {
+        let id = PubkyId::from(Keypair::random().public_key());
+        for (cursor, expected) in [("\"0000000000000\"", 0), ("\"42\"", 42)] {
+            let json = format!(r#"{{"id":"{id}","cursor":{cursor}}}"#);
+            let homeserver: Homeserver = serde_json::from_str(&json).unwrap();
+
+            assert_eq!(homeserver.cursor, expected);
+        }
+    }
+
+    #[test]
+    fn test_deserialize_cursor_from_number() {
+        let id = PubkyId::from(Keypair::random().public_key());
+        for (cursor, expected) in [("0", 0), ("1234567890123", 1_234_567_890_123)] {
+            let json = format!(r#"{{"id":"{id}","cursor":{cursor}}}"#);
+            let homeserver: Homeserver = serde_json::from_str(&json).unwrap();
+
+            assert_eq!(homeserver.cursor, expected);
+        }
+    }
+
     #[tokio_shared_rt::test(shared)]
     async fn test_put_to_get_from_graph() -> Result<(), DynError> {
         StackManager::setup(&StackConfig::default()).await?;
@@ -223,6 +270,101 @@ mod tests {
     }
 
     #[tokio_shared_rt::test(shared)]
+    async fn test_cursor_forwards_accepted() -> Result<(), DynError> {
+        StackManager::setup(&StackConfig::default()).await?;
+
+        let id = PubkyId::from(Keypair::random().public_key());
+        Homeserver::try_from_cursor(id.clone(), "100")
+            .await?
+            .put_to_index()
+            .await?;
+        Homeserver::try_from_cursor(id.clone(), "200")
+            .await?
+            .put_to_index()
+            .await?;
+
+        let homeserver = Homeserver::get_from_index(&id)
+            .await?
+            .expect("homeserver should be in the index");
+        assert_eq!(homeserver.cursor, 200);
+
+        Ok(())
+    }
+
+    #[tokio_shared_rt::test(shared)]
+    async fn test_cursor_backwards_rejected_by_put_to_index() -> Result<(), DynError> {
+        StackManager::setup(&StackConfig::default()).await?;
+
+        let id = PubkyId::from(Keypair::random().public_key());
+        Homeserver::try_from_cursor(id.clone(), "500")
+            .await?
+            .put_to_index()
+            .await?;
+
+        let err = Homeserver {
+            id: id.clone(),
+            cursor: 100,
+        }
+        .put_to_index()
+        .await
+        .expect_err("backward cursor must be rejected");
+        assert!(matches!(err, RedisError::InvalidInput(_)));
+
+        let homeserver = Homeserver::get_from_index(&id)
+            .await?
+            .expect("homeserver should remain in the index");
+        assert_eq!(homeserver.cursor, 500);
+
+        Ok(())
+    }
+
+    #[tokio_shared_rt::test(shared)]
+    async fn test_cursor_backwards_rejected_by_try_from_cursor() -> Result<(), DynError> {
+        StackManager::setup(&StackConfig::default()).await?;
+
+        let id = PubkyId::from(Keypair::random().public_key());
+        Homeserver::try_from_cursor(id.clone(), "300")
+            .await?
+            .put_to_index()
+            .await?;
+
+        let err = Homeserver::try_from_cursor(id.clone(), "50")
+            .await
+            .expect_err("backward cursor must be rejected");
+        assert!(matches!(
+            err,
+            ModelError::KvOperationFailed(RedisError::InvalidInput(_))
+        ));
+
+        let homeserver = Homeserver::try_from_cursor(id, "400").await?;
+        assert_eq!(homeserver.cursor, 400);
+
+        Ok(())
+    }
+
+    #[tokio_shared_rt::test(shared)]
+    async fn test_cursor_equal_value_accepted() -> Result<(), DynError> {
+        StackManager::setup(&StackConfig::default()).await?;
+
+        let id = PubkyId::from(Keypair::random().public_key());
+        Homeserver::try_from_cursor(id.clone(), "200")
+            .await?
+            .put_to_index()
+            .await?;
+        Homeserver::try_from_cursor(id.clone(), "200")
+            .await?
+            .put_to_index()
+            .await?;
+
+        let homeserver = Homeserver::get_from_index(&id)
+            .await?
+            .expect("homeserver should be in the index");
+        assert_eq!(homeserver.cursor, 200);
+
+        Ok(())
+    }
+
+    #[tokio_shared_rt::test(shared)]
     async fn test_persist_if_unknown_first_time_install_writes_both() -> Result<(), DynError> {
         StackManager::setup(&StackConfig::default()).await?;
 
@@ -261,7 +403,7 @@ mod tests {
             .await?
             .expect("index should be re-seeded after persist_if_unknown");
         assert_eq!(from_index.id, id);
-        assert_eq!(from_index.cursor, "0000000000000");
+        assert_eq!(from_index.cursor, 0);
         Ok(())
     }
 
@@ -275,7 +417,8 @@ mod tests {
         // Seed both stores with a non-default cursor to prove the no-op
         // branch doesn't overwrite an existing index entry.
         Homeserver::new(id.clone()).put_to_graph().await?;
-        Homeserver::try_from_cursor(id.clone(), "1234567890123")?
+        Homeserver::try_from_cursor(id.clone(), "1234567890123")
+            .await?
             .put_to_index()
             .await?;
 
@@ -285,7 +428,7 @@ mod tests {
             .await?
             .expect("index entry should still be present");
         assert_eq!(
-            from_index.cursor, "1234567890123",
+            from_index.cursor, 1_234_567_890_123,
             "existing cursor must not be overwritten"
         );
         Ok(())

--- a/nexus-common/src/models/homeserver.rs
+++ b/nexus-common/src/models/homeserver.rs
@@ -70,7 +70,10 @@ impl Homeserver {
         Homeserver { id, cursor: 0 }
     }
 
-    /// Creates a new homeserver instance with the specified cursor
+    /// Creates a new homeserver instance with the specified cursor.
+    ///
+    /// Includes a validation call to [Self::validate_cursor_change],
+    /// so that callers can detect invalid cursors early.
     pub async fn try_from_cursor<T: Into<String>>(id: PubkyId, cursor: T) -> ModelResult<Self> {
         let cursor = cursor.into();
         let cursor = cursor.parse().map_err(|_| {

--- a/nexus-common/src/models/user/cursor.rs
+++ b/nexus-common/src/models/user/cursor.rs
@@ -58,8 +58,14 @@ impl UserHsCursor {
             .collect()
     }
 
-    /// Persists a single user's event cursor for `hs_id` to its `USER_HS_CURSOR` sorted set.
+    /// Persists a single user's event cursor for `hs_id` without moving it backward.
     pub async fn write(user_id: &str, hs_id: &str, cursor: u64) -> RedisResult<()> {
+        let stored_cursor = Self::read(&[user_id], hs_id)
+            .await?
+            .into_iter()
+            .next()
+            .unwrap_or_default();
+        let cursor = cursor.max(stored_cursor);
         let key = user_hs_cursor_key(user_id);
         Self::put_index_sorted_set(&key, &[(cursor as f64, hs_id)], None, None).await
     }
@@ -72,7 +78,7 @@ mod tests {
     use crate::{types::DynError, utils::test_utils::random_pubky_id, StackConfig, StackManager};
 
     /// `write` persists a per-user cursor that `read` reads back, missing entries
-    /// default to 0, and re-writing overwrites the value.
+    /// default to 0, and lower re-writes do not rewind the value.
     #[tokio_shared_rt::test(shared)]
     async fn test_hs_cursor_read_write_roundtrip() -> Result<(), DynError> {
         StackManager::setup(&StackConfig::default()).await?;
@@ -95,8 +101,13 @@ mod tests {
         .await?;
         assert_eq!(cursors, vec![42, 0]);
 
-        // Writing again overwrites the previous value.
+        // Writing a higher cursor advances the value.
         UserHsCursor::write(&user_with_cursor, &hs_id, 100).await?;
+        let cursors = UserHsCursor::read(&[user_with_cursor.as_str()], &hs_id).await?;
+        assert_eq!(cursors, vec![100]);
+
+        // Writing a lower cursor leaves the existing value intact.
+        UserHsCursor::write(&user_with_cursor, &hs_id, 50).await?;
         let cursors = UserHsCursor::read(&[user_with_cursor.as_str()], &hs_id).await?;
         assert_eq!(cursors, vec![100]);
 

--- a/nexus-common/src/models/user/cursor.rs
+++ b/nexus-common/src/models/user/cursor.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::db::kv::{RedisError, RedisResult};
+use crate::db::kv::{ensure_cursor_not_backwards, RedisError, RedisResult};
 use crate::db::RedisOps;
 
 const USER_HS_CURSOR: [&str; 2] = ["Users", "Homeservers"];
@@ -58,16 +58,39 @@ impl UserHsCursor {
             .collect()
     }
 
-    /// Persists a single user's event cursor for `hs_id` without moving it backward.
+    /// Advances a user's event cursor for `hs_id`, rejecting a value that would
+    /// move it backward. Mirrors `Homeserver::put_to_index` so both cursor types
+    /// share one monotonicity rule.
+    ///
+    /// Read-then-write is not atomic but is race-free in practice: a given
+    /// `(user_id, hs_id)` pair is only ever written by one processor run at a
+    /// time (users are processed sequentially within a poll cycle, and cycles
+    /// for the same homeserver do not overlap).
     pub async fn write(user_id: &str, hs_id: &str, cursor: u64) -> RedisResult<()> {
         let stored_cursor = Self::read(&[user_id], hs_id)
             .await?
             .into_iter()
             .next()
             .unwrap_or_default();
-        let cursor = cursor.max(stored_cursor);
+        ensure_cursor_not_backwards(cursor, stored_cursor)?;
         let key = user_hs_cursor_key(user_id);
         Self::put_index_sorted_set(&key, &[(cursor as f64, hs_id)], None, None).await
+    }
+
+    /// Seeds the user's cursor to `0` the first time we track them on `hs_id`,
+    /// and no-ops if one already exists (e.g. re-ingestion after it advanced),
+    /// establishing the floor without ever rewinding it.
+    pub async fn init(user_id: &str, hs_id: &str) -> RedisResult<()> {
+        let key = user_hs_cursor_key(user_id);
+        // Check the raw score, not `read` (which maps a missing entry to 0 and
+        // so can't tell "absent" from "present == 0").
+        if Self::check_sorted_set_member(None, &key, &[hs_id])
+            .await?
+            .is_some()
+        {
+            return Ok(());
+        }
+        Self::put_index_sorted_set(&key, &[(0.0, hs_id)], None, None).await
     }
 }
 
@@ -78,7 +101,7 @@ mod tests {
     use crate::{types::DynError, utils::test_utils::random_pubky_id, StackConfig, StackManager};
 
     /// `write` persists a per-user cursor that `read` reads back, missing entries
-    /// default to 0, and lower re-writes do not rewind the value.
+    /// default to 0, and a lower re-write is rejected rather than rewinding.
     #[tokio_shared_rt::test(shared)]
     async fn test_hs_cursor_read_write_roundtrip() -> Result<(), DynError> {
         StackManager::setup(&StackConfig::default()).await?;
@@ -106,9 +129,34 @@ mod tests {
         let cursors = UserHsCursor::read(&[user_with_cursor.as_str()], &hs_id).await?;
         assert_eq!(cursors, vec![100]);
 
-        // Writing a lower cursor leaves the existing value intact.
-        UserHsCursor::write(&user_with_cursor, &hs_id, 50).await?;
+        // Writing a lower cursor is rejected and leaves the existing value intact.
+        let err = UserHsCursor::write(&user_with_cursor, &hs_id, 50)
+            .await
+            .expect_err("backward cursor must be rejected");
+        assert!(matches!(err, RedisError::InvalidInput(_)));
         let cursors = UserHsCursor::read(&[user_with_cursor.as_str()], &hs_id).await?;
+        assert_eq!(cursors, vec![100]);
+
+        Ok(())
+    }
+
+    /// `init` seeds a fresh user's cursor to 0 and never rewinds an existing one.
+    #[tokio_shared_rt::test(shared)]
+    async fn test_hs_cursor_init_seeds_without_rewinding() -> Result<(), DynError> {
+        StackManager::setup(&StackConfig::default()).await?;
+
+        let user_id = random_pubky_id().to_string();
+        let hs_id = random_pubky_id().to_string();
+
+        // First init seeds the starting cursor at 0.
+        UserHsCursor::init(&user_id, &hs_id).await?;
+        let cursors = UserHsCursor::read(&[user_id.as_str()], &hs_id).await?;
+        assert_eq!(cursors, vec![0]);
+
+        // Advance the cursor, then init again (e.g. re-ingestion): it must not rewind.
+        UserHsCursor::write(&user_id, &hs_id, 100).await?;
+        UserHsCursor::init(&user_id, &hs_id).await?;
+        let cursors = UserHsCursor::read(&[user_id.as_str()], &hs_id).await?;
         assert_eq!(cursors, vec![100]);
 
         Ok(())

--- a/nexus-common/src/models/user/cursor.rs
+++ b/nexus-common/src/models/user/cursor.rs
@@ -80,6 +80,9 @@ impl UserHsCursor {
     /// Seeds the user's cursor to `0` the first time we track them on `hs_id`,
     /// and no-ops if one already exists (e.g. re-ingestion after it advanced),
     /// establishing the floor without ever rewinding it.
+    ///
+    /// The check-then-set is non-atomic and safe under the same single-writer invariant,
+    /// as [`Self::write`].
     pub async fn init(user_id: &str, hs_id: &str) -> RedisResult<()> {
         let key = user_hs_cursor_key(user_id);
         // Check the raw score, not `read` (which maps a missing entry to 0 and

--- a/nexus-common/src/models/user/cursor.rs
+++ b/nexus-common/src/models/user/cursor.rs
@@ -62,10 +62,11 @@ impl UserHsCursor {
     /// move it backward. Mirrors `Homeserver::put_to_index` so both cursor types
     /// share one monotonicity rule.
     ///
-    /// Read-then-write is not atomic but is race-free in practice: a given
-    /// `(user_id, hs_id)` pair is only ever written by one processor run at a
-    /// time (users are processed sequentially within a poll cycle, and cycles
-    /// for the same homeserver do not overlap).
+    /// Read-then-write is not atomic but is race-free in practice: the external-HS
+    /// event processor is its only caller, and it writes a given `(user_id, hs_id)`
+    /// pair from one run at a time (users are processed sequentially within a poll
+    /// cycle, and cycles for the same homeserver do not overlap). Per-process only:
+    /// the invariant would not survive running the watcher as several replicas.
     pub async fn write(user_id: &str, hs_id: &str, cursor: u64) -> RedisResult<()> {
         let stored_cursor = Self::read(&[user_id], hs_id)
             .await?
@@ -81,19 +82,15 @@ impl UserHsCursor {
     /// and no-ops if one already exists (e.g. re-ingestion after it advanced),
     /// establishing the floor without ever rewinding it.
     ///
-    /// The check-then-set is non-atomic and safe under the same single-writer invariant,
-    /// as [`Self::write`].
+    /// Seeded atomically (`ZADD NX`) rather than under [`Self::write`]'s
+    /// single-writer invariant, which does not reach here: the caller is the user
+    /// ingestor, running on the primary-HS and retry-processor tasks, and it
+    /// publishes the user's `HOSTED_BY` edge before seeding — so the concurrent
+    /// external-HS task can fetch, index and `write` a real cursor in between. A
+    /// read-then-write would clobber that with 0 and re-index the user's history.
     pub async fn init(user_id: &str, hs_id: &str) -> RedisResult<()> {
         let key = user_hs_cursor_key(user_id);
-        // Check the raw score, not `read` (which maps a missing entry to 0 and
-        // so can't tell "absent" from "present == 0").
-        if Self::check_sorted_set_member(None, &key, &[hs_id])
-            .await?
-            .is_some()
-        {
-            return Ok(());
-        }
-        Self::put_index_sorted_set(&key, &[(0.0, hs_id)], None, None).await
+        Self::put_index_sorted_set_if_absent(&key, 0.0, hs_id, None).await
     }
 }
 

--- a/nexus-common/src/models/user/cursor.rs
+++ b/nexus-common/src/models/user/cursor.rs
@@ -90,7 +90,7 @@ impl UserHsCursor {
     /// read-then-write would clobber that with 0 and re-index the user's history.
     pub async fn init(user_id: &str, hs_id: &str) -> RedisResult<()> {
         let key = user_hs_cursor_key(user_id);
-        Self::put_index_sorted_set_if_absent(&key, 0.0, hs_id, None).await
+        Self::add_index_sorted_set_if_absent(&key, 0.0, hs_id, None).await
     }
 }
 

--- a/nexus-common/src/models/user/ingestor.rs
+++ b/nexus-common/src/models/user/ingestor.rs
@@ -101,8 +101,8 @@ impl UserIngestor {
         // Bind the user to their HS (HOSTED_BY + resolved_at), since we just resolved the HS
         set_user_homeserver(&user_id_str, &hs_id).await?;
 
-        // Store the start point of the user's HS cursor
-        UserHsCursor::write(user_id, &hs_id, 0).await?;
+        // Seed the user's HS cursor floor (no-op if we're already tracking them).
+        UserHsCursor::init(user_id, &hs_id).await?;
 
         Ok(())
     }

--- a/nexus-watcher/src/errors.rs
+++ b/nexus-watcher/src/errors.rs
@@ -35,6 +35,15 @@ pub enum EventProcessorError {
         event_user_id: String,
     },
 
+    /// A homeserver returned a per-user event cursor lower than an earlier event.
+    #[error("HS returned an out-of-order event cursor: hs_id={hs_id}, user_id={user_id}, cursor={cursor}, max_cursor={max_cursor}")]
+    EventCursorOutOfOrder {
+        hs_id: String,
+        user_id: String,
+        cursor: u64,
+        max_cursor: u64,
+    },
+
     /// The event payload deserialized but failed `pubky-app-specs` validation
     /// (e.g. unknown post kind, malformed Collection envelope, oversized field).
     /// Non-retryable: re-running the same payload will produce the same error.

--- a/nexus-watcher/src/errors.rs
+++ b/nexus-watcher/src/errors.rs
@@ -35,13 +35,14 @@ pub enum EventProcessorError {
         event_user_id: String,
     },
 
-    /// A homeserver returned a per-user event cursor lower than an earlier event.
-    #[error("HS returned an out-of-order event cursor: hs_id={hs_id}, user_id={user_id}, cursor={cursor}, max_cursor={max_cursor}")]
+    /// An external HS returned a per-user event cursor at or below the cursor
+    /// floor: the user's stored cursor, or an earlier event in the same batch.
+    #[error("HS returned an out-of-order event cursor: hs_id={hs_id}, user_id={user_id}, cursor={cursor}, cursor_floor={cursor_floor}")]
     EventCursorOutOfOrder {
         hs_id: String,
         user_id: String,
         cursor: u64,
-        max_cursor: u64,
+        cursor_floor: u64,
     },
 
     /// The event payload deserialized but failed `pubky-app-specs` validation

--- a/nexus-watcher/src/errors.rs
+++ b/nexus-watcher/src/errors.rs
@@ -170,10 +170,20 @@ impl EventProcessorError {
         Self::HsEventsStreamTransportFailed(source.to_string())
     }
 
-    /// Returns whether or not we should refrain from retrying this error right now.
+    /// Returns whether processing should stop and this error should be propagated
+    /// to the caller instead of being handled as an isolated event.
     ///
-    /// These are the kinds of errors that are expected to be thrown again
-    /// if the event processor caller continues processing other events.
+    /// This method does not schedule a retry or backoff itself. Callers decide the
+    /// consequence:
+    ///
+    /// - Event-processing loops abort the current batch or HS run.
+    /// - In the external key-based runner, a propagated error produces a non-`Ok`
+    ///   run status and therefore triggers per-HS backoff.
+    /// - The retry processor reschedules the event without consuming its retry
+    ///   allowance, then stops its current batch.
+    ///
+    /// `false` does not necessarily mean the error will be retried; the caller may
+    /// skip it, enqueue it, or continue processing.
     pub fn should_not_retry_now(&self) -> bool {
         matches!(
             self,
@@ -181,6 +191,11 @@ impl EventProcessorError {
                 | Self::IndexOperationFailed(true, _)
                 | Self::HsEventsStreamRateLimitExhausted
                 | Self::HsEventsStreamTransportFailed(_)
+
+                // For a key-based runner, this indicates the external HS either
+                // has a temporary glitch or is malicious. Including it here to
+                // abort this run and let the runner apply per-HS backoff.
+                | Self::EventCursorOutOfOrder { .. }
         )
     }
 

--- a/nexus-watcher/src/events/retry/scheduler.rs
+++ b/nexus-watcher/src/events/retry/scheduler.rs
@@ -70,7 +70,8 @@ impl RetryScheduler {
             | EventProcessorError::HsBlacklisted { .. }
             | EventProcessorError::HsEventsStreamRateLimitExhausted
             | EventProcessorError::FetchSizeExceeded(_, _)
-            | EventProcessorError::UserIdMismatch { .. } => false,
+            | EventProcessorError::UserIdMismatch { .. }
+            | EventProcessorError::EventCursorOutOfOrder { .. } => false,
 
             _ => true,
         }

--- a/nexus-watcher/src/service/indexer/homeserver.rs
+++ b/nexus-watcher/src/service/indexer/homeserver.rs
@@ -235,7 +235,7 @@ impl HsEventProcessor {
 
             if let Some(cursor) = line.strip_prefix("cursor: ") {
                 info!("Received cursor for the next request: {cursor}");
-                match Homeserver::try_from_cursor(self.homeserver.id.clone(), cursor) {
+                match Homeserver::try_from_cursor(self.homeserver.id.clone(), cursor).await {
                     Ok(hs) => hs.put_to_index().await?,
                     Err(e) => warn!("{e}"),
                 }

--- a/nexus-watcher/src/service/indexer/homeserver.rs
+++ b/nexus-watcher/src/service/indexer/homeserver.rs
@@ -25,6 +25,19 @@ static REJECTED: LazyLock<Counter<u64>> = LazyLock::new(|| {
         .build()
 });
 
+/// Counter for cursor lines the homeserver sent that could not be applied.
+///
+/// A non-empty count means the HS returned a cursor we cannot parse or that
+/// would move the stored cursor backward, so the cursor is not advanced and the
+/// same batch is re-fetched on the next poll. A sustained non-zero rate for one
+/// HS indicates it is stuck replaying a batch and needs operator attention.
+static INVALID_CURSOR: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    global::meter(METER_NAME)
+        .u64_counter("watcher.cursor.invalid")
+        .with_description("Cursor lines from a homeserver that could not be applied")
+        .build()
+});
+
 /// A user's `HOSTED_BY` mapping, classified relative to a processor's HS.
 ///
 /// The `stale` flag is only carried where it is meaningful: a stale mapping means
@@ -237,7 +250,12 @@ impl HsEventProcessor {
                 info!("Received cursor for the next request: {cursor}");
                 match Homeserver::try_from_cursor(self.homeserver.id.clone(), cursor).await {
                     Ok(hs) => hs.put_to_index().await?,
-                    Err(e) => warn!("{e}"),
+                    Err(e) => {
+                        // Cursor could not be parsed or would rewind
+                        INVALID_CURSOR
+                            .add(1, &[KeyValue::new("hs_id", self.homeserver.id.to_string())]);
+                        warn!(hs_id = %self.homeserver.id, "Ignoring invalid cursor '{cursor}': {e}");
+                    }
                 }
                 continue;
             }

--- a/nexus-watcher/src/service/indexer/homeserver.rs
+++ b/nexus-watcher/src/service/indexer/homeserver.rs
@@ -14,27 +14,24 @@ use tokio::sync::watch::Receiver;
 use tokio::sync::Mutex;
 use tracing::{debug, error, info, warn};
 
-/// OpenTelemetry meter name for all watcher metrics.
-const METER_NAME: &str = "nexus.watcher";
-
 /// Counter for events permanently rejected for exceeding a fetch size limit.
 static REJECTED: LazyLock<Counter<u64>> = LazyLock::new(|| {
-    global::meter(METER_NAME)
+    global::meter(super::METER_NAME)
         .u64_counter("watcher.fetch.rejected")
         .with_description("Event fetches rejected for exceeding a size limit")
         .build()
 });
 
-/// Counter for cursor lines the homeserver sent that could not be applied.
+/// Counter for cursor lines the Primary HS sent that could not be applied.
 ///
 /// A non-empty count means the HS returned a cursor we cannot parse or that
 /// would move the stored cursor backward, so the cursor is not advanced and the
 /// same batch is re-fetched on the next poll. A sustained non-zero rate for one
 /// HS indicates it is stuck replaying a batch and needs operator attention.
-static INVALID_CURSOR: LazyLock<Counter<u64>> = LazyLock::new(|| {
-    global::meter(METER_NAME)
-        .u64_counter("watcher.cursor.invalid")
-        .with_description("Cursor lines from a homeserver that could not be applied")
+static INVALID_CURSOR_PRIMARY_HS: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    global::meter(super::METER_NAME)
+        .u64_counter("watcher.primary_hs.cursor.invalid")
+        .with_description("Cursor lines from the Primary HS that could not be applied")
         .build()
 });
 
@@ -252,7 +249,7 @@ impl HsEventProcessor {
                     Ok(hs) => hs.put_to_index().await?,
                     Err(e) => {
                         // Cursor could not be parsed or would rewind
-                        INVALID_CURSOR
+                        INVALID_CURSOR_PRIMARY_HS
                             .add(1, &[KeyValue::new("hs_id", self.homeserver.id.to_string())]);
                         warn!(hs_id = %self.homeserver.id, "Ignoring invalid cursor '{cursor}': {e}");
                     }

--- a/nexus-watcher/src/service/indexer/homeserver.rs
+++ b/nexus-watcher/src/service/indexer/homeserver.rs
@@ -26,10 +26,10 @@ static REJECTED: LazyLock<Counter<u64>> = LazyLock::new(|| {
 
 /// Counter for cursor lines the Primary HS sent that could not be applied.
 ///
-/// A non-empty count means the HS returned a cursor we cannot parse or that
-/// would move the stored cursor backward, so the cursor is not advanced and the
-/// same batch is re-fetched on the next poll. A sustained non-zero rate for one
-/// HS indicates it is stuck replaying a batch and needs operator attention.
+/// A non-empty count means the HS returned a cursor we cannot parse, that would
+/// move the stored cursor backward, or that advances without delivering events.
+/// The cursor is not advanced and the same position is fetched on the next poll.
+/// A sustained non-zero rate for one HS indicates it needs operator attention.
 static INVALID_CURSOR_PRIMARY_HS: LazyLock<Counter<u64>> = LazyLock::new(|| {
     global::meter(super::METER_NAME)
         .u64_counter("watcher.primary_hs.cursor.invalid")
@@ -109,7 +109,7 @@ impl<'a> EventBatch<'a> {
 
 /// Why a batch's closing cursor was not applied. Each variant has its own metric.
 enum CursorRejection {
-    /// Unparseable, or it would rewind the stored cursor.
+    /// Unparseable, would rewind the stored cursor, or advances without events.
     Invalid,
     /// The batch carried events, yet the checkpoint cannot move past them: the
     /// cursor holds at the position the batch was fetched with, or the batch
@@ -400,15 +400,24 @@ impl HsEventProcessor {
         // batch was requested with (`self.homeserver.cursor`, read from Redis
         // when this processor was built and unchanged since — one poll per run).
         // A cursor merely holding at that position would make the next poll
-        // re-request and re-process this exact batch, indefinitely. An empty
-        // batch is just an idle poll, where repeating the cursor is the normal
-        // reply and `try_from_cursor`'s no-rewind rule is guard enough.
+        // re-request and re-process this exact batch, indefinitely.
         if batch_had_events && homeserver.cursor <= self.homeserver.cursor {
             let reason = format!(
                 "batch carried events but cursor '{raw_cursor}' does not advance past the requested {}",
                 self.homeserver.cursor
             );
             self.reject_batch(&CursorRejection::Stalled, &reason);
+            return Ok(None);
+        }
+
+        // An idle response cannot prove that any intervening events were
+        // delivered, so it may repeat the requested cursor but never advance it.
+        if !batch_had_events && homeserver.cursor != self.homeserver.cursor {
+            let reason = format!(
+                "batch carried no events but cursor '{raw_cursor}' differs from the requested {}",
+                self.homeserver.cursor
+            );
+            self.reject_batch(&CursorRejection::Invalid, &reason);
             return Ok(None);
         }
 

--- a/nexus-watcher/src/service/indexer/homeserver.rs
+++ b/nexus-watcher/src/service/indexer/homeserver.rs
@@ -2,7 +2,9 @@ use super::TEventProcessor;
 use crate::errors::EventProcessorError;
 use crate::events::retry::RetryScheduler;
 use crate::events::{read_stream_capped, Event, EventHandler, MAX_EVENTS_BODY};
+use nexus_common::db::kv::RedisError;
 use nexus_common::db::{fetch_row_from_graph, queries, GraphResult, PubkyConnector};
+use nexus_common::models::error::ModelError;
 use nexus_common::models::homeserver::Homeserver;
 use opentelemetry::metrics::Counter;
 use opentelemetry::{global, KeyValue};
@@ -35,6 +37,20 @@ static INVALID_CURSOR_PRIMARY_HS: LazyLock<Counter<u64>> = LazyLock::new(|| {
         .build()
 });
 
+/// Counter for Primary HS batches that carried events but did not advance the cursor.
+///
+/// Distinct from [`INVALID_CURSOR_PRIMARY_HS`]: the cursor parses and does not
+/// rewind, it simply holds at the position the batch was fetched with. Applying
+/// it would make the next poll re-request and re-process the identical batch, so
+/// the batch is skipped instead. Any non-zero count means the HS stream cannot
+/// make progress and needs operator attention.
+static STALLED_CURSOR_PRIMARY_HS: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    global::meter(super::METER_NAME)
+        .u64_counter("watcher.primary_hs.cursor.stalled")
+        .with_description("Primary HS batches whose cursor did not advance past the requested one")
+        .build()
+});
+
 /// A user's `HOSTED_BY` mapping, classified relative to a processor's HS.
 ///
 /// The `stale` flag is only carried where it is meaningful: a stale mapping means
@@ -48,6 +64,57 @@ pub enum HsMapping {
     Current { stale: bool },
     /// The user is mapped to a different HS.
     Other { hs_id: String },
+}
+
+/// A homeserver response, split into its event lines and the cursor closing the batch.
+///
+/// The homeserver sends the cursor line last, but that is positional convention
+/// rather than something we can rely on from an untrusted peer: the split is
+/// order-independent, and if a batch carries several cursor lines the last one
+/// wins, being the position the homeserver ends the batch at.
+struct EventBatch<'a> {
+    event_lines: Vec<&'a str>,
+    /// Raw, still unparsed value of the batch's cursor line, if it carried one.
+    cursor: Option<&'a str>,
+}
+
+impl<'a> EventBatch<'a> {
+    fn split(lines: &'a [String]) -> Self {
+        let mut event_lines = Vec::with_capacity(lines.len());
+        let mut cursor = None;
+
+        for line in lines {
+            match line.strip_prefix("cursor: ") {
+                Some(value) => cursor = Some(value),
+                None => event_lines.push(line.as_str()),
+            }
+        }
+
+        Self {
+            event_lines,
+            cursor,
+        }
+    }
+
+    /// Whether the batch carried anything other than its cursor line.
+    ///
+    /// Deliberately counts *every* non-cursor line, including ones that later
+    /// parse as skipped or unrecognized: those still legitimately advance the
+    /// cursor, so narrowing this to "lines that reached a handler" would let a
+    /// non-advancing cursor through and re-open the replay loop.
+    fn has_events(&self) -> bool {
+        !self.event_lines.is_empty()
+    }
+}
+
+/// Why a batch's closing cursor was not applied. Each variant has its own metric.
+enum CursorRejection {
+    /// Unparseable, or it would rewind the stored cursor.
+    Invalid,
+    /// The batch carried events, yet the checkpoint cannot move past them: the
+    /// cursor holds at the position the batch was fetched with, or the batch
+    /// carries no cursor line at all.
+    Stalled,
 }
 
 /// Event processor for the primary homeserver
@@ -227,7 +294,14 @@ impl HsEventProcessor {
 
     /// Processes a batch of event lines retrieved from the homeserver.
     ///
-    /// This function implements the retry logic:
+    /// The batch's cursor is validated *before* any handler runs and persisted
+    /// only once the whole batch has been processed. A cursor the homeserver
+    /// should not have sent — or failed to send at all — therefore costs
+    /// nothing: the batch is skipped whole, the stored cursor stays put, and the
+    /// next poll re-fetches from the same position instead of repeating side
+    /// effects the cursor would never record.
+    ///
+    /// Per-event retry logic:
     /// - On error that should not be retried right now: stops the batch, cursor is not saved, next tick replays from same position
     /// - On MissingDependency: stores event in retry queue, continues processing
     /// - On 404 (blob not found): skips indexing, continues processing
@@ -237,29 +311,198 @@ impl HsEventProcessor {
     /// - `lines`: A vector of strings representing event lines retrieved from the homeserver.
     #[tracing::instrument(name = "event_batch.process", skip_all, fields(batch.size = lines.len()))]
     pub async fn process_event_lines(&self, lines: Vec<String>) -> Result<(), EventProcessorError> {
-        for line in &lines {
-            if *self.shutdown_rx.borrow() {
-                debug!(hs_id = %self.homeserver.id, "Shutdown detected; exiting event processing loop");
+        let batch = EventBatch::split(&lines);
+
+        let next_cursor = match batch.cursor {
+            Some(raw_cursor) => {
+                match self
+                    .resolve_batch_cursor(raw_cursor, batch.has_events())
+                    .await?
+                {
+                    Some(homeserver) => Some(homeserver),
+                    // Rejected: skip the batch entirely. Running the handlers
+                    // would only queue up work the next poll has to repeat,
+                    // since the cursor stays where it is either way.
+                    None => return Ok(()),
+                }
+            }
+
+            // Events with no cursor line to close them leave the checkpoint
+            // exactly where a non-advancing cursor would, so the next poll
+            // re-fetches and re-processes this same batch — the same stall,
+            // reached by omission rather than by repetition. A homeserver
+            // sending events always sends the cursor that closes them, so this
+            // is a truncated or malformed response.
+            None if batch.has_events() => {
+                self.reject_batch(
+                    &CursorRejection::Stalled,
+                    "batch carried events but no cursor line to advance the checkpoint",
+                );
                 return Ok(());
             }
 
-            if let Some(cursor) = line.strip_prefix("cursor: ") {
-                info!("Received cursor for the next request: {cursor}");
-                match Homeserver::try_from_cursor(self.homeserver.id.clone(), cursor).await {
-                    Ok(hs) => hs.put_to_index().await?,
-                    Err(e) => {
-                        // Cursor could not be parsed or would rewind
-                        INVALID_CURSOR_PRIMARY_HS
-                            .add(1, &[KeyValue::new("hs_id", self.homeserver.id.to_string())]);
-                        warn!(hs_id = %self.homeserver.id, "Ignoring invalid cursor '{cursor}': {e}");
-                    }
-                }
-                continue;
+            None => None,
+        };
+
+        for line in &batch.event_lines {
+            if *self.shutdown_rx.borrow() {
+                debug!(hs_id = %self.homeserver.id, "Shutdown detected; exiting event processing loop");
+                // The cursor is deliberately left unpersisted: the batch is only
+                // partly processed, so the next run has to replay it.
+                return Ok(());
             }
 
             self.process_event_line(line).await?;
         }
 
+        if let Some(homeserver) = next_cursor {
+            homeserver.put_to_index().await?;
+        }
+
         Ok(())
+    }
+
+    /// Resolves the cursor line closing a batch into the homeserver record to
+    /// persist once the batch has been processed.
+    ///
+    /// `batch_had_events` reports whether the batch carried anything besides the
+    /// cursor line itself, which decides how strict the check is.
+    ///
+    /// Returns `Ok(None)` when the cursor must not be applied, so the caller
+    /// skips the batch. Redis failures propagate instead of being charged to the
+    /// homeserver as bad input, so the run is recorded as failed and retried on
+    /// the next scheduled execution.
+    async fn resolve_batch_cursor(
+        &self,
+        raw_cursor: &str,
+        batch_had_events: bool,
+    ) -> Result<Option<Homeserver>, EventProcessorError> {
+        info!("Received cursor for the next request: {raw_cursor}");
+
+        let homeserver = match Homeserver::try_from_cursor(self.homeserver.id.clone(), raw_cursor)
+            .await
+        {
+            Ok(homeserver) => homeserver,
+            // Only the monotonicity guard raises `InvalidInput`; every other
+            // Redis error is our own infrastructure failing, not bad HS input,
+            // and must fail the run rather than silently skip a batch.
+            Err(ModelError::KvOperationFailed(e)) if !matches!(e, RedisError::InvalidInput(_)) => {
+                return Err(ModelError::KvOperationFailed(e).into());
+            }
+            // Unparseable, or it would rewind the stored cursor.
+            Err(e) => {
+                let reason = format!("cursor '{raw_cursor}' cannot be applied: {e}");
+                self.reject_batch(&CursorRejection::Invalid, &reason);
+                return Ok(None);
+            }
+        };
+
+        // A batch carrying events has to move the cursor strictly forward. The
+        // fetch is cursor-exclusive, so those events sit above the cursor the
+        // batch was requested with (`self.homeserver.cursor`, read from Redis
+        // when this processor was built and unchanged since — one poll per run).
+        // A cursor merely holding at that position would make the next poll
+        // re-request and re-process this exact batch, indefinitely. An empty
+        // batch is just an idle poll, where repeating the cursor is the normal
+        // reply and `try_from_cursor`'s no-rewind rule is guard enough.
+        if batch_had_events && homeserver.cursor <= self.homeserver.cursor {
+            let reason = format!(
+                "batch carried events but cursor '{raw_cursor}' does not advance past the requested {}",
+                self.homeserver.cursor
+            );
+            self.reject_batch(&CursorRejection::Stalled, &reason);
+            return Ok(None);
+        }
+
+        Ok(Some(homeserver))
+    }
+
+    /// Records a skipped batch on the metric matching `rejection`, and warns.
+    fn reject_batch(&self, rejection: &CursorRejection, reason: &str) {
+        let counter = match rejection {
+            CursorRejection::Invalid => &INVALID_CURSOR_PRIMARY_HS,
+            CursorRejection::Stalled => &STALLED_CURSOR_PRIMARY_HS,
+        };
+        counter.add(1, &[KeyValue::new("hs_id", self.homeserver.id.to_string())]);
+
+        warn!(hs_id = %self.homeserver.id, "Skipping batch: {reason}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::EventBatch;
+
+    fn lines(raw: &[&str]) -> Vec<String> {
+        raw.iter().map(|l| l.to_string()).collect()
+    }
+
+    /// The usual shape: events followed by the cursor that closes the batch.
+    #[test]
+    fn splits_events_from_the_trailing_cursor() {
+        let lines = lines(&["PUT pubky://a/pub/x", "DEL pubky://b/pub/y", "cursor: 42"]);
+        let batch = EventBatch::split(&lines);
+
+        assert_eq!(
+            batch.event_lines,
+            vec!["PUT pubky://a/pub/x", "DEL pubky://b/pub/y"]
+        );
+        assert_eq!(batch.cursor, Some("42"));
+        assert!(batch.has_events());
+    }
+
+    /// An idle poll: a cursor and nothing else, which must not read as "had events".
+    #[test]
+    fn cursor_only_batch_has_no_events() {
+        let lines = lines(&["cursor: 42"]);
+        let batch = EventBatch::split(&lines);
+
+        assert!(batch.event_lines.is_empty());
+        assert_eq!(batch.cursor, Some("42"));
+        assert!(!batch.has_events());
+    }
+
+    /// The cursor is found wherever it sits, not only in last position.
+    #[test]
+    fn cursor_is_found_out_of_position() {
+        let lines = lines(&["cursor: 42", "PUT pubky://a/pub/x"]);
+        let batch = EventBatch::split(&lines);
+
+        assert_eq!(batch.event_lines, vec!["PUT pubky://a/pub/x"]);
+        assert_eq!(batch.cursor, Some("42"));
+    }
+
+    /// Several cursor lines: the last one wins, being where the batch ends.
+    #[test]
+    fn last_cursor_line_wins() {
+        let lines = lines(&["cursor: 41", "PUT pubky://a/pub/x", "cursor: 42"]);
+        let batch = EventBatch::split(&lines);
+
+        assert_eq!(batch.event_lines, vec!["PUT pubky://a/pub/x"]);
+        assert_eq!(batch.cursor, Some("42"));
+    }
+
+    /// A batch with no cursor line at all, which the caller rejects as stalled
+    /// when it carries events: there is nothing to move the checkpoint with.
+    #[test]
+    fn batch_without_cursor_line() {
+        let lines = lines(&["PUT pubky://a/pub/x"]);
+        let batch = EventBatch::split(&lines);
+
+        assert_eq!(batch.event_lines, vec!["PUT pubky://a/pub/x"]);
+        assert_eq!(batch.cursor, None);
+        assert!(batch.has_events());
+    }
+
+    /// Lines that will later parse as skipped or unrecognized still count as
+    /// events: they legitimately advance the cursor, so a batch made only of
+    /// them must not be treated as an idle poll.
+    #[test]
+    fn unrecognized_lines_count_as_events() {
+        let lines = lines(&["garbage", "cursor: 42"]);
+        let batch = EventBatch::split(&lines);
+
+        assert_eq!(batch.event_lines, vec!["garbage"]);
+        assert!(batch.has_events());
     }
 }

--- a/nexus-watcher/src/service/indexer/key_based.rs
+++ b/nexus-watcher/src/service/indexer/key_based.rs
@@ -302,6 +302,7 @@ impl KeyBasedEventProcessor {
         stream_events: Vec<StreamEvent>,
     ) -> (Option<u64>, Result<(), EventProcessorError>) {
         let mut latest_cursor: Option<u64> = None;
+        let mut max_cursor: Option<u64> = None;
 
         for stream_event in stream_events {
             if *self.shutdown_rx.borrow() {
@@ -310,6 +311,19 @@ impl KeyBasedEventProcessor {
             }
 
             let cursor_id = stream_event.cursor.id();
+            let next_latest_cursor = Some(cursor_id);
+            let next_max_cursor = max_cursor.map_or(cursor_id, |max| max.max(cursor_id));
+            if next_latest_cursor != Some(next_max_cursor) {
+                return (
+                    latest_cursor,
+                    Err(EventProcessorError::EventCursorOutOfOrder {
+                        hs_id: hs_id.into(),
+                        user_id: user_id.into(),
+                        cursor: cursor_id,
+                        max_cursor: next_max_cursor,
+                    }),
+                );
+            }
 
             match Event::from_stream_event(&stream_event) {
                 Ok(Some(event)) => {
@@ -331,7 +345,8 @@ impl KeyBasedEventProcessor {
             // Advance after successful handling, unsupported resources, or
             // logged parse errors. UserIdMismatch and handler errors return
             // before this point, so their cursor is not persisted.
-            latest_cursor = Some(cursor_id);
+            latest_cursor = next_latest_cursor;
+            max_cursor = Some(next_max_cursor);
         }
 
         (latest_cursor, Ok(()))

--- a/nexus-watcher/src/service/indexer/key_based.rs
+++ b/nexus-watcher/src/service/indexer/key_based.rs
@@ -315,14 +315,13 @@ impl KeyBasedEventProcessor {
             }
 
             let cursor_id = stream_event.cursor.id();
-            // Ordering floor: the highest cursor we have already advanced past —
-            // an event handled earlier in this batch, or the persisted cursor if
-            // none has been handled yet. Rejecting events strictly below this
-            // stops a misbehaving homeserver from replaying already-indexed
-            // events; the in-batch guard alone misses events below the persisted
-            // cursor because `latest_cursor` starts empty on every batch.
+            // Fetches are cursor-exclusive, so a correct HS only returns events
+            // above the floor; anything at or below it is a replay. Seeding the
+            // floor from `persisted_cursor` matters because `latest_cursor`
+            // resets each batch — the in-batch check alone would miss a replay
+            // of an already-indexed event.
             let ordering_floor = latest_cursor.unwrap_or(persisted_cursor);
-            if cursor_id < ordering_floor {
+            if cursor_id <= ordering_floor {
                 return (
                     latest_cursor,
                     Err(EventProcessorError::EventCursorOutOfOrder {

--- a/nexus-watcher/src/service/indexer/key_based.rs
+++ b/nexus-watcher/src/service/indexer/key_based.rs
@@ -302,7 +302,6 @@ impl KeyBasedEventProcessor {
         stream_events: Vec<StreamEvent>,
     ) -> (Option<u64>, Result<(), EventProcessorError>) {
         let mut latest_cursor: Option<u64> = None;
-        let mut max_cursor: Option<u64> = None;
 
         for stream_event in stream_events {
             if *self.shutdown_rx.borrow() {
@@ -311,18 +310,18 @@ impl KeyBasedEventProcessor {
             }
 
             let cursor_id = stream_event.cursor.id();
-            let next_latest_cursor = Some(cursor_id);
-            let next_max_cursor = max_cursor.map_or(cursor_id, |max| max.max(cursor_id));
-            if next_latest_cursor != Some(next_max_cursor) {
-                return (
-                    latest_cursor,
-                    Err(EventProcessorError::EventCursorOutOfOrder {
-                        hs_id: hs_id.into(),
-                        user_id: user_id.into(),
-                        cursor: cursor_id,
-                        max_cursor: next_max_cursor,
-                    }),
-                );
+            if let Some(previous_cursor) = latest_cursor {
+                if cursor_id < previous_cursor {
+                    return (
+                        latest_cursor,
+                        Err(EventProcessorError::EventCursorOutOfOrder {
+                            hs_id: hs_id.into(),
+                            user_id: user_id.into(),
+                            cursor: cursor_id,
+                            max_cursor: previous_cursor,
+                        }),
+                    );
+                }
             }
 
             match Event::from_stream_event(&stream_event) {
@@ -345,8 +344,7 @@ impl KeyBasedEventProcessor {
             // Advance after successful handling, unsupported resources, or
             // logged parse errors. UserIdMismatch and handler errors return
             // before this point, so their cursor is not persisted.
-            latest_cursor = next_latest_cursor;
-            max_cursor = Some(next_max_cursor);
+            latest_cursor = Some(cursor_id);
         }
 
         (latest_cursor, Ok(()))

--- a/nexus-watcher/src/service/indexer/key_based.rs
+++ b/nexus-watcher/src/service/indexer/key_based.rs
@@ -240,7 +240,7 @@ impl KeyBasedEventProcessor {
 
         let user_id = user_pk.z32();
         let (latest_cursor, result) = self
-            .process_user_events(hs_id, &user_id, stream_events)
+            .process_user_events(hs_id, &user_id, cursor.id(), stream_events)
             .await;
 
         if let Some(cursor_val) = latest_cursor {
@@ -292,6 +292,10 @@ impl KeyBasedEventProcessor {
 
     /// Processes already-fetched events for a single user stream.
     ///
+    /// `persisted_cursor` is the user's currently stored cursor for this
+    /// homeserver; it acts as the initial ordering floor so that events at or
+    /// below what we have already indexed are rejected before any handler runs.
+    ///
     /// Returns the latest cursor that is safe to persist, plus the processing
     /// result. Cursor advancement is intentionally skipped for `UserIdMismatch`
     /// and handler errors so those events are fetched again on the next run.
@@ -299,6 +303,7 @@ impl KeyBasedEventProcessor {
         &self,
         hs_id: &str,
         user_id: &str,
+        persisted_cursor: u64,
         stream_events: Vec<StreamEvent>,
     ) -> (Option<u64>, Result<(), EventProcessorError>) {
         let mut latest_cursor: Option<u64> = None;
@@ -310,18 +315,23 @@ impl KeyBasedEventProcessor {
             }
 
             let cursor_id = stream_event.cursor.id();
-            if let Some(previous_cursor) = latest_cursor {
-                if cursor_id < previous_cursor {
-                    return (
-                        latest_cursor,
-                        Err(EventProcessorError::EventCursorOutOfOrder {
-                            hs_id: hs_id.into(),
-                            user_id: user_id.into(),
-                            cursor: cursor_id,
-                            max_cursor: previous_cursor,
-                        }),
-                    );
-                }
+            // Ordering floor: the highest cursor we have already advanced past —
+            // an event handled earlier in this batch, or the persisted cursor if
+            // none has been handled yet. Rejecting events strictly below this
+            // stops a misbehaving homeserver from replaying already-indexed
+            // events; the in-batch guard alone misses events below the persisted
+            // cursor because `latest_cursor` starts empty on every batch.
+            let ordering_floor = latest_cursor.unwrap_or(persisted_cursor);
+            if cursor_id < ordering_floor {
+                return (
+                    latest_cursor,
+                    Err(EventProcessorError::EventCursorOutOfOrder {
+                        hs_id: hs_id.into(),
+                        user_id: user_id.into(),
+                        cursor: cursor_id,
+                        max_cursor: ordering_floor,
+                    }),
+                );
             }
 
             match Event::from_stream_event(&stream_event) {

--- a/nexus-watcher/src/service/indexer/key_based.rs
+++ b/nexus-watcher/src/service/indexer/key_based.rs
@@ -1,4 +1,7 @@
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{Arc, LazyLock},
+    time::Duration,
+};
 
 use crate::errors::EventProcessorError;
 use crate::events::Event;
@@ -6,6 +9,8 @@ use futures::StreamExt;
 use nexus_common::db::PubkyConnector;
 use nexus_common::models::homeserver::HsBlacklist;
 use nexus_common::models::user::UserHsCursor;
+use opentelemetry::metrics::Counter;
+use opentelemetry::{global, KeyValue};
 use pubky::{Event as StreamEvent, EventCursor, PublicKey};
 use pubky_app_specs::PubkyId;
 use tokio::sync::watch::Receiver;
@@ -18,6 +23,17 @@ use crate::service::runner::UserNotFoundBackoff;
 use crate::service::user_hs_resolver;
 
 const FETCH_EVENTS_429_BACKOFF_SECS: [u64; 3] = [1, 2, 3];
+
+/// Counter for per-user stream events an External HS returned at or below the
+/// user's stored cursor — replays of already-indexed events, rejected before any
+/// handler runs. A sustained non-zero rate for one HS means it is stuck replaying
+/// and needs operator attention. Labelled by `hs_id` only to avoid per-user metric cardinality.
+static OUT_OF_ORDER_CURSOR_EXTERNAL_HS: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    global::meter(super::METER_NAME)
+        .u64_counter("watcher.external_hs.cursor.out_of_order")
+        .with_description("Per-user stream events a homeserver returned out of cursor order")
+        .build()
+});
 
 #[async_trait::async_trait]
 pub trait KeyBasedEventSource: Send + Sync + 'static {
@@ -322,6 +338,8 @@ impl KeyBasedEventProcessor {
             // of an already-indexed event.
             let ordering_floor = latest_cursor.unwrap_or(persisted_cursor);
             if cursor_id <= ordering_floor {
+                OUT_OF_ORDER_CURSOR_EXTERNAL_HS
+                    .add(1, &[KeyValue::new("hs_id", hs_id.to_string())]);
                 return (
                     latest_cursor,
                     Err(EventProcessorError::EventCursorOutOfOrder {

--- a/nexus-watcher/src/service/indexer/key_based.rs
+++ b/nexus-watcher/src/service/indexer/key_based.rs
@@ -26,9 +26,11 @@ use crate::service::user_hs_resolver;
 const FETCH_EVENTS_429_BACKOFF_SECS: [u64; 3] = [1, 2, 3];
 
 /// Counter for per-user stream events an External HS returned at or below the
-/// user's stored cursor — replays of already-indexed events, rejected before any
-/// handler runs. A sustained non-zero rate for one HS means it is stuck replaying
-/// and needs operator attention. Labelled by `hs_id` only to avoid per-user metric cardinality.
+/// ordering floor — a replay of already-indexed data, or a regression against an
+/// earlier event in the same batch. Both are rejected before any handler runs and
+/// stop the batch, stalling the user entirely when its first event trips the check.
+/// A sustained non-zero rate for one HS means it is misbehaving and needs operator
+/// attention. Labelled by `hs_id` only to avoid per-user metric cardinality.
 static OUT_OF_ORDER_CURSOR_EXTERNAL_HS: LazyLock<Counter<u64>> = LazyLock::new(|| {
     global::meter(super::METER_NAME)
         .u64_counter("watcher.external_hs.cursor.out_of_order")
@@ -342,13 +344,13 @@ impl KeyBasedEventProcessor {
             }
 
             let cursor_id = stream_event.cursor.id();
-            // Fetches are cursor-exclusive, so a correct HS only returns events
-            // above the floor; anything at or below it is a replay. Seeding the
-            // floor from `persisted_cursor` matters because `latest_cursor`
-            // resets each batch — the in-batch check alone would miss a replay
-            // of an already-indexed event.
-            let ordering_floor = latest_cursor.unwrap_or(persisted_cursor);
-            if cursor_id <= ordering_floor {
+            // Fetches are cursor-exclusive and a correct HS returns events in
+            // increasing order, so every event must sit strictly above the floor:
+            // the stored cursor for the first event, the previous event after that.
+            // Seeding from `persisted_cursor` matters because `latest_cursor` resets
+            // each batch — the in-batch check alone would miss a replay.
+            let cursor_floor = latest_cursor.unwrap_or(persisted_cursor);
+            if cursor_id <= cursor_floor {
                 OUT_OF_ORDER_CURSOR_EXTERNAL_HS
                     .add(1, &[KeyValue::new("hs_id", hs_id.to_string())]);
                 return (
@@ -357,7 +359,7 @@ impl KeyBasedEventProcessor {
                         hs_id: hs_id.into(),
                         user_id: user_id.into(),
                         cursor: cursor_id,
-                        max_cursor: ordering_floor,
+                        cursor_floor,
                     }),
                 );
             }

--- a/nexus-watcher/src/service/indexer/key_based.rs
+++ b/nexus-watcher/src/service/indexer/key_based.rs
@@ -25,18 +25,10 @@ use crate::service::user_hs_resolver;
 
 const FETCH_EVENTS_429_BACKOFF_SECS: [u64; 3] = [1, 2, 3];
 
-/// Counter for per-user stream events an External HS returned out of cursor
-/// order, rejected before any handler runs. The `reason` label separates the two
-/// ways the ordering contract can break, which have different causes and
-/// different consequences:
-///
-/// - `replay`: the event is at or below the user's stored cursor, so it was
-///   already indexed. Skipped, and the batch continues.
-/// - `unsorted`: the event is above the stored cursor but below one already seen
-///   in this same batch, so the HS returned an unsorted response. The batch stops.
-///
-/// A sustained non-zero rate for one HS means it is misbehaving and needs
-/// operator attention. Labelled by `hs_id` only to avoid per-user metric cardinality.
+/// Counter for per-user stream events an External HS returned at or below the
+/// user's stored cursor — replays of already-indexed events, rejected before any
+/// handler runs. A sustained non-zero rate for one HS means it is stuck replaying
+/// and needs operator attention. Labelled by `hs_id` only to avoid per-user metric cardinality.
 static OUT_OF_ORDER_CURSOR_EXTERNAL_HS: LazyLock<Counter<u64>> = LazyLock::new(|| {
     global::meter(super::METER_NAME)
         .u64_counter("watcher.external_hs.cursor.out_of_order")
@@ -328,9 +320,8 @@ impl KeyBasedEventProcessor {
     /// Processes already-fetched events for a single user stream.
     ///
     /// `persisted_cursor` is the user's currently stored cursor for this
-    /// homeserver. Events at or below it are replays of already-indexed data and
-    /// are skipped before any handler runs; events that regress against an
-    /// earlier event *in this batch* stop it. See the ordering checks below.
+    /// homeserver; it acts as the initial ordering floor so that events at or
+    /// below what we have already indexed are rejected before any handler runs.
     ///
     /// Returns the latest cursor that is safe to persist, plus the processing
     /// result. Cursor advancement is intentionally skipped for `UserIdMismatch`
@@ -351,49 +342,22 @@ impl KeyBasedEventProcessor {
             }
 
             let cursor_id = stream_event.cursor.id();
-
             // Fetches are cursor-exclusive, so a correct HS only returns events
-            // above the cursor it was asked with. An event at or below it breaks
-            // that contract in one of two ways, which are handled differently.
-
-            // Below the stored cursor: a replay of an event already indexed on a
-            // previous run. Skipping it is safe — the data is in the graph — and
-            // it is the only way to make progress: the stored cursor cannot move
-            // past a replay, so aborting here would leave the next poll asking
-            // for the same range, receiving the same replay, and wedging this
-            // user forever behind one stale event.
-            //
-            // The primary-HS path (`homeserver.rs`) skips the whole batch in the
-            // equivalent situation. The asymmetry is deliberate: that homeserver
-            // is ours, so a stalled cursor is an actionable alert someone can go
-            // and fix. An external HS is third-party, and a stall there is an
-            // open-ended outage for the user with no lever on our side to end it.
-            if cursor_id <= persisted_cursor {
-                Self::record_out_of_order(hs_id, "replay");
-                warn!(
-                    %hs_id, %user_id, %cursor_id, %persisted_cursor,
-                    "Homeserver replayed an already-indexed event; skipping it and continuing",
-                );
-                continue;
-            }
-
-            // Above the stored cursor but below one already seen in this batch:
-            // the HS returned an unsorted response, so this event may never have
-            // been indexed. It is not skipped, because handling it after a later
-            // event would let a stale write land on top of a newer one; the batch
-            // stops instead so the HS can re-deliver it in order. This cannot
-            // wedge the user: `latest_cursor` is above `persisted_cursor` by
-            // construction, so it is persisted on the way out and the next poll
-            // asks for a strictly higher range.
-            if let Some(latest_cursor) = latest_cursor.filter(|latest| cursor_id <= *latest) {
-                Self::record_out_of_order(hs_id, "unsorted");
+            // above the floor; anything at or below it is a replay. Seeding the
+            // floor from `persisted_cursor` matters because `latest_cursor`
+            // resets each batch — the in-batch check alone would miss a replay
+            // of an already-indexed event.
+            let ordering_floor = latest_cursor.unwrap_or(persisted_cursor);
+            if cursor_id <= ordering_floor {
+                OUT_OF_ORDER_CURSOR_EXTERNAL_HS
+                    .add(1, &[KeyValue::new("hs_id", hs_id.to_string())]);
                 return (
-                    Some(latest_cursor),
+                    latest_cursor,
                     Err(EventProcessorError::EventCursorOutOfOrder {
                         hs_id: hs_id.into(),
                         user_id: user_id.into(),
                         cursor: cursor_id,
-                        max_cursor: latest_cursor,
+                        max_cursor: ordering_floor,
                     }),
                 );
             }
@@ -422,18 +386,6 @@ impl KeyBasedEventProcessor {
         }
 
         (latest_cursor, Ok(()))
-    }
-
-    /// Records an out-of-order event on [`OUT_OF_ORDER_CURSOR_EXTERNAL_HS`],
-    /// where `reason` is `replay` or `unsorted`.
-    fn record_out_of_order(hs_id: &str, reason: &'static str) {
-        OUT_OF_ORDER_CURSOR_EXTERNAL_HS.add(
-            1,
-            &[
-                KeyValue::new("hs_id", hs_id.to_string()),
-                KeyValue::new("reason", reason),
-            ],
-        );
     }
 
     fn validate_user_id(

--- a/nexus-watcher/src/service/indexer/key_based.rs
+++ b/nexus-watcher/src/service/indexer/key_based.rs
@@ -365,13 +365,17 @@ impl KeyBasedEventProcessor {
             }
 
             let cursor_id = stream_event.cursor.id();
+
+            // External homeservers must not index another user's URI.
+            // Validate the raw resource before [Event::from_stream_event],
+            // because a foreign user PK with an unsupported path would
+            // return Ok(None) thus skipping but also advancing latest_cursor.
+            if let Err(err) = Self::validate_user_id(hs_id, &stream_event, user_id) {
+                return (latest_cursor, Err(err));
+            }
+
             match Event::from_stream_event(&stream_event) {
                 Ok(Some(event)) => {
-                    // External homeservers must not index another user's URI.
-                    if let Err(err) = Self::validate_user_id(hs_id, &event, user_id) {
-                        return (latest_cursor, Err(err));
-                    }
-
                     if let Err(err) = self.handle_event(&event).await {
                         return (latest_cursor, Err(err));
                     }
@@ -398,10 +402,10 @@ impl KeyBasedEventProcessor {
 
     fn validate_user_id(
         hs_id: &str,
-        event: &Event,
+        stream_event: &StreamEvent,
         expected_user_id: &str,
     ) -> Result<(), EventProcessorError> {
-        let event_user_id = event.parsed_uri.user_id().to_string();
+        let event_user_id = stream_event.resource.owner.z32();
         if event_user_id != expected_user_id {
             return Err(EventProcessorError::UserIdMismatch {
                 hs_id: hs_id.into(),

--- a/nexus-watcher/src/service/indexer/key_based.rs
+++ b/nexus-watcher/src/service/indexer/key_based.rs
@@ -25,10 +25,18 @@ use crate::service::user_hs_resolver;
 
 const FETCH_EVENTS_429_BACKOFF_SECS: [u64; 3] = [1, 2, 3];
 
-/// Counter for per-user stream events an External HS returned at or below the
-/// user's stored cursor — replays of already-indexed events, rejected before any
-/// handler runs. A sustained non-zero rate for one HS means it is stuck replaying
-/// and needs operator attention. Labelled by `hs_id` only to avoid per-user metric cardinality.
+/// Counter for per-user stream events an External HS returned out of cursor
+/// order, rejected before any handler runs. The `reason` label separates the two
+/// ways the ordering contract can break, which have different causes and
+/// different consequences:
+///
+/// - `replay`: the event is at or below the user's stored cursor, so it was
+///   already indexed. Skipped, and the batch continues.
+/// - `unsorted`: the event is above the stored cursor but below one already seen
+///   in this same batch, so the HS returned an unsorted response. The batch stops.
+///
+/// A sustained non-zero rate for one HS means it is misbehaving and needs
+/// operator attention. Labelled by `hs_id` only to avoid per-user metric cardinality.
 static OUT_OF_ORDER_CURSOR_EXTERNAL_HS: LazyLock<Counter<u64>> = LazyLock::new(|| {
     global::meter(super::METER_NAME)
         .u64_counter("watcher.external_hs.cursor.out_of_order")
@@ -320,8 +328,9 @@ impl KeyBasedEventProcessor {
     /// Processes already-fetched events for a single user stream.
     ///
     /// `persisted_cursor` is the user's currently stored cursor for this
-    /// homeserver; it acts as the initial ordering floor so that events at or
-    /// below what we have already indexed are rejected before any handler runs.
+    /// homeserver. Events at or below it are replays of already-indexed data and
+    /// are skipped before any handler runs; events that regress against an
+    /// earlier event *in this batch* stop it. See the ordering checks below.
     ///
     /// Returns the latest cursor that is safe to persist, plus the processing
     /// result. Cursor advancement is intentionally skipped for `UserIdMismatch`
@@ -342,22 +351,49 @@ impl KeyBasedEventProcessor {
             }
 
             let cursor_id = stream_event.cursor.id();
+
             // Fetches are cursor-exclusive, so a correct HS only returns events
-            // above the floor; anything at or below it is a replay. Seeding the
-            // floor from `persisted_cursor` matters because `latest_cursor`
-            // resets each batch — the in-batch check alone would miss a replay
-            // of an already-indexed event.
-            let ordering_floor = latest_cursor.unwrap_or(persisted_cursor);
-            if cursor_id <= ordering_floor {
-                OUT_OF_ORDER_CURSOR_EXTERNAL_HS
-                    .add(1, &[KeyValue::new("hs_id", hs_id.to_string())]);
+            // above the cursor it was asked with. An event at or below it breaks
+            // that contract in one of two ways, which are handled differently.
+
+            // Below the stored cursor: a replay of an event already indexed on a
+            // previous run. Skipping it is safe — the data is in the graph — and
+            // it is the only way to make progress: the stored cursor cannot move
+            // past a replay, so aborting here would leave the next poll asking
+            // for the same range, receiving the same replay, and wedging this
+            // user forever behind one stale event.
+            //
+            // The primary-HS path (`homeserver.rs`) skips the whole batch in the
+            // equivalent situation. The asymmetry is deliberate: that homeserver
+            // is ours, so a stalled cursor is an actionable alert someone can go
+            // and fix. An external HS is third-party, and a stall there is an
+            // open-ended outage for the user with no lever on our side to end it.
+            if cursor_id <= persisted_cursor {
+                Self::record_out_of_order(hs_id, "replay");
+                warn!(
+                    %hs_id, %user_id, %cursor_id, %persisted_cursor,
+                    "Homeserver replayed an already-indexed event; skipping it and continuing",
+                );
+                continue;
+            }
+
+            // Above the stored cursor but below one already seen in this batch:
+            // the HS returned an unsorted response, so this event may never have
+            // been indexed. It is not skipped, because handling it after a later
+            // event would let a stale write land on top of a newer one; the batch
+            // stops instead so the HS can re-deliver it in order. This cannot
+            // wedge the user: `latest_cursor` is above `persisted_cursor` by
+            // construction, so it is persisted on the way out and the next poll
+            // asks for a strictly higher range.
+            if let Some(latest_cursor) = latest_cursor.filter(|latest| cursor_id <= *latest) {
+                Self::record_out_of_order(hs_id, "unsorted");
                 return (
-                    latest_cursor,
+                    Some(latest_cursor),
                     Err(EventProcessorError::EventCursorOutOfOrder {
                         hs_id: hs_id.into(),
                         user_id: user_id.into(),
                         cursor: cursor_id,
-                        max_cursor: ordering_floor,
+                        max_cursor: latest_cursor,
                     }),
                 );
             }
@@ -386,6 +422,18 @@ impl KeyBasedEventProcessor {
         }
 
         (latest_cursor, Ok(()))
+    }
+
+    /// Records an out-of-order event on [`OUT_OF_ORDER_CURSOR_EXTERNAL_HS`],
+    /// where `reason` is `replay` or `unsorted`.
+    fn record_out_of_order(hs_id: &str, reason: &'static str) {
+        OUT_OF_ORDER_CURSOR_EXTERNAL_HS.add(
+            1,
+            &[
+                KeyValue::new("hs_id", hs_id.to_string()),
+                KeyValue::new("reason", reason),
+            ],
+        );
     }
 
     fn validate_user_id(

--- a/nexus-watcher/src/service/indexer/key_based.rs
+++ b/nexus-watcher/src/service/indexer/key_based.rs
@@ -27,10 +27,8 @@ const FETCH_EVENTS_429_BACKOFF_SECS: [u64; 3] = [1, 2, 3];
 
 /// Counter for per-user stream events an External HS returned at or below the
 /// ordering floor — a replay of already-indexed data, or a regression against an
-/// earlier event in the same batch. Both are rejected before any handler runs and
-/// stop the batch, stalling the user entirely when its first event trips the check.
-/// A sustained non-zero rate for one HS means it is misbehaving and needs operator
-/// attention. Labelled by `hs_id` only to avoid per-user metric cardinality.
+/// earlier event in the same batch. The whole batch is rejected before any handler
+/// runs. Labelled by `hs_id` only to avoid per-user metric cardinality.
 static OUT_OF_ORDER_CURSOR_EXTERNAL_HS: LazyLock<Counter<u64>> = LazyLock::new(|| {
     global::meter(super::METER_NAME)
         .u64_counter("watcher.external_hs.cursor.out_of_order")
@@ -321,7 +319,8 @@ impl KeyBasedEventProcessor {
     ///
     /// `persisted_cursor` is the user's currently stored cursor for this
     /// homeserver; it acts as the initial ordering floor so that events at or
-    /// below what we have already indexed are rejected before any handler runs.
+    /// below what we have already indexed are rejected. The complete batch is
+    /// validated before any handler runs.
     ///
     /// Returns the latest cursor that is safe to persist, plus the processing
     /// result. Cursor advancement is intentionally skipped for `UserIdMismatch`
@@ -333,6 +332,30 @@ impl KeyBasedEventProcessor {
         persisted_cursor: u64,
         stream_events: Vec<StreamEvent>,
     ) -> (Option<u64>, Result<(), EventProcessorError>) {
+        if *self.shutdown_rx.borrow() {
+            debug!(%user_id, "Shutdown detected; exiting event loop");
+            return (None, Ok(()));
+        }
+
+        let mut cursor_floor = persisted_cursor;
+        for stream_event in &stream_events {
+            let cursor_id = stream_event.cursor.id();
+            if cursor_id <= cursor_floor {
+                OUT_OF_ORDER_CURSOR_EXTERNAL_HS
+                    .add(1, &[KeyValue::new("hs_id", hs_id.to_string())]);
+                return (
+                    None,
+                    Err(EventProcessorError::EventCursorOutOfOrder {
+                        hs_id: hs_id.into(),
+                        user_id: user_id.into(),
+                        cursor: cursor_id,
+                        cursor_floor,
+                    }),
+                );
+            }
+            cursor_floor = cursor_id;
+        }
+
         let mut latest_cursor: Option<u64> = None;
 
         for stream_event in stream_events {
@@ -342,26 +365,6 @@ impl KeyBasedEventProcessor {
             }
 
             let cursor_id = stream_event.cursor.id();
-            // Fetches are cursor-exclusive and a correct HS returns events in
-            // increasing order, so every event must sit strictly above the floor:
-            // the stored cursor for the first event, the previous event after that.
-            // Seeding from `persisted_cursor` matters because `latest_cursor` resets
-            // each batch — the in-batch check alone would miss a replay.
-            let cursor_floor = latest_cursor.unwrap_or(persisted_cursor);
-            if cursor_id <= cursor_floor {
-                OUT_OF_ORDER_CURSOR_EXTERNAL_HS
-                    .add(1, &[KeyValue::new("hs_id", hs_id.to_string())]);
-                return (
-                    latest_cursor,
-                    Err(EventProcessorError::EventCursorOutOfOrder {
-                        hs_id: hs_id.into(),
-                        user_id: user_id.into(),
-                        cursor: cursor_id,
-                        cursor_floor,
-                    }),
-                );
-            }
-
             match Event::from_stream_event(&stream_event) {
                 Ok(Some(event)) => {
                     // External homeservers must not index another user's URI.

--- a/nexus-watcher/src/service/indexer/mod.rs
+++ b/nexus-watcher/src/service/indexer/mod.rs
@@ -3,17 +3,18 @@ mod key_based;
 
 pub use homeserver::HsEventProcessor;
 pub use key_based::{KeyBasedEventProcessor, KeyBasedEventSource, PubkyKeyBasedEventSource};
+
 use std::{fmt::Display, sync::Arc, time::Duration};
 
-use tracing::Instrument;
-
 use crate::errors::EventProcessorError;
-use crate::events::{Event, ParseResult};
-use tracing::{debug, error, warn};
-
 use crate::events::retry::RetryScheduler;
 use crate::events::EventHandler;
+use crate::events::{Event, ParseResult};
 use crate::service::PROCESSING_TIMEOUT_SECS;
+use tracing::{debug, error, warn, Instrument};
+
+/// OpenTelemetry meter name shared by all watcher indexer metrics.
+pub(super) const METER_NAME: &str = "nexus.watcher";
 
 /// Possible error types of an event processor run
 #[derive(Debug)]

--- a/nexus-watcher/tests/event_processor/posts/raw.rs
+++ b/nexus-watcher/tests/event_processor/posts/raw.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use super::utils::find_post_details;
 use super::utils::{
     check_member_global_timeline_user_post, check_member_user_post_timeline, find_post_counts,
@@ -8,7 +6,6 @@ use crate::event_processor::users::utils::{check_member_user_influencer, find_us
 use crate::event_processor::utils::watcher::WatcherTest;
 use anyhow::Result;
 use nexus_common::models::event::EventLine;
-use nexus_common::models::homeserver::Homeserver;
 use nexus_common::models::post::{PostCounts, PostDetails};
 use pubky::Keypair;
 use pubky_app_specs::{PubkyAppPost, PubkyAppPostKind, PubkyAppUser};
@@ -69,15 +66,6 @@ async fn test_homeserver_put_post_event() -> Result<()> {
     assert_eq!(post_details.uri, post_detail_cache.uri);
     assert_eq!(post_details.indexed_at, post_detail_cache.indexed_at);
 
-    reindex_and_ensure_cache_and_graph_unchanged(
-        &mut test,
-        &post_details,
-        &post_detail_cache,
-        &user_id,
-        &post_id,
-    )
-    .await?;
-
     // User:Counts:user_id:post_id
     let post_counts: PostCounts = find_post_counts(&user_id, &post_id).await;
     assert_eq!(post_counts.reposts, 0);
@@ -116,36 +104,6 @@ async fn test_homeserver_put_post_event() -> Result<()> {
     //     .unwrap();
 
     // assert!(result_post.is_none(), "The post should have been deleted");
-
-    Ok(())
-}
-
-async fn reindex_and_ensure_cache_and_graph_unchanged(
-    test: &mut WatcherTest,
-    post_details_from_graph: &PostDetails,
-    post_detail_from_cache: &PostDetails,
-    user_id: &str,
-    post_id: &str,
-) -> Result<()> {
-    // Wait for a few ms, so that re-indexing determines a different indexed_at (epoch timestamp in ms)
-    tokio::time::sleep(Duration::from_millis(10)).await;
-
-    // Reset the cursor, to ensure the events are re-indexed
-    let homeserver = Homeserver::new(test.homeserver_id.clone());
-    homeserver.put_to_graph().await.unwrap();
-    homeserver.put_to_index().await.unwrap();
-    test.ensure_event_processing_complete().await?;
-
-    // Check that nothing changed in the graph (DB)
-    let post_details_2 = find_post_details(user_id, post_id).await.unwrap();
-    assert_eq!(post_details_from_graph, &post_details_2);
-
-    // Check that nothing changed in the index (cache)
-    let post_detail_cache_2: PostDetails = PostDetails::get_from_index(user_id, post_id)
-        .await
-        .unwrap()
-        .expect("The new post detail was not served from Nexus cache");
-    assert_eq!(post_detail_from_cache, &post_detail_cache_2);
 
     Ok(())
 }

--- a/nexus-watcher/tests/service/hs_event_processor.rs
+++ b/nexus-watcher/tests/service/hs_event_processor.rs
@@ -588,6 +588,36 @@ async fn test_idle_batch_may_repeat_cursor() -> Result<()> {
 }
 
 // ============================================================================
+// An idle poll may not advance the cursor
+// Without event lines, the response cannot prove the watcher received the
+// events between the requested and returned cursors. Advancing would skip them.
+// ============================================================================
+
+#[tokio_shared_rt::test(shared)]
+async fn test_idle_batch_may_not_advance_cursor() -> Result<()> {
+    setup().await?;
+
+    let store = new_in_memory_store();
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let handler = create_mock_handler(Ok(()), None);
+    let processor =
+        build_processor_at_cursor(10, store.clone(), handler.clone(), shutdown_rx).await?;
+
+    processor
+        .process_event_lines(vec!["cursor: 20".to_string()])
+        .await?;
+
+    assert_eq!(
+        stored_cursor(&processor.homeserver.id).await?,
+        10,
+        "An idle poll must not advance past events it did not deliver"
+    );
+
+    let _ = shutdown_tx.send(true);
+    Ok(())
+}
+
+// ============================================================================
 // An advancing cursor is persisted once the batch has been processed
 // ============================================================================
 

--- a/nexus-watcher/tests/service/hs_event_processor.rs
+++ b/nexus-watcher/tests/service/hs_event_processor.rs
@@ -18,9 +18,29 @@ use crate::service::utils::{new_in_memory_store, setup};
 
 const TEST_HS_ID: &str = "1hb71xx9km3f4pw5izsy1gn19ff1uuuqonw4mcygzobwkryujoiy";
 
+/// Cursor line closing the batches of tests that are not about cursor handling.
+///
+/// Any value above the 0 that [`build_processor`] sits at works, and using a
+/// single shared one keeps it valid however many of these tests persist it for
+/// [`TEST_HS_ID`]: re-persisting the same cursor is not a rewind.
+const TEST_NEXT_CURSOR: &str = "cursor: 1";
+
 /// Returns a fresh random user id (z32 public key) that has no graph state yet.
 fn random_user_id() -> String {
     random_pk().to_z32()
+}
+
+/// Closes `event_lines` into a well-formed batch, the way a homeserver ends a
+/// non-empty response.
+///
+/// Tests that are not about cursor handling still need this: a batch carrying
+/// events but no cursor line is rejected as stalled, since nothing in it could
+/// move the checkpoint past the events it delivers.
+fn batch(event_lines: impl IntoIterator<Item = String>) -> Vec<String> {
+    event_lines
+        .into_iter()
+        .chain([TEST_NEXT_CURSOR.to_string()])
+        .collect()
 }
 
 /// Creates a `User` node and, when `hs_id` is `Some`, links it to that homeserver
@@ -72,6 +92,48 @@ fn build_processor(
     })
 }
 
+/// Assembles an [`HsEventProcessor`] sitting at `cursor` on a fresh random
+/// homeserver, with that same cursor seeded in Redis — mirroring a real
+/// processor, which is built by reading the stored cursor and then requesting
+/// events from exactly that position.
+///
+/// A random homeserver id keeps the stored cursor from leaking between tests.
+async fn build_processor_at_cursor(
+    cursor: u64,
+    store: Arc<dyn RetryStore>,
+    event_handler: Arc<dyn EventHandler>,
+    shutdown_rx: watch::Receiver<bool>,
+) -> Result<Arc<HsEventProcessor>> {
+    let hs_id = random_pubky_id();
+    let homeserver = Homeserver { id: hs_id, cursor };
+    homeserver.put_to_index().await?;
+
+    let retry_scheduler = Arc::new(RetryScheduler::new(
+        store,
+        InitialBackoff {
+            missing_dep_ms: 60_000,
+            transient_ms: 10_000,
+        },
+    ));
+
+    Ok(Arc::new(HsEventProcessor {
+        homeserver,
+        limit: 100,
+        event_handler,
+        shutdown_rx,
+        retry_scheduler,
+        hs_mapping_cache: Default::default(),
+    }))
+}
+
+/// Reads a homeserver's currently stored cursor.
+async fn stored_cursor(hs_id: &str) -> Result<u64> {
+    Ok(Homeserver::get_from_index(hs_id)
+        .await?
+        .expect("Homeserver must be present in the index")
+        .cursor)
+}
+
 // ============================================================================
 // Batch continues after a single event fails
 // A retryable application error on one event must not halt the batch — later
@@ -89,7 +151,7 @@ async fn test_batch_continues_after_single_failure() -> Result<()> {
     let first_uri = post_uri_builder(user_id.clone(), first_post_id.to_string());
     let second_uri = post_uri_builder(user_id, second_post_id.to_string());
 
-    let lines = vec![format!("PUT {first_uri}"), format!("PUT {second_uri}")];
+    let lines = batch([format!("PUT {first_uri}"), format!("PUT {second_uri}")]);
 
     let store = new_in_memory_store();
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
@@ -154,7 +216,7 @@ async fn test_retry_event_carries_origin_homeserver_id() -> Result<()> {
     let processor = build_processor(store.clone(), handler.clone(), shutdown_rx);
 
     processor
-        .process_event_lines(vec![format!("PUT {uri}")])
+        .process_event_lines(batch([format!("PUT {uri}")]))
         .await?;
 
     let retry_event = store
@@ -193,7 +255,7 @@ async fn test_skips_event_when_user_hosted_on_different_homeserver() -> Result<(
     let processor = build_processor(store.clone(), handler.clone(), shutdown_rx);
 
     processor
-        .process_event_lines(vec![format!("PUT {uri}")])
+        .process_event_lines(batch([format!("PUT {uri}")]))
         .await?;
 
     assert_eq!(
@@ -226,7 +288,7 @@ async fn test_processes_event_when_user_hosted_on_same_homeserver() -> Result<()
     let processor = build_processor(store.clone(), handler.clone(), shutdown_rx);
 
     processor
-        .process_event_lines(vec![format!("PUT {uri}")])
+        .process_event_lines(batch([format!("PUT {uri}")]))
         .await?;
 
     assert_eq!(
@@ -264,7 +326,7 @@ async fn test_skips_event_when_user_mapping_to_this_homeserver_is_stale() -> Res
     let processor = build_processor(store.clone(), handler.clone(), shutdown_rx);
 
     processor
-        .process_event_lines(vec![format!("PUT {uri}")])
+        .process_event_lines(batch([format!("PUT {uri}")]))
         .await?;
 
     assert_eq!(
@@ -297,7 +359,7 @@ async fn test_processes_event_when_user_has_no_homeserver_edge() -> Result<()> {
     let processor = build_processor(store.clone(), handler.clone(), shutdown_rx);
 
     processor
-        .process_event_lines(vec![format!("PUT {uri}")])
+        .process_event_lines(batch([format!("PUT {uri}")]))
         .await?;
 
     assert_eq!(
@@ -332,7 +394,7 @@ async fn test_user_homeserver_mapping_is_cached_across_events() -> Result<()> {
     let processor = build_processor(store.clone(), handler.clone(), shutdown_rx);
 
     processor
-        .process_event_lines(vec![format!("PUT {first_uri}")])
+        .process_event_lines(batch([format!("PUT {first_uri}")]))
         .await?;
 
     // Map the user to a *different* homeserver. A fresh lookup would now skip,
@@ -341,7 +403,7 @@ async fn test_user_homeserver_mapping_is_cached_across_events() -> Result<()> {
     create_user_hosted_on(&user_id, Some(&other_hs_id)).await;
 
     processor
-        .process_event_lines(vec![format!("PUT {second_uri}")])
+        .process_event_lines(batch([format!("PUT {second_uri}")]))
         .await?;
 
     assert_eq!(
@@ -371,7 +433,7 @@ async fn test_batch_stops_on_infrastructure_error() -> Result<()> {
     let first_uri = post_uri_builder(user_id.clone(), first_post_id.to_string());
     let second_uri = post_uri_builder(user_id, second_post_id.to_string());
 
-    let lines = vec![format!("PUT {first_uri}"), format!("PUT {second_uri}")];
+    let lines = batch([format!("PUT {first_uri}"), format!("PUT {second_uri}")]);
 
     let store = new_in_memory_store();
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
@@ -413,6 +475,262 @@ async fn test_batch_stops_on_infrastructure_error() -> Result<()> {
     assert!(
         store.get(&IndexKey::for_uri(&second_uri)).await?.is_none(),
         "Second event must not be queued — batch should have stopped at the first failure"
+    );
+
+    let _ = shutdown_tx.send(true);
+    Ok(())
+}
+
+// ============================================================================
+// A batch carrying events must advance the cursor
+// A response fetched at cursor 10 that carries events but closes at cursor 10
+// would be re-requested and re-processed on every subsequent poll. The batch is
+// skipped before any handler runs, and the cursor is left where it was.
+// ============================================================================
+
+#[tokio_shared_rt::test(shared)]
+async fn test_non_advancing_cursor_skips_batch_with_events() -> Result<()> {
+    setup().await?;
+
+    let uri = post_uri_builder(random_user_id(), "stalled".to_string());
+
+    let store = new_in_memory_store();
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let handler = create_mock_handler(Ok(()), None);
+    let processor =
+        build_processor_at_cursor(10, store.clone(), handler.clone(), shutdown_rx).await?;
+
+    processor
+        .process_event_lines(vec![format!("PUT {uri}"), "cursor: 10".to_string()])
+        .await?;
+
+    assert_eq!(
+        handler.get_handle_count(),
+        0,
+        "Batch must be skipped before any handler runs — the cursor could never record the work"
+    );
+    assert_eq!(
+        stored_cursor(&processor.homeserver.id).await?,
+        10,
+        "A non-advancing cursor must not be persisted"
+    );
+
+    let _ = shutdown_tx.send(true);
+    Ok(())
+}
+
+// ============================================================================
+// A batch carrying events but no cursor line is skipped
+// Nothing in such a batch can move the checkpoint past the events it delivers,
+// so the next poll would re-fetch and re-process it — the same stall as a
+// non-advancing cursor, reached by omission rather than repetition.
+// ============================================================================
+
+#[tokio_shared_rt::test(shared)]
+async fn test_batch_without_cursor_line_is_skipped() -> Result<()> {
+    setup().await?;
+
+    let uri = post_uri_builder(random_user_id(), "nocursor".to_string());
+
+    let store = new_in_memory_store();
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let handler = create_mock_handler(Ok(()), None);
+    let processor =
+        build_processor_at_cursor(10, store.clone(), handler.clone(), shutdown_rx).await?;
+
+    processor
+        .process_event_lines(vec![format!("PUT {uri}")])
+        .await?;
+
+    assert_eq!(
+        handler.get_handle_count(),
+        0,
+        "A batch with events but no cursor line must be skipped before any handler runs"
+    );
+    assert_eq!(
+        stored_cursor(&processor.homeserver.id).await?,
+        10,
+        "A batch with no cursor line must leave the cursor untouched"
+    );
+
+    let _ = shutdown_tx.send(true);
+    Ok(())
+}
+
+// ============================================================================
+// An idle poll may repeat the cursor
+// A response with no event lines legitimately closes at the cursor it was
+// fetched with; that is the homeserver saying "nothing new", not a stall.
+// ============================================================================
+
+#[tokio_shared_rt::test(shared)]
+async fn test_idle_batch_may_repeat_cursor() -> Result<()> {
+    setup().await?;
+
+    let store = new_in_memory_store();
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let handler = create_mock_handler(Ok(()), None);
+    let processor =
+        build_processor_at_cursor(10, store.clone(), handler.clone(), shutdown_rx).await?;
+
+    processor
+        .process_event_lines(vec!["cursor: 10".to_string()])
+        .await?;
+
+    assert_eq!(
+        stored_cursor(&processor.homeserver.id).await?,
+        10,
+        "An idle poll repeating the cursor must be accepted and leave it in place"
+    );
+
+    let _ = shutdown_tx.send(true);
+    Ok(())
+}
+
+// ============================================================================
+// An advancing cursor is persisted once the batch has been processed
+// ============================================================================
+
+#[tokio_shared_rt::test(shared)]
+async fn test_advancing_cursor_is_persisted_after_batch() -> Result<()> {
+    setup().await?;
+
+    let uri = post_uri_builder(random_user_id(), "advance".to_string());
+
+    let store = new_in_memory_store();
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let handler = create_mock_handler(Ok(()), None);
+    let processor =
+        build_processor_at_cursor(10, store.clone(), handler.clone(), shutdown_rx).await?;
+
+    processor
+        .process_event_lines(vec![format!("PUT {uri}"), "cursor: 11".to_string()])
+        .await?;
+
+    assert_eq!(
+        handler.get_handle_count(),
+        1,
+        "Event must be handled when the batch closes with an advancing cursor"
+    );
+    assert_eq!(
+        stored_cursor(&processor.homeserver.id).await?,
+        11,
+        "An advancing cursor must be persisted after the batch"
+    );
+
+    let _ = shutdown_tx.send(true);
+    Ok(())
+}
+
+// ============================================================================
+// A rewinding or unparseable cursor skips the batch before handlers run
+// Validating up front means bad homeserver input costs no handler work, since
+// the cursor stays put and the next poll re-fetches the same batch anyway.
+// ============================================================================
+
+#[tokio_shared_rt::test(shared)]
+async fn test_rewinding_cursor_skips_batch_before_handlers() -> Result<()> {
+    setup().await?;
+
+    let uri = post_uri_builder(random_user_id(), "rewind".to_string());
+
+    let store = new_in_memory_store();
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let handler = create_mock_handler(Ok(()), None);
+    let processor =
+        build_processor_at_cursor(10, store.clone(), handler.clone(), shutdown_rx).await?;
+
+    processor
+        .process_event_lines(vec![format!("PUT {uri}"), "cursor: 5".to_string()])
+        .await?;
+
+    assert_eq!(
+        handler.get_handle_count(),
+        0,
+        "A rewinding cursor must skip the batch before any handler runs"
+    );
+    assert_eq!(
+        stored_cursor(&processor.homeserver.id).await?,
+        10,
+        "A rewinding cursor must not be persisted"
+    );
+
+    let _ = shutdown_tx.send(true);
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_unparseable_cursor_skips_batch_before_handlers() -> Result<()> {
+    setup().await?;
+
+    let uri = post_uri_builder(random_user_id(), "garbage".to_string());
+
+    let store = new_in_memory_store();
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let handler = create_mock_handler(Ok(()), None);
+    let processor =
+        build_processor_at_cursor(10, store.clone(), handler.clone(), shutdown_rx).await?;
+
+    processor
+        .process_event_lines(vec![
+            format!("PUT {uri}"),
+            "cursor: not-a-number".to_string(),
+        ])
+        .await?;
+
+    assert_eq!(
+        handler.get_handle_count(),
+        0,
+        "An unparseable cursor must skip the batch before any handler runs"
+    );
+    assert_eq!(
+        stored_cursor(&processor.homeserver.id).await?,
+        10,
+        "An unparseable cursor must not be persisted"
+    );
+
+    let _ = shutdown_tx.send(true);
+    Ok(())
+}
+
+// ============================================================================
+// The cursor is persisted only after the whole batch succeeds
+// A should-not-retry-now error stops the batch partway, so the valid cursor
+// closing it must not be applied — the next run has to replay from the same
+// position.
+// ============================================================================
+
+#[tokio_shared_rt::test(shared)]
+async fn test_cursor_not_persisted_when_batch_stops() -> Result<()> {
+    setup().await?;
+
+    let post_id = "cursorhalt";
+    let uri = post_uri_builder(random_user_id(), post_id.to_string());
+
+    let store = new_in_memory_store();
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let handler = create_mock_handler(
+        Err(EventProcessorError::IndexOperationFailed(
+            true,
+            "simulated infra failure".to_string(),
+        )),
+        Some(post_id),
+    );
+    let processor =
+        build_processor_at_cursor(10, store.clone(), handler.clone(), shutdown_rx).await?;
+
+    let result = processor
+        .process_event_lines(vec![format!("PUT {uri}"), "cursor: 11".to_string()])
+        .await;
+    assert!(
+        result.is_err(),
+        "Should-not-retry-now error must propagate and stop the batch"
+    );
+
+    assert_eq!(
+        stored_cursor(&processor.homeserver.id).await?,
+        10,
+        "Cursor must not advance past events the stopped batch never processed"
     );
 
     let _ = shutdown_tx.send(true);

--- a/nexus-watcher/tests/service/key_based_event_processor.rs
+++ b/nexus-watcher/tests/service/key_based_event_processor.rs
@@ -317,6 +317,40 @@ async fn key_based_processor_does_not_rewind_stored_cursor() -> Result<(), DynEr
     Ok(())
 }
 
+/// Verifies an event whose cursor equals the stored one is rejected. Fetches are
+/// cursor-exclusive, so re-returning the boundary cursor is a replay, not progress.
+#[tokio_shared_rt::test(shared)]
+async fn key_based_processor_rejects_cursor_equal_to_stored() -> Result<(), DynError> {
+    setup().await?;
+
+    let (_hs_keypair, homeserver) = create_homeserver().await?;
+    let hs_id = homeserver.id.to_string();
+    let user_id = create_user_on_homeserver(&homeserver).await?;
+    let cursor_key = user_hs_cursor_key(&user_id);
+    UserDetails::put_index_sorted_set(&cursor_key, &[(42.0, hs_id.as_str())], None, None).await?;
+
+    // Asked to continue from 42, the homeserver re-returns the event at 42.
+    let source =
+        Arc::new(
+            MockKeyBasedEventSource::default().with_events(vec![vec![stream_event(
+                42,
+                &user_id,
+                "/pub/pubky.app/profile.json",
+            )?]]),
+        );
+    let handler = create_mock_handler(Ok(()), None);
+    let processor = processor(homeserver, handler.clone(), source);
+
+    processor.run().await?;
+
+    // The boundary event must be rejected before the handler runs, and the
+    // persisted cursor stays at 42.
+    assert_eq!(handler.get_handle_count(), 0);
+    assert_eq!(user_cursor(&user_id, &hs_id).await?, Some(42));
+
+    Ok(())
+}
+
 /// Verifies cursor persistence stops at the last safe event before a mismatch.
 #[tokio_shared_rt::test(shared)]
 async fn key_based_processor_persists_last_safe_cursor_before_mismatch() -> Result<(), DynError> {

--- a/nexus-watcher/tests/service/key_based_event_processor.rs
+++ b/nexus-watcher/tests/service/key_based_event_processor.rs
@@ -305,10 +305,13 @@ async fn key_based_processor_does_not_rewind_stored_cursor() -> Result<(), DynEr
             )?]]),
         );
     let handler = create_mock_handler(Ok(()), None);
-    let processor = processor(homeserver, handler, source);
+    let processor = processor(homeserver, handler.clone(), source);
 
     processor.run().await?;
 
+    // The stale event must be rejected before the handler runs (not merely
+    // ignored at cursor-write time), and the persisted cursor stays at 42.
+    assert_eq!(handler.get_handle_count(), 0);
     assert_eq!(user_cursor(&user_id, &hs_id).await?, Some(42));
 
     Ok(())

--- a/nexus-watcher/tests/service/key_based_event_processor.rs
+++ b/nexus-watcher/tests/service/key_based_event_processor.rs
@@ -237,7 +237,7 @@ async fn key_based_processor_passes_stored_cursor_and_limit_to_source() -> Resul
     Ok(())
 }
 
-/// Verifies successful event processing persists the last stream cursor.
+/// Verifies successful event processing persists the latest stream cursor.
 #[tokio_shared_rt::test(shared)]
 async fn key_based_processor_persists_latest_cursor_after_success() -> Result<(), DynError> {
     setup().await?;
@@ -256,6 +256,60 @@ async fn key_based_processor_persists_latest_cursor_after_success() -> Result<()
 
     assert_eq!(handler.get_handle_count(), 2);
     assert_eq!(user_cursor(&user_id, &hs_id).await?, Some(4));
+
+    Ok(())
+}
+
+/// Verifies an out-of-order stream cursor is rejected before its event is handled.
+#[tokio_shared_rt::test(shared)]
+async fn key_based_processor_rejects_out_of_order_cursor() -> Result<(), DynError> {
+    setup().await?;
+
+    let (_hs_keypair, homeserver) = create_homeserver().await?;
+    let hs_id = homeserver.id.to_string();
+    let user_id = create_user_on_homeserver(&homeserver).await?;
+    let source = Arc::new(MockKeyBasedEventSource::default().with_events(vec![vec![
+        stream_event(4, &user_id, "/pub/pubky.app/profile.json")?,
+        stream_event(1, &user_id, "/pub/pubky.app/profile.json")?,
+    ]]));
+    let handler = create_mock_handler(Ok(()), None);
+    let processor = processor(homeserver, handler.clone(), source);
+
+    processor.run().await?;
+
+    assert_eq!(handler.get_handle_count(), 1);
+    assert_eq!(user_cursor(&user_id, &hs_id).await?, Some(4));
+
+    Ok(())
+}
+
+/// Verifies a homeserver cannot rewind a stored per-user cursor.
+#[tokio_shared_rt::test(shared)]
+async fn key_based_processor_does_not_rewind_stored_cursor() -> Result<(), DynError> {
+    setup().await?;
+
+    let (_hs_keypair, homeserver) = create_homeserver().await?;
+    let hs_id = homeserver.id.to_string();
+    let user_id = create_user_on_homeserver(&homeserver).await?;
+    let cursor_key = user_hs_cursor_key(&user_id);
+    UserDetails::put_index_sorted_set(&cursor_key, &[(42.0, hs_id.as_str())], None, None).await?;
+
+    // A malformed or malicious homeserver could return an old event after being
+    // asked for cursor 42. The persisted cursor must remain at 42.
+    let source =
+        Arc::new(
+            MockKeyBasedEventSource::default().with_events(vec![vec![stream_event(
+                9,
+                &user_id,
+                "/pub/pubky.app/profile.json",
+            )?]]),
+        );
+    let handler = create_mock_handler(Ok(()), None);
+    let processor = processor(homeserver, handler, source);
+
+    processor.run().await?;
+
+    assert_eq!(user_cursor(&user_id, &hs_id).await?, Some(42));
 
     Ok(())
 }

--- a/nexus-watcher/tests/service/key_based_event_processor.rs
+++ b/nexus-watcher/tests/service/key_based_event_processor.rs
@@ -262,9 +262,9 @@ async fn key_based_processor_persists_latest_cursor_after_success() -> Result<()
     Ok(())
 }
 
-/// Verifies an out-of-order stream cursor is rejected before its event is handled.
+/// Verifies an out-of-order stream cursor rejects the whole batch before handling.
 #[tokio_shared_rt::test(shared)]
-async fn key_based_processor_rejects_out_of_order_cursor() -> Result<(), DynError> {
+async fn key_based_processor_rejects_out_of_order_batch() -> Result<(), DynError> {
     setup().await?;
 
     let (_hs_keypair, homeserver) = create_homeserver().await?;
@@ -284,8 +284,8 @@ async fn key_based_processor_rejects_out_of_order_cursor() -> Result<(), DynErro
 
     assert_internal_event_cursor_out_of_order(err);
 
-    assert_eq!(handler.get_handle_count(), 1);
-    assert_eq!(user_cursor(&user_id, &hs_id).await?, Some(4));
+    assert_eq!(handler.get_handle_count(), 0);
+    assert_eq!(user_cursor(&user_id, &hs_id).await?, None);
 
     Ok(())
 }

--- a/nexus-watcher/tests/service/key_based_event_processor.rs
+++ b/nexus-watcher/tests/service/key_based_event_processor.rs
@@ -10,12 +10,14 @@ use nexus_common::models::traits::Collection;
 use nexus_common::models::user::{set_user_homeserver, user_hs_cursor_key, UserDetails};
 use nexus_common::types::DynError;
 use nexus_common::utils::test_utils::random_pubky_id;
+use nexus_common::WatcherConfig;
 use nexus_watcher::errors::EventProcessorError;
 use nexus_watcher::events::retry::{InitialBackoff, RetryScheduler};
 use nexus_watcher::events::Event;
 use nexus_watcher::events::EventHandler;
 use nexus_watcher::service::indexer::{KeyBasedEventProcessor, RunError, TEventProcessor};
 use nexus_watcher::service::runner::UserNotFoundBackoff;
+use nexus_watcher::service::{KeyBasedEventProcessorRunner, TEventProcessorRunner};
 use pubky::{Event as StreamEvent, EventCursor, EventType, Keypair, PubkyResource, PublicKey};
 use pubky_app_specs::PubkyId;
 use tokio::sync::watch;
@@ -275,10 +277,58 @@ async fn key_based_processor_rejects_out_of_order_cursor() -> Result<(), DynErro
     let handler = create_mock_handler(Ok(()), None);
     let processor = processor(homeserver, handler.clone(), source);
 
-    processor.run().await?;
+    let err = processor
+        .run()
+        .await
+        .expect_err("out-of-order cursor must abort the homeserver run");
+
+    assert_internal_event_cursor_out_of_order(err);
 
     assert_eq!(handler.get_handle_count(), 1);
     assert_eq!(user_cursor(&user_id, &hs_id).await?, Some(4));
+
+    Ok(())
+}
+
+/// Verifies an out-of-order cursor backs off the whole external homeserver, so
+/// the next runner pass skips it instead of fetching the malformed stream again.
+#[tokio_shared_rt::test(shared)]
+async fn key_based_runner_backs_off_homeserver_after_out_of_order_cursor() -> Result<(), DynError> {
+    setup().await?;
+
+    let (_hs_keypair, homeserver) = create_homeserver().await?;
+    let hs_id = homeserver.id.to_string();
+    let user_id = create_user_on_homeserver(&homeserver).await?;
+    let source = Arc::new(MockKeyBasedEventSource::default().with_user_events(vec![(
+        user_id.clone(),
+        vec![
+            stream_event(4, &user_id, "/pub/pubky.app/profile.json")?,
+            stream_event(1, &user_id, "/pub/pubky.app/profile.json")?,
+        ],
+    )]));
+    let mut runner = KeyBasedEventProcessorRunner::from_config(
+        &WatcherConfig::default(),
+        watch::channel(false).1,
+    );
+    runner.monitored_hs_limit = usize::MAX;
+    runner.event_handler = create_mock_handler(Ok(()), None);
+    runner.event_source = source.clone();
+    runner.primary_homeserver = random_pubky_id();
+
+    runner.run().await?;
+    assert!(runner.backoff.lock().await.should_skip(&hs_id));
+
+    runner.run().await?;
+    let target_fetches = source
+        .calls()
+        .await
+        .into_iter()
+        .filter(|called_user| called_user == &user_id)
+        .count();
+    assert_eq!(
+        target_fetches, 1,
+        "backed-off homeserver must not be fetched again"
+    );
 
     Ok(())
 }
@@ -307,7 +357,11 @@ async fn key_based_processor_does_not_rewind_stored_cursor() -> Result<(), DynEr
     let handler = create_mock_handler(Ok(()), None);
     let processor = processor(homeserver, handler.clone(), source);
 
-    processor.run().await?;
+    let err = processor
+        .run()
+        .await
+        .expect_err("rewound cursor must abort the homeserver run");
+    assert_internal_event_cursor_out_of_order(err);
 
     // The stale event must be rejected before the handler runs (not merely
     // ignored at cursor-write time), and the persisted cursor stays at 42.
@@ -341,7 +395,11 @@ async fn key_based_processor_rejects_cursor_equal_to_stored() -> Result<(), DynE
     let handler = create_mock_handler(Ok(()), None);
     let processor = processor(homeserver, handler.clone(), source);
 
-    processor.run().await?;
+    let err = processor
+        .run()
+        .await
+        .expect_err("replayed boundary cursor must abort the homeserver run");
+    assert_internal_event_cursor_out_of_order(err);
 
     // The boundary event must be rejected before the handler runs, and the
     // persisted cursor stays at 42.
@@ -958,6 +1016,13 @@ fn assert_internal_hs_rate_limit_exhausted(err: RunError) {
         other => {
             panic!("expected internal HsEventsStreamRateLimitExhausted error, got {other:?}")
         }
+    }
+}
+
+fn assert_internal_event_cursor_out_of_order(err: RunError) {
+    match err {
+        RunError::Internal(EventProcessorError::EventCursorOutOfOrder { .. }) => {}
+        other => panic!("expected internal EventCursorOutOfOrder error, got {other:?}"),
     }
 }
 

--- a/nexus-watcher/tests/service/key_based_event_processor.rs
+++ b/nexus-watcher/tests/service/key_based_event_processor.rs
@@ -260,9 +260,11 @@ async fn key_based_processor_persists_latest_cursor_after_success() -> Result<()
     Ok(())
 }
 
-/// Verifies an out-of-order stream cursor is rejected before its event is handled.
+/// Verifies an unsorted batch — an event regressing against an earlier one in the
+/// same response — stops at the offending event, which is never handled. The
+/// homeserver has to re-deliver it, and everything after it, in order.
 #[tokio_shared_rt::test(shared)]
-async fn key_based_processor_rejects_out_of_order_cursor() -> Result<(), DynError> {
+async fn key_based_processor_stops_on_unsorted_batch() -> Result<(), DynError> {
     setup().await?;
 
     let (_hs_keypair, homeserver) = create_homeserver().await?;
@@ -271,14 +273,51 @@ async fn key_based_processor_rejects_out_of_order_cursor() -> Result<(), DynErro
     let source = Arc::new(MockKeyBasedEventSource::default().with_events(vec![vec![
         stream_event(4, &user_id, "/pub/pubky.app/profile.json")?,
         stream_event(1, &user_id, "/pub/pubky.app/profile.json")?,
+        stream_event(7, &user_id, "/pub/pubky.app/profile.json")?,
     ]]));
     let handler = create_mock_handler(Ok(()), None);
     let processor = processor(homeserver, handler.clone(), source);
 
     processor.run().await?;
 
+    // Only the event at 4 is handled: 1 regresses against it, and the batch stops
+    // there rather than skipping ahead to 7. The cursor holds at the last safe
+    // event, which is strictly above where the poll started — so the next poll
+    // asks for a higher range and the user cannot get stuck here.
     assert_eq!(handler.get_handle_count(), 1);
     assert_eq!(user_cursor(&user_id, &hs_id).await?, Some(4));
+
+    Ok(())
+}
+
+/// Verifies a replayed event does not block newer events behind it. The stored
+/// cursor can never move past a replay, so stopping the batch would leave the
+/// next poll re-fetching the same response indefinitely.
+#[tokio_shared_rt::test(shared)]
+async fn key_based_processor_skips_replay_and_continues_batch() -> Result<(), DynError> {
+    setup().await?;
+
+    let (_hs_keypair, homeserver) = create_homeserver().await?;
+    let hs_id = homeserver.id.to_string();
+    let user_id = create_user_on_homeserver(&homeserver).await?;
+    let cursor_key = user_hs_cursor_key(&user_id);
+    UserDetails::put_index_sorted_set(&cursor_key, &[(12.0, hs_id.as_str())], None, None).await?;
+
+    // Asked to continue from 12, the homeserver leads with an already-indexed
+    // event before the genuinely new one.
+    let source = Arc::new(MockKeyBasedEventSource::default().with_events(vec![vec![
+        stream_event(9, &user_id, "/pub/pubky.app/profile.json")?,
+        stream_event(13, &user_id, "/pub/pubky.app/profile.json")?,
+    ]]));
+    let handler = create_mock_handler(Ok(()), None);
+    let processor = processor(homeserver, handler.clone(), source);
+
+    processor.run().await?;
+
+    // The replay is skipped without reaching a handler, and the event at 13 is
+    // still indexed and checkpointed.
+    assert_eq!(handler.get_handle_count(), 1);
+    assert_eq!(user_cursor(&user_id, &hs_id).await?, Some(13));
 
     Ok(())
 }

--- a/nexus-watcher/tests/service/key_based_event_processor.rs
+++ b/nexus-watcher/tests/service/key_based_event_processor.rs
@@ -82,6 +82,33 @@ async fn key_based_processor_skips_unrecognized_events() -> Result<(), DynError>
 }
 
 #[tokio_shared_rt::test(shared)]
+async fn key_based_processor_rejects_unrecognized_event_for_mismatched_user() -> Result<(), DynError>
+{
+    setup().await?;
+
+    let (_hs_keypair, homeserver) = create_homeserver().await?;
+    let hs_id = homeserver.id.to_string();
+    let user_id = create_user_on_homeserver(&homeserver).await?;
+    let mismatched_user_id = random_pubky_id().to_string();
+    let cursor_key = user_hs_cursor_key(&user_id);
+    UserDetails::put_index_sorted_set(&cursor_key, &[(10.0, hs_id.as_str())], None, None).await?;
+
+    let source = Arc::new(MockKeyBasedEventSource::default().with_events(vec![vec![
+        stream_event(100, &mismatched_user_id, "/pub/other.app/profile.json")?,
+        stream_event(101, &user_id, "/pub/pubky.app/profile.json")?,
+    ]]));
+    let handler = create_mock_handler(Ok(()), None);
+    let processor = processor(homeserver, handler.clone(), source);
+
+    processor.run().await?;
+
+    assert_eq!(handler.get_handle_count(), 0);
+    assert_eq!(user_cursor(&user_id, &hs_id).await?, Some(10));
+
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
 async fn key_based_processor_stops_mismatched_user_stream_but_continues_other_users(
 ) -> Result<(), DynError> {
     setup().await?;

--- a/nexus-watcher/tests/service/key_based_event_processor.rs
+++ b/nexus-watcher/tests/service/key_based_event_processor.rs
@@ -260,11 +260,9 @@ async fn key_based_processor_persists_latest_cursor_after_success() -> Result<()
     Ok(())
 }
 
-/// Verifies an unsorted batch — an event regressing against an earlier one in the
-/// same response — stops at the offending event, which is never handled. The
-/// homeserver has to re-deliver it, and everything after it, in order.
+/// Verifies an out-of-order stream cursor is rejected before its event is handled.
 #[tokio_shared_rt::test(shared)]
-async fn key_based_processor_stops_on_unsorted_batch() -> Result<(), DynError> {
+async fn key_based_processor_rejects_out_of_order_cursor() -> Result<(), DynError> {
     setup().await?;
 
     let (_hs_keypair, homeserver) = create_homeserver().await?;
@@ -273,51 +271,14 @@ async fn key_based_processor_stops_on_unsorted_batch() -> Result<(), DynError> {
     let source = Arc::new(MockKeyBasedEventSource::default().with_events(vec![vec![
         stream_event(4, &user_id, "/pub/pubky.app/profile.json")?,
         stream_event(1, &user_id, "/pub/pubky.app/profile.json")?,
-        stream_event(7, &user_id, "/pub/pubky.app/profile.json")?,
     ]]));
     let handler = create_mock_handler(Ok(()), None);
     let processor = processor(homeserver, handler.clone(), source);
 
     processor.run().await?;
 
-    // Only the event at 4 is handled: 1 regresses against it, and the batch stops
-    // there rather than skipping ahead to 7. The cursor holds at the last safe
-    // event, which is strictly above where the poll started — so the next poll
-    // asks for a higher range and the user cannot get stuck here.
     assert_eq!(handler.get_handle_count(), 1);
     assert_eq!(user_cursor(&user_id, &hs_id).await?, Some(4));
-
-    Ok(())
-}
-
-/// Verifies a replayed event does not block newer events behind it. The stored
-/// cursor can never move past a replay, so stopping the batch would leave the
-/// next poll re-fetching the same response indefinitely.
-#[tokio_shared_rt::test(shared)]
-async fn key_based_processor_skips_replay_and_continues_batch() -> Result<(), DynError> {
-    setup().await?;
-
-    let (_hs_keypair, homeserver) = create_homeserver().await?;
-    let hs_id = homeserver.id.to_string();
-    let user_id = create_user_on_homeserver(&homeserver).await?;
-    let cursor_key = user_hs_cursor_key(&user_id);
-    UserDetails::put_index_sorted_set(&cursor_key, &[(12.0, hs_id.as_str())], None, None).await?;
-
-    // Asked to continue from 12, the homeserver leads with an already-indexed
-    // event before the genuinely new one.
-    let source = Arc::new(MockKeyBasedEventSource::default().with_events(vec![vec![
-        stream_event(9, &user_id, "/pub/pubky.app/profile.json")?,
-        stream_event(13, &user_id, "/pub/pubky.app/profile.json")?,
-    ]]));
-    let handler = create_mock_handler(Ok(()), None);
-    let processor = processor(homeserver, handler.clone(), source);
-
-    processor.run().await?;
-
-    // The replay is skipped without reaching a handler, and the event at 13 is
-    // still indexed and checkpointed.
-    assert_eq!(handler.get_handle_count(), 1);
-    assert_eq!(user_cursor(&user_id, &hs_id).await?, Some(13));
 
     Ok(())
 }


### PR DESCRIPTION
This PR prevents homeserver event reindexing by enforcing monotonic cursors:

- The primary HS cursor may never rewind. Non-empty batches must advance past the requested cursor, are validated before handlers run, and are checkpointed only after successful processing.
- External HS per-user cursors must advance past both the stored cursor and earlier events in the same batch. Violations abort that HS run and trigger the existing configurable per-HS exponential backoff.
- Primary HS cursors are represented numerically while remaining compatible with numeric values previously stored as strings.

Records the following metrics:

| Metric | Meaning |
|---|---|
| `watcher.primary_hs.cursor.invalid` | Primary HS cursor was unparseable or would rewind |
| `watcher.primary_hs.cursor.stalled` | A non-empty primary HS batch could not advance its checkpoint |
| `watcher.external_hs.cursor.out_of_order` | External HS returned a replayed or out-of-order per-user cursor |

Supersedes #662 by reimplementing it on the latest `main`.

---

### Pre-submission Checklist

- [x] I manually reviewed the PR
- [x] I asked one or more LLMs to review the PR
- [x] I asked one or more LLMs to check if this PR can be simplified [^1]
- [x] If appropriate, I added tests for the changes in this PR
- [ ] If appropriate, I added performance benchmarks for the APIs added in this PR [^2]

[^1]: Sample prompt: "Can this be simplified? Can the code, comments, or logic introduced by these changes be simplfied, clarified or otherwise made more terse, concise and understandable, without affecting functionality?"
[^2]: `cargo bench -p nexus-webapi`
