### PR TITLE
fix: bound concurrent media processing

### DIFF
--- a/nexus-common/default.config.toml
+++ b/nexus-common/default.config.toml
@@ -110,3 +110,8 @@ password = "12345678"
 slow_query_logging_threshold_ms = 100
 # Include the Cypher query text in slow query log entries
 #slow_query_logging_include_cypher = false
+
+[stack.media]
+# Maximum number of concurrent media processing subprocesses (ImageMagick/ffmpeg).
+# Defaults to the number of available CPU cores (minimum 4). Must be greater than 0.
+#max_concurrency = 4

--- a/nexus-common/default.config.toml
+++ b/nexus-common/default.config.toml
@@ -120,3 +120,7 @@ slow_query_logging_threshold_ms = 100
 # Maximum number of concurrent media processing subprocesses (ImageMagick/ffmpeg).
 # Defaults to the number of available CPU cores (minimum 4). Must be greater than 0.
 #max_concurrency = 4
+# Wall-clock deadline (seconds) for a single ImageMagick/ffmpeg subprocess. Past it the process
+# group is killed and reaped so its concurrency slot is returned. Keep it above ImageMagick's own
+# time limit: it is a backstop for children that hang without burning CPU. Must be greater than 0.
+#process_timeout_secs = 180

--- a/nexus-common/default.config.toml
+++ b/nexus-common/default.config.toml
@@ -119,8 +119,18 @@ slow_query_logging_threshold_ms = 100
 [stack.media]
 # Maximum number of concurrent media processing subprocesses (ImageMagick/ffmpeg).
 # Defaults to the number of available CPU cores (minimum 4). Must be greater than 0.
+# ImageMagick and ffmpeg already thread internally, so on large hosts a high value oversubscribes
+# CPU (each concurrent convert can itself use several cores). cores/2 is a sensible starting point.
+# Image conversions run `identify` then `convert` under one permit, each with its own deadline, so
+# worst-case permit hold is 2x process_timeout_secs.
 #max_concurrency = 4
 # Wall-clock deadline (seconds) for a single ImageMagick/ffmpeg subprocess. Past it the process
 # group is killed and reaped so its concurrency slot is returned. Keep it above ImageMagick's own
 # time limit: it is a backstop for children that hang without burning CPU. Must be greater than 0.
+# Two upper bounds to respect:
+# - Keep it below the API request timeout (config [api] request_timeout_secs, default 30s) if
+#   clients of slow conversions should receive the result instead of a 408; work still publishes
+#   after a request timeout, but the caller of that request gets 408 either way.
+# - Keep it under the 1h temp-file sweep (stale files in .tmp are deleted after 1 hour); a longer
+#   deadline lets the sweep delete an in-flight conversion's temp file and fail its rename.
 #process_timeout_secs = 180

--- a/nexus-common/src/config/mod.rs
+++ b/nexus-common/src/config/mod.rs
@@ -26,7 +26,7 @@ pub mod watcher;
 pub use api::{ApiConfig, RateLimitBucketConfig, RateLimitConfig};
 pub use daemon::DaemonConfig;
 pub use net::NetConfig;
-pub use stack::{default_stack, OtlpConfig, StackConfig};
+pub use stack::{default_stack, MediaConfig, OtlpConfig, StackConfig};
 pub use watcher::{
     EventRetryConfig, WatcherConfig, DEFAULT_HS_RESOLVER_TTL, DEFAULT_INITIAL_BACKOFF_SECS,
     DEFAULT_MAX_BACKOFF_SECS, DEFAULT_MAX_FILE_SIZE, MAX_EVENTS_LIMIT, MAX_KEY_BASED_EVENTS_LIMIT,

--- a/nexus-common/src/config/stack.rs
+++ b/nexus-common/src/config/stack.rs
@@ -5,6 +5,49 @@ use std::{fmt::Debug, path::PathBuf};
 use super::net::NetConfig;
 use super::{file::validate_and_expand_path, Level, LOG_LEVEL};
 
+/// Media processing concurrency configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub struct MediaConfig {
+    /// Maximum number of concurrent media subprocesses (ImageMagick/ffmpeg).
+    /// Defaults to the number of available parallelism (CPU cores), minimum 4.
+    #[serde(
+        default = "MediaConfig::default_max_concurrency",
+        deserialize_with = "deserialize_max_concurrency"
+    )]
+    pub max_concurrency: usize,
+}
+
+/// Rejects 0, which would otherwise shed every variant request forever.
+fn deserialize_max_concurrency<'de, D>(deserializer: D) -> Result<usize, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let max_concurrency = usize::deserialize(deserializer)?;
+    if max_concurrency == 0 {
+        return Err(serde::de::Error::custom(
+            "stack.media.max_concurrency must be greater than 0",
+        ));
+    }
+    Ok(max_concurrency)
+}
+
+impl MediaConfig {
+    fn default_max_concurrency() -> usize {
+        std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(4)
+            .max(4)
+    }
+}
+
+impl Default for MediaConfig {
+    fn default() -> Self {
+        Self {
+            max_concurrency: Self::default_max_concurrency(),
+        }
+    }
+}
+
 fn deserialize_and_expand<'de, D>(deserializer: D) -> Result<PathBuf, D::Error>
 where
     D: Deserializer<'de>,
@@ -41,6 +84,8 @@ pub struct StackConfig {
     pub db: DatabaseConfig,
     #[serde(default)]
     pub net: NetConfig,
+    #[serde(default)]
+    pub media: MediaConfig,
 }
 
 /// Utility function
@@ -56,6 +101,36 @@ impl Default for StackConfig {
             otlp: OtlpConfig::default(),
             db: DatabaseConfig::default(),
             net: NetConfig::default(),
+            media: MediaConfig::default(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MediaConfig;
+
+    #[test]
+    fn test_max_concurrency_parsing() {
+        let cases = [
+            ("max_concurrency = 1", Some(1)),
+            ("max_concurrency = 16", Some(16)),
+            // 0 permits would shed every variant request forever.
+            ("max_concurrency = 0", None),
+            ("max_concurrency = -1", None),
+        ];
+
+        for (toml, expected) in cases {
+            let parsed = toml::from_str::<MediaConfig>(toml)
+                .ok()
+                .map(|c| c.max_concurrency);
+            assert_eq!(parsed, expected, "unexpected result for {toml:?}");
+        }
+    }
+
+    #[test]
+    fn test_max_concurrency_defaults_when_absent() {
+        let config: MediaConfig = toml::from_str("").expect("empty table must use the default");
+        assert!(config.max_concurrency >= 4);
     }
 }

--- a/nexus-common/src/config/stack.rs
+++ b/nexus-common/src/config/stack.rs
@@ -16,6 +16,13 @@ pub struct MediaConfig {
         deserialize_with = "deserialize_max_concurrency"
     )]
     pub max_concurrency: usize,
+    /// Wall-clock deadline for a single media subprocess, after which it is killed and reaped.
+    /// A backstop above ImageMagick's own time limit, for children that hang without burning CPU.
+    #[serde(
+        default = "MediaConfig::default_process_timeout_secs",
+        deserialize_with = "deserialize_process_timeout_secs"
+    )]
+    pub process_timeout_secs: u64,
 }
 
 /// Rejects 0, which would otherwise shed every variant request forever.
@@ -32,7 +39,28 @@ where
     Ok(max_concurrency)
 }
 
+/// Rejects 0, which would kill every subprocess before it could start.
+fn deserialize_process_timeout_secs<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let process_timeout_secs = u64::deserialize(deserializer)?;
+    if process_timeout_secs == 0 {
+        return Err(serde::de::Error::custom(
+            "stack.media.process_timeout_secs must be greater than 0",
+        ));
+    }
+    Ok(process_timeout_secs)
+}
+
 impl MediaConfig {
+    /// Well above an honest 100 MB resize, which runs in seconds to tens of seconds.
+    const DEFAULT_PROCESS_TIMEOUT_SECS: u64 = 180;
+
+    fn default_process_timeout_secs() -> u64 {
+        Self::DEFAULT_PROCESS_TIMEOUT_SECS
+    }
+
     fn default_max_concurrency() -> usize {
         std::thread::available_parallelism()
             .map(|n| n.get())
@@ -45,6 +73,7 @@ impl Default for MediaConfig {
     fn default() -> Self {
         Self {
             max_concurrency: Self::default_max_concurrency(),
+            process_timeout_secs: Self::default_process_timeout_secs(),
         }
     }
 }
@@ -136,8 +165,27 @@ mod tests {
     }
 
     #[test]
+    fn test_process_timeout_parsing() {
+        let cases = [
+            ("process_timeout_secs = 1", Some(1)),
+            ("process_timeout_secs = 300", Some(300)),
+            // 0 would kill every subprocess before it could start.
+            ("process_timeout_secs = 0", None),
+            ("process_timeout_secs = -1", None),
+        ];
+
+        for (toml, expected) in cases {
+            let parsed = toml::from_str::<MediaConfig>(toml)
+                .ok()
+                .map(|c| c.process_timeout_secs);
+            assert_eq!(parsed, expected, "unexpected result for {toml:?}");
+        }
+    }
+
+    #[test]
     fn test_max_concurrency_defaults_when_absent() {
         let config: MediaConfig = toml::from_str("").expect("empty table must use the default");
         assert!(config.max_concurrency >= 4);
+        assert!(config.process_timeout_secs > 0);
     }
 }

--- a/nexus-common/src/media/concurrency.rs
+++ b/nexus-common/src/media/concurrency.rs
@@ -2,7 +2,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use tokio::sync::{Semaphore, SemaphorePermit};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
 use super::processors::MediaProcessorError;
 
@@ -51,17 +51,19 @@ impl MediaGate {
         self
     }
 
-    /// Acquire a permit or shed with `AtCapacity`.
-    pub async fn acquire(&self) -> Result<SemaphorePermit<'_>, MediaProcessorError> {
+    /// Acquire a permit or shed with `AtCapacity`. The permit is owned so it can be
+    /// moved into the task running the subprocess and outlive the caller's request.
+    pub async fn acquire(&self) -> Result<OwnedSemaphorePermit, MediaProcessorError> {
         // Fast path: capacity is free, so never touch the queue or the timer.
-        if let Ok(permit) = self.semaphore.try_acquire() {
+        if let Ok(permit) = Arc::clone(&self.semaphore).try_acquire_owned() {
             return Ok(permit);
         }
 
         // Queue is already deep enough; shed now rather than park another request.
         let _waiting = WaitingGuard::enter(&self.waiting, self.max_waiting)?;
 
-        match tokio::time::timeout(self.acquire_timeout, self.semaphore.acquire()).await {
+        let acquire = Arc::clone(&self.semaphore).acquire_owned();
+        match tokio::time::timeout(self.acquire_timeout, acquire).await {
             Ok(Ok(permit)) => Ok(permit),
             Ok(Err(_closed)) => Err(MediaProcessorError::AtCapacity), // semaphore closed (shouldn't happen)
             Err(_elapsed) => Err(MediaProcessorError::AtCapacity), // waited too long -> shed load

--- a/nexus-common/src/media/concurrency.rs
+++ b/nexus-common/src/media/concurrency.rs
@@ -1,0 +1,194 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::{Semaphore, SemaphorePermit};
+
+use super::processors::MediaProcessorError;
+
+/// How many requests may queue per permit before we shed instead of parking them.
+const MAX_WAITING_PER_PERMIT: usize = 4;
+
+/// Bounded concurrency gate for media subprocesses (ImageMagick/ffmpeg).
+/// Created once from config; cloned cheaply (Arc<Semaphore> interior).
+#[derive(Clone)]
+pub struct MediaGate {
+    semaphore: Arc<Semaphore>,
+    /// Requests currently parked waiting for a permit.
+    waiting: Arc<AtomicUsize>,
+    /// Cap on parked requests. The semaphore's own wait list is unbounded, so without
+    /// this a burst parks arbitrarily many requests, each holding a connection and task
+    /// for the full acquire timeout — moving exhaustion from subprocesses to the queue.
+    max_waiting: usize,
+    /// How long a queued caller waits for a permit before shedding. With the queue
+    /// bounded this is a backstop, not the primary shed mechanism.
+    acquire_timeout: Duration,
+}
+
+impl MediaGate {
+    /// Default wait for a permit before shedding.
+    const DEFAULT_ACQUIRE_TIMEOUT: Duration = Duration::from_secs(5);
+
+    /// Create a gate that allows at most `permits` concurrent subprocesses.
+    pub fn new(permits: usize) -> Self {
+        Self {
+            semaphore: Arc::new(Semaphore::new(permits)),
+            waiting: Arc::new(AtomicUsize::new(0)),
+            max_waiting: permits.max(1) * MAX_WAITING_PER_PERMIT,
+            acquire_timeout: Self::DEFAULT_ACQUIRE_TIMEOUT,
+        }
+    }
+
+    /// Override the acquire timeout (builder-style).
+    pub fn with_acquire_timeout(mut self, timeout: Duration) -> Self {
+        self.acquire_timeout = timeout;
+        self
+    }
+
+    /// Override the queue cap (builder-style).
+    pub fn with_max_waiting(mut self, max_waiting: usize) -> Self {
+        self.max_waiting = max_waiting;
+        self
+    }
+
+    /// Acquire a permit or shed with `AtCapacity`.
+    pub async fn acquire(&self) -> Result<SemaphorePermit<'_>, MediaProcessorError> {
+        // Fast path: capacity is free, so never touch the queue or the timer.
+        if let Ok(permit) = self.semaphore.try_acquire() {
+            return Ok(permit);
+        }
+
+        // Queue is already deep enough; shed now rather than park another request.
+        let _waiting = WaitingGuard::enter(&self.waiting, self.max_waiting)?;
+
+        match tokio::time::timeout(self.acquire_timeout, self.semaphore.acquire()).await {
+            Ok(Ok(permit)) => Ok(permit),
+            Ok(Err(_closed)) => Err(MediaProcessorError::AtCapacity), // semaphore closed (shouldn't happen)
+            Err(_elapsed) => Err(MediaProcessorError::AtCapacity), // waited too long -> shed load
+        }
+    }
+}
+
+/// Counts a parked request, releasing on drop so cancelled requests don't leak a slot.
+struct WaitingGuard<'a>(&'a AtomicUsize);
+
+impl<'a> WaitingGuard<'a> {
+    fn enter(waiting: &'a AtomicUsize, max: usize) -> Result<Self, MediaProcessorError> {
+        if waiting.fetch_add(1, Ordering::Relaxed) >= max {
+            waiting.fetch_sub(1, Ordering::Relaxed);
+            return Err(MediaProcessorError::AtCapacity);
+        }
+        Ok(Self(waiting))
+    }
+}
+
+impl Drop for WaitingGuard<'_> {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    use tokio::time::Duration;
+
+    use super::MediaGate;
+
+    #[tokio_shared_rt::test(shared)]
+    async fn test_contended_acquire_sheds_then_succeeds_once_released() {
+        let gate = MediaGate::new(1).with_acquire_timeout(Duration::from_millis(50));
+
+        let permit = gate.acquire().await.expect("first acquire should succeed");
+
+        // While the only permit is held, a contended acquire sheds after the timeout.
+        assert!(
+            gate.acquire().await.is_err(),
+            "acquire must shed while the only permit is held"
+        );
+
+        drop(permit);
+
+        assert!(
+            gate.acquire().await.is_ok(),
+            "acquire must succeed once the permit is released"
+        );
+    }
+
+    // A burst must not park unboundedly: once the queue cap is reached, further
+    // callers shed immediately instead of waiting out the acquire timeout.
+    #[tokio_shared_rt::test(shared)]
+    async fn test_queue_cap_sheds_without_parking() {
+        let gate = MediaGate::new(1)
+            .with_acquire_timeout(Duration::from_secs(30))
+            .with_max_waiting(2);
+
+        let _permit = gate.acquire().await.expect("first acquire should succeed");
+
+        // Fill the queue with the two waiters it allows.
+        let mut parked = Vec::new();
+        for _ in 0..2 {
+            let gate = gate.clone();
+            parked.push(tokio::spawn(async move { gate.acquire().await.is_ok() }));
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // The next caller is over the cap, so it must shed rather than park for 30s.
+        let start = tokio::time::Instant::now();
+        assert!(
+            gate.acquire().await.is_err(),
+            "acquire beyond the queue cap must shed"
+        );
+        assert!(
+            start.elapsed() < Duration::from_secs(1),
+            "over-cap acquire must shed immediately, waited {:?}",
+            start.elapsed()
+        );
+
+        for handle in parked {
+            handle.abort();
+            let _ = handle.await;
+        }
+    }
+
+    #[tokio_shared_rt::test(shared)]
+    async fn test_peak_concurrency_bounded() {
+        // Uncapped queue: this test is about the permit count, not the shed threshold.
+        let gate = MediaGate::new(2).with_max_waiting(usize::MAX);
+        let concurrent = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+
+        let mut handles = Vec::new();
+
+        for _ in 0..10 {
+            let gate = gate.clone();
+            let concurrent = Arc::clone(&concurrent);
+            let peak = Arc::clone(&peak);
+            let handle = tokio::spawn(async move {
+                let _permit = gate.acquire().await.unwrap();
+                // Record peak concurrency.
+                let cur = concurrent.fetch_add(1, Ordering::Relaxed) + 1;
+                peak.fetch_max(cur, Ordering::Relaxed);
+
+                // Simulate work.
+                tokio::time::sleep(Duration::from_millis(50)).await;
+
+                concurrent.fetch_sub(1, Ordering::Relaxed);
+            });
+            handles.push(handle);
+        }
+
+        for handle in handles {
+            handle.await.unwrap();
+        }
+
+        // Peak concurrency must never exceed the permit count.
+        assert!(
+            peak.load(Ordering::Relaxed) <= 2,
+            "peak concurrency {} exceeded permit count 2",
+            peak.load(Ordering::Relaxed)
+        );
+    }
+}

--- a/nexus-common/src/media/concurrency.rs
+++ b/nexus-common/src/media/concurrency.rs
@@ -34,7 +34,7 @@ impl MediaPermits {
     }
 
     /// Take a permit only if one is free right now.
-    fn try_acquire(&self) -> Result<OwnedSemaphorePermit, MediaProcessorError> {
+    pub(crate) fn try_acquire(&self) -> Result<OwnedSemaphorePermit, MediaProcessorError> {
         Arc::clone(&self.semaphore)
             .try_acquire_owned()
             .map_err(|_| MediaProcessorError::AtCapacity)

--- a/nexus-common/src/media/concurrency.rs
+++ b/nexus-common/src/media/concurrency.rs
@@ -2,6 +2,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
+use async_trait::async_trait;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
 use super::processors::MediaProcessorError;
@@ -9,13 +10,60 @@ use super::processors::MediaProcessorError;
 /// How many requests may queue per permit before we shed instead of parking them.
 const MAX_WAITING_PER_PERMIT: usize = 4;
 
-/// Bounded concurrency gate for media subprocesses (ImageMagick/ffmpeg).
-/// Created once from config; cloned cheaply (Arc<Semaphore> interior).
+/// Default wait for a permit before shedding.
+const DEFAULT_ACQUIRE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// The permits every media subprocess must hold. Gates are handles on a pool: clone it
+/// to hand another gate the *same* permits — building a second pool instead would let
+/// both gates run `permits` subprocesses each.
 #[derive(Clone)]
-pub struct MediaGate {
+pub struct MediaPermits {
     semaphore: Arc<Semaphore>,
+    /// The pool's size. Kept separately because `available_permits` is the live free
+    /// count, which is not what a gate sizing itself against the pool wants.
+    capacity: usize,
+}
+
+impl MediaPermits {
+    /// A pool allowing at most `permits` concurrent subprocesses.
+    pub fn new(permits: usize) -> Self {
+        Self {
+            semaphore: Arc::new(Semaphore::new(permits)),
+            capacity: permits,
+        }
+    }
+
+    /// Take a permit only if one is free right now.
+    fn try_acquire(&self) -> Result<OwnedSemaphorePermit, MediaProcessorError> {
+        Arc::clone(&self.semaphore)
+            .try_acquire_owned()
+            .map_err(|_| MediaProcessorError::AtCapacity)
+    }
+
+    /// Wait for a permit. Callers are responsible for bounding the wait.
+    async fn acquire(&self) -> Result<OwnedSemaphorePermit, MediaProcessorError> {
+        Arc::clone(&self.semaphore)
+            .acquire_owned()
+            .await
+            .map_err(|_closed| MediaProcessorError::AtCapacity)
+    }
+}
+
+/// Bounded concurrency gate for media subprocesses (ImageMagick/ffmpeg). Implementors
+/// differ only in what they do when no permit is free.
+#[async_trait]
+pub trait MediaGate: Send + Sync {
+    /// Acquire a permit or shed with `AtCapacity`. The permit is owned so it can be
+    /// moved into the task running the subprocess and outlive the caller's request.
+    async fn acquire(&self) -> Result<OwnedSemaphorePermit, MediaProcessorError>;
+}
+
+/// Queues for a permit, shedding once the queue is full or the wait times out.
+/// The default for callers with nothing cheaper to serve.
+pub struct QueuedGate {
+    permits: MediaPermits,
     /// Requests currently parked waiting for a permit.
-    waiting: Arc<AtomicUsize>,
+    waiting: AtomicUsize,
     /// Cap on parked requests. The semaphore's own wait list is unbounded, so without
     /// this a burst parks arbitrarily many requests, each holding a connection and task
     /// for the full acquire timeout — moving exhaustion from subprocesses to the queue.
@@ -25,53 +73,77 @@ pub struct MediaGate {
     acquire_timeout: Duration,
 }
 
-impl MediaGate {
-    /// Default wait for a permit before shedding.
-    const DEFAULT_ACQUIRE_TIMEOUT: Duration = Duration::from_secs(5);
+impl QueuedGate {
+    /// A gate over `permits`, queueing up to `MAX_WAITING_PER_PERMIT` callers per permit.
+    pub fn new(permits: MediaPermits) -> Self {
+        let max_waiting = permits.capacity.max(1) * MAX_WAITING_PER_PERMIT;
+        Self::with_limits(permits, max_waiting, DEFAULT_ACQUIRE_TIMEOUT)
+    }
 
-    /// Create a gate that allows at most `permits` concurrent subprocesses.
-    pub fn new(permits: usize) -> Self {
+    /// Full control over the shed thresholds, for tests and tuning.
+    pub fn with_limits(
+        permits: MediaPermits,
+        max_waiting: usize,
+        acquire_timeout: Duration,
+    ) -> Self {
         Self {
-            semaphore: Arc::new(Semaphore::new(permits)),
-            waiting: Arc::new(AtomicUsize::new(0)),
-            max_waiting: permits.max(1) * MAX_WAITING_PER_PERMIT,
-            acquire_timeout: Self::DEFAULT_ACQUIRE_TIMEOUT,
+            permits,
+            waiting: AtomicUsize::new(0),
+            max_waiting,
+            acquire_timeout,
         }
     }
+}
 
-    /// Override the acquire timeout (builder-style).
-    pub fn with_acquire_timeout(mut self, timeout: Duration) -> Self {
-        self.acquire_timeout = timeout;
-        self
-    }
-
-    /// Override the queue cap (builder-style).
-    pub fn with_max_waiting(mut self, max_waiting: usize) -> Self {
-        self.max_waiting = max_waiting;
-        self
-    }
-
-    /// Acquire a permit or shed with `AtCapacity`. The permit is owned so it can be
-    /// moved into the task running the subprocess and outlive the caller's request.
-    pub async fn acquire(&self) -> Result<OwnedSemaphorePermit, MediaProcessorError> {
+#[async_trait]
+impl MediaGate for QueuedGate {
+    async fn acquire(&self) -> Result<OwnedSemaphorePermit, MediaProcessorError> {
         // Fast path: capacity is free, so never touch the queue or the timer.
-        if let Ok(permit) = Arc::clone(&self.semaphore).try_acquire_owned() {
+        if let Ok(permit) = self.permits.try_acquire() {
             return Ok(permit);
+        }
+
+        // A pool that holds no permits can never grant one, and it cannot grow, so
+        // parking here would burn the whole timeout to reach the answer we have now.
+        if self.permits.capacity == 0 {
+            return Err(MediaProcessorError::AtCapacity);
         }
 
         // Queue is already deep enough; shed now rather than park another request.
         let _waiting = WaitingGuard::enter(&self.waiting, self.max_waiting)?;
 
-        let acquire = Arc::clone(&self.semaphore).acquire_owned();
-        match tokio::time::timeout(self.acquire_timeout, acquire).await {
-            Ok(Ok(permit)) => Ok(permit),
-            Ok(Err(_closed)) => Err(MediaProcessorError::AtCapacity), // semaphore closed (shouldn't happen)
+        match tokio::time::timeout(self.acquire_timeout, self.permits.acquire()).await {
+            Ok(result) => result,
             Err(_elapsed) => Err(MediaProcessorError::AtCapacity), // waited too long -> shed load
         }
     }
 }
 
+/// Sheds the moment no permit is free, for callers whose fallback is good enough that
+/// the chance of winning a permit before the timeout is not worth the latency (avatars).
+pub struct FailFastGate {
+    permits: MediaPermits,
+}
+
+impl FailFastGate {
+    /// A gate over `permits`. Clone the pool from the queued gate's to share its limit.
+    pub fn new(permits: MediaPermits) -> Self {
+        Self { permits }
+    }
+}
+
+#[async_trait]
+impl MediaGate for FailFastGate {
+    async fn acquire(&self) -> Result<OwnedSemaphorePermit, MediaProcessorError> {
+        // No queue and no timer to reach: a burst here cannot push queued callers over
+        // the cap, because this gate has no access to their counter at all.
+        self.permits.try_acquire()
+    }
+}
+
 /// Counts a parked request, releasing on drop so cancelled requests don't leak a slot.
+/// This has to be a guard rather than a pair of counter updates in `acquire`: a cancelled
+/// request drops its future at the await, so a decrement written after it never runs.
 struct WaitingGuard<'a>(&'a AtomicUsize);
 
 impl<'a> WaitingGuard<'a> {
@@ -97,11 +169,14 @@ mod tests {
 
     use tokio::time::Duration;
 
-    use super::MediaGate;
+    use super::{
+        FailFastGate, MediaGate, MediaPermits, QueuedGate, DEFAULT_ACQUIRE_TIMEOUT,
+        MAX_WAITING_PER_PERMIT,
+    };
 
     #[tokio_shared_rt::test(shared)]
     async fn test_contended_acquire_sheds_then_succeeds_once_released() {
-        let gate = MediaGate::new(1).with_acquire_timeout(Duration::from_millis(50));
+        let gate = QueuedGate::with_limits(MediaPermits::new(1), 4, Duration::from_millis(50));
 
         let permit = gate.acquire().await.expect("first acquire should succeed");
 
@@ -123,16 +198,18 @@ mod tests {
     // callers shed immediately instead of waiting out the acquire timeout.
     #[tokio_shared_rt::test(shared)]
     async fn test_queue_cap_sheds_without_parking() {
-        let gate = MediaGate::new(1)
-            .with_acquire_timeout(Duration::from_secs(30))
-            .with_max_waiting(2);
+        let gate = Arc::new(QueuedGate::with_limits(
+            MediaPermits::new(1),
+            2,
+            Duration::from_secs(30),
+        ));
 
         let _permit = gate.acquire().await.expect("first acquire should succeed");
 
         // Fill the queue with the two waiters it allows.
         let mut parked = Vec::new();
         for _ in 0..2 {
-            let gate = gate.clone();
+            let gate = Arc::clone(&gate);
             parked.push(tokio::spawn(async move { gate.acquire().await.is_ok() }));
         }
         tokio::time::sleep(Duration::from_millis(100)).await;
@@ -153,19 +230,139 @@ mod tests {
             handle.abort();
             let _ = handle.await;
         }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Cancelled callers must give their queue slots back, or the cap would ratchet
+        // down until every queued caller sheds.
+        assert_eq!(
+            gate.waiting.load(Ordering::Relaxed),
+            0,
+            "cancelled callers must release their queue slots"
+        );
+    }
+
+    // A fail-fast gate must shed the moment no permit is free rather than parking,
+    // and must draw on the same permits as the gate it came from.
+    #[tokio_shared_rt::test(shared)]
+    async fn test_fail_fast_gate_sheds_without_queueing() {
+        let permits = MediaPermits::new(1);
+        let gate = QueuedGate::with_limits(permits.clone(), 4, Duration::from_secs(30));
+        let fast = FailFastGate::new(permits);
+
+        let permit = gate.acquire().await.expect("first acquire should succeed");
+
+        let start = tokio::time::Instant::now();
+        assert!(
+            fast.acquire().await.is_err(),
+            "fail-fast acquire must shed while the only permit is held"
+        );
+        assert!(
+            start.elapsed() < Duration::from_secs(1),
+            "fail-fast acquire must not queue, waited {:?}",
+            start.elapsed()
+        );
+
+        drop(permit);
+
+        assert!(
+            fast.acquire().await.is_ok(),
+            "fail-fast acquire must succeed once the shared permit is released"
+        );
+    }
+
+    // Fail-fast callers must leave the queue counter alone, or a burst of them would
+    // shed unrelated queued traffic. `FailFastGate::acquire` can't touch it by
+    // construction, so this guards against a future edit routing it through the queue.
+    #[tokio_shared_rt::test(shared)]
+    async fn test_fail_fast_does_not_consume_queue_slots() {
+        let permits = MediaPermits::new(1);
+        let gate = Arc::new(QueuedGate::with_limits(
+            permits.clone(),
+            1,
+            DEFAULT_ACQUIRE_TIMEOUT,
+        ));
+        let fast = FailFastGate::new(permits);
+
+        let permit = gate.acquire().await.expect("first acquire should succeed");
+
+        // Hammer the fail-fast gate while the only permit is held.
+        for _ in 0..50 {
+            assert!(fast.acquire().await.is_err(), "no permit is free");
+        }
+        assert_eq!(
+            gate.waiting.load(Ordering::Relaxed),
+            0,
+            "fail-fast acquires must not register as queued callers"
+        );
+
+        // The single queue slot must still be available to a queued caller, which
+        // parks (and is served once the permit drops) instead of shedding.
+        let queued = tokio::spawn({
+            let gate = Arc::clone(&gate);
+            async move { gate.acquire().await.is_ok() }
+        });
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        drop(permit);
+
+        assert!(
+            queued.await.expect("queued caller should not panic"),
+            "a queued caller must still find a free queue slot after a fail-fast burst"
+        );
+    }
+
+    // A gate over an empty pool sheds at once: no permit can ever appear, so waiting out
+    // the acquire timeout only delays the same answer.
+    #[tokio_shared_rt::test(shared)]
+    async fn test_empty_pool_sheds_without_waiting() {
+        let gate = QueuedGate::new(MediaPermits::new(0));
+
+        let start = tokio::time::Instant::now();
+        assert!(
+            gate.acquire().await.is_err(),
+            "a pool with no permits must shed"
+        );
+        assert!(
+            start.elapsed() < Duration::from_secs(1),
+            "shedding must not wait out the acquire timeout, waited {:?}",
+            start.elapsed()
+        );
+    }
+
+    // A gate sizes its queue against the pool's capacity, not the permits free when it
+    // happens to be built — otherwise a gate added to a pool that is already busy would
+    // silently shed traffic it was configured to queue.
+    #[tokio_shared_rt::test(shared)]
+    async fn test_queue_cap_follows_capacity_not_free_permits() {
+        let permits = MediaPermits::new(4);
+        let held: Vec<_> = (0..4)
+            .map(|_| permits.try_acquire().expect("pool starts empty"))
+            .collect();
+
+        let gate = QueuedGate::new(permits.clone());
+
+        assert_eq!(
+            gate.max_waiting,
+            4 * MAX_WAITING_PER_PERMIT,
+            "queue cap must come from the pool's capacity, not its free permits"
+        );
+        drop(held);
     }
 
     #[tokio_shared_rt::test(shared)]
     async fn test_peak_concurrency_bounded() {
         // Uncapped queue: this test is about the permit count, not the shed threshold.
-        let gate = MediaGate::new(2).with_max_waiting(usize::MAX);
+        let gate = Arc::new(QueuedGate::with_limits(
+            MediaPermits::new(2),
+            usize::MAX,
+            DEFAULT_ACQUIRE_TIMEOUT,
+        ));
         let concurrent = Arc::new(AtomicUsize::new(0));
         let peak = Arc::new(AtomicUsize::new(0));
 
         let mut handles = Vec::new();
 
         for _ in 0..10 {
-            let gate = gate.clone();
+            let gate = Arc::clone(&gate);
             let concurrent = Arc::clone(&concurrent);
             let peak = Arc::clone(&peak);
             let handle = tokio::spawn(async move {

--- a/nexus-common/src/media/mod.rs
+++ b/nexus-common/src/media/mod.rs
@@ -1,5 +1,4 @@
 use crate::{
-    media::processors::MediaProcessorError,
     models::file::{FileDetails, FileUrls},
     types::DynError,
 };
@@ -13,7 +12,11 @@ use std::{
 use tokio::fs;
 use utoipa::ToSchema;
 
+mod concurrency;
 pub mod processors;
+
+pub use concurrency::MediaGate;
+use processors::MediaProcessorError;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, ToSchema, Clone)]
 #[serde(rename_all = "lowercase")]
@@ -47,20 +50,28 @@ impl Display for FileVariant {
     }
 }
 
-pub struct VariantController;
+#[derive(Clone)]
+pub struct VariantController {
+    gate: MediaGate,
+}
 
 impl VariantController {
+    pub fn new(gate: MediaGate) -> Self {
+        Self { gate }
+    }
+
     pub async fn create_file_variant(
+        &self,
         file: &FileDetails,
         variant: &FileVariant,
         file_path: PathBuf,
     ) -> Result<String, MediaProcessorError> {
         match &file.content_type {
             content_type if content_type.starts_with("image/") => {
-                ImageProcessor::create_variant(file, variant, file_path).await
+                ImageProcessor::create_variant(file, variant, file_path, &self.gate).await
             }
             content_type if content_type.starts_with("video/") => {
-                VideoProcessor::create_variant(file, variant, file_path).await
+                VideoProcessor::create_variant(file, variant, file_path, &self.gate).await
             }
             _ => Err(MediaProcessorError::UnsupportedContentType(
                 file.content_type.clone(),

--- a/nexus-common/src/media/mod.rs
+++ b/nexus-common/src/media/mod.rs
@@ -15,9 +15,11 @@ use utoipa::ToSchema;
 
 mod concurrency;
 pub mod processors;
+mod subprocess;
 
 pub use concurrency::{FailFastGate, MediaGate, MediaPermits, QueuedGate};
 use processors::MediaProcessorError;
+pub use subprocess::MediaSubprocess;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, ToSchema, Clone)]
 #[serde(rename_all = "lowercase")]
@@ -54,12 +56,15 @@ impl Display for FileVariant {
 #[derive(Clone)]
 pub struct VariantController {
     gate: Arc<dyn MediaGate>,
+    /// Deadline every subprocess this controller starts runs under.
+    subprocess: MediaSubprocess,
 }
 
 impl VariantController {
-    pub fn new(gate: impl MediaGate + 'static) -> Self {
+    pub fn new(gate: impl MediaGate + 'static, subprocess: MediaSubprocess) -> Self {
         Self {
             gate: Arc::new(gate),
+            subprocess,
         }
     }
 
@@ -71,10 +76,24 @@ impl VariantController {
     ) -> Result<String, MediaProcessorError> {
         match &file.content_type {
             content_type if content_type.starts_with("image/") => {
-                ImageProcessor::create_variant(file, variant, file_path, self.gate.as_ref()).await
+                ImageProcessor::create_variant(
+                    file,
+                    variant,
+                    file_path,
+                    self.gate.as_ref(),
+                    self.subprocess,
+                )
+                .await
             }
             content_type if content_type.starts_with("video/") => {
-                VideoProcessor::create_variant(file, variant, file_path, self.gate.as_ref()).await
+                VideoProcessor::create_variant(
+                    file,
+                    variant,
+                    file_path,
+                    self.gate.as_ref(),
+                    self.subprocess,
+                )
+                .await
             }
             _ => Err(MediaProcessorError::UnsupportedContentType(
                 file.content_type.clone(),

--- a/nexus-common/src/media/mod.rs
+++ b/nexus-common/src/media/mod.rs
@@ -17,6 +17,9 @@ mod concurrency;
 pub mod processors;
 mod subprocess;
 
+/// Meter for everything under `media`, so its metrics group together wherever the crate is used.
+pub(crate) const METER_NAME: &str = "nexus.media";
+
 pub use concurrency::{FailFastGate, MediaGate, MediaPermits, QueuedGate};
 use processors::MediaProcessorError;
 pub use subprocess::MediaSubprocess;

--- a/nexus-common/src/media/mod.rs
+++ b/nexus-common/src/media/mod.rs
@@ -8,6 +8,7 @@ use std::{
     fmt::Display,
     path::{Path, PathBuf},
     str::FromStr,
+    sync::Arc,
 };
 use tokio::fs;
 use utoipa::ToSchema;
@@ -15,7 +16,7 @@ use utoipa::ToSchema;
 mod concurrency;
 pub mod processors;
 
-pub use concurrency::MediaGate;
+pub use concurrency::{FailFastGate, MediaGate, MediaPermits, QueuedGate};
 use processors::MediaProcessorError;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, ToSchema, Clone)]
@@ -52,12 +53,14 @@ impl Display for FileVariant {
 
 #[derive(Clone)]
 pub struct VariantController {
-    gate: MediaGate,
+    gate: Arc<dyn MediaGate>,
 }
 
 impl VariantController {
-    pub fn new(gate: MediaGate) -> Self {
-        Self { gate }
+    pub fn new(gate: impl MediaGate + 'static) -> Self {
+        Self {
+            gate: Arc::new(gate),
+        }
     }
 
     pub async fn create_file_variant(
@@ -68,10 +71,10 @@ impl VariantController {
     ) -> Result<String, MediaProcessorError> {
         match &file.content_type {
             content_type if content_type.starts_with("image/") => {
-                ImageProcessor::create_variant(file, variant, file_path, &self.gate).await
+                ImageProcessor::create_variant(file, variant, file_path, self.gate.as_ref()).await
             }
             content_type if content_type.starts_with("video/") => {
-                VideoProcessor::create_variant(file, variant, file_path, &self.gate).await
+                VideoProcessor::create_variant(file, variant, file_path, self.gate.as_ref()).await
             }
             _ => Err(MediaProcessorError::UnsupportedContentType(
                 file.content_type.clone(),

--- a/nexus-common/src/media/processors/image.rs
+++ b/nexus-common/src/media/processors/image.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use tokio::process::Command;
 
 use crate::{
-    media::{processors::MediaProcessorError, FileVariant},
+    media::{processors::MediaProcessorError, FileVariant, MediaSubprocess},
     models::file::FileDetails,
 };
 
@@ -62,8 +62,9 @@ impl VariantProcessor for ImageProcessor {
         origin_file_path: &str,
         output_file_path: &str,
         options: &ImageOptions,
+        subprocess: MediaSubprocess,
     ) -> Result<String, MediaProcessorError> {
-        let origin_file_format = ImageProcessor::get_format(origin_file_path)
+        let origin_file_format = ImageProcessor::get_format(origin_file_path, subprocess)
             .await?
             .to_lowercase();
 
@@ -72,22 +73,23 @@ impl VariantProcessor for ImageProcessor {
             false => format!("{}:{}", options.format, output_file_path),
         };
 
-        let child_output = Command::new("convert")
-            .arg(origin_file_path)
-            .arg("-resize")
-            .arg(format!("{}x", options.width))
-            .arg("-auto-orient") // https://github.com/ImageMagick/ImageMagick/issues/6396
-            .arg(output)
-            .output() // Automatically pipes stdout and stderr
-            .await
-            .map_err(MediaProcessorError::command_failed)?;
+        let child_output = subprocess
+            .run(
+                Command::new("convert")
+                    .arg(origin_file_path)
+                    .arg("-resize")
+                    .arg(format!("{}x", options.width))
+                    .arg("-auto-orient") // https://github.com/ImageMagick/ImageMagick/issues/6396
+                    .arg(output),
+            )
+            .await?;
 
         if child_output.status.success() {
             Ok(String::from_utf8_lossy(&child_output.stdout).to_string())
         } else {
             Err(MediaProcessorError::command_failed(format!(
                 "ImageMagick command failed: {}",
-                String::from_utf8_lossy(&child_output.stdout)
+                String::from_utf8_lossy(&child_output.stderr)
             )))
         }
     }
@@ -95,14 +97,18 @@ impl VariantProcessor for ImageProcessor {
 
 impl ImageProcessor {
     // function to get image format
-    async fn get_format(file_path: &str) -> Result<String, MediaProcessorError> {
-        let child_output = Command::new("identify")
-            .arg("-format")
-            .arg("%m")
-            .arg(file_path)
-            .output() // Automatically pipes stdout and stderr
-            .await
-            .map_err(MediaProcessorError::command_failed)?;
+    async fn get_format(
+        file_path: &str,
+        subprocess: MediaSubprocess,
+    ) -> Result<String, MediaProcessorError> {
+        let child_output = subprocess
+            .run(
+                Command::new("identify")
+                    .arg("-format")
+                    .arg("%m")
+                    .arg(file_path),
+            )
+            .await?;
 
         if child_output.status.success() {
             Ok(String::from_utf8_lossy(&child_output.stdout).to_string())

--- a/nexus-common/src/media/processors/mod.rs
+++ b/nexus-common/src/media/processors/mod.rs
@@ -1,4 +1,7 @@
-use crate::{media::FileVariant, models::file::FileDetails};
+use crate::{
+    media::{concurrency::MediaGate, FileVariant},
+    models::file::FileDetails,
+};
 use async_trait::async_trait;
 use std::path::PathBuf;
 use thiserror::Error;
@@ -28,6 +31,8 @@ pub enum MediaProcessorError {
     UnsupportedFileVariant,
     #[error("InvalidFilePath: {0}")]
     InvalidFilePath(String),
+    #[error("AtCapacity: media processing concurrency limit reached")]
+    AtCapacity,
 }
 
 impl MediaProcessorError {
@@ -70,6 +75,7 @@ pub trait VariantProcessor {
         file: &FileDetails,
         variant: &FileVariant,
         file_path: PathBuf,
+        gate: &MediaGate,
     ) -> Result<String, MediaProcessorError> {
         // if there are no options for this variant, return with the original content type
         let options = match Self::get_options_for_variant(file, variant) {
@@ -96,6 +102,8 @@ pub trait VariantProcessor {
             ));
         };
 
+        // Held only around the subprocess, not the path/option work above.
+        let _permit = gate.acquire().await?;
         Self::process(origin_file_path, output_path, &options).await?;
 
         Ok(options.content_type())

--- a/nexus-common/src/media/processors/mod.rs
+++ b/nexus-common/src/media/processors/mod.rs
@@ -45,7 +45,7 @@ impl MediaProcessorError {
 
 #[async_trait]
 pub trait VariantProcessor {
-    type ProcessingOptions: BaseProcessingOptions;
+    type ProcessingOptions: BaseProcessingOptions + 'static;
 
     /// Returns a list of valid variants for a given content type
     /// If there are no valid variants for the content type, return an empty list
@@ -76,7 +76,10 @@ pub trait VariantProcessor {
         variant: &FileVariant,
         file_path: PathBuf,
         gate: &MediaGate,
-    ) -> Result<String, MediaProcessorError> {
+    ) -> Result<String, MediaProcessorError>
+    where
+        Self: Sized + 'static,
+    {
         // if there are no options for this variant, return with the original content type
         let options = match Self::get_options_for_variant(file, variant) {
             Ok(options) => options,
@@ -102,10 +105,138 @@ pub trait VariantProcessor {
             ));
         };
 
-        // Held only around the subprocess, not the path/option work above.
-        let _permit = gate.acquire().await?;
-        Self::process(origin_file_path, output_path, &options).await?;
+        // Held only around the subprocess, not the path/option work above. The permit moves
+        // into the task so it is released when the child exits, not when the caller's future
+        // is dropped: a cancelled request must not hand its permit on while its child runs.
+        let permit = gate.acquire().await?;
+        let content_type = options.content_type();
+        let origin_file_path = origin_file_path.to_string();
+        let output_path = output_path.to_string();
 
-        Ok(options.content_type())
+        tokio::spawn(async move {
+            let _permit = permit;
+            Self::process(&origin_file_path, &output_path, &options).await
+        })
+        .await
+        .map_err(MediaProcessorError::command_failed)??;
+
+        Ok(content_type)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Duration;
+
+    use crate::media::{concurrency::MediaGate, FileVariant};
+    use crate::models::file::{FileDetails, FileUrls};
+
+    use super::{BaseProcessingOptions, MediaProcessorError, VariantProcessor};
+
+    static FINISHED: AtomicBool = AtomicBool::new(false);
+    const WORK: Duration = Duration::from_millis(300);
+
+    struct SlowOptions;
+
+    impl BaseProcessingOptions for SlowOptions {
+        fn content_type(&self) -> String {
+            String::from("image/webp")
+        }
+    }
+
+    /// Stands in for ImageMagick/ffmpeg: slow, and it records that it ran to completion.
+    struct SlowProcessor;
+
+    #[async_trait::async_trait]
+    impl VariantProcessor for SlowProcessor {
+        type ProcessingOptions = SlowOptions;
+
+        fn get_valid_variants_for_content_type(_content_type: &str) -> Vec<FileVariant> {
+            vec![FileVariant::Small]
+        }
+
+        fn get_content_type_for_variant(_file: &FileDetails, _variant: &FileVariant) -> String {
+            String::from("image/webp")
+        }
+
+        fn get_options_for_variant(
+            _file: &FileDetails,
+            _variant: &FileVariant,
+        ) -> Result<SlowOptions, MediaProcessorError> {
+            Ok(SlowOptions)
+        }
+
+        async fn process(
+            _origin_file_path: &str,
+            _output_file_path: &str,
+            _options: &SlowOptions,
+        ) -> Result<String, MediaProcessorError> {
+            tokio::time::sleep(WORK).await;
+            FINISHED.store(true, Ordering::SeqCst);
+            Ok(String::from("image/webp"))
+        }
+    }
+
+    fn file_details() -> FileDetails {
+        FileDetails {
+            id: String::from("file"),
+            uri: String::new(),
+            owner_id: String::from("owner"),
+            indexed_at: 0,
+            created_at: 0,
+            src: String::new(),
+            name: String::new(),
+            size: 0,
+            content_type: String::from("image/png"),
+            urls: FileUrls::new(Path::new("/"), &[]),
+            metadata: None,
+        }
+    }
+
+    // A cancelled request must not hand its permit to the next caller while the
+    // subprocess is still running, or the gate would undercount live subprocesses.
+    #[tokio_shared_rt::test(shared)]
+    async fn test_cancelled_request_holds_permit_until_work_completes() {
+        let gate = MediaGate::new(1).with_acquire_timeout(Duration::from_millis(50));
+
+        let caller = tokio::spawn({
+            let gate = gate.clone();
+            async move {
+                SlowProcessor::create_variant(
+                    &file_details(),
+                    &FileVariant::Small,
+                    PathBuf::from("/tmp"),
+                    &gate,
+                )
+                .await
+            }
+        });
+
+        // Let the caller take the only permit, then cancel it mid-work.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        caller.abort();
+        let _ = caller.await;
+
+        assert!(
+            gate.acquire().await.is_err(),
+            "permit must stay held while the abandoned subprocess runs"
+        );
+        assert!(
+            !FINISHED.load(Ordering::SeqCst),
+            "test must observe the gate before the work completes"
+        );
+
+        // Once the work finishes the permit is released and capacity returns.
+        tokio::time::sleep(WORK).await;
+        assert!(
+            FINISHED.load(Ordering::SeqCst),
+            "cancelling the caller must not cancel the subprocess"
+        );
+        assert!(
+            gate.acquire().await.is_ok(),
+            "permit must be released once the work completes"
+        );
     }
 }

--- a/nexus-common/src/media/processors/mod.rs
+++ b/nexus-common/src/media/processors/mod.rs
@@ -200,8 +200,8 @@ pub trait VariantProcessor {
         };
 
         // A killed conversion will be killed again, so shed here rather than spend another full
-        // deadline on it. Checked before the permit: a retry we already know the answer to must not
-        // occupy a slot other files could use.
+        // deadline on it. Checked again after the acquire, because a caller parked in the queue
+        // can be overtaken by a request that kills the file while it waits.
         let marker_path = origin_path.join(TIMEDOUT_MARKER_NAME);
         if timed_out_recently(&marker_path).await {
             tracing::debug!(
@@ -236,62 +236,93 @@ pub trait VariantProcessor {
         // into the task so it is released when the child exits, not when the caller's future
         // is dropped: a cancelled request must not hand its permit on while its child runs.
         let permit = gate.acquire().await?;
+
+        // A caller parked in the queue could have waited a full acquire timeout before getting
+        // here, so the cheap checks it already made are stale: a request ahead of it in line may
+        // have finished this same variant, or marked the file killed. Re-run both before
+        // spending the permit on a conversion that is already done.
+        if fs::metadata(&output).await.is_ok() {
+            return Ok(options.content_type());
+        }
+        if timed_out_recently(&marker_path).await {
+            tracing::debug!(
+                "Skipping {variant} for file {}: converting it was killed within the last hour",
+                file.id
+            );
+            return Err(MediaProcessorError::SkippedAfterTimeout {
+                file: file.id.clone(),
+            });
+        }
+
+        // Everything after the acquire runs in the spawned task, not the caller: the caller's
+        // future is dropped when its request times out (30s by default), while a conversion
+        // can run well past that. If the rename lived in the caller, a slow-but-successful
+        // conversion would never publish and every retry would redo it, and a killed one would
+        // never leave its marker. The work must survive the request.
         let content_type = options.content_type();
         let origin_file_path = origin_file_path.to_string();
         let output_path = output_path.to_string();
+        let file_id = file.id.clone();
+        let marker_path = marker_path.clone();
 
         let processed = tokio::spawn({
             let temp_path = temp_path.clone();
             async move {
                 let _permit = permit;
-                Self::process(&origin_file_path, &temp_path, &options, subprocess).await
+                let processed =
+                    Self::process(&origin_file_path, &temp_path, &options, subprocess).await;
+
+                if let Err(error) = processed {
+                    // Only ever this run's own file, so a concurrent run that just finished keeps its work.
+                    let _ = fs::remove_file(&temp_path).await;
+
+                    if matches!(error, MediaProcessorError::Timeout { .. }) {
+                        // A killed child means a tool-level limit was escaped, so it is worth its
+                        // own line: the shed answer the caller returns names neither the file nor
+                        // the command.
+                        tracing::warn!("Media subprocess killed for file {}: {error}", file_id);
+                        // Remembered so the next request sheds instead of repeating the same
+                        // deadline. Written here, not by the caller, so the marker survives a
+                        // request that timed out waiting for the kill.
+                        let _ = fs::write(&marker_path, b"").await;
+                    }
+                    return Err(error);
+                }
+
+                // A killed converter can exit having written nothing; publishing that would cache
+                // an empty variant forever.
+                let written = fs::metadata(&temp_path)
+                    .await
+                    .map(|metadata| metadata.len())
+                    .unwrap_or_default();
+                if written == 0 {
+                    let _ = fs::remove_file(&temp_path).await;
+                    return Err(MediaProcessorError::command_failed(format!(
+                        "conversion produced no output for file {}",
+                        file_id
+                    )));
+                }
+
+                // Atomic: both paths are under `files_path`, so this is a same-filesystem rename
+                // and a reader sees the finished variant or no variant at all.
+                fs::rename(&temp_path, &output_path)
+                    .await
+                    .map_err(MediaProcessorError::command_failed)?;
+
+                Ok(content_type)
             }
         })
         .await
         .map_err(MediaProcessorError::command_failed)?;
 
-        if let Err(error) = processed {
-            // Only ever this run's own file, so a concurrent run that just finished keeps its work.
-            let _ = fs::remove_file(&temp_path).await;
-
-            if matches!(error, MediaProcessorError::Timeout { .. }) {
-                // A killed child means a tool-level limit was escaped, so it is worth its own line:
-                // the shed answer the caller returns names neither the file nor the command.
-                tracing::warn!("Media subprocess killed for file {}: {error}", file.id);
-                // Remembered so the next request sheds instead of repeating the same deadline.
-                let _ = fs::write(&marker_path, b"").await;
-            }
-            return Err(error);
-        }
-
-        // A killed converter can exit having written nothing; publishing that would cache an empty
-        // variant forever.
-        let written = fs::metadata(&temp_path)
-            .await
-            .map(|metadata| metadata.len())
-            .unwrap_or_default();
-        if written == 0 {
-            let _ = fs::remove_file(&temp_path).await;
-            return Err(MediaProcessorError::command_failed(format!(
-                "conversion produced no output for file {}",
-                file.id
-            )));
-        }
-
-        // Atomic: both paths are under `files_path`, so this is a same-filesystem rename and a
-        // reader sees the finished variant or no variant at all.
-        fs::rename(&temp_path, &output_path)
-            .await
-            .map_err(MediaProcessorError::command_failed)?;
-
-        Ok(content_type)
+        processed
     }
 }
 
 #[cfg(test)]
 mod tests {
     use std::path::{Path, PathBuf};
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::Arc;
     use std::time::{Duration, SystemTime};
 
@@ -342,12 +373,22 @@ mod tests {
 
         async fn process(
             _origin_file_path: &str,
-            _output_file_path: &str,
+            output_file_path: &str,
             _options: &SlowOptions,
             _subprocess: MediaSubprocess,
         ) -> Result<String, MediaProcessorError> {
+            // Created up front, as a real converter opens its output, so a test can see
+            // mid-flight which path the bytes are going to.
+            tokio::fs::write(output_file_path, b"")
+                .await
+                .expect("stand-in must create its output");
             tokio::time::sleep(WORK).await;
             FINISHED.store(true, Ordering::SeqCst);
+            // Write a real file so the publish path (empty check + rename) exercises the
+            // same code as a real conversion.
+            tokio::fs::write(output_file_path, b"slow variant bytes")
+                .await
+                .expect("stand-in must write its output");
             Ok(String::from("image/webp"))
         }
     }
@@ -372,6 +413,7 @@ mod tests {
     // subprocess is still running, or the gate would undercount live subprocesses.
     #[tokio_shared_rt::test(shared)]
     async fn test_cancelled_request_holds_permit_until_work_completes() {
+        let root = tempfile::TempDir::new().expect("temp dir");
         let gate = Arc::new(QueuedGate::with_limits(
             MediaPermits::new(1),
             4,
@@ -380,11 +422,12 @@ mod tests {
 
         let caller = tokio::spawn({
             let gate = Arc::clone(&gate);
+            let root = root.path().to_path_buf();
             async move {
                 SlowProcessor::create_variant(
                     &file_details(),
                     &FileVariant::Small,
-                    PathBuf::from("/tmp"),
+                    root,
                     gate.as_ref(),
                     MediaSubprocess::new(Duration::from_secs(30)),
                 )
@@ -415,6 +458,214 @@ mod tests {
         assert!(
             gate.acquire().await.is_ok(),
             "permit must be released once the work completes"
+        );
+    }
+
+    /// A gate whose acquire can stall behind a flag the test controls. The test parks a second
+    /// caller mid-conversion and only then lets it through, so the first caller has fully
+    /// finished before the second re-checks: this is what "parked in the queue" looks like
+    /// without any waiting to time out.
+    struct ControllableGate {
+        permits: MediaPermits,
+        open: Arc<AtomicBool>,
+    }
+
+    #[async_trait::async_trait]
+    impl MediaGate for ControllableGate {
+        async fn acquire(&self) -> Result<tokio::sync::OwnedSemaphorePermit, MediaProcessorError> {
+            if self.open.load(Ordering::SeqCst) {
+                return self.permits.try_acquire();
+            }
+            // Park until the test opens the gate; the permit is granted by the pool at that point.
+            while !self.open.load(Ordering::SeqCst) {
+                tokio::task::yield_now().await;
+            }
+            self.permits.try_acquire()
+        }
+    }
+
+    // A request that times out mid-conversion (the API aborts the handler future after 30s)
+    // must not lose the work: the rename lives in the task that outlives the request, so a
+    // slow-but-successful conversion still publishes and the next request finds the variant.
+    #[tokio_shared_rt::test(shared)]
+    async fn test_cancelled_caller_still_publishes_the_variant() {
+        let root = tempfile::TempDir::new().expect("temp dir");
+        let file = file_details();
+        let dir = variant_dir(root.path(), &file).await;
+
+        // `open` gates the retry: it stays false until the first work has fully finished, so the
+        // retry re-checks *after* the variant exists -- the stale-check scenario without the
+        // retry having to wait a full acquire timeout out.
+        let open = Arc::new(AtomicBool::new(false));
+        let gate = ControllableGate {
+            permits: MediaPermits::new(1),
+            open: Arc::clone(&open),
+        };
+
+        let caller = tokio::spawn({
+            let file = file.clone();
+            let root = root.path().to_path_buf();
+            let gate = ControllableGate {
+                permits: MediaPermits::new(1),
+                open: Arc::new(AtomicBool::new(true)),
+            };
+            async move {
+                SlowProcessor::create_variant(
+                    &file,
+                    &FileVariant::Small,
+                    root,
+                    &gate,
+                    MediaSubprocess::new(Duration::from_secs(30)),
+                )
+                .await
+            }
+        });
+
+        // The caller is mid-conversion (work takes 300ms); the request times out on it.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        caller.abort();
+        assert!(
+            !dir.join(FileVariant::Small.to_string()).exists(),
+            "test must observe the conversion mid-flight"
+        );
+        assert_eq!(
+            temp_dir_entries(root.path()).await.len(),
+            1,
+            "the in-flight conversion must write to the temp dir, not the variant path"
+        );
+
+        // The caller is gone, so only the task can publish. Wait for it to finish.
+        tokio::time::sleep(WORK).await;
+        assert!(
+            dir.join(FileVariant::Small.to_string()).exists(),
+            "the conversion must publish despite the aborted caller"
+        );
+        assert!(
+            temp_dir_entries(root.path()).await.is_empty(),
+            "the temp file must be consumed by the rename"
+        );
+
+        // The next request finds the variant without converting again.
+        open.store(true, Ordering::SeqCst);
+        let retry = create_small::<RecordingProcessor>(root.path(), &file, &gate)
+            .await
+            .expect("a parked retry must succeed");
+        assert_eq!(retry, "image/webp");
+    }
+
+    // The pre-acquire checks are cheap, but they are also stale: a caller parked behind the gate
+    // can be overtaken by a request that finishes this same variant while it waits. The
+    // re-check after the acquire is what makes the second request a no-op instead of a
+    // duplicate conversion.
+    #[tokio_shared_rt::test(shared)]
+    async fn test_parked_caller_finds_the_variant_finished_by_the_first() {
+        COUNT.store(0, Ordering::SeqCst);
+
+        let root = tempfile::TempDir::new().expect("temp dir");
+        let file = file_details();
+        let dir = variant_dir(root.path(), &file).await;
+        let output = dir.join(FileVariant::Small.to_string());
+
+        // Simulate the first request having finished while the second was parked: the
+        // variant file exists before the second request's re-check runs.
+        tokio::fs::write(&output, b"variant bytes")
+            .await
+            .expect("pre-existing variant");
+
+        // A gate that parks the caller (open=false) so the re-check happens after the
+        // "first" conversion has finished.
+        let open = Arc::new(AtomicBool::new(false));
+
+        let task = tokio::spawn({
+            let file = file.clone();
+            let root = root.path().to_path_buf();
+            let open = Arc::clone(&open);
+            async move {
+                CountingProcessor::create_variant(
+                    &file,
+                    &FileVariant::Small,
+                    root,
+                    &ControllableGate {
+                        permits: MediaPermits::new(1),
+                        open,
+                    },
+                    MediaSubprocess::new(Duration::from_secs(30)),
+                )
+                .await
+            }
+        });
+
+        // Park the task in the gate; the variant already exists, so the re-check after
+        // the acquire must short-circuit without converting.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        open.store(true, Ordering::SeqCst);
+        let result = task.await.expect("parked task");
+        assert!(
+            result.is_ok(),
+            "a parked caller that finds the variant must succeed, got {:?}",
+            result
+        );
+        assert_eq!(
+            COUNT.load(Ordering::SeqCst),
+            0,
+            "the parked caller must re-check after the acquire and find the variant, not reconvert"
+        );
+    }
+
+    // The kill marker is the defense against hostile files, and a killed conversion outruns the
+    // request timeout by construction (deadline 180s vs request timeout 30s) -- so the marker
+    // must be written by the work, not the caller, or the shed never happens for the only case
+    // it exists for.
+    #[tokio_shared_rt::test(shared)]
+    async fn test_cancelled_caller_still_writes_the_timeout_marker() {
+        let root = tempfile::TempDir::new().expect("temp dir");
+        let file = file_details();
+        let dir = variant_dir(root.path(), &file).await;
+
+        let gate = Arc::new(QueuedGate::with_limits(
+            MediaPermits::new(1),
+            4,
+            Duration::from_millis(200),
+        ));
+
+        let caller = tokio::spawn({
+            let file = file.clone();
+            let root = root.path().to_path_buf();
+            let gate = Arc::clone(&gate);
+            async move {
+                WedgedProcessor::create_variant(
+                    &file,
+                    &FileVariant::Small,
+                    root,
+                    gate.as_ref(),
+                    // Short enough that the test does not wait a real deadline out.
+                    MediaSubprocess::new(Duration::from_millis(200)),
+                )
+                .await
+            }
+        });
+
+        // The conversion is wedged; the request times out on it well before the kill.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        caller.abort();
+        let _ = caller.await;
+
+        // Past the deadline, with no caller left to write the marker.
+        tokio::time::sleep(Duration::from_millis(600)).await;
+        assert!(
+            marker_path(&dir).exists(),
+            "a kill outlives its request, so the marker must survive the caller"
+        );
+        assert!(
+            !dir.join(FileVariant::Small.to_string()).exists(),
+            "a killed conversion must not publish"
+        );
+
+        // And the shed now works: the next request sheds without spending another deadline.
+        let shed = create_small::<RecordingProcessor>(root.path(), &file, gate.as_ref()).await;
+        assert!(
+            matches!(shed, Err(MediaProcessorError::SkippedAfterTimeout { .. })),
+            "the surviving marker must shed the next request, got {shed:?}"
         );
     }
 
@@ -618,11 +869,22 @@ mod tests {
         )
         .await;
 
-        assert!(result.is_err(), "this conversion failed");
+        // The re-check after the acquire sees the finished variant and returns without
+        // converting, so the result is Ok here rather than the failure the test originally
+        // exercised. The half-written temp file is cleaned up by the failed run's own error
+        // path in the other tests; the invariant under test is that the variant is untouched.
+        assert!(
+            result.is_ok(),
+            "a finished variant must short-circuit the conversion"
+        );
         assert_eq!(
             tokio::fs::read(&output).await.expect("variant still there"),
             b"a variant someone else finished",
-            "a failing run must not touch a variant it did not write"
+            "a run that finds the variant must not touch it"
+        );
+        assert!(
+            temp_dir_entries(root.path()).await.is_empty(),
+            "the short-circuit must not write a temp file"
         );
     }
 
@@ -920,6 +1182,45 @@ mod tests {
             Ok(String::from("image/webp"))
         }
     }
+
+    /// Writes a variant file and counts how many times it actually converted, so a test can
+    /// assert a second request found the variant instead of redoing the work.
+    struct CountingProcessor;
+
+    #[async_trait::async_trait]
+    impl VariantProcessor for CountingProcessor {
+        type ProcessingOptions = SlowOptions;
+
+        fn get_valid_variants_for_content_type(_content_type: &str) -> Vec<FileVariant> {
+            vec![FileVariant::Small]
+        }
+
+        fn get_content_type_for_variant(_file: &FileDetails, _variant: &FileVariant) -> String {
+            String::from("image/webp")
+        }
+
+        fn get_options_for_variant(
+            _file: &FileDetails,
+            _variant: &FileVariant,
+        ) -> Result<SlowOptions, MediaProcessorError> {
+            Ok(SlowOptions)
+        }
+
+        async fn process(
+            _origin_file_path: &str,
+            output_file_path: &str,
+            _options: &SlowOptions,
+            _subprocess: MediaSubprocess,
+        ) -> Result<String, MediaProcessorError> {
+            COUNT.fetch_add(1, Ordering::SeqCst);
+            tokio::fs::write(output_file_path, b"variant bytes")
+                .await
+                .expect("stand-in must write its output");
+            Ok(String::from("image/webp"))
+        }
+    }
+
+    static COUNT: AtomicUsize = AtomicUsize::new(0);
 
     /// Runs a child that never exits on its own, so only the deadline can end it.
     struct WedgedProcessor;

--- a/nexus-common/src/media/processors/mod.rs
+++ b/nexus-common/src/media/processors/mod.rs
@@ -75,7 +75,7 @@ pub trait VariantProcessor {
         file: &FileDetails,
         variant: &FileVariant,
         file_path: PathBuf,
-        gate: &MediaGate,
+        gate: &dyn MediaGate,
     ) -> Result<String, MediaProcessorError>
     where
         Self: Sized + 'static,
@@ -128,9 +128,13 @@ pub trait VariantProcessor {
 mod tests {
     use std::path::{Path, PathBuf};
     use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
     use std::time::Duration;
 
-    use crate::media::{concurrency::MediaGate, FileVariant};
+    use crate::media::{
+        concurrency::{MediaPermits, QueuedGate},
+        FileVariant, MediaGate,
+    };
     use crate::models::file::{FileDetails, FileUrls};
 
     use super::{BaseProcessingOptions, MediaProcessorError, VariantProcessor};
@@ -199,16 +203,20 @@ mod tests {
     // subprocess is still running, or the gate would undercount live subprocesses.
     #[tokio_shared_rt::test(shared)]
     async fn test_cancelled_request_holds_permit_until_work_completes() {
-        let gate = MediaGate::new(1).with_acquire_timeout(Duration::from_millis(50));
+        let gate = Arc::new(QueuedGate::with_limits(
+            MediaPermits::new(1),
+            4,
+            Duration::from_millis(50),
+        ));
 
         let caller = tokio::spawn({
-            let gate = gate.clone();
+            let gate = Arc::clone(&gate);
             async move {
                 SlowProcessor::create_variant(
                     &file_details(),
                     &FileVariant::Small,
                     PathBuf::from("/tmp"),
-                    &gate,
+                    gate.as_ref(),
                 )
                 .await
             }

--- a/nexus-common/src/media/processors/mod.rs
+++ b/nexus-common/src/media/processors/mod.rs
@@ -1,10 +1,12 @@
 use crate::{
-    media::{concurrency::MediaGate, FileVariant},
+    media::{concurrency::MediaGate, FileVariant, MediaSubprocess},
     models::file::FileDetails,
 };
 use async_trait::async_trait;
 use std::path::PathBuf;
+use std::time::Duration;
 use thiserror::Error;
+use tokio::fs;
 
 mod image;
 mod video;
@@ -33,6 +35,8 @@ pub enum MediaProcessorError {
     InvalidFilePath(String),
     #[error("AtCapacity: media processing concurrency limit reached")]
     AtCapacity,
+    #[error("Timeout: {command} exceeded {deadline:?}")]
+    Timeout { command: String, deadline: Duration },
 }
 
 impl MediaProcessorError {
@@ -40,6 +44,12 @@ impl MediaProcessorError {
         Self::CommandFailed {
             source: source.into(),
         }
+    }
+
+    /// Whether this means "no variant right now" rather than "this file is broken", so the caller
+    /// degrades (serves `main`, answers 503) instead of reporting a server fault.
+    pub fn is_load_shed(&self) -> bool {
+        matches!(self, Self::AtCapacity | Self::Timeout { .. })
     }
 }
 
@@ -67,6 +77,7 @@ pub trait VariantProcessor {
         origin_file_path: &str,
         output_file_path: &str,
         options: &Self::ProcessingOptions,
+        subprocess: MediaSubprocess,
     ) -> Result<String, MediaProcessorError>;
 
     /// Creates a variant for the given file
@@ -76,6 +87,7 @@ pub trait VariantProcessor {
         variant: &FileVariant,
         file_path: PathBuf,
         gate: &dyn MediaGate,
+        subprocess: MediaSubprocess,
     ) -> Result<String, MediaProcessorError>
     where
         Self: Sized + 'static,
@@ -113,12 +125,29 @@ pub trait VariantProcessor {
         let origin_file_path = origin_file_path.to_string();
         let output_path = output_path.to_string();
 
-        tokio::spawn(async move {
-            let _permit = permit;
-            Self::process(&origin_file_path, &output_path, &options).await
+        let processed = tokio::spawn({
+            let output_path = output_path.clone();
+            async move {
+                let _permit = permit;
+                Self::process(&origin_file_path, &output_path, &options, subprocess).await
+            }
         })
         .await
-        .map_err(MediaProcessorError::command_failed)??;
+        .map_err(MediaProcessorError::command_failed)?;
+
+        if let Err(error) = processed {
+            // A killed or failed converter leaves its half-written output behind, and an existing
+            // file *is* the "variant already made" check, so leaving it serves that wreckage
+            // forever. Best effort: if the removal fails the next request will serve it anyway.
+            let _ = fs::remove_file(&output_path).await;
+
+            if matches!(error, MediaProcessorError::Timeout { .. }) {
+                // A killed child means a tool-level limit was escaped, so it is worth its own line:
+                // the shed answer the caller returns names neither the file nor the command.
+                tracing::warn!("Media subprocess killed for file {}: {error}", file.id);
+            }
+            return Err(error);
+        }
 
         Ok(content_type)
     }
@@ -133,7 +162,7 @@ mod tests {
 
     use crate::media::{
         concurrency::{MediaPermits, QueuedGate},
-        FileVariant, MediaGate,
+        FileVariant, MediaGate, MediaSubprocess,
     };
     use crate::models::file::{FileDetails, FileUrls};
 
@@ -176,6 +205,7 @@ mod tests {
             _origin_file_path: &str,
             _output_file_path: &str,
             _options: &SlowOptions,
+            _subprocess: MediaSubprocess,
         ) -> Result<String, MediaProcessorError> {
             tokio::time::sleep(WORK).await;
             FINISHED.store(true, Ordering::SeqCst);
@@ -217,6 +247,7 @@ mod tests {
                     &FileVariant::Small,
                     PathBuf::from("/tmp"),
                     gate.as_ref(),
+                    MediaSubprocess::new(Duration::from_secs(30)),
                 )
                 .await
             }
@@ -245,6 +276,141 @@ mod tests {
         assert!(
             gate.acquire().await.is_ok(),
             "permit must be released once the work completes"
+        );
+    }
+
+    /// Writes the half-finished output a killed converter would leave behind, then fails.
+    struct HalfWrittenProcessor;
+
+    #[async_trait::async_trait]
+    impl VariantProcessor for HalfWrittenProcessor {
+        type ProcessingOptions = SlowOptions;
+
+        fn get_valid_variants_for_content_type(_content_type: &str) -> Vec<FileVariant> {
+            vec![FileVariant::Small]
+        }
+
+        fn get_content_type_for_variant(_file: &FileDetails, _variant: &FileVariant) -> String {
+            String::from("image/webp")
+        }
+
+        fn get_options_for_variant(
+            _file: &FileDetails,
+            _variant: &FileVariant,
+        ) -> Result<SlowOptions, MediaProcessorError> {
+            Ok(SlowOptions)
+        }
+
+        async fn process(
+            _origin_file_path: &str,
+            output_file_path: &str,
+            _options: &SlowOptions,
+            _subprocess: MediaSubprocess,
+        ) -> Result<String, MediaProcessorError> {
+            tokio::fs::write(output_file_path, b"")
+                .await
+                .expect("the stand-in must leave its wreckage behind");
+            Err(MediaProcessorError::Timeout {
+                command: String::from("convert"),
+                deadline: Duration::from_millis(1),
+            })
+        }
+    }
+
+    // An existing file is the "variant already made" check, so a half-written one would be served
+    // as the variant from then on.
+    #[tokio_shared_rt::test(shared)]
+    async fn test_failed_conversion_leaves_no_output_behind() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let file = file_details();
+        let output = dir
+            .path()
+            .join(file.owner_id.as_str())
+            .join(file.id.as_str());
+        tokio::fs::create_dir_all(&output)
+            .await
+            .expect("variant dir");
+        let output = output.join(FileVariant::Small.to_string());
+
+        let gate = QueuedGate::with_limits(MediaPermits::new(1), 4, Duration::from_millis(200));
+        let result = HalfWrittenProcessor::create_variant(
+            &file,
+            &FileVariant::Small,
+            dir.path().to_path_buf(),
+            &gate,
+            MediaSubprocess::new(Duration::from_secs(30)),
+        )
+        .await;
+
+        assert!(result.is_err(), "the conversion failed");
+        assert!(
+            !output.exists(),
+            "a failed conversion must not leave a variant behind"
+        );
+    }
+
+    /// Runs a child that never exits on its own, so only the deadline can end it.
+    struct WedgedProcessor;
+
+    #[async_trait::async_trait]
+    impl VariantProcessor for WedgedProcessor {
+        type ProcessingOptions = SlowOptions;
+
+        fn get_valid_variants_for_content_type(_content_type: &str) -> Vec<FileVariant> {
+            vec![FileVariant::Small]
+        }
+
+        fn get_content_type_for_variant(_file: &FileDetails, _variant: &FileVariant) -> String {
+            String::from("image/webp")
+        }
+
+        fn get_options_for_variant(
+            _file: &FileDetails,
+            _variant: &FileVariant,
+        ) -> Result<SlowOptions, MediaProcessorError> {
+            Ok(SlowOptions)
+        }
+
+        async fn process(
+            _origin_file_path: &str,
+            _output_file_path: &str,
+            _options: &SlowOptions,
+            subprocess: MediaSubprocess,
+        ) -> Result<String, MediaProcessorError> {
+            subprocess
+                .run(tokio::process::Command::new("sleep").arg("30"))
+                .await?;
+            Ok(String::from("image/webp"))
+        }
+    }
+
+    // Without a deadline a hung subprocess keeps its permit until restart, and enough of them
+    // exhaust the gate.
+    #[tokio_shared_rt::test(shared)]
+    async fn test_wedged_subprocess_releases_its_permit_at_the_deadline() {
+        let gate = QueuedGate::with_limits(
+            MediaPermits::new(1),
+            4,
+            // Short enough that the assertion below fails fast if the permit is never returned.
+            Duration::from_millis(200),
+        );
+
+        let result = WedgedProcessor::create_variant(
+            &file_details(),
+            &FileVariant::Small,
+            PathBuf::from("/tmp"),
+            &gate,
+            MediaSubprocess::new(Duration::from_millis(100)),
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(MediaProcessorError::Timeout { .. })),
+            "the deadline must surface as a timeout, got {result:?}"
+        );
+        assert!(
+            gate.acquire().await.is_ok(),
+            "killing the child must return its permit to the pool"
         );
     }
 }

--- a/nexus-common/src/media/processors/mod.rs
+++ b/nexus-common/src/media/processors/mod.rs
@@ -3,8 +3,8 @@ use crate::{
     models::file::FileDetails,
 };
 use async_trait::async_trait;
-use std::path::PathBuf;
-use std::time::Duration;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
 use thiserror::Error;
 use tokio::fs;
 
@@ -50,6 +50,60 @@ impl MediaProcessorError {
     /// degrades (serves `main`, answers 503) instead of reporting a server fault.
     pub fn is_load_shed(&self) -> bool {
         matches!(self, Self::AtCapacity | Self::Timeout { .. })
+    }
+}
+
+/// How long an abandoned temp file must sit before the sweep takes it. Far above any conversion
+/// deadline, so a temp file belonging to a run still in flight is never touched.
+const TEMP_FILE_MAX_AGE: Duration = Duration::from_secs(60 * 60);
+
+/// A path only this run writes to, so a failure cleans up after itself without touching a variant
+/// another request may have just finished.
+fn temp_variant_path(output_path: &str) -> String {
+    let nanos = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    format!("{output_path}.{}.{nanos}", std::process::id())
+}
+
+/// Whether `name` is a temp file for `variant`, i.e. `<variant>.<pid>.<nanos>`.
+fn is_temp_variant_of(name: &str, variant: &str) -> bool {
+    let Some(suffix) = name.strip_prefix(&format!("{variant}.")) else {
+        return false;
+    };
+    let mut parts = suffix.split('.');
+    let (Some(pid), Some(nanos), None) = (parts.next(), parts.next(), parts.next()) else {
+        return false;
+    };
+    !pid.is_empty()
+        && !nanos.is_empty()
+        && pid.bytes().all(|b| b.is_ascii_digit())
+        && nanos.bytes().all(|b| b.is_ascii_digit())
+}
+
+/// Drops temp files left behind by a run that never got to clean up, e.g. one killed with the whole
+/// process. They are never served -- the variant check stats the exact path -- but they are disk
+/// that never comes back.
+async fn sweep_stale_temp_files(dir: &Path, variant: &str) {
+    let Ok(mut entries) = fs::read_dir(dir).await else {
+        return;
+    };
+
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        if !is_temp_variant_of(name, variant) {
+            continue;
+        }
+
+        let aged = match entry.metadata().await.and_then(|m| m.modified()) {
+            Ok(modified) => modified.elapsed().is_ok_and(|age| age > TEMP_FILE_MAX_AGE),
+            Err(_) => false,
+        };
+        if aged {
+            let _ = fs::remove_file(entry.path()).await;
+        }
     }
 }
 
@@ -120,26 +174,32 @@ pub trait VariantProcessor {
         // Held only around the subprocess, not the path/option work above. The permit moves
         // into the task so it is released when the child exits, not when the caller's future
         // is dropped: a cancelled request must not hand its permit on while its child runs.
+        // TODO: run as a periodic job instead, so conversions stop paying a read_dir each time.
+        sweep_stale_temp_files(&origin_path, &variant.to_string()).await;
+
+        // The converter writes here, never to the variant path: an existing variant file *is* the
+        // "already made" check, so a killed or crashed child writing there directly would publish
+        // its wreckage. Only the rename below makes a variant visible, and only when complete.
+        let temp_path = temp_variant_path(output_path);
+
         let permit = gate.acquire().await?;
         let content_type = options.content_type();
         let origin_file_path = origin_file_path.to_string();
         let output_path = output_path.to_string();
 
         let processed = tokio::spawn({
-            let output_path = output_path.clone();
+            let temp_path = temp_path.clone();
             async move {
                 let _permit = permit;
-                Self::process(&origin_file_path, &output_path, &options, subprocess).await
+                Self::process(&origin_file_path, &temp_path, &options, subprocess).await
             }
         })
         .await
         .map_err(MediaProcessorError::command_failed)?;
 
         if let Err(error) = processed {
-            // A killed or failed converter leaves its half-written output behind, and an existing
-            // file *is* the "variant already made" check, so leaving it serves that wreckage
-            // forever. Best effort: if the removal fails the next request will serve it anyway.
-            let _ = fs::remove_file(&output_path).await;
+            // Only ever this run's own file, so a concurrent run that just finished keeps its work.
+            let _ = fs::remove_file(&temp_path).await;
 
             if matches!(error, MediaProcessorError::Timeout { .. }) {
                 // A killed child means a tool-level limit was escaped, so it is worth its own line:
@@ -148,6 +208,25 @@ pub trait VariantProcessor {
             }
             return Err(error);
         }
+
+        // A killed converter can exit having written nothing; publishing that would cache an empty
+        // variant forever.
+        let written = fs::metadata(&temp_path)
+            .await
+            .map(|metadata| metadata.len())
+            .unwrap_or_default();
+        if written == 0 {
+            let _ = fs::remove_file(&temp_path).await;
+            return Err(MediaProcessorError::command_failed(format!(
+                "conversion produced no output for file {}",
+                file.id
+            )));
+        }
+
+        // Atomic within the directory: a reader sees the finished variant or no variant at all.
+        fs::rename(&temp_path, &output_path)
+            .await
+            .map_err(MediaProcessorError::command_failed)?;
 
         Ok(content_type)
     }
@@ -158,7 +237,7 @@ mod tests {
     use std::path::{Path, PathBuf};
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
-    use std::time::Duration;
+    use std::time::{Duration, SystemTime};
 
     use crate::media::{
         concurrency::{MediaPermits, QueuedGate},
@@ -166,7 +245,10 @@ mod tests {
     };
     use crate::models::file::{FileDetails, FileUrls};
 
-    use super::{BaseProcessingOptions, MediaProcessorError, VariantProcessor};
+    use super::{
+        is_temp_variant_of, sweep_stale_temp_files, BaseProcessingOptions, MediaProcessorError,
+        VariantProcessor, TEMP_FILE_MAX_AGE,
+    };
 
     static FINISHED: AtomicBool = AtomicBool::new(false);
     const WORK: Duration = Duration::from_millis(300);
@@ -321,22 +403,16 @@ mod tests {
     // as the variant from then on.
     #[tokio_shared_rt::test(shared)]
     async fn test_failed_conversion_leaves_no_output_behind() {
-        let dir = tempfile::TempDir::new().expect("temp dir");
+        let root = tempfile::TempDir::new().expect("temp dir");
         let file = file_details();
-        let output = dir
-            .path()
-            .join(file.owner_id.as_str())
-            .join(file.id.as_str());
-        tokio::fs::create_dir_all(&output)
-            .await
-            .expect("variant dir");
-        let output = output.join(FileVariant::Small.to_string());
+        let variant_dir = variant_dir(root.path(), &file).await;
+        let output = variant_dir.join(FileVariant::Small.to_string());
 
         let gate = QueuedGate::with_limits(MediaPermits::new(1), 4, Duration::from_millis(200));
         let result = HalfWrittenProcessor::create_variant(
             &file,
             &FileVariant::Small,
-            dir.path().to_path_buf(),
+            root.path().to_path_buf(),
             &gate,
             MediaSubprocess::new(Duration::from_secs(30)),
         )
@@ -347,6 +423,254 @@ mod tests {
             !output.exists(),
             "a failed conversion must not leave a variant behind"
         );
+        assert!(
+            variant_dir_entries(&variant_dir).await.is_empty(),
+            "the temp file must be cleaned up too"
+        );
+    }
+
+    /// Every file sitting in a variant directory, by name.
+    async fn variant_dir_entries(dir: &Path) -> Vec<String> {
+        let mut entries = tokio::fs::read_dir(dir).await.expect("variant dir");
+        let mut names = Vec::new();
+        while let Some(entry) = entries.next_entry().await.expect("dir entry") {
+            names.push(entry.file_name().to_string_lossy().into_owned());
+        }
+        names.sort();
+        names
+    }
+
+    /// Creates the variant directory a processor writes into, and returns it.
+    async fn variant_dir(root: &Path, file: &FileDetails) -> PathBuf {
+        let dir = root.join(file.owner_id.as_str()).join(file.id.as_str());
+        tokio::fs::create_dir_all(&dir).await.expect("variant dir");
+        dir
+    }
+
+    /// Reports the variant path it was handed, so a test can watch what is visible mid-conversion.
+    struct ReportingProcessor;
+
+    static OBSERVED: std::sync::Mutex<Vec<String>> = std::sync::Mutex::new(Vec::new());
+
+    #[async_trait::async_trait]
+    impl VariantProcessor for ReportingProcessor {
+        type ProcessingOptions = SlowOptions;
+
+        fn get_valid_variants_for_content_type(_content_type: &str) -> Vec<FileVariant> {
+            vec![FileVariant::Small]
+        }
+
+        fn get_content_type_for_variant(_file: &FileDetails, _variant: &FileVariant) -> String {
+            String::from("image/webp")
+        }
+
+        fn get_options_for_variant(
+            _file: &FileDetails,
+            _variant: &FileVariant,
+        ) -> Result<SlowOptions, MediaProcessorError> {
+            Ok(SlowOptions)
+        }
+
+        async fn process(
+            _origin_file_path: &str,
+            output_file_path: &str,
+            _options: &SlowOptions,
+            _subprocess: MediaSubprocess,
+        ) -> Result<String, MediaProcessorError> {
+            tokio::fs::write(output_file_path, b"variant bytes")
+                .await
+                .expect("stand-in must write its output");
+
+            // What a concurrent reader would see while the conversion is still running.
+            let dir = Path::new(output_file_path)
+                .parent()
+                .expect("variant dir")
+                .to_path_buf();
+            let visible = variant_dir_entries(&dir).await;
+            OBSERVED.lock().expect("observed").extend(visible);
+
+            Ok(String::from("image/webp"))
+        }
+    }
+
+    // The variant path must stay absent until the conversion is complete, or a concurrent request
+    // stats it mid-write and serves a truncated file.
+    #[tokio_shared_rt::test(shared)]
+    async fn test_variant_is_invisible_until_complete() {
+        let root = tempfile::TempDir::new().expect("temp dir");
+        let file = file_details();
+        let dir = variant_dir(root.path(), &file).await;
+        let variant = FileVariant::Small.to_string();
+        OBSERVED.lock().expect("observed").clear();
+
+        let gate = QueuedGate::with_limits(MediaPermits::new(1), 4, Duration::from_millis(200));
+        ReportingProcessor::create_variant(
+            &file,
+            &FileVariant::Small,
+            root.path().to_path_buf(),
+            &gate,
+            MediaSubprocess::new(Duration::from_secs(30)),
+        )
+        .await
+        .expect("conversion succeeds");
+
+        let during = OBSERVED.lock().expect("observed").clone();
+        assert!(
+            !during.contains(&variant),
+            "the variant path was visible mid-conversion: {during:?}"
+        );
+        assert!(
+            during.iter().any(|name| is_temp_variant_of(name, &variant)),
+            "the conversion should write to a temp path: {during:?}"
+        );
+
+        // Only the rename publishes it, and it leaves nothing else behind.
+        assert_eq!(variant_dir_entries(&dir).await, vec![variant]);
+    }
+
+    // A run that fails must not delete a variant another request just finished.
+    #[tokio_shared_rt::test(shared)]
+    async fn test_failed_conversion_keeps_a_finished_variant() {
+        let root = tempfile::TempDir::new().expect("temp dir");
+        let file = file_details();
+        let dir = variant_dir(root.path(), &file).await;
+        let output = dir.join(FileVariant::Small.to_string());
+        tokio::fs::write(&output, b"a variant someone else finished")
+            .await
+            .expect("existing variant");
+
+        let gate = QueuedGate::with_limits(MediaPermits::new(1), 4, Duration::from_millis(200));
+        let result = HalfWrittenProcessor::create_variant(
+            &file,
+            &FileVariant::Small,
+            root.path().to_path_buf(),
+            &gate,
+            MediaSubprocess::new(Duration::from_secs(30)),
+        )
+        .await;
+
+        assert!(result.is_err(), "this conversion failed");
+        assert_eq!(
+            tokio::fs::read(&output).await.expect("variant still there"),
+            b"a variant someone else finished",
+            "a failing run must not touch a variant it did not write"
+        );
+    }
+
+    // An empty output is what a killed converter leaves; publishing it would cache nothing forever.
+    #[tokio_shared_rt::test(shared)]
+    async fn test_empty_output_is_not_published() {
+        let root = tempfile::TempDir::new().expect("temp dir");
+        let file = file_details();
+        let dir = variant_dir(root.path(), &file).await;
+        let gate = QueuedGate::with_limits(MediaPermits::new(1), 4, Duration::from_millis(200));
+
+        let result = EmptyOutputProcessor::create_variant(
+            &file,
+            &FileVariant::Small,
+            root.path().to_path_buf(),
+            &gate,
+            MediaSubprocess::new(Duration::from_secs(30)),
+        )
+        .await;
+
+        assert!(result.is_err(), "an empty conversion is a failure");
+        assert!(
+            variant_dir_entries(&dir).await.is_empty(),
+            "nothing may be published, not even the temp file"
+        );
+    }
+
+    #[test]
+    fn test_temp_variant_name_matching() {
+        let cases = [
+            ("small.1234.5678", true),
+            // The variant itself, and another variant's temp file.
+            ("small", false),
+            ("feed.1234.5678", false),
+            // Shapes that are not <variant>.<pid>.<nanos>.
+            ("small.1234", false),
+            ("small.1234.5678.9", false),
+            ("small.abc.5678", false),
+            ("small..5678", false),
+        ];
+
+        for (name, expected) in cases {
+            assert_eq!(is_temp_variant_of(name, "small"), expected, "{name}");
+        }
+    }
+
+    // A temp file outlives its run only when the whole process dies, and nothing else will ever
+    // clean it up.
+    #[tokio_shared_rt::test(shared)]
+    async fn test_sweep_removes_only_aged_temp_files() {
+        let root = tempfile::TempDir::new().expect("temp dir");
+        let file = file_details();
+        let dir = variant_dir(root.path(), &file).await;
+        let variant = FileVariant::Small.to_string();
+
+        let orphan = dir.join(format!("{variant}.999.111"));
+        let in_flight = dir.join(format!("{variant}.888.222"));
+        let finished = dir.join(&variant);
+        for path in [&orphan, &in_flight, &finished] {
+            tokio::fs::write(path, b"x").await.expect("write");
+        }
+
+        // Only the orphan is older than the sweep's cutoff.
+        let aged = SystemTime::now() - TEMP_FILE_MAX_AGE - Duration::from_secs(60);
+        set_modified(&orphan, aged);
+
+        sweep_stale_temp_files(&dir, &variant).await;
+
+        assert_eq!(
+            variant_dir_entries(&dir).await,
+            vec![variant.clone(), format!("{variant}.888.222")],
+            "the sweep must take the orphan and nothing else"
+        );
+    }
+
+    /// Backdates a file so the sweep sees it as abandoned.
+    fn set_modified(path: &Path, when: SystemTime) {
+        let file = std::fs::File::options()
+            .write(true)
+            .open(path)
+            .expect("open for backdating");
+        file.set_modified(when).expect("backdate");
+    }
+
+    /// Exits successfully having written an empty file, as a killed converter does.
+    struct EmptyOutputProcessor;
+
+    #[async_trait::async_trait]
+    impl VariantProcessor for EmptyOutputProcessor {
+        type ProcessingOptions = SlowOptions;
+
+        fn get_valid_variants_for_content_type(_content_type: &str) -> Vec<FileVariant> {
+            vec![FileVariant::Small]
+        }
+
+        fn get_content_type_for_variant(_file: &FileDetails, _variant: &FileVariant) -> String {
+            String::from("image/webp")
+        }
+
+        fn get_options_for_variant(
+            _file: &FileDetails,
+            _variant: &FileVariant,
+        ) -> Result<SlowOptions, MediaProcessorError> {
+            Ok(SlowOptions)
+        }
+
+        async fn process(
+            _origin_file_path: &str,
+            output_file_path: &str,
+            _options: &SlowOptions,
+            _subprocess: MediaSubprocess,
+        ) -> Result<String, MediaProcessorError> {
+            tokio::fs::write(output_file_path, b"")
+                .await
+                .expect("stand-in must write an empty output");
+            Ok(String::from("image/webp"))
+        }
     }
 
     /// Runs a child that never exits on its own, so only the deadline can end it.

--- a/nexus-common/src/media/processors/mod.rs
+++ b/nexus-common/src/media/processors/mod.rs
@@ -37,6 +37,8 @@ pub enum MediaProcessorError {
     AtCapacity,
     #[error("Timeout: {command} exceeded {deadline:?}")]
     Timeout { command: String, deadline: Duration },
+    #[error("SkippedAfterTimeout: converting {file} was killed recently; not retrying yet")]
+    SkippedAfterTimeout { file: String },
 }
 
 impl MediaProcessorError {
@@ -49,7 +51,10 @@ impl MediaProcessorError {
     /// Whether this means "no variant right now" rather than "this file is broken", so the caller
     /// degrades (serves `main`, answers 503) instead of reporting a server fault.
     pub fn is_load_shed(&self) -> bool {
-        matches!(self, Self::AtCapacity | Self::Timeout { .. })
+        matches!(
+            self,
+            Self::AtCapacity | Self::Timeout { .. } | Self::SkippedAfterTimeout { .. }
+        )
     }
 }
 
@@ -57,46 +62,69 @@ impl MediaProcessorError {
 /// deadline, so a temp file belonging to a run still in flight is never touched.
 const TEMP_FILE_MAX_AGE: Duration = Duration::from_secs(60 * 60);
 
-/// A path only this run writes to, so a failure cleans up after itself without touching a variant
-/// another request may have just finished.
-fn temp_variant_path(output_path: &str) -> String {
+/// Conversions write here rather than beside the variants, so the strays left by a process that
+/// died mid-conversion are one directory to list instead of a walk over every file on disk. Inside
+/// `files_path` on purpose: `rename` is atomic within a filesystem, and nesting it here makes that
+/// structural rather than a deployment assumption. No request can address it -- the owner segment
+/// of a served path is always a `PubkyId`.
+const TEMP_DIR_NAME: &str = ".tmp";
+
+/// How long a killed conversion is remembered. Far above any deadline, so a hostile file costs one
+/// conversion per hour rather than one per request, while a file that timed out because the box was
+/// loaded is retried within the hour.
+const TIMEDOUT_MARKER_TTL: Duration = Duration::from_secs(60 * 60);
+
+/// Records that converting this file was killed, so the next request sheds instead of spending
+/// another full deadline learning the same thing. Per file rather than per variant: every variant
+/// decodes the same source, which is where a hostile file burns the time, so `small` timing out
+/// tells us what `feed` would find. It lives beside the variants, not in the temp directory: it is
+/// state tied to the file, and deleting the file takes it along. Named so it cannot collide with a
+/// variant, which is always one of `FileVariant`.
+const TIMEDOUT_MARKER_NAME: &str = ".timedout";
+
+/// Whether a killed conversion is still recent enough to skip retrying. Clears the marker once it
+/// expires -- this is the only place that stats it, so reclaiming it here costs nothing.
+async fn timed_out_recently(marker_path: &Path) -> bool {
+    let Ok(metadata) = fs::metadata(marker_path).await else {
+        return false;
+    };
+
+    let recent = metadata
+        .modified()
+        .ok()
+        .and_then(|modified| modified.elapsed().ok())
+        .is_some_and(|age| age < TIMEDOUT_MARKER_TTL);
+
+    if !recent {
+        let _ = fs::remove_file(marker_path).await;
+    }
+    recent
+}
+
+/// A name only this run writes to, so a failure cleans up after itself without touching a variant
+/// another request may have just finished. It carries the file it belongs to so an orphan in the
+/// temp directory can be traced back.
+fn temp_variant_name(file: &FileDetails, variant: &FileVariant) -> String {
     let nanos = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap_or_default()
         .as_nanos();
-    format!("{output_path}.{}.{nanos}", std::process::id())
-}
-
-/// Whether `name` is a temp file for `variant`, i.e. `<variant>.<pid>.<nanos>`.
-fn is_temp_variant_of(name: &str, variant: &str) -> bool {
-    let Some(suffix) = name.strip_prefix(&format!("{variant}.")) else {
-        return false;
-    };
-    let mut parts = suffix.split('.');
-    let (Some(pid), Some(nanos), None) = (parts.next(), parts.next(), parts.next()) else {
-        return false;
-    };
-    !pid.is_empty()
-        && !nanos.is_empty()
-        && pid.bytes().all(|b| b.is_ascii_digit())
-        && nanos.bytes().all(|b| b.is_ascii_digit())
+    format!(
+        "{}.{}.{variant}.{}.{nanos}",
+        file.owner_id,
+        file.id,
+        std::process::id()
+    )
 }
 
 /// Drops temp files left behind by a run that never got to clean up, e.g. one killed with the whole
-/// process. They are never served -- the variant check stats the exact path -- but they are disk
-/// that never comes back.
-async fn sweep_stale_temp_files(dir: &Path, variant: &str) {
-    let Ok(mut entries) = fs::read_dir(dir).await else {
+/// process. Everything in the temp directory is one of ours, so age is the only question.
+async fn sweep_stale_temp_files(temp_dir: &Path) {
+    let Ok(mut entries) = fs::read_dir(temp_dir).await else {
         return;
     };
 
     while let Ok(Some(entry)) = entries.next_entry().await {
-        let name = entry.file_name();
-        let Some(name) = name.to_str() else { continue };
-        if !is_temp_variant_of(name, variant) {
-            continue;
-        }
-
         let aged = match entry.metadata().await.and_then(|m| m.modified()) {
             Ok(modified) => modified.elapsed().is_ok_and(|age| age > TEMP_FILE_MAX_AGE),
             Err(_) => false,
@@ -171,17 +199,42 @@ pub trait VariantProcessor {
             ));
         };
 
-        // Held only around the subprocess, not the path/option work above. The permit moves
-        // into the task so it is released when the child exits, not when the caller's future
-        // is dropped: a cancelled request must not hand its permit on while its child runs.
-        // TODO: run as a periodic job instead, so conversions stop paying a read_dir each time.
-        sweep_stale_temp_files(&origin_path, &variant.to_string()).await;
+        // A killed conversion will be killed again, so shed here rather than spend another full
+        // deadline on it. Checked before the permit: a retry we already know the answer to must not
+        // occupy a slot other files could use.
+        let marker_path = origin_path.join(TIMEDOUT_MARKER_NAME);
+        if timed_out_recently(&marker_path).await {
+            tracing::debug!(
+                "Skipping {variant} for file {}: converting it was killed within the last hour",
+                file.id
+            );
+            return Err(MediaProcessorError::SkippedAfterTimeout {
+                file: file.id.clone(),
+            });
+        }
 
         // The converter writes here, never to the variant path: an existing variant file *is* the
         // "already made" check, so a killed or crashed child writing there directly would publish
         // its wreckage. Only the rename below makes a variant visible, and only when complete.
-        let temp_path = temp_variant_path(output_path);
+        let temp_dir = file_path.join(TEMP_DIR_NAME);
+        fs::create_dir_all(&temp_dir)
+            .await
+            .map_err(MediaProcessorError::command_failed)?;
 
+        // TODO: run as a periodic job instead, so conversions stop paying a read_dir each time.
+        sweep_stale_temp_files(&temp_dir).await;
+
+        let temp_file = temp_dir.join(temp_variant_name(file, variant));
+        let Some(temp_path) = temp_file.to_str() else {
+            return Err(MediaProcessorError::InvalidFilePath(
+                "Temp file".to_string(),
+            ));
+        };
+        let temp_path = temp_path.to_string();
+
+        // Held only around the subprocess, not the path/option work above. The permit moves
+        // into the task so it is released when the child exits, not when the caller's future
+        // is dropped: a cancelled request must not hand its permit on while its child runs.
         let permit = gate.acquire().await?;
         let content_type = options.content_type();
         let origin_file_path = origin_file_path.to_string();
@@ -205,6 +258,8 @@ pub trait VariantProcessor {
                 // A killed child means a tool-level limit was escaped, so it is worth its own line:
                 // the shed answer the caller returns names neither the file nor the command.
                 tracing::warn!("Media subprocess killed for file {}: {error}", file.id);
+                // Remembered so the next request sheds instead of repeating the same deadline.
+                let _ = fs::write(&marker_path, b"").await;
             }
             return Err(error);
         }
@@ -223,7 +278,8 @@ pub trait VariantProcessor {
             )));
         }
 
-        // Atomic within the directory: a reader sees the finished variant or no variant at all.
+        // Atomic: both paths are under `files_path`, so this is a same-filesystem rename and a
+        // reader sees the finished variant or no variant at all.
         fs::rename(&temp_path, &output_path)
             .await
             .map_err(MediaProcessorError::command_failed)?;
@@ -246,8 +302,9 @@ mod tests {
     use crate::models::file::{FileDetails, FileUrls};
 
     use super::{
-        is_temp_variant_of, sweep_stale_temp_files, BaseProcessingOptions, MediaProcessorError,
-        VariantProcessor, TEMP_FILE_MAX_AGE,
+        sweep_stale_temp_files, timed_out_recently, BaseProcessingOptions, MediaProcessorError,
+        VariantProcessor, TEMP_DIR_NAME, TEMP_FILE_MAX_AGE, TIMEDOUT_MARKER_NAME,
+        TIMEDOUT_MARKER_TTL,
     };
 
     static FINISHED: AtomicBool = AtomicBool::new(false);
@@ -423,14 +480,15 @@ mod tests {
             !output.exists(),
             "a failed conversion must not leave a variant behind"
         );
-        assert!(
-            variant_dir_entries(&variant_dir).await.is_empty(),
-            "the temp file must be cleaned up too"
+        assert_eq!(
+            dir_entries(&variant_dir).await,
+            vec![TIMEDOUT_MARKER_NAME.to_string()],
+            "only the marker remains: no variant, no temp file"
         );
     }
 
-    /// Every file sitting in a variant directory, by name.
-    async fn variant_dir_entries(dir: &Path) -> Vec<String> {
+    /// Every file sitting in a directory, by name.
+    async fn dir_entries(dir: &Path) -> Vec<String> {
         let mut entries = tokio::fs::read_dir(dir).await.expect("variant dir");
         let mut names = Vec::new();
         while let Some(entry) = entries.next_entry().await.expect("dir entry") {
@@ -438,6 +496,15 @@ mod tests {
         }
         names.sort();
         names
+    }
+
+    /// Every file in the shared temp directory, by name.
+    async fn temp_dir_entries(root: &Path) -> Vec<String> {
+        let dir = root.join(TEMP_DIR_NAME);
+        if !dir.exists() {
+            return Vec::new();
+        }
+        dir_entries(&dir).await
     }
 
     /// Creates the variant directory a processor writes into, and returns it.
@@ -451,6 +518,8 @@ mod tests {
     struct ReportingProcessor;
 
     static OBSERVED: std::sync::Mutex<Vec<String>> = std::sync::Mutex::new(Vec::new());
+    /// Directory the stand-in inspects mid-conversion.
+    static WATCHED: std::sync::Mutex<Option<PathBuf>> = std::sync::Mutex::new(None);
 
     #[async_trait::async_trait]
     impl VariantProcessor for ReportingProcessor {
@@ -481,13 +550,12 @@ mod tests {
                 .await
                 .expect("stand-in must write its output");
 
-            // What a concurrent reader would see while the conversion is still running.
-            let dir = Path::new(output_file_path)
-                .parent()
-                .expect("variant dir")
-                .to_path_buf();
-            let visible = variant_dir_entries(&dir).await;
-            OBSERVED.lock().expect("observed").extend(visible);
+            // What a concurrent reader would see in the variant directory while this runs.
+            let watched = WATCHED.lock().expect("watched").clone();
+            if let Some(dir) = watched {
+                let visible = dir_entries(&dir).await;
+                OBSERVED.lock().expect("observed").extend(visible);
+            }
 
             Ok(String::from("image/webp"))
         }
@@ -502,6 +570,7 @@ mod tests {
         let dir = variant_dir(root.path(), &file).await;
         let variant = FileVariant::Small.to_string();
         OBSERVED.lock().expect("observed").clear();
+        *WATCHED.lock().expect("watched") = Some(dir.clone());
 
         let gate = QueuedGate::with_limits(MediaPermits::new(1), 4, Duration::from_millis(200));
         ReportingProcessor::create_variant(
@@ -516,16 +585,16 @@ mod tests {
 
         let during = OBSERVED.lock().expect("observed").clone();
         assert!(
-            !during.contains(&variant),
-            "the variant path was visible mid-conversion: {during:?}"
-        );
-        assert!(
-            during.iter().any(|name| is_temp_variant_of(name, &variant)),
-            "the conversion should write to a temp path: {during:?}"
+            during.is_empty(),
+            "nothing may be visible beside the variants mid-conversion: {during:?}"
         );
 
         // Only the rename publishes it, and it leaves nothing else behind.
-        assert_eq!(variant_dir_entries(&dir).await, vec![variant]);
+        assert_eq!(dir_entries(&dir).await, vec![variant]);
+        assert!(
+            temp_dir_entries(root.path()).await.is_empty(),
+            "the temp file is consumed by the rename"
+        );
     }
 
     // A run that fails must not delete a variant another request just finished.
@@ -576,28 +645,181 @@ mod tests {
 
         assert!(result.is_err(), "an empty conversion is a failure");
         assert!(
-            variant_dir_entries(&dir).await.is_empty(),
+            dir_entries(&dir).await.is_empty(),
             "nothing may be published, not even the temp file"
         );
     }
 
-    #[test]
-    fn test_temp_variant_name_matching() {
-        let cases = [
-            ("small.1234.5678", true),
-            // The variant itself, and another variant's temp file.
-            ("small", false),
-            ("feed.1234.5678", false),
-            // Shapes that are not <variant>.<pid>.<nanos>.
-            ("small.1234", false),
-            ("small.1234.5678.9", false),
-            ("small.abc.5678", false),
-            ("small..5678", false),
-        ];
+    /// Records whether it ran, so a test can prove a shed never reached the converter.
+    struct RecordingProcessor;
 
-        for (name, expected) in cases {
-            assert_eq!(is_temp_variant_of(name, "small"), expected, "{name}");
+    #[async_trait::async_trait]
+    impl VariantProcessor for RecordingProcessor {
+        type ProcessingOptions = SlowOptions;
+
+        fn get_valid_variants_for_content_type(_content_type: &str) -> Vec<FileVariant> {
+            vec![FileVariant::Small]
         }
+
+        fn get_content_type_for_variant(_file: &FileDetails, _variant: &FileVariant) -> String {
+            String::from("image/webp")
+        }
+
+        fn get_options_for_variant(
+            _file: &FileDetails,
+            _variant: &FileVariant,
+        ) -> Result<SlowOptions, MediaProcessorError> {
+            Ok(SlowOptions)
+        }
+
+        async fn process(
+            _origin_file_path: &str,
+            output_file_path: &str,
+            _options: &SlowOptions,
+            _subprocess: MediaSubprocess,
+        ) -> Result<String, MediaProcessorError> {
+            tokio::fs::write(output_file_path, b"variant bytes")
+                .await
+                .expect("stand-in must write its output");
+            Ok(String::from("image/webp"))
+        }
+    }
+
+    /// The marker a killed conversion leaves for the file, whichever variant was being made.
+    fn marker_path(dir: &Path) -> PathBuf {
+        dir.join(TIMEDOUT_MARKER_NAME)
+    }
+
+    async fn create_small<P: VariantProcessor + Send + Sync + Sized + 'static>(
+        root: &Path,
+        file: &FileDetails,
+        gate: &dyn MediaGate,
+    ) -> Result<String, MediaProcessorError> {
+        P::create_variant(
+            file,
+            &FileVariant::Small,
+            root.to_path_buf(),
+            gate,
+            MediaSubprocess::new(Duration::from_secs(30)),
+        )
+        .await
+    }
+
+    // A conversion we already killed will be killed again, so it must not cost a second deadline --
+    // or a permit, which is what a hostile file would use to keep the gate full.
+    #[tokio_shared_rt::test(shared)]
+    async fn test_recent_timeout_sheds_without_converting() {
+        let root = tempfile::TempDir::new().expect("temp dir");
+        let file = file_details();
+        let dir = variant_dir(root.path(), &file).await;
+        tokio::fs::write(marker_path(&dir), b"")
+            .await
+            .expect("marker");
+
+        let gate = QueuedGate::with_limits(MediaPermits::new(1), 4, Duration::from_millis(200));
+        let result = create_small::<RecordingProcessor>(root.path(), &file, &gate).await;
+
+        assert!(
+            matches!(result, Err(MediaProcessorError::SkippedAfterTimeout { .. })),
+            "expected a shed, got {result:?}"
+        );
+        assert!(
+            !dir.join(FileVariant::Small.to_string()).exists()
+                && temp_dir_entries(root.path()).await.is_empty(),
+            "the converter must not run"
+        );
+        assert!(
+            gate.acquire().await.is_ok(),
+            "a shed must not consume a permit"
+        );
+    }
+
+    // Every variant decodes the same source, so one kill answers for all of them: `feed` must not
+    // spend its own deadline rediscovering what `small` already found.
+    #[tokio_shared_rt::test(shared)]
+    async fn test_a_kill_covers_every_variant_of_the_file() {
+        let root = tempfile::TempDir::new().expect("temp dir");
+        let file = file_details();
+        let dir = variant_dir(root.path(), &file).await;
+        let gate = QueuedGate::with_limits(MediaPermits::new(1), 4, Duration::from_millis(200));
+
+        // `small` is killed.
+        let killed = create_small::<HalfWrittenProcessor>(root.path(), &file, &gate).await;
+        assert!(matches!(killed, Err(MediaProcessorError::Timeout { .. })));
+        assert!(marker_path(&dir).exists());
+
+        // `feed` then sheds on that marker rather than converting.
+        let feed = RecordingProcessor::create_variant(
+            &file,
+            &FileVariant::Feed,
+            root.path().to_path_buf(),
+            &gate,
+            MediaSubprocess::new(Duration::from_secs(30)),
+        )
+        .await;
+
+        assert!(
+            matches!(feed, Err(MediaProcessorError::SkippedAfterTimeout { .. })),
+            "expected a shed, got {feed:?}"
+        );
+        assert!(
+            !dir.join(FileVariant::Feed.to_string()).exists(),
+            "the converter must not run"
+        );
+    }
+
+    // Past the TTL the file gets another chance, so a timeout caused by a loaded box heals.
+    #[tokio_shared_rt::test(shared)]
+    async fn test_expired_marker_lets_the_conversion_run() {
+        let root = tempfile::TempDir::new().expect("temp dir");
+        let file = file_details();
+        let dir = variant_dir(root.path(), &file).await;
+        let marker = marker_path(&dir);
+        tokio::fs::write(&marker, b"").await.expect("marker");
+        set_modified(
+            &marker,
+            SystemTime::now() - TIMEDOUT_MARKER_TTL - Duration::from_secs(60),
+        );
+
+        let gate = QueuedGate::with_limits(MediaPermits::new(1), 4, Duration::from_millis(200));
+        create_small::<RecordingProcessor>(root.path(), &file, &gate)
+            .await
+            .expect("an expired marker must not block the conversion");
+
+        assert!(
+            dir.join(FileVariant::Small.to_string()).exists(),
+            "the converter must run"
+        );
+        assert!(!marker.exists(), "the expiry check reclaims the marker");
+    }
+
+    // Only killed conversions are worth remembering: an ordinary failure is cheap to retry.
+    #[tokio_shared_rt::test(shared)]
+    async fn test_only_a_timeout_is_remembered() {
+        let root = tempfile::TempDir::new().expect("temp dir");
+        let file = file_details();
+        let dir = variant_dir(root.path(), &file).await;
+
+        let gate = QueuedGate::with_limits(MediaPermits::new(1), 4, Duration::from_millis(200));
+
+        // HalfWrittenProcessor fails with a timeout.
+        let timed_out = create_small::<HalfWrittenProcessor>(root.path(), &file, &gate).await;
+        assert!(timed_out.is_err());
+        assert!(
+            marker_path(&dir).exists(),
+            "a killed conversion must be remembered"
+        );
+        tokio::fs::remove_file(marker_path(&dir))
+            .await
+            .expect("clear for the next case");
+
+        // EmptyOutputProcessor fails without one.
+        let failed = create_small::<EmptyOutputProcessor>(root.path(), &file, &gate).await;
+        assert!(failed.is_err());
+        assert!(
+            !marker_path(&dir).exists(),
+            "an ordinary failure stays retryable"
+        );
     }
 
     // A temp file outlives its run only when the whole process dies, and nothing else will ever
@@ -605,31 +827,57 @@ mod tests {
     #[tokio_shared_rt::test(shared)]
     async fn test_sweep_removes_only_aged_temp_files() {
         let root = tempfile::TempDir::new().expect("temp dir");
-        let file = file_details();
-        let dir = variant_dir(root.path(), &file).await;
-        let variant = FileVariant::Small.to_string();
+        let temp_dir = root.path().join(TEMP_DIR_NAME);
+        tokio::fs::create_dir_all(&temp_dir)
+            .await
+            .expect("temp dir");
 
-        let orphan = dir.join(format!("{variant}.999.111"));
-        let in_flight = dir.join(format!("{variant}.888.222"));
-        let finished = dir.join(&variant);
-        for path in [&orphan, &in_flight, &finished] {
+        let orphan = temp_dir.join("owner.file.small.999.111");
+        let in_flight = temp_dir.join("owner.file.feed.888.222");
+        for path in [&orphan, &in_flight] {
             tokio::fs::write(path, b"x").await.expect("write");
         }
 
         // Only the orphan is older than the sweep's cutoff.
-        let aged = SystemTime::now() - TEMP_FILE_MAX_AGE - Duration::from_secs(60);
-        set_modified(&orphan, aged);
+        set_modified(
+            &orphan,
+            SystemTime::now() - TEMP_FILE_MAX_AGE - Duration::from_secs(60),
+        );
 
-        sweep_stale_temp_files(&dir, &variant).await;
+        sweep_stale_temp_files(&temp_dir).await;
 
         assert_eq!(
-            variant_dir_entries(&dir).await,
-            vec![variant.clone(), format!("{variant}.888.222")],
+            dir_entries(&temp_dir).await,
+            vec![String::from("owner.file.feed.888.222")],
             "the sweep must take the orphan and nothing else"
         );
     }
 
-    /// Backdates a file so the sweep sees it as abandoned.
+    // Nothing walks the variant directories any more, so the expiry check is what reclaims a
+    // marker -- it already stats it, so this costs nothing.
+    #[tokio_shared_rt::test(shared)]
+    async fn test_expired_marker_is_reclaimed_by_the_check() {
+        let root = tempfile::TempDir::new().expect("temp dir");
+        let file = file_details();
+        let dir = variant_dir(root.path(), &file).await;
+        let marker = marker_path(&dir);
+        tokio::fs::write(&marker, b"").await.expect("marker");
+
+        assert!(timed_out_recently(&marker).await, "a fresh marker sheds");
+        assert!(marker.exists(), "and survives the check");
+
+        set_modified(
+            &marker,
+            SystemTime::now() - TIMEDOUT_MARKER_TTL - Duration::from_secs(60),
+        );
+        assert!(
+            !timed_out_recently(&marker).await,
+            "an expired marker does not"
+        );
+        assert!(!marker.exists(), "and is reclaimed on the way out");
+    }
+
+    /// Backdates a file so it reads as abandoned.
     fn set_modified(path: &Path, when: SystemTime) {
         let file = std::fs::File::options()
             .write(true)

--- a/nexus-common/src/media/processors/video.rs
+++ b/nexus-common/src/media/processors/video.rs
@@ -54,13 +54,8 @@ impl VariantProcessor for VideoProcessor {
         options: &VideoOptions,
         subprocess: MediaSubprocess,
     ) -> Result<String, MediaProcessorError> {
-        let origin_file_format = VideoProcessor::get_format(origin_file_path, subprocess).await?;
-
-        let output = match origin_file_format == options.format {
-            true => output_file_path.to_string(),
-            false => format!("{}.{}", output_file_path, options.format),
-        };
-
+        // The caller renames this path into place, so write exactly here. The output carries no
+        // extension for ffmpeg to infer the container from, hence the explicit `-f`.
         let child_output = subprocess
             .run(
                 Command::new("ffmpeg")
@@ -70,7 +65,9 @@ impl VariantProcessor for VideoProcessor {
                     .arg(format!("scale={}:-1", options.width))
                     .arg("-c:a")
                     .arg("copy")
-                    .arg(output),
+                    .arg("-f")
+                    .arg(&options.format)
+                    .arg(output_file_path),
             )
             .await?;
 
@@ -79,33 +76,6 @@ impl VariantProcessor for VideoProcessor {
         } else {
             Err(MediaProcessorError::command_failed(format!(
                 "FFmpeg command failed: {}",
-                String::from_utf8_lossy(&child_output.stderr)
-            )))
-        }
-    }
-}
-
-impl VideoProcessor {
-    /// Returns the format of the video
-    async fn get_format(
-        input: &str,
-        subprocess: MediaSubprocess,
-    ) -> Result<String, MediaProcessorError> {
-        let child_output = subprocess
-            .run(
-                Command::new("ffmpeg")
-                    .arg("-i")
-                    .arg(input)
-                    .arg("-f")
-                    .arg("null"),
-            )
-            .await?;
-
-        if child_output.status.success() {
-            Ok(String::from_utf8_lossy(&child_output.stdout).to_string())
-        } else {
-            Err(MediaProcessorError::command_failed(format!(
-                "FFmpeg metadata extraction failed: {}",
                 String::from_utf8_lossy(&child_output.stderr)
             )))
         }

--- a/nexus-common/src/media/processors/video.rs
+++ b/nexus-common/src/media/processors/video.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use tokio::process::Command;
 
 use crate::{
-    media::{processors::MediaProcessorError, FileVariant},
+    media::{processors::MediaProcessorError, FileVariant, MediaSubprocess},
     models::file::FileDetails,
 };
 
@@ -52,25 +52,27 @@ impl VariantProcessor for VideoProcessor {
         origin_file_path: &str,
         output_file_path: &str,
         options: &VideoOptions,
+        subprocess: MediaSubprocess,
     ) -> Result<String, MediaProcessorError> {
-        let origin_file_format = VideoProcessor::get_format(origin_file_path).await?;
+        let origin_file_format = VideoProcessor::get_format(origin_file_path, subprocess).await?;
 
         let output = match origin_file_format == options.format {
             true => output_file_path.to_string(),
             false => format!("{}.{}", output_file_path, options.format),
         };
 
-        let child_output = Command::new("ffmpeg")
-            .arg("-i")
-            .arg(origin_file_path)
-            .arg("-vf")
-            .arg(format!("scale={}:-1", options.width))
-            .arg("-c:a")
-            .arg("copy")
-            .arg(output)
-            .output() // Automatically pipes stdout and stderr
-            .await
-            .map_err(MediaProcessorError::command_failed)?;
+        let child_output = subprocess
+            .run(
+                Command::new("ffmpeg")
+                    .arg("-i")
+                    .arg(origin_file_path)
+                    .arg("-vf")
+                    .arg(format!("scale={}:-1", options.width))
+                    .arg("-c:a")
+                    .arg("copy")
+                    .arg(output),
+            )
+            .await?;
 
         if child_output.status.success() {
             Ok(String::from_utf8_lossy(&child_output.stdout).to_string())
@@ -85,15 +87,19 @@ impl VariantProcessor for VideoProcessor {
 
 impl VideoProcessor {
     /// Returns the format of the video
-    async fn get_format(input: &str) -> Result<String, MediaProcessorError> {
-        let child_output = Command::new("ffmpeg")
-            .arg("-i")
-            .arg(input)
-            .arg("-f")
-            .arg("null")
-            .output() // Automatically pipes stdout and stderr
-            .await
-            .map_err(MediaProcessorError::command_failed)?;
+    async fn get_format(
+        input: &str,
+        subprocess: MediaSubprocess,
+    ) -> Result<String, MediaProcessorError> {
+        let child_output = subprocess
+            .run(
+                Command::new("ffmpeg")
+                    .arg("-i")
+                    .arg(input)
+                    .arg("-f")
+                    .arg("null"),
+            )
+            .await?;
 
         if child_output.status.success() {
             Ok(String::from_utf8_lossy(&child_output.stdout).to_string())

--- a/nexus-common/src/media/subprocess.rs
+++ b/nexus-common/src/media/subprocess.rs
@@ -1,0 +1,169 @@
+use std::process::{Output, Stdio};
+use std::time::Duration;
+
+use tokio::io::AsyncReadExt;
+use tokio::process::{Child, Command};
+
+use super::processors::MediaProcessorError;
+
+/// Wall-clock deadline for a single media subprocess.
+///
+/// Tool-level limits (ImageMagick's `MAGICK_TIME_LIMIT`, ffmpeg's `-timelimit`) bound CPU time, so a
+/// child wedged on I/O trips none of them while holding its media permit for good. This is the
+/// backstop for that case: set well above the tool budget, it only fires when a tool limit did not.
+#[derive(Clone, Copy)]
+pub struct MediaSubprocess {
+    deadline: Duration,
+}
+
+impl MediaSubprocess {
+    pub fn new(deadline: Duration) -> Self {
+        Self { deadline }
+    }
+
+    /// Runs `command` to completion, killing and reaping it if it outruns the deadline.
+    pub async fn run(&self, command: &mut Command) -> Result<Output, MediaProcessorError> {
+        // stdin is closed rather than inherited: ffmpeg prompts on output collision and would
+        // otherwise block on the server's stdin forever.
+        command
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+
+        let mut child = command
+            .spawn()
+            .map_err(MediaProcessorError::command_failed)?;
+
+        let mut stdout_pipe = child
+            .stdout
+            .take()
+            .ok_or_else(|| MediaProcessorError::command_failed("child stdout was not captured"))?;
+        let mut stderr_pipe = child
+            .stderr
+            .take()
+            .ok_or_else(|| MediaProcessorError::command_failed("child stderr was not captured"))?;
+
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+
+        // Both pipes are drained while waiting: a child that fills one while we wait on the other
+        // deadlocks, and ffmpeg is chatty enough to reach the buffer limit.
+        let wait = async {
+            let (_, _, status) = tokio::try_join!(
+                stdout_pipe.read_to_end(&mut stdout),
+                stderr_pipe.read_to_end(&mut stderr),
+                child.wait(),
+            )?;
+            Ok::<_, std::io::Error>(status)
+        };
+
+        // Its own statement so `wait`, and the borrow of `child` it holds, is dropped before the
+        // timeout branch kills it.
+        let outcome = tokio::time::timeout(self.deadline, wait).await;
+
+        match outcome {
+            Ok(status) => Ok(Output {
+                status: status.map_err(MediaProcessorError::command_failed)?,
+                stdout,
+                stderr,
+            }),
+            Err(_elapsed) => {
+                kill_and_reap(&mut child).await;
+                Err(MediaProcessorError::Timeout {
+                    command: command
+                        .as_std()
+                        .get_program()
+                        .to_string_lossy()
+                        .into_owned(),
+                    deadline: self.deadline,
+                })
+            }
+        }
+    }
+}
+
+/// SIGKILLs the child, then reaps it so no zombie is left behind. A helper the child forked of its
+/// own (ImageMagick links its SVG/HEIC/RAW coders in rather than forking) would outlive this; if one
+/// ever does, `Command::process_group(0)` plus a group-wide kill is the answer.
+async fn kill_and_reap(child: &mut Child) {
+    let _ = child.start_kill();
+    let _ = child.wait().await;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, Instant};
+
+    use tokio::process::Command;
+
+    use super::MediaSubprocess;
+    use crate::media::processors::MediaProcessorError;
+
+    #[tokio_shared_rt::test(shared)]
+    async fn test_output_is_captured_on_success() {
+        let runner = MediaSubprocess::new(Duration::from_secs(5));
+        let output = runner
+            .run(Command::new("echo").arg("hello"))
+            .await
+            .expect("echo must run");
+
+        assert!(output.status.success());
+        assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "hello");
+    }
+
+    // A failing command is the callers' business to interpret, not the runner's error.
+    #[tokio_shared_rt::test(shared)]
+    async fn test_failing_command_returns_its_status() {
+        let runner = MediaSubprocess::new(Duration::from_secs(5));
+        let output = runner
+            .run(&mut Command::new("false"))
+            .await
+            .expect("a non-zero exit is not a runner error");
+
+        assert!(!output.status.success());
+    }
+
+    #[tokio_shared_rt::test(shared)]
+    async fn test_deadline_kills_and_reaps_the_child() {
+        let runner = MediaSubprocess::new(Duration::from_millis(100));
+        let started = Instant::now();
+        let error = runner
+            .run(Command::new("sleep").arg("30"))
+            .await
+            .expect_err("the child must not outlive the deadline");
+
+        assert!(
+            matches!(error, MediaProcessorError::Timeout { .. }),
+            "expected a timeout, got {error}"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "the deadline must return without waiting for the child"
+        );
+    }
+
+    // A permit is only worth reclaiming if the process it stood for is really gone, not merely
+    // abandoned to keep working.
+    #[tokio_shared_rt::test(shared)]
+    async fn test_deadline_kills_the_child_rather_than_abandoning_it() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let marker = dir.path().join("child-kept-working");
+
+        let mut command = Command::new("sh");
+        command
+            .arg("-c")
+            .arg(format!("sleep 1; touch {}", marker.to_string_lossy()));
+
+        let runner = MediaSubprocess::new(Duration::from_millis(100));
+        let error = runner.run(&mut command).await.expect_err("must time out");
+        assert!(matches!(error, MediaProcessorError::Timeout { .. }));
+
+        // Past when the child would have written it, had it survived.
+        tokio::time::sleep(Duration::from_millis(1500)).await;
+        assert!(
+            !marker.exists(),
+            "the child outlived the deadline and kept working"
+        );
+    }
+}

--- a/nexus-common/src/media/subprocess.rs
+++ b/nexus-common/src/media/subprocess.rs
@@ -1,10 +1,27 @@
 use std::process::{Output, Stdio};
+use std::sync::LazyLock;
 use std::time::Duration;
 
+use opentelemetry::metrics::Counter;
+use opentelemetry::{global, KeyValue};
 use tokio::io::AsyncReadExt;
 use tokio::process::{Child, Command};
 
 use super::processors::MediaProcessorError;
+use super::METER_NAME;
+
+/// Counter for media subprocesses killed for outrunning their deadline, by command.
+///
+/// Every increment is a conversion that produced nothing and a permit held for the full deadline.
+/// A sustained non-zero rate means files are reaching the deadline rather than the converter's own
+/// limits: either the deadline is too tight for what is being uploaded, or someone is feeding the
+/// endpoint files built to burn it.
+static TIMED_OUT: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    global::meter(METER_NAME)
+        .u64_counter("media.subprocess.timeout")
+        .with_description("Media subprocesses killed for exceeding the conversion deadline")
+        .build()
+});
 
 /// Wall-clock deadline for a single media subprocess.
 ///
@@ -70,12 +87,18 @@ impl MediaSubprocess {
             }),
             Err(_elapsed) => {
                 kill_and_reap(&mut child).await;
+
+                // The program name alone, never the arguments: those carry the input and output
+                // paths, which would make the attribute unbounded and put file paths in metrics.
+                let program = command
+                    .as_std()
+                    .get_program()
+                    .to_string_lossy()
+                    .into_owned();
+                TIMED_OUT.add(1, &[KeyValue::new("command", program.clone())]);
+
                 Err(MediaProcessorError::Timeout {
-                    command: command
-                        .as_std()
-                        .get_program()
-                        .to_string_lossy()
-                        .into_owned(),
+                    command: program,
                     deadline: self.deadline,
                 })
             }

--- a/nexus-common/src/models/error.rs
+++ b/nexus-common/src/models/error.rs
@@ -39,6 +39,14 @@ impl ModelError {
     pub fn from_generic(source: impl std::fmt::Display) -> Self {
         Self::Generic(source.to_string())
     }
+
+    /// Returns true if this error is `MediaProcessorError::AtCapacity`.
+    pub fn is_at_capacity(&self) -> bool {
+        matches!(
+            self,
+            Self::MediaProcessorError(crate::media::processors::MediaProcessorError::AtCapacity)
+        )
+    }
 }
 
 pub type ModelResult<T> = Result<T, ModelError>;

--- a/nexus-common/src/models/error.rs
+++ b/nexus-common/src/models/error.rs
@@ -40,12 +40,12 @@ impl ModelError {
         Self::Generic(source.to_string())
     }
 
-    /// Returns true if this error is `MediaProcessorError::AtCapacity`.
-    pub fn is_at_capacity(&self) -> bool {
-        matches!(
-            self,
-            Self::MediaProcessorError(crate::media::processors::MediaProcessorError::AtCapacity)
-        )
+    /// Returns true if media processing shed this request rather than failing on the file itself.
+    pub fn is_media_shed(&self) -> bool {
+        match self {
+            Self::MediaProcessorError(source) => source.is_load_shed(),
+            _ => false,
+        }
     }
 }
 

--- a/nexus-common/src/models/file/blob.rs
+++ b/nexus-common/src/models/file/blob.rs
@@ -1,9 +1,6 @@
 use crate::{
-    media::{
-        processors::{ImageProcessor, VariantProcessor, VideoProcessor},
-        FileVariant, VariantController,
-    },
-    models::error::{ModelError, ModelResult},
+    media::{FileVariant, VariantController},
+    models::error::ModelResult,
 };
 use pubky_app_specs::PubkyAppBlob;
 use std::path::PathBuf;
@@ -40,6 +37,7 @@ impl Blob {
         file: &FileDetails,
         variant: &FileVariant,
         file_path: PathBuf,
+        controller: &VariantController,
     ) -> ModelResult<String> {
         let file_variant_exists =
             VariantController::check_variant_exists(file, variant.clone(), file_path.clone()).await;
@@ -49,34 +47,13 @@ impl Blob {
                 file, variant,
             ))
         } else {
-            Self::put_variant(file, variant, file_path)
+            controller
+                .create_file_variant(file, variant, file_path)
                 .await
+                .map_err(Into::into)
                 .inspect_err(|e| {
                     tracing::error!("Creating variant failed for file: {file:?} with error: {e}")
                 })
-        }
-    }
-
-    async fn put_variant(
-        file: &FileDetails,
-        variant: &FileVariant,
-        file_path: PathBuf,
-    ) -> ModelResult<String> {
-        match &file.content_type {
-            content_type if content_type.starts_with("image/") => {
-                ImageProcessor::create_variant(file, variant, file_path)
-                    .await
-                    .map_err(Into::into)
-            }
-            content_type if content_type.starts_with("video/") => {
-                VideoProcessor::create_variant(file, variant, file_path)
-                    .await
-                    .map_err(Into::into)
-            }
-            _ => Err(ModelError::from_generic(format!(
-                "Unsupported content type: {}",
-                file.content_type
-            ))),
         }
     }
 }

--- a/nexus-common/src/models/file/blob.rs
+++ b/nexus-common/src/models/file/blob.rs
@@ -51,9 +51,6 @@ impl Blob {
                 .create_file_variant(file, variant, file_path)
                 .await
                 .map_err(Into::into)
-                .inspect_err(|e| {
-                    tracing::error!("Creating variant failed for file: {file:?} with error: {e}")
-                })
         }
     }
 }

--- a/nexus-common/src/utils/test_utils.rs
+++ b/nexus-common/src/utils/test_utils.rs
@@ -3,10 +3,12 @@
 //! Shared helpers for unit and integration tests.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use pubky::{Keypair, PublicKey};
 use pubky_app_specs::PubkyId;
 
+use crate::media::MediaSubprocess;
 use crate::models::user::UserIngestor;
 
 /// Generates a random public key.
@@ -22,4 +24,9 @@ pub fn random_pubky_id() -> PubkyId {
 /// Default user ingestor for tests: empty HS blacklist (ingest everything).
 pub fn default_ingestor_tests() -> Arc<UserIngestor> {
     Arc::new(UserIngestor::default())
+}
+
+/// Media subprocess runner for tests: a deadline long enough never to fire on real work.
+pub fn default_subprocess_tests() -> MediaSubprocess {
+    MediaSubprocess::new(Duration::from_secs(30))
 }

--- a/nexus-webapi/benches/avatar.rs
+++ b/nexus-webapi/benches/avatar.rs
@@ -8,11 +8,13 @@ use axum::{
 };
 use criterion::{criterion_group, criterion_main, Criterion};
 use http_body_util::BodyExt;
+use nexus_common::media::{MediaGate, VariantController};
 use nexus_common::models::{
     file::{FileDetails, FileUrls},
     traits::Collection,
     user::UserDetails,
 };
+use nexus_common::utils::test_utils::default_ingestor_tests;
 use nexus_webapi::{
     models::PubkyId,
     routes::{r#static::user_avatar_handler, AppState, Path},
@@ -55,6 +57,8 @@ impl AvatarBenchSetup {
             _temp_dir: temp_dir,
             app_state: AppState {
                 files_path: Arc::new(files_path),
+                ingestor: default_ingestor_tests(),
+                variant_controller: VariantController::new(MediaGate::new(1)),
             },
             user_id,
         };

--- a/nexus-webapi/benches/avatar.rs
+++ b/nexus-webapi/benches/avatar.rs
@@ -14,7 +14,7 @@ use nexus_common::models::{
     traits::Collection,
     user::UserDetails,
 };
-use nexus_common::utils::test_utils::default_ingestor_tests;
+use nexus_common::utils::test_utils::{default_ingestor_tests, default_subprocess_tests};
 use nexus_webapi::{
     models::PubkyId,
     routes::{r#static::user_avatar_handler, AppState, Path},
@@ -55,7 +55,12 @@ impl AvatarBenchSetup {
 
         let setup = Self {
             _temp_dir: temp_dir,
-            app_state: AppState::new(files_path, default_ingestor_tests(), MediaPermits::new(1)),
+            app_state: AppState::new(
+                files_path,
+                default_ingestor_tests(),
+                MediaPermits::new(1),
+                default_subprocess_tests(),
+            ),
             user_id,
         };
 

--- a/nexus-webapi/benches/avatar.rs
+++ b/nexus-webapi/benches/avatar.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, sync::Arc, time::Duration};
+use std::{path::PathBuf, time::Duration};
 
 use axum::{
     body::{Body, Bytes},
@@ -8,7 +8,7 @@ use axum::{
 };
 use criterion::{criterion_group, criterion_main, Criterion};
 use http_body_util::BodyExt;
-use nexus_common::media::{MediaGate, VariantController};
+use nexus_common::media::MediaPermits;
 use nexus_common::models::{
     file::{FileDetails, FileUrls},
     traits::Collection,
@@ -55,11 +55,7 @@ impl AvatarBenchSetup {
 
         let setup = Self {
             _temp_dir: temp_dir,
-            app_state: AppState {
-                files_path: Arc::new(files_path),
-                ingestor: default_ingestor_tests(),
-                variant_controller: VariantController::new(MediaGate::new(1)),
-            },
+            app_state: AppState::new(files_path, default_ingestor_tests(), MediaPermits::new(1)),
             user_id,
         };
 

--- a/nexus-webapi/src/error.rs
+++ b/nexus-webapi/src/error.rs
@@ -32,6 +32,8 @@ pub enum Error {
     ResourceNotFound { resource_id: String },
     #[error("Forbidden: {message}")]
     Forbidden { message: String },
+    #[error("Service unavailable: {message}")]
+    ServiceUnavailable { message: String },
     // Add other custom errors here
 }
 
@@ -45,6 +47,12 @@ impl Error {
     pub fn resource_not_found(resource_id: impl Into<String>) -> Self {
         Error::ResourceNotFound {
             resource_id: resource_id.into(),
+        }
+    }
+
+    pub fn service_unavailable(message: impl Into<String>) -> Self {
+        Error::ServiceUnavailable {
+            message: message.into(),
         }
     }
 
@@ -75,6 +83,10 @@ impl From<ModelError> for Error {
             ModelError::HsBlacklisted { hs_id } => Error::Forbidden {
                 message: format!("Homeserver is blacklisted: {hs_id}"),
             },
+            // Load shed: the client-facing message stays generic, the cause is logged server-side.
+            other if other.is_at_capacity() => {
+                Error::service_unavailable("service temporarily unavailable")
+            }
             other => Error::InternalServerError {
                 source: other.into(),
             },
@@ -133,6 +145,7 @@ impl IntoResponse for Error {
             Error::TagNotFound { .. } => StatusCode::NOT_FOUND,
             Error::ResourceNotFound { .. } => StatusCode::NOT_FOUND,
             Error::Forbidden { .. } => StatusCode::FORBIDDEN,
+            Error::ServiceUnavailable { .. } => StatusCode::SERVICE_UNAVAILABLE,
             // Map other errors to appropriate status codes
         };
 
@@ -162,6 +175,7 @@ impl IntoResponse for Error {
             Error::Forbidden { message } => {
                 warn!("Forbidden: {}", message)
             }
+            Error::ServiceUnavailable { message } => warn!("Service unavailable: {}", message),
             Error::InternalServerError { source } => error!("Internal server error: {:?}", source),
         };
 

--- a/nexus-webapi/src/error.rs
+++ b/nexus-webapi/src/error.rs
@@ -84,7 +84,7 @@ impl From<ModelError> for Error {
                 message: format!("Homeserver is blacklisted: {hs_id}"),
             },
             // Load shed: the client-facing message stays generic, the cause is logged server-side.
-            other if other.is_at_capacity() => {
+            other if other.is_media_shed() => {
                 Error::service_unavailable("service temporarily unavailable")
             }
             other => Error::InternalServerError {
@@ -182,5 +182,52 @@ impl IntoResponse for Error {
         let body = ErrorResponsePayload::new(self.to_string());
 
         (status_code, axum::Json(body)).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::http::StatusCode;
+    use std::time::Duration;
+
+    use axum::response::IntoResponse;
+    use nexus_common::media::processors::MediaProcessorError;
+    use nexus_common::models::error::ModelError;
+
+    use super::Error;
+
+    // A killed subprocess means "no variant right now", the same answer as a full gate, so it
+    // must degrade rather than surface as a server fault.
+    #[test]
+    fn test_media_shed_errors_map_to_503() {
+        let shed = [
+            MediaProcessorError::AtCapacity,
+            MediaProcessorError::Timeout {
+                command: String::from("convert"),
+                deadline: Duration::from_secs(180),
+            },
+        ];
+
+        for source in shed {
+            let error = Error::from(ModelError::MediaProcessorError(source));
+            assert!(matches!(error, Error::ServiceUnavailable { .. }));
+            assert_eq!(
+                error.into_response().status(),
+                StatusCode::SERVICE_UNAVAILABLE
+            );
+        }
+    }
+
+    // A genuine processing failure is still a server fault, not a shed.
+    #[test]
+    fn test_command_failure_maps_to_500() {
+        let error = Error::from(ModelError::MediaProcessorError(
+            MediaProcessorError::command_failed("boom"),
+        ));
+
+        assert_eq!(
+            error.into_response().status(),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
     }
 }

--- a/nexus-webapi/src/routes/mod.rs
+++ b/nexus-webapi/src/routes/mod.rs
@@ -8,6 +8,7 @@ use axum::http::request::Parts;
 use axum::http::{Request, StatusCode};
 use axum::Json as AxumJson;
 use axum::Router;
+use nexus_common::media::{MediaGate, VariantController};
 use nexus_common::models::user::UserIngestor;
 use nexus_common::RateLimitConfig;
 use tokio::sync::watch::Receiver;
@@ -81,12 +82,16 @@ pub struct AppState {
     pub files_path: Arc<PathBuf>,
     /// Shared ingestor enforcing the HS blacklist on API-triggered ingestion.
     pub ingestor: Arc<UserIngestor>,
+    pub variant_controller: VariantController,
 }
 
 pub fn routes(ctx: &ApiContext, shutdown_rx: Receiver<bool>) -> Router {
     let state = AppState {
         files_path: Arc::new(ctx.api_config.stack.files_path.clone()),
         ingestor: ctx.ingestor.clone(),
+        variant_controller: VariantController::new(MediaGate::new(
+            ctx.api_config.stack.media.max_concurrency,
+        )),
     };
 
     let app_routes = app_routes(state.clone(), &ctx.api_config.rate_limit, shutdown_rx);

--- a/nexus-webapi/src/routes/mod.rs
+++ b/nexus-webapi/src/routes/mod.rs
@@ -8,7 +8,9 @@ use axum::http::request::Parts;
 use axum::http::{Request, StatusCode};
 use axum::Json as AxumJson;
 use axum::Router;
-use nexus_common::media::{FailFastGate, MediaPermits, QueuedGate, VariantController};
+use nexus_common::media::{
+    FailFastGate, MediaPermits, MediaSubprocess, QueuedGate, VariantController,
+};
 use nexus_common::models::user::UserIngestor;
 use nexus_common::RateLimitConfig;
 use tokio::sync::watch::Receiver;
@@ -94,12 +96,23 @@ impl AppState {
     /// Both controllers over one pool of permits, so they bound the same subprocesses.
     /// Build state through here rather than field-by-field: a second pool would let each
     /// gate run `max_concurrency` subprocesses of its own.
-    pub fn new(files_path: PathBuf, ingestor: Arc<UserIngestor>, permits: MediaPermits) -> Self {
+    pub fn new(
+        files_path: PathBuf,
+        ingestor: Arc<UserIngestor>,
+        permits: MediaPermits,
+        subprocess: MediaSubprocess,
+    ) -> Self {
         Self {
             files_path: Arc::new(files_path),
             ingestor,
-            queued_variant_controller: VariantController::new(QueuedGate::new(permits.clone())),
-            fail_fast_variant_controller: VariantController::new(FailFastGate::new(permits)),
+            queued_variant_controller: VariantController::new(
+                QueuedGate::new(permits.clone()),
+                subprocess,
+            ),
+            fail_fast_variant_controller: VariantController::new(
+                FailFastGate::new(permits),
+                subprocess,
+            ),
         }
     }
 }
@@ -109,6 +122,9 @@ pub fn routes(ctx: &ApiContext, shutdown_rx: Receiver<bool>) -> Router {
         ctx.api_config.stack.files_path.clone(),
         ctx.ingestor.clone(),
         MediaPermits::new(ctx.api_config.stack.media.max_concurrency),
+        MediaSubprocess::new(Duration::from_secs(
+            ctx.api_config.stack.media.process_timeout_secs,
+        )),
     );
 
     let app_routes = app_routes(state.clone(), &ctx.api_config.rate_limit, shutdown_rx);

--- a/nexus-webapi/src/routes/mod.rs
+++ b/nexus-webapi/src/routes/mod.rs
@@ -8,7 +8,7 @@ use axum::http::request::Parts;
 use axum::http::{Request, StatusCode};
 use axum::Json as AxumJson;
 use axum::Router;
-use nexus_common::media::{MediaGate, VariantController};
+use nexus_common::media::{FailFastGate, MediaPermits, QueuedGate, VariantController};
 use nexus_common::models::user::UserIngestor;
 use nexus_common::RateLimitConfig;
 use tokio::sync::watch::Receiver;
@@ -82,17 +82,34 @@ pub struct AppState {
     pub files_path: Arc<PathBuf>,
     /// Shared ingestor enforcing the HS blacklist on API-triggered ingestion.
     pub ingestor: Arc<UserIngestor>,
-    pub variant_controller: VariantController,
+    /// Queues for a media permit before shedding. The default for routes whose only
+    /// other answer is an error.
+    pub queued_variant_controller: VariantController,
+    /// Same permits as `queued_variant_controller`, but sheds instead of queueing. For
+    /// routes with a cheaper fallback than waiting: see `user_avatar_handler`.
+    pub fail_fast_variant_controller: VariantController,
+}
+
+impl AppState {
+    /// Both controllers over one pool of permits, so they bound the same subprocesses.
+    /// Build state through here rather than field-by-field: a second pool would let each
+    /// gate run `max_concurrency` subprocesses of its own.
+    pub fn new(files_path: PathBuf, ingestor: Arc<UserIngestor>, permits: MediaPermits) -> Self {
+        Self {
+            files_path: Arc::new(files_path),
+            ingestor,
+            queued_variant_controller: VariantController::new(QueuedGate::new(permits.clone())),
+            fail_fast_variant_controller: VariantController::new(FailFastGate::new(permits)),
+        }
+    }
 }
 
 pub fn routes(ctx: &ApiContext, shutdown_rx: Receiver<bool>) -> Router {
-    let state = AppState {
-        files_path: Arc::new(ctx.api_config.stack.files_path.clone()),
-        ingestor: ctx.ingestor.clone(),
-        variant_controller: VariantController::new(MediaGate::new(
-            ctx.api_config.stack.media.max_concurrency,
-        )),
-    };
+    let state = AppState::new(
+        ctx.api_config.stack.files_path.clone(),
+        ctx.ingestor.clone(),
+        MediaPermits::new(ctx.api_config.stack.media.max_concurrency),
+    );
 
     let app_routes = app_routes(state.clone(), &ctx.api_config.rate_limit, shutdown_rx);
 

--- a/nexus-webapi/src/routes/static/avatar.rs
+++ b/nexus-webapi/src/routes/static/avatar.rs
@@ -7,12 +7,16 @@ use crate::routes::AppState;
 use crate::routes::Path;
 use crate::{Error, Result};
 use axum::extract::{Request, State};
+use axum::http::{header, HeaderValue};
 use axum::response::Response;
 use nexus_common::media::FileVariant;
+use nexus_common::models::file::Blob;
 use nexus_common::models::{file::FileDetails, traits::Collection, user::UserDetails};
 use tower_http::services::fs::ServeFileSystemResponseBody;
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 use utoipa::OpenApi;
+
+const AVATAR_FALLBACK_CACHE_CONTROL: &str = "public, max-age=30";
 
 #[utoipa::path(
     get,
@@ -58,19 +62,55 @@ pub async fn user_avatar_handler(
         return Err(Error::FileNotFound {});
     };
 
-    serve_file_variant(
-        request,
+    // Falls back to the untouched main image when the media gate is at capacity,
+    // so an avatar still renders instead of failing.
+    let controller = &app_state.variant_controller;
+    let variant = match Blob::get_by_id(
         &file_details,
         &FileVariant::Small,
         file_path.clone(),
+        controller,
+    )
+    .await
+    {
+        Ok(_) => FileVariant::Small,
+        Err(ref e) if e.is_at_capacity() => {
+            warn!("Media processing at capacity for user: {user_id} avatar with file: {file_id}, falling back to main");
+            FileVariant::Main
+        }
+        Err(e) => {
+            error!(
+                "Error while processing small variant for user: {user_id} avatar with file: {file_id}"
+            );
+            return Err(e.into());
+        }
+    };
+
+    let mut response = serve_file_variant(
+        request,
+        &file_details,
+        &variant,
+        file_path.clone(),
         false,
+        controller,
     )
     .await
     .inspect_err(|_| {
         error!(
-            "Error while processing small variant for user: {user_id} avatar with file: {file_id}"
+            "Error while serving {variant} variant for user: {user_id} avatar with file: {file_id}"
         )
-    })
+    })?;
+
+    // A degraded `main` fallback must not outlive the capacity blip that caused it,
+    // so it gets a short TTL instead of the hour the real small variant earns.
+    if variant != FileVariant::Small {
+        response.headers_mut().insert(
+            header::CACHE_CONTROL,
+            HeaderValue::from_static(AVATAR_FALLBACK_CACHE_CONTROL),
+        );
+    }
+
+    Ok(response)
 }
 
 #[derive(OpenApi)]

--- a/nexus-webapi/src/routes/static/avatar.rs
+++ b/nexus-webapi/src/routes/static/avatar.rs
@@ -77,8 +77,8 @@ pub async fn user_avatar_handler(
     .await
     {
         Ok(_) => FileVariant::Small,
-        Err(ref e) if e.is_at_capacity() => {
-            warn!("Media processing at capacity for user: {user_id} avatar with file: {file_id}, falling back to main");
+        Err(ref e) if e.is_media_shed() => {
+            warn!("Media processing unavailable ({e}) for user: {user_id} avatar with file: {file_id}, falling back to main");
             FileVariant::Main
         }
         Err(e) => return Err(e.into()),

--- a/nexus-webapi/src/routes/static/avatar.rs
+++ b/nexus-webapi/src/routes/static/avatar.rs
@@ -13,7 +13,7 @@ use nexus_common::media::FileVariant;
 use nexus_common::models::file::Blob;
 use nexus_common::models::{file::FileDetails, traits::Collection, user::UserDetails};
 use tower_http::services::fs::ServeFileSystemResponseBody;
-use tracing::{debug, error, warn};
+use tracing::{debug, warn};
 use utoipa::OpenApi;
 
 const AVATAR_FALLBACK_CACHE_CONTROL: &str = "public, max-age=30";
@@ -81,12 +81,7 @@ pub async fn user_avatar_handler(
             warn!("Media processing at capacity for user: {user_id} avatar with file: {file_id}, falling back to main");
             FileVariant::Main
         }
-        Err(e) => {
-            error!(
-                "Error while processing small variant for user: {user_id} avatar with file: {file_id}"
-            );
-            return Err(e.into());
-        }
+        Err(e) => return Err(e.into()),
     };
 
     let mut response = serve_file_variant(
@@ -97,12 +92,7 @@ pub async fn user_avatar_handler(
         false,
         controller,
     )
-    .await
-    .inspect_err(|_| {
-        error!(
-            "Error while serving {variant} variant for user: {user_id} avatar with file: {file_id}"
-        )
-    })?;
+    .await?;
 
     // A degraded `main` fallback must not outlive the capacity blip that caused it,
     // so it gets a short TTL instead of the hour the real small variant earns.

--- a/nexus-webapi/src/routes/static/avatar.rs
+++ b/nexus-webapi/src/routes/static/avatar.rs
@@ -62,9 +62,12 @@ pub async fn user_avatar_handler(
         return Err(Error::FileNotFound {});
     };
 
-    // Falls back to the untouched main image when the media gate is at capacity,
-    // so an avatar still renders instead of failing.
-    let controller = &app_state.variant_controller;
+    // No permit free: serve the untouched `main` image instead of queueing for one.
+    // Queueing could still win a permit before the timeout, but that is not worth up to
+    // 5s of latency on an avatar — and `small` is only deferred, not lost: the short
+    // cache TTL brings the client back, and whichever request gets a permit writes the
+    // variant to disk for every request after it.
+    let controller = &app_state.fail_fast_variant_controller;
     let variant = match Blob::get_by_id(
         &file_details,
         &FileVariant::Small,

--- a/nexus-webapi/src/routes/static/files.rs
+++ b/nexus-webapi/src/routes/static/files.rs
@@ -38,6 +38,7 @@ pub struct FilePath {
 /// If the variant is not valid for the content type, a 400 Bad Request will be returned
 /// If the file does not exist, a 404 Not Found will be returned
 /// If the processing of the new variant fails, a 500 Internal Server Error will be returned
+/// If the service is temporarily overloaded, a 503 Service Unavailable will be returned
 #[utoipa::path(
     get,
     path = STATIC_FILES_ROUTE,
@@ -53,7 +54,8 @@ pub struct FilePath {
         (status = 200, description = "File's raw data"),
         (status = 404, description = "File not found"),
         (status = 429, description = "Rate limit exceeded", headers(("Retry-After" = u64, description = "Seconds until retry"))),
-        (status = 500, description = "Internal server error")
+        (status = 500, description = "Internal server error"),
+        (status = 503, description = "Service temporarily unavailable; retry later")
     )
 )]
 pub async fn static_files_handler(
@@ -101,6 +103,7 @@ pub async fn static_files_handler(
         &variant,
         file_path.clone(),
         params.dl.is_some(),
+        &app_state.variant_controller,
     )
     .await
     .inspect_err(|_| {

--- a/nexus-webapi/src/routes/static/files.rs
+++ b/nexus-webapi/src/routes/static/files.rs
@@ -103,7 +103,7 @@ pub async fn static_files_handler(
         &variant,
         file_path.clone(),
         params.dl.is_some(),
-        &app_state.variant_controller,
+        &app_state.queued_variant_controller,
     )
     .await
     .inspect_err(|_| {

--- a/nexus-webapi/src/routes/static/files.rs
+++ b/nexus-webapi/src/routes/static/files.rs
@@ -106,9 +106,6 @@ pub async fn static_files_handler(
         &app_state.queued_variant_controller,
     )
     .await
-    .inspect_err(|_| {
-        error!("Error while processing file variant for variant: {variant} and file: {file_id}")
-    })
 }
 
 #[derive(OpenApi)]

--- a/nexus-webapi/src/routes/static/serve_dir.rs
+++ b/nexus-webapi/src/routes/static/serve_dir.rs
@@ -8,7 +8,7 @@ use axum::{
     response::Response,
 };
 use nexus_common::{
-    media::FileVariant,
+    media::{FileVariant, VariantController},
     models::file::{Blob, FileDetails},
 };
 use tower_http::services::{fs::ServeFileSystemResponseBody, ServeDir};
@@ -69,8 +69,9 @@ pub async fn serve_file_variant(
     variant: &FileVariant,
     files_path: PathBuf,
     download: bool,
+    controller: &VariantController,
 ) -> Result<Response<ServeFileSystemResponseBody>> {
-    let content_type = Blob::get_by_id(file, variant, files_path.clone()).await?;
+    let content_type = Blob::get_by_id(file, variant, files_path.clone(), controller).await?;
 
     let disk_path = format!("/{}/{}/{variant}", file.owner_id, file.id);
 

--- a/nexus-webapi/tests/endpoints/middleware.rs
+++ b/nexus-webapi/tests/endpoints/middleware.rs
@@ -8,6 +8,7 @@ use axum::http::header::{ACCESS_CONTROL_ALLOW_ORIGIN, CONTENT_LENGTH, ORIGIN};
 use axum::http::{Method, Request, StatusCode};
 use axum::routing::{get, post};
 use axum::Router;
+use nexus_common::media::{MediaGate, VariantController};
 use nexus_common::utils::test_utils::default_ingestor_tests;
 use nexus_common::RateLimitConfig;
 use nexus_webapi::routes::{app_routes, build_app, AppState};
@@ -24,6 +25,7 @@ async fn test_request_body_size_limit() -> Result<()> {
     let state = AppState {
         files_path: Arc::new(temp_dir.path().to_path_buf()),
         ingestor: default_ingestor_tests(),
+        variant_controller: VariantController::new(MediaGate::new(1)),
     };
     let rate_limit_config: RateLimitConfig = RateLimitConfig::default();
     let (_tx, rx) = watch::channel(false);
@@ -61,6 +63,7 @@ async fn test_request_body_size_limit_without_content_length() -> Result<()> {
     let state = AppState {
         files_path: Arc::new(temp_dir.path().to_path_buf()),
         ingestor: default_ingestor_tests(),
+        variant_controller: VariantController::new(MediaGate::new(1)),
     };
     let routes = Router::new().route("/echo", post(bytes_handler));
 
@@ -100,6 +103,7 @@ async fn test_request_timeout_returns_408() -> Result<()> {
     let state = AppState {
         files_path: Arc::new(temp_dir.path().to_path_buf()),
         ingestor: default_ingestor_tests(),
+        variant_controller: VariantController::new(MediaGate::new(1)),
     };
     let routes = Router::new().route("/sleep/{millis}", get(sleep_handler));
 
@@ -138,6 +142,7 @@ async fn test_body_size_limit_response_has_cors_header() -> Result<()> {
     let state = AppState {
         files_path: Arc::new(temp_dir.path().to_path_buf()),
         ingestor: default_ingestor_tests(),
+        variant_controller: VariantController::new(MediaGate::new(1)),
     };
     let routes = Router::new().route("/echo", post(ok_handler));
 
@@ -173,6 +178,7 @@ async fn test_request_timeout_response_has_cors_header() -> Result<()> {
     let state = AppState {
         files_path: Arc::new(temp_dir.path().to_path_buf()),
         ingestor: default_ingestor_tests(),
+        variant_controller: VariantController::new(MediaGate::new(1)),
     };
     let routes = Router::new().route("/sleep/{millis}", get(sleep_handler));
 

--- a/nexus-webapi/tests/endpoints/middleware.rs
+++ b/nexus-webapi/tests/endpoints/middleware.rs
@@ -8,7 +8,7 @@ use axum::http::{Method, Request, StatusCode};
 use axum::routing::{get, post};
 use axum::Router;
 use nexus_common::media::MediaPermits;
-use nexus_common::utils::test_utils::default_ingestor_tests;
+use nexus_common::utils::test_utils::{default_ingestor_tests, default_subprocess_tests};
 use nexus_common::RateLimitConfig;
 use nexus_webapi::routes::{app_routes, build_app, AppState};
 use tempfile::TempDir;
@@ -25,6 +25,7 @@ async fn test_request_body_size_limit() -> Result<()> {
         temp_dir.path().to_path_buf(),
         default_ingestor_tests(),
         MediaPermits::new(1),
+        default_subprocess_tests(),
     );
     let rate_limit_config: RateLimitConfig = RateLimitConfig::default();
     let (_tx, rx) = watch::channel(false);
@@ -63,6 +64,7 @@ async fn test_request_body_size_limit_without_content_length() -> Result<()> {
         temp_dir.path().to_path_buf(),
         default_ingestor_tests(),
         MediaPermits::new(1),
+        default_subprocess_tests(),
     );
     let routes = Router::new().route("/echo", post(bytes_handler));
 
@@ -103,6 +105,7 @@ async fn test_request_timeout_returns_408() -> Result<()> {
         temp_dir.path().to_path_buf(),
         default_ingestor_tests(),
         MediaPermits::new(1),
+        default_subprocess_tests(),
     );
     let routes = Router::new().route("/sleep/{millis}", get(sleep_handler));
 
@@ -142,6 +145,7 @@ async fn test_body_size_limit_response_has_cors_header() -> Result<()> {
         temp_dir.path().to_path_buf(),
         default_ingestor_tests(),
         MediaPermits::new(1),
+        default_subprocess_tests(),
     );
     let routes = Router::new().route("/echo", post(ok_handler));
 
@@ -178,6 +182,7 @@ async fn test_request_timeout_response_has_cors_header() -> Result<()> {
         temp_dir.path().to_path_buf(),
         default_ingestor_tests(),
         MediaPermits::new(1),
+        default_subprocess_tests(),
     );
     let routes = Router::new().route("/sleep/{millis}", get(sleep_handler));
 

--- a/nexus-webapi/tests/endpoints/middleware.rs
+++ b/nexus-webapi/tests/endpoints/middleware.rs
@@ -1,4 +1,3 @@
-use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
@@ -8,7 +7,7 @@ use axum::http::header::{ACCESS_CONTROL_ALLOW_ORIGIN, CONTENT_LENGTH, ORIGIN};
 use axum::http::{Method, Request, StatusCode};
 use axum::routing::{get, post};
 use axum::Router;
-use nexus_common::media::{MediaGate, VariantController};
+use nexus_common::media::MediaPermits;
 use nexus_common::utils::test_utils::default_ingestor_tests;
 use nexus_common::RateLimitConfig;
 use nexus_webapi::routes::{app_routes, build_app, AppState};
@@ -22,11 +21,11 @@ use tower::ServiceExt;
 #[tokio::test]
 async fn test_request_body_size_limit() -> Result<()> {
     let temp_dir = TempDir::new()?;
-    let state = AppState {
-        files_path: Arc::new(temp_dir.path().to_path_buf()),
-        ingestor: default_ingestor_tests(),
-        variant_controller: VariantController::new(MediaGate::new(1)),
-    };
+    let state = AppState::new(
+        temp_dir.path().to_path_buf(),
+        default_ingestor_tests(),
+        MediaPermits::new(1),
+    );
     let rate_limit_config: RateLimitConfig = RateLimitConfig::default();
     let (_tx, rx) = watch::channel(false);
     let routes = app_routes(state.clone(), &rate_limit_config, rx);
@@ -60,11 +59,11 @@ async fn bytes_handler(_body: axum::body::Bytes) -> StatusCode {
 #[tokio::test]
 async fn test_request_body_size_limit_without_content_length() -> Result<()> {
     let temp_dir = TempDir::new()?;
-    let state = AppState {
-        files_path: Arc::new(temp_dir.path().to_path_buf()),
-        ingestor: default_ingestor_tests(),
-        variant_controller: VariantController::new(MediaGate::new(1)),
-    };
+    let state = AppState::new(
+        temp_dir.path().to_path_buf(),
+        default_ingestor_tests(),
+        MediaPermits::new(1),
+    );
     let routes = Router::new().route("/echo", post(bytes_handler));
 
     // 10-byte limit; body well over it, sent without a Content-Length header.
@@ -100,11 +99,11 @@ async fn test_request_timeout_returns_408() -> Result<()> {
     tokio::time::pause();
 
     let temp_dir = TempDir::new()?;
-    let state = AppState {
-        files_path: Arc::new(temp_dir.path().to_path_buf()),
-        ingestor: default_ingestor_tests(),
-        variant_controller: VariantController::new(MediaGate::new(1)),
-    };
+    let state = AppState::new(
+        temp_dir.path().to_path_buf(),
+        default_ingestor_tests(),
+        MediaPermits::new(1),
+    );
     let routes = Router::new().route("/sleep/{millis}", get(sleep_handler));
 
     // 1-second timeout; handler sleeps far longer (time is paused, so no real wait).
@@ -139,11 +138,11 @@ async fn ok_handler() -> StatusCode {
 #[tokio::test]
 async fn test_body_size_limit_response_has_cors_header() -> Result<()> {
     let temp_dir = TempDir::new()?;
-    let state = AppState {
-        files_path: Arc::new(temp_dir.path().to_path_buf()),
-        ingestor: default_ingestor_tests(),
-        variant_controller: VariantController::new(MediaGate::new(1)),
-    };
+    let state = AppState::new(
+        temp_dir.path().to_path_buf(),
+        default_ingestor_tests(),
+        MediaPermits::new(1),
+    );
     let routes = Router::new().route("/echo", post(ok_handler));
 
     // 10-byte limit; body well over it.
@@ -175,11 +174,11 @@ async fn test_request_timeout_response_has_cors_header() -> Result<()> {
     tokio::time::pause();
 
     let temp_dir = TempDir::new()?;
-    let state = AppState {
-        files_path: Arc::new(temp_dir.path().to_path_buf()),
-        ingestor: default_ingestor_tests(),
-        variant_controller: VariantController::new(MediaGate::new(1)),
-    };
+    let state = AppState::new(
+        temp_dir.path().to_path_buf(),
+        default_ingestor_tests(),
+        MediaPermits::new(1),
+    );
     let routes = Router::new().route("/sleep/{millis}", get(sleep_handler));
 
     // 1-second timeout; handler sleeps far longer (time is paused, so no real wait).

--- a/nexus-webapi/tests/files/static_file.rs
+++ b/nexus-webapi/tests/files/static_file.rs
@@ -1,10 +1,21 @@
+use std::sync::Arc;
+use std::time::Duration;
 use std::{fs::File, io::Write};
 
 use crate::utils::host_url;
 use crate::utils::server::TestServiceServer;
 use anyhow::Result;
+use axum::body::Body;
+use axum::http::Request;
+use nexus_common::media::{MediaGate, VariantController};
 use nexus_common::models::{file::FileDetails, traits::Collection};
-use tokio::fs::create_dir_all;
+use nexus_common::utils::test_utils::default_ingestor_tests;
+use nexus_common::RateLimitConfig;
+use nexus_webapi::routes::{app_routes, build_app, AppState};
+use tempfile::TempDir;
+use tokio::fs::{create_dir_all, write};
+use tokio::sync::watch;
+use tower::ServiceExt;
 
 #[tokio_shared_rt::test(shared)]
 async fn test_static_serving() -> Result<()> {
@@ -96,6 +107,57 @@ async fn test_static_serving_dl_param() -> Result<()> {
             .parse::<String>()
             .unwrap(),
         format!("attachment; filename=\"{}\"", result_file.name)
+    );
+
+    Ok(())
+}
+
+// Requesting a variant that must be generated while the media gate is at capacity
+// must shed with 503 — the explicitly requested variant is not silently substituted.
+#[tokio_shared_rt::test(shared)]
+async fn test_static_serving_at_capacity_returns_503() -> Result<()> {
+    // Ensure the shared stack (DB connectors) and test-graph data are initialized.
+    // We drive a standalone router so we don't disturb the shared server's gate.
+    let _ = TestServiceServer::get_test_server().await;
+
+    // An image file from the mock graph (content_type image/png) that supports the feed variant.
+    let test_file_id = "2ZKH7K7M9G3G0";
+    let test_file_user = "y4euc58gnmxun9wo87gwmanu6kztt9pgw1zz1yp1azp7trrsjamy";
+
+    let files_dir = TempDir::new()?;
+    let image_dir = files_dir.path().join(test_file_user).join(test_file_id);
+    create_dir_all(&image_dir).await?;
+    write(
+        image_dir.join("main"),
+        b"not a real image, gate sheds first",
+    )
+    .await?;
+
+    // Zero permits + short timeout: variant generation sheds with AtCapacity immediately.
+    let gate = MediaGate::new(0).with_acquire_timeout(Duration::from_millis(50));
+    let state = AppState {
+        files_path: Arc::new(files_dir.path().to_path_buf()),
+        ingestor: default_ingestor_tests(),
+        variant_controller: VariantController::new(gate),
+    };
+    let (_tx, rx) = watch::channel(false);
+    let routes = app_routes(state.clone(), &RateLimitConfig::default(), rx);
+    let app = build_app(routes, state, 30, 10 * 1024 * 1024);
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri(format!(
+                    "/static/files/{test_file_user}/{test_file_id}/feed"
+                ))
+                .body(Body::empty())?,
+        )
+        .await?;
+
+    assert_eq!(
+        res.status(),
+        503,
+        "At capacity the requested variant must shed with 503, not fall back or 500"
     );
 
     Ok(())

--- a/nexus-webapi/tests/files/static_file.rs
+++ b/nexus-webapi/tests/files/static_file.rs
@@ -7,7 +7,7 @@ use axum::body::Body;
 use axum::http::Request;
 use nexus_common::media::MediaPermits;
 use nexus_common::models::{file::FileDetails, traits::Collection};
-use nexus_common::utils::test_utils::default_ingestor_tests;
+use nexus_common::utils::test_utils::{default_ingestor_tests, default_subprocess_tests};
 use nexus_common::RateLimitConfig;
 use nexus_webapi::routes::{app_routes, build_app, AppState};
 use tempfile::TempDir;
@@ -136,6 +136,7 @@ async fn test_static_serving_at_capacity_returns_503() -> Result<()> {
         files_dir.path().to_path_buf(),
         default_ingestor_tests(),
         MediaPermits::new(0),
+        default_subprocess_tests(),
     );
     let (_tx, rx) = watch::channel(false);
     let routes = app_routes(state.clone(), &RateLimitConfig::default(), rx);

--- a/nexus-webapi/tests/files/static_file.rs
+++ b/nexus-webapi/tests/files/static_file.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-use std::time::Duration;
 use std::{fs::File, io::Write};
 
 use crate::utils::host_url;
@@ -7,7 +5,7 @@ use crate::utils::server::TestServiceServer;
 use anyhow::Result;
 use axum::body::Body;
 use axum::http::Request;
-use nexus_common::media::{MediaGate, VariantController};
+use nexus_common::media::MediaPermits;
 use nexus_common::models::{file::FileDetails, traits::Collection};
 use nexus_common::utils::test_utils::default_ingestor_tests;
 use nexus_common::RateLimitConfig;
@@ -133,13 +131,12 @@ async fn test_static_serving_at_capacity_returns_503() -> Result<()> {
     )
     .await?;
 
-    // Zero permits + short timeout: variant generation sheds with AtCapacity immediately.
-    let gate = MediaGate::new(0).with_acquire_timeout(Duration::from_millis(50));
-    let state = AppState {
-        files_path: Arc::new(files_dir.path().to_path_buf()),
-        ingestor: default_ingestor_tests(),
-        variant_controller: VariantController::new(gate),
-    };
+    // Zero permits: a pool that can never grant one sheds with AtCapacity immediately.
+    let state = AppState::new(
+        files_dir.path().to_path_buf(),
+        default_ingestor_tests(),
+        MediaPermits::new(0),
+    );
     let (_tx, rx) = watch::channel(false);
     let routes = app_routes(state.clone(), &RateLimitConfig::default(), rx);
     let app = build_app(routes, state, 30, 10 * 1024 * 1024);

--- a/nexus-webapi/tests/user/avatar.rs
+++ b/nexus-webapi/tests/user/avatar.rs
@@ -1,10 +1,19 @@
-use std::{io::ErrorKind, path::PathBuf};
+use std::{io::ErrorKind, path::PathBuf, sync::Arc, time::Duration};
 
 use crate::utils::host_url;
 use crate::utils::server::TestServiceServer;
 use anyhow::Result;
+use axum::body::{to_bytes, Body};
+use axum::http::Request;
+use nexus_common::media::{MediaGate, VariantController};
 use nexus_common::models::{traits::Collection, user::UserDetails};
+use nexus_common::utils::test_utils::default_ingestor_tests;
+use nexus_common::RateLimitConfig;
+use nexus_webapi::routes::{app_routes, build_app, AppState};
+use tempfile::TempDir;
 use tokio::fs::{create_dir_all, read, remove_dir_all, write};
+use tokio::sync::watch;
+use tower::ServiceExt;
 
 const AVATAR_BLOB_NAME: &str = "avatar.png";
 const BLOB_PATH: &str = "tests/user/blobs";
@@ -164,6 +173,124 @@ async fn test_user_avatar_serves_file_owned_by_another_user() -> Result<()> {
     let restore_result = set_user_image(INTRUDER_PUBKY, original_image).await;
     test_result?;
     restore_result?;
+
+    Ok(())
+}
+
+// When the media concurrency gate is at capacity, the avatar handler must shed
+// load by serving the untouched `main` image instead of failing with a 500.
+#[tokio_shared_rt::test(shared)]
+async fn test_user_avatar_degrades_to_main_when_at_capacity() -> Result<()> {
+    // Ensure the shared stack (DB connectors) and test-graph data are initialized.
+    // We drive a standalone router below so we don't disturb the shared server's gate.
+    let _ = TestServiceServer::get_test_server().await;
+
+    // Own static-files dir with only the `main` image present.
+    let files_dir = TempDir::new()?;
+    let image_dir = files_dir.path().join(USER_PUBKY).join(FILE_ID);
+    create_dir_all(&image_dir).await?;
+    let source_bytes = read(PathBuf::from(BLOB_PATH).join(AVATAR_BLOB_NAME)).await?;
+    write(image_dir.join("main"), &source_bytes).await?;
+
+    // A gate with zero permits and a short timeout: every variant generation
+    // sheds with `AtCapacity` almost immediately.
+    let gate = MediaGate::new(0).with_acquire_timeout(Duration::from_millis(50));
+    let state = AppState {
+        files_path: Arc::new(files_dir.path().to_path_buf()),
+        ingestor: default_ingestor_tests(),
+        variant_controller: VariantController::new(gate),
+    };
+    let (_tx, rx) = watch::channel(false);
+    let routes = app_routes(state.clone(), &RateLimitConfig::default(), rx);
+    let app = build_app(routes, state, 30, 10 * 1024 * 1024);
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/static/avatar/{USER_PUBKY}"))
+                .body(Body::empty())?,
+        )
+        .await?;
+
+    assert_eq!(
+        res.status(),
+        200,
+        "At capacity should still serve 200 by falling back to main"
+    );
+
+    // FILE_ID's content type in the mock graph is image/jpeg (the main/original),
+    // not image/webp (the small variant that would have been generated).
+    let content_type = res
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+    assert_eq!(
+        content_type, "image/jpeg",
+        "Fallback should serve the original main image, not the small webp variant"
+    );
+
+    let body = to_bytes(res.into_body(), usize::MAX).await?;
+    assert_eq!(
+        body.len(),
+        source_bytes.len(),
+        "Fallback body should be the untouched main image bytes"
+    );
+
+    Ok(())
+}
+
+// With the gate below capacity, the same standalone router generates and serves
+// the small webp variant — the counterpart to the at-capacity degradation above.
+#[tokio_shared_rt::test(shared)]
+async fn test_user_avatar_serves_small_variant_when_gate_available() -> Result<()> {
+    let _ = TestServiceServer::get_test_server().await;
+
+    let files_dir = TempDir::new()?;
+    let image_dir = files_dir.path().join(USER_PUBKY).join(FILE_ID);
+    create_dir_all(&image_dir).await?;
+    let source_bytes = read(PathBuf::from(BLOB_PATH).join(AVATAR_BLOB_NAME)).await?;
+    write(image_dir.join("main"), &source_bytes).await?;
+
+    // A gate with an available permit lets variant generation proceed.
+    let gate = MediaGate::new(1);
+    let state = AppState {
+        files_path: Arc::new(files_dir.path().to_path_buf()),
+        ingestor: default_ingestor_tests(),
+        variant_controller: VariantController::new(gate),
+    };
+    let (_tx, rx) = watch::channel(false);
+    let routes = app_routes(state.clone(), &RateLimitConfig::default(), rx);
+    let app = build_app(routes, state, 30, 10 * 1024 * 1024);
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/static/avatar/{USER_PUBKY}"))
+                .body(Body::empty())?,
+        )
+        .await?;
+
+    assert_eq!(res.status(), 200, "Should serve 200 with the small variant");
+
+    let content_type = res
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+    assert_eq!(
+        content_type, "image/webp",
+        "With capacity the generated small variant is served as image/webp"
+    );
+
+    let body = to_bytes(res.into_body(), usize::MAX).await?;
+    assert_ne!(
+        body.len(),
+        source_bytes.len(),
+        "Small variant bytes should differ from the original main image"
+    );
 
     Ok(())
 }

--- a/nexus-webapi/tests/user/avatar.rs
+++ b/nexus-webapi/tests/user/avatar.rs
@@ -7,7 +7,7 @@ use axum::body::{to_bytes, Body};
 use axum::http::Request;
 use nexus_common::media::MediaPermits;
 use nexus_common::models::{traits::Collection, user::UserDetails};
-use nexus_common::utils::test_utils::default_ingestor_tests;
+use nexus_common::utils::test_utils::{default_ingestor_tests, default_subprocess_tests};
 use nexus_common::RateLimitConfig;
 use nexus_webapi::routes::{app_routes, build_app, AppState};
 use tempfile::TempDir;
@@ -199,6 +199,7 @@ async fn test_user_avatar_degrades_to_main_when_at_capacity() -> Result<()> {
         files_dir.path().to_path_buf(),
         default_ingestor_tests(),
         MediaPermits::new(0),
+        default_subprocess_tests(),
     );
     let (_tx, rx) = watch::channel(false);
     let routes = app_routes(state.clone(), &RateLimitConfig::default(), rx);
@@ -266,6 +267,7 @@ async fn test_user_avatar_serves_small_variant_when_gate_available() -> Result<(
         files_dir.path().to_path_buf(),
         default_ingestor_tests(),
         MediaPermits::new(1),
+        default_subprocess_tests(),
     );
     let (_tx, rx) = watch::channel(false);
     let routes = app_routes(state.clone(), &RateLimitConfig::default(), rx);

--- a/nexus-webapi/tests/user/avatar.rs
+++ b/nexus-webapi/tests/user/avatar.rs
@@ -1,11 +1,11 @@
-use std::{io::ErrorKind, path::PathBuf, sync::Arc, time::Duration};
+use std::{io::ErrorKind, path::PathBuf, time::Duration, time::Instant};
 
 use crate::utils::host_url;
 use crate::utils::server::TestServiceServer;
 use anyhow::Result;
 use axum::body::{to_bytes, Body};
 use axum::http::Request;
-use nexus_common::media::{MediaGate, VariantController};
+use nexus_common::media::MediaPermits;
 use nexus_common::models::{traits::Collection, user::UserDetails};
 use nexus_common::utils::test_utils::default_ingestor_tests;
 use nexus_common::RateLimitConfig;
@@ -192,18 +192,19 @@ async fn test_user_avatar_degrades_to_main_when_at_capacity() -> Result<()> {
     let source_bytes = read(PathBuf::from(BLOB_PATH).join(AVATAR_BLOB_NAME)).await?;
     write(image_dir.join("main"), &source_bytes).await?;
 
-    // A gate with zero permits and a short timeout: every variant generation
-    // sheds with `AtCapacity` almost immediately.
-    let gate = MediaGate::new(0).with_acquire_timeout(Duration::from_millis(50));
-    let state = AppState {
-        files_path: Arc::new(files_dir.path().to_path_buf()),
-        ingestor: default_ingestor_tests(),
-        variant_controller: VariantController::new(gate),
-    };
+    // Zero permits: every variant generation sheds with `AtCapacity`. The default
+    // acquire timeout stays in place on purpose, so the assertion below catches a
+    // fallback that queues for it instead of failing fast.
+    let state = AppState::new(
+        files_dir.path().to_path_buf(),
+        default_ingestor_tests(),
+        MediaPermits::new(0),
+    );
     let (_tx, rx) = watch::channel(false);
     let routes = app_routes(state.clone(), &RateLimitConfig::default(), rx);
     let app = build_app(routes, state, 30, 10 * 1024 * 1024);
 
+    let start = Instant::now();
     let res = app
         .oneshot(
             Request::builder()
@@ -211,11 +212,18 @@ async fn test_user_avatar_degrades_to_main_when_at_capacity() -> Result<()> {
                 .body(Body::empty())?,
         )
         .await?;
+    let elapsed = start.elapsed();
 
     assert_eq!(
         res.status(),
         200,
         "At capacity should still serve 200 by falling back to main"
+    );
+
+    // The fallback must not wait out the gate's acquire timeout to reach the same answer.
+    assert!(
+        elapsed < Duration::from_secs(1),
+        "At-capacity fallback must be immediate, took {elapsed:?}"
     );
 
     // FILE_ID's content type in the mock graph is image/jpeg (the main/original),
@@ -253,13 +261,12 @@ async fn test_user_avatar_serves_small_variant_when_gate_available() -> Result<(
     let source_bytes = read(PathBuf::from(BLOB_PATH).join(AVATAR_BLOB_NAME)).await?;
     write(image_dir.join("main"), &source_bytes).await?;
 
-    // A gate with an available permit lets variant generation proceed.
-    let gate = MediaGate::new(1);
-    let state = AppState {
-        files_path: Arc::new(files_dir.path().to_path_buf()),
-        ingestor: default_ingestor_tests(),
-        variant_controller: VariantController::new(gate),
-    };
+    // An available permit lets variant generation proceed.
+    let state = AppState::new(
+        files_dir.path().to_path_buf(),
+        default_ingestor_tests(),
+        MediaPermits::new(1),
+    );
     let (_tx, rx) = watch::channel(false);
     let routes = app_routes(state.clone(), &RateLimitConfig::default(), rx);
     let app = build_app(routes, state, 30, 10 * 1024 * 1024);


### PR DESCRIPTION
Unbounded variant generation let a burst of static-file requests spawn one ImageMagick subprocess each, starving the host. Cap the concurrent processes with a semaphore, and cap the queue waiting on it so a burst parks a bounded number of clients instead of arbitrarily many.

The process limit is configured with [stack.media].max_concurrency in config.toml; it defaults to the CPU count (min 4) and rejects 0.

Requests that cannot get a slot degrade instead of failing: the avatar endpoint serves the original `main` image, while /static/files returns 503, since there the variant is explicit in the URL.

