### PR TITLE
chore: bump pubky-app-specs to 0.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4011,9 +4011,9 @@ dependencies = [
 
 [[package]]
 name = "pubky-app-specs"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd944a903233197176255797961fcf7a55d426c4da911a4aa291ba2938740641"
+checksum = "81a006a19bae082c05c40d4cc954f07e7be1d43463452021e7518d1289243e52"
 dependencies = [
  "base32",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ redis = "1.0.4"
 opentelemetry = "0.32"
 opentelemetry_sdk = { version = "0.32", features = ["rt-tokio"] }
 pubky = "0.9.3"
-pubky-app-specs = { version = "0.6.1", features = ["openapi"] }
+pubky-app-specs = { version = "0.6.2", features = ["openapi"] }
 pubky-testnet = "0.9.3"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.149"

--- a/nexus-watcher/tests/user_ingestion/ingest_user_from_post_events.rs
+++ b/nexus-watcher/tests/user_ingestion/ingest_user_from_post_events.rs
@@ -221,9 +221,8 @@ async fn test_collection_ingests_each_item_author() -> Result<()> {
 
     let envelope = PubkyAppCollectionContent {
         name: "Curated".to_string(),
-        description: None,
         items: vec![item1_uri.clone(), item2_uri.clone()],
-        cover_image: None,
+        ..Default::default()
     };
     let collection = PubkyAppPost {
         content: serde_json::to_string(&envelope).unwrap(),


### PR DESCRIPTION
Picks up the new optional collection `layout` field (pubky/pubky-app-specs#147).

No indexing changes needed, nexus stores the raw content envelope and old collections without the field keep parsing fine (layout = None). Only had to touch a test struct literal.