### PR TITLE
chore: check benchmarks in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,4 +33,4 @@ jobs:
           cache-on-failure: true
 
       - name: Run clippy
-        run: cargo clippy --tests -- -D warnings # Fail on clippy warnings (checks main code and tests)
+        run: cargo clippy --all-targets -- -D warnings # Fail on clippy warnings (main code, tests and benches)


### PR DESCRIPTION
Widen clippy check to include benchmarks too. Currently nothing in CI checks benchmarks code and broken code is pushed ocassionaly.

#1004 needs to be merged first