### PR TITLE
chore: gate `test_utils` module behind `test-utils` Cargo feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3031,7 +3031,6 @@ dependencies = [
  "futures",
  "hex",
  "neo4rs",
- "nexus-common",
  "opentelemetry 0.32.0",
  "opentelemetry-appender-tracing",
  "opentelemetry-otlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3031,6 +3031,7 @@ dependencies = [
  "futures",
  "hex",
  "neo4rs",
+ "nexus-common",
  "opentelemetry 0.32.0",
  "opentelemetry-appender-tracing",
  "opentelemetry-otlp",

--- a/nexus-common/Cargo.toml
+++ b/nexus-common/Cargo.toml
@@ -39,7 +39,6 @@ url = { workspace = true }
 utoipa = { workspace = true }
 
 [dev-dependencies]
-nexus-common = { path = ".", features = ["test-utils"] }
 tempfile = { workspace = true }
 tokio-shared-rt = { workspace = true }
 tracing-test = { workspace = true }

--- a/nexus-common/Cargo.toml
+++ b/nexus-common/Cargo.toml
@@ -7,6 +7,9 @@ homepage = "https://github.com/pubky/pubky-nexus"
 repository = "https://github.com/pubky/pubky-nexus"
 license = "MIT"
 
+[features]
+test-utils = []
+
 [dependencies]
 async-trait = { workspace = true }
 blake3 = { workspace = true }
@@ -36,6 +39,7 @@ url = { workspace = true }
 utoipa = { workspace = true }
 
 [dev-dependencies]
+nexus-common = { path = ".", features = ["test-utils"] }
 tempfile = { workspace = true }
 tokio-shared-rt = { workspace = true }
 tracing-test = { workspace = true }

--- a/nexus-common/src/utils/mod.rs
+++ b/nexus-common/src/utils/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "test-utils")]
+#[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;
 
 use tokio::sync::watch::Receiver;

--- a/nexus-common/src/utils/mod.rs
+++ b/nexus-common/src/utils/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "test-utils")]
 pub mod test_utils;
 
 use tokio::sync::watch::Receiver;

--- a/nexus-watcher/Cargo.toml
+++ b/nexus-watcher/Cargo.toml
@@ -27,6 +27,7 @@ tracing = { workspace = true }
 anyhow = { workspace = true }
 base32 = "0.5"
 http = "1"
+nexus-common = { path = "../nexus-common", features = ["test-utils"] }
 pubky-testnet = { workspace = true }
 rand = "0.10.1"
 tempfile = { workspace = true }

--- a/nexus-webapi/Cargo.toml
+++ b/nexus-webapi/Cargo.toml
@@ -42,6 +42,7 @@ anyhow = { workspace = true }
 criterion = { version = "0.8", features = ["async_tokio"] }
 http-body-util = "0.1.3"
 httpc-test = "0.1.10"
+nexus-common = { path = "../nexus-common", features = ["test-utils"] }
 pubky-testnet = { workspace = true }
 serde_urlencoded = "0.7"
 tempfile = { workspace = true }


### PR DESCRIPTION
Add a `test-utils` feature to `nexus-common` and gate the `test_utils` module behind `#[cfg(feature = "test-utils")]` so that test-only code is excluded from production builds.