### PR TITLE
chore(nexus-common): drop dead serde/utoipa derives from Pagination

### DIFF
--- a/nexus-common/src/types/pagination.rs
+++ b/nexus-common/src/types/pagination.rs
@@ -1,39 +1,8 @@
-use serde::de::{self, Deserializer};
-use serde::Deserialize;
-use utoipa::ToSchema;
-
-#[derive(Default, Deserialize, Debug, ToSchema, Clone)]
+/// Pagination parameters for the DB layer.
+#[derive(Default, Debug, Clone, Copy)]
 pub struct Pagination {
-    #[serde(default, deserialize_with = "parse_string_to_usize")]
     pub skip: Option<usize>,
-    #[serde(default, deserialize_with = "parse_string_to_usize")]
     pub limit: Option<usize>,
-    #[serde(default, deserialize_with = "parse_string_to_f64")]
     pub start: Option<f64>,
-    #[serde(default, deserialize_with = "parse_string_to_f64")]
     pub end: Option<f64>,
-}
-
-// Parse a string into a usize
-fn parse_string_to_usize<'de, D>(deserializer: D) -> Result<Option<usize>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let s: Option<String> = Option::deserialize(deserializer)?;
-    match s {
-        Some(s) => s.parse::<usize>().map(Some).map_err(de::Error::custom),
-        None => Ok(None),
-    }
-}
-
-// Parsing strings or floats into f64
-fn parse_string_to_f64<'de, D>(deserializer: D) -> Result<Option<f64>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let s: Option<String> = Option::deserialize(deserializer)?;
-    match s {
-        Some(s) => s.parse::<f64>().map(Some).map_err(de::Error::custom),
-        None => Ok(None),
-    }
 }


### PR DESCRIPTION
Pagination stopped being a wire type when BoundedPagination took over the HTTP boundary; the Deserialize impl and its string-parsing helpers were unreachable. Removing the derive also makes `Query<Pagination>` a compile error, so new routes can't bypass the BoundedSkip/BoundedLimit caps.