### PR TITLE
feat: Replace [DELETED] sentinel with boolean deleted flag

### DIFF
--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -430,7 +430,7 @@ pub fn get_all_homeservers_with_active_users() -> Query {
     Query::new(
         "get_all_homeservers_with_active_users",
         "MATCH (u:User)-[r:HOSTED_BY]->(hs:Homeserver)
-        WHERE u.name <> '[DELETED]' AND NOT coalesce(r.stale, false)
+        WHERE NOT coalesce(u.deleted, false) AND NOT coalesce(r.stale, false)
         WITH hs.id AS id, count(u) AS active_users
         ORDER BY active_users DESC
         RETURN collect(id) AS homeservers_list",
@@ -443,7 +443,7 @@ pub fn get_users_needing_hs_resolution(ttl_ms: u64) -> Query {
     Query::new(
         "get_users_needing_hs_resolution",
         "MATCH (u:User)
-         WHERE u.name <> '[DELETED]'
+         WHERE NOT coalesce(u.deleted, false)
          OPTIONAL MATCH (u)-[r:HOSTED_BY]->(:Homeserver)
          WITH u, r
          WHERE r IS NULL
@@ -474,7 +474,7 @@ pub fn get_active_users_by_homeserver(hs_id: &str) -> Query {
     Query::new(
         "get_active_users_by_homeserver",
         "MATCH (u:User)-[r:HOSTED_BY]->(:Homeserver {id: $hs_id})
-         WHERE u.name <> '[DELETED]' AND NOT coalesce(r.stale, false)
+         WHERE NOT coalesce(u.deleted, false) AND NOT coalesce(r.stale, false)
          RETURN collect(u.id) AS user_ids",
     )
     .param("hs_id", hs_id.to_string())
@@ -776,7 +776,7 @@ pub fn get_influencers_by_reach(
         {}
         WHERE user.id = $user_id
         WITH DISTINCT reach
-        WHERE reach.name <> '[DELETED]'
+        WHERE NOT coalesce(reach.deleted, false)
 
         CALL (reach) {{
             MATCH (others:User)-[follow:FOLLOWS]->(reach)
@@ -819,7 +819,7 @@ pub fn get_global_influencers(skip: usize, limit: usize, timeframe: &Timeframe) 
         "get_global_influencers",
         "
         MATCH (user:User)
-        WHERE user.name <> '[DELETED]'
+        WHERE NOT coalesce(user.deleted, false)
         WITH DISTINCT user
 
         // Each count is a scoped CALL(user){} subquery so it stays per-user
@@ -1257,7 +1257,8 @@ pub fn post_is_safe_to_delete(author_id: &str, post_id: &str) -> Query {
 }
 
 /// Find user recommendations: active users (with 5+ posts) who are 1-3 degrees of separation away
-/// from the given user, but not directly followed by them
+/// from the given user, but not directly followed by them.
+/// Deleted users are filtered in Cypher; only the user ID is projected (no name column).
 pub fn recommend_users(user_id: &str, limit: usize) -> Query {
     Query::new(
         "recommend_users",
@@ -1266,11 +1267,12 @@ pub fn recommend_users(user_id: &str, limit: usize) -> Query {
         MATCH (user)-[:FOLLOWS*1..3]->(potential:User)
         WHERE NOT (user)-[:FOLLOWS]->(potential)
         AND potential.id <> $user_id
+        AND NOT coalesce(potential.deleted, false)
         WITH DISTINCT potential
         MATCH (potential)-[:AUTHORED]->(post:Post)
         WITH potential, COUNT(post) AS post_count
         WHERE post_count >= 5
-        RETURN potential.id AS recommended_user_id, potential.name AS recommended_user_name
+        RETURN potential.id AS recommended_user_id
         LIMIT $limit
     ",
     )

--- a/nexus-common/src/db/graph/queries/put.rs
+++ b/nexus-common/src/db/graph/queries/put.rs
@@ -12,7 +12,7 @@ pub fn create_user(user: &UserDetails) -> GraphResult<Query> {
     let query = Query::new(
         "create_user",
         "MERGE (u:User {id: $id})
-         SET u.name = $name, u.bio = $bio, u.status = $status, u.links = $links, u.image = $image, u.indexed_at = $indexed_at;",
+         SET u.name = $name, u.bio = $bio, u.status = $status, u.links = $links, u.image = $image, u.indexed_at = $indexed_at, u.deleted = $deleted;",
     )
     .param("id", user.id.to_string())
     .param("name", user.name.clone())
@@ -20,7 +20,8 @@ pub fn create_user(user: &UserDetails) -> GraphResult<Query> {
     .param("status", user.status.clone())
     .param("links", links)
     .param("image", user.image.clone())
-    .param("indexed_at", user.indexed_at);
+    .param("indexed_at", user.indexed_at)
+    .param("deleted", user.deleted);
 
     Ok(query)
 }

--- a/nexus-common/src/db/kv/index/sorted_sets.rs
+++ b/nexus-common/src/db/kv/index/sorted_sets.rs
@@ -308,10 +308,12 @@ pub async fn del(prefix: &str, key: &str, values: &[&str]) -> RedisResult<()> {
 /// * `sorted_set_prefix` - Prefix of the destination sorted set key.
 /// * `sorted_set_key` - Key of the destination sorted set.
 /// * `member` - The sorted-set member to write or remove.
-/// * `removal_guard` - Optional `(json_key, json_path)`: when the JSON
-///   document at `json_key` holds `true` at `json_path`, the member is
-///   removed regardless of cardinality. A missing key or path reads as
-///   `false`. Checked inside the same script, so the guard cannot race the
+/// * `removal_guard` - Optional `(json_key, json_path, value)`: when the JSON
+///   document at `json_key` holds `value` at `json_path`, the member is
+///   removed regardless of cardinality. The stored JSON scalar is compared by
+///   its text form, so `value` is `"true"` for a boolean flag and the bare
+///   string for a string field (no JSON quoting). A missing key or path never
+///   matches. Checked inside the same script, so the guard cannot race the
 ///   write.
 ///
 /// # Errors
@@ -323,7 +325,7 @@ pub async fn sync_score_from_set_cardinality(
     sorted_set_prefix: &str,
     sorted_set_key: &str,
     member: &str,
-    removal_guard: Option<(&str, &str)>,
+    removal_guard: Option<(&str, &str, &str)>,
 ) -> RedisResult<()> {
     let set_index_key = format!("{set_prefix}:{set_key}");
     let sorted_set_index_key = format!("{sorted_set_prefix}:{sorted_set_key}");
@@ -340,15 +342,29 @@ pub async fn sync_score_from_set_cardinality(
     "#;
 
     let invocation = match removal_guard {
-        Some((json_key, json_path)) => {
+        Some((json_key, json_path, value)) => {
+            // cjson maps JSON scalars onto Lua types, so a boolean field decodes to a
+            // Lua boolean and never equals the string in ARGV[3]. Compare text forms
+            // instead, which keeps one guard working for `true` and for a string
+            // sentinel alike. Anything else (null, object, array) cannot match.
             let script = Script::new(&format!(
                 r#"
                 local guarded = redis.call('JSON.GET', KEYS[3], ARGV[2])
                 if guarded then
                     local decoded = cjson.decode(guarded)
-                    if type(decoded) == 'table' and decoded[1] == true then
-                        redis.call('ZREM', KEYS[2], ARGV[1])
-                        return 0
+                    if type(decoded) == 'table' then
+                        local found = decoded[1]
+                        local kind = type(found)
+                        local as_text
+                        if kind == 'boolean' then
+                            as_text = found and 'true' or 'false'
+                        elseif kind == 'string' or kind == 'number' then
+                            as_text = tostring(found)
+                        end
+                        if as_text == ARGV[3] then
+                            redis.call('ZREM', KEYS[2], ARGV[1])
+                            return 0
+                        end
                     end
                 end
                 {derive}
@@ -360,6 +376,7 @@ pub async fn sync_score_from_set_cardinality(
                 .key(json_key)
                 .arg(member)
                 .arg(json_path)
+                .arg(value)
                 .invoke_async(&mut redis_conn)
                 .await
         }
@@ -376,4 +393,123 @@ pub async fn sync_score_from_set_cardinality(
 
     let _: i64 = invocation?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::kv::index::json;
+    use crate::{types::DynError, StackConfig, StackManager};
+    use serde::Serialize;
+
+    const TEST_SET_PREFIX: &str = "GuardTestSet";
+    const TEST_JSON_PREFIX: &str = "GuardTestJson";
+
+    #[derive(Serialize)]
+    struct GuardDoc {
+        name: &'static str,
+        deleted: bool,
+    }
+
+    /// The removal guard compares the stored JSON scalar by its text form, so the
+    /// same helper serves a boolean flag and a string sentinel. Each case seeds a
+    /// non-empty source set, so a removal can only come from the guard, never from
+    /// the cardinality derive.
+    #[tokio_shared_rt::test(shared)]
+    async fn test_removal_guard_matches_scalar_by_text_form() -> Result<(), DynError> {
+        StackManager::setup(&StackConfig::default()).await?;
+
+        let cases = [
+            (
+                "bool_set",
+                "$.deleted",
+                "true",
+                GuardDoc {
+                    name: "alice",
+                    deleted: true,
+                },
+                true,
+            ),
+            (
+                "bool_clear",
+                "$.deleted",
+                "true",
+                GuardDoc {
+                    name: "alice",
+                    deleted: false,
+                },
+                false,
+            ),
+            (
+                "str_match",
+                "$.name",
+                "[DELETED]",
+                GuardDoc {
+                    name: "[DELETED]",
+                    deleted: false,
+                },
+                true,
+            ),
+            (
+                "str_other",
+                "$.name",
+                "[DELETED]",
+                GuardDoc {
+                    name: "alice",
+                    deleted: false,
+                },
+                false,
+            ),
+            (
+                "missing_path",
+                "$.absent",
+                "true",
+                GuardDoc {
+                    name: "alice",
+                    deleted: true,
+                },
+                false,
+            ),
+        ];
+
+        for (case, path, value, doc, should_remove) in cases {
+            let member = "member";
+            let sorted_key = format!("GuardTest:sorted:{case}");
+            let mut conn = get_redis_conn().await?;
+            let _: () = conn.del(format!("{SORTED_PREFIX}:{sorted_key}")).await?;
+            let _: () = conn.del(format!("{TEST_SET_PREFIX}:{case}")).await?;
+            json::del_multiple(TEST_JSON_PREFIX, &[case]).await?;
+
+            // Non-empty source set: the derive alone would always ZADD a score of 2
+            let _: () = conn
+                .sadd(
+                    format!("{TEST_SET_PREFIX}:{case}"),
+                    &["tagger_a", "tagger_b"],
+                )
+                .await?;
+            json::put(TEST_JSON_PREFIX, case, &doc, None, None).await?;
+
+            sync_score_from_set_cardinality(
+                TEST_SET_PREFIX,
+                case,
+                SORTED_PREFIX,
+                &sorted_key,
+                member,
+                Some((&format!("{TEST_JSON_PREFIX}:{case}"), path, value)),
+            )
+            .await?;
+
+            let score = check_member(SORTED_PREFIX, &sorted_key, member).await?;
+            if should_remove {
+                assert!(score.is_none(), "{case}: guard must remove the member");
+            } else {
+                assert_eq!(score, Some(2), "{case}: derive must set the cardinality");
+            }
+
+            let _: () = conn.del(format!("{SORTED_PREFIX}:{sorted_key}")).await?;
+            let _: () = conn.del(format!("{TEST_SET_PREFIX}:{case}")).await?;
+            json::del_multiple(TEST_JSON_PREFIX, &[case]).await?;
+        }
+        Ok(())
+    }
 }

--- a/nexus-common/src/db/kv/traits.rs
+++ b/nexus-common/src/db/kv/traits.rs
@@ -644,9 +644,9 @@ pub trait RedisOps: Serialize + DeserializeOwned + Send + Sync {
     /// * `source_set_key_parts` - Key parts of the source set whose cardinality becomes the score.
     /// * `sorted_set_key_parts` - Key parts of the destination sorted set (under the `Sorted` prefix).
     /// * `member` - The sorted-set member to write or remove.
-    /// * `removal_guard` - Optional `(json_key, json_path)` that forces removal
-    ///   when the JSON document holds `true` at that path, checked atomically
-    ///   with the write.
+    /// * `removal_guard` - Optional `(json_key, json_path, value)` that forces
+    ///   removal when the JSON document holds `value` at that path, compared by
+    ///   text form (`"true"` for a boolean flag), checked atomically with the write.
     ///
     /// # Errors
     ///
@@ -656,7 +656,7 @@ pub trait RedisOps: Serialize + DeserializeOwned + Send + Sync {
         source_set_key_parts: &[&str],
         sorted_set_key_parts: &[&str],
         member: &str,
-        removal_guard: Option<(&str, &str)>,
+        removal_guard: Option<(&str, &str, &str)>,
     ) -> RedisResult<()> {
         sorted_sets::sync_score_from_set_cardinality(
             source_set_prefix,

--- a/nexus-common/src/models/user/details.rs
+++ b/nexus-common/src/models/user/details.rs
@@ -208,13 +208,11 @@ mod tests {
         );
     }
 
-    /// Deserializing a UserDetails from a BoltNode with `deleted: true` should
-    /// preserve the flag — this is the shape after the one-shot migration has
-    /// marked a sentinel tombstone.
+    /// A present `deleted: true` deserializes as true — the other branch of the custom deserializer.
     #[test]
     fn deserialize_from_node_with_deleted_true() {
         let mut props = BoltMap::new();
-        props.put(BoltString::from("name"), BoltType::from("[DELETED]"));
+        props.put(BoltString::from("name"), BoltType::from(""));
         props.put(
             BoltString::from("id"),
             BoltType::from("uo7jgkykft4885n8cruizwy6khw71mnu5pq3ay9i8pw1ymcn85ko"),

--- a/nexus-common/src/models/user/details.rs
+++ b/nexus-common/src/models/user/details.rs
@@ -45,6 +45,8 @@ pub struct UserDetails {
     pub status: Option<String>,
     pub image: Option<String>,
     pub indexed_at: i64,
+    #[serde(deserialize_with = "deserialize_user_deleted", default)]
+    pub deleted: bool,
 }
 
 fn deserialize_user_links<'de, D>(
@@ -82,6 +84,19 @@ where
     }
 }
 
+fn deserialize_user_deleted<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    // Neo4j drops null/missing properties, so pre-migration nodes will lack the
+    // `deleted` field entirely. Redis JSON cache entries written before the
+    // migration similarly lack this key. Deserialize through Option<bool> so a
+    // missing property yields None (→ false), while a present value is respected.
+    // Serializes as a plain non-optional `bool` for the API.
+    let value = Option::<bool>::deserialize(deserializer)?;
+    Ok(value.unwrap_or(false))
+}
+
 impl UserDetails {
     /// Retrieves details by user ID, first trying to get from Redis, then from Neo4j if not found.
     pub async fn get_by_id(user_id: &str) -> ModelResult<Option<Self>> {
@@ -101,6 +116,7 @@ impl UserDetails {
             links: None,
             status: None,
             image: None,
+            deleted: false,
         }
     }
 
@@ -113,6 +129,23 @@ impl UserDetails {
             image: homeserver_user.image,
             id: user_id.clone(),
             indexed_at: Utc::now().timestamp_millis(),
+            deleted: false,
+        }
+    }
+
+    /// Cleared profile written when a user with relationships is deleted.
+    /// Every field is wiped; `deleted` is the only signal. `name` is emptied
+    /// rather than dropped because it is not optional.
+    pub fn tombstone(user_id: &PubkyId) -> Self {
+        UserDetails {
+            name: String::new(),
+            bio: None,
+            id: user_id.clone(),
+            links: None,
+            status: None,
+            image: None,
+            indexed_at: Utc::now().timestamp_millis(),
+            deleted: true,
         }
     }
 
@@ -169,5 +202,36 @@ mod tests {
             .expect("should deserialize without links property (Neo4j drops null properties)");
         assert_eq!(details.name, "Dave");
         assert!(details.links.is_none());
+        assert!(
+            !details.deleted,
+            "missing 'deleted' property should deserialize as false (pre-migration compatibility)"
+        );
+    }
+
+    /// Deserializing a UserDetails from a BoltNode with `deleted: true` should
+    /// preserve the flag — this is the shape after the one-shot migration has
+    /// marked a sentinel tombstone.
+    #[test]
+    fn deserialize_from_node_with_deleted_true() {
+        let mut props = BoltMap::new();
+        props.put(BoltString::from("name"), BoltType::from("[DELETED]"));
+        props.put(
+            BoltString::from("id"),
+            BoltType::from("uo7jgkykft4885n8cruizwy6khw71mnu5pq3ay9i8pw1ymcn85ko"),
+        );
+        props.put(
+            BoltString::from("indexed_at"),
+            BoltType::from(1724134095000_i64),
+        );
+        props.put(BoltString::from("deleted"), BoltType::from(true));
+
+        let node = Node::new(BoltNode::new(
+            BoltInteger::new(1),
+            BoltList::from(vec![BoltType::from("User")]),
+            props,
+        ));
+
+        let details: UserDetails = node.to().expect("should deserialize with deleted: true");
+        assert!(details.deleted);
     }
 }

--- a/nexus-common/src/models/user/influencers.rs
+++ b/nexus-common/src/models/user/influencers.rs
@@ -9,7 +9,7 @@ use std::ops::Deref;
 use tracing::debug;
 use utoipa::ToSchema;
 
-use super::{UserDetails, USER_DELETED_SENTINEL, USER_INFLUENCERS_KEY_PARTS};
+use super::{UserDetails, USER_INFLUENCERS_KEY_PARTS};
 use crate::db::{fetch_key_from_graph, queries, RedisOps};
 
 const GLOBAL_INFLUENCERS_PREFIX: &str = "Cache:Influencers";
@@ -237,7 +237,7 @@ impl Influencers {
 
         for ((id, score), details) in influencers.0.into_iter().zip(details_list) {
             match details {
-                Some(ref d) if d.name != USER_DELETED_SENTINEL => kept.push((id, score)),
+                Some(ref d) if !d.deleted => kept.push((id, score)),
                 _ => deleted_ids.push(id),
             }
         }

--- a/nexus-common/src/models/user/mod.rs
+++ b/nexus-common/src/models/user/mod.rs
@@ -21,8 +21,3 @@ pub use stream::{
     USER_INFLUENCERS_KEY_PARTS, USER_MOSTFOLLOWED_KEY_PARTS,
 };
 pub use view::UserView;
-
-/// Sentinel value used to mark deleted users in the system.
-/// When a user with relationships is deleted, their name field is set to this value
-/// instead of fully removing their profile data.
-pub const USER_DELETED_SENTINEL: &str = "[DELETED]";

--- a/nexus-common/src/models/user/search.rs
+++ b/nexus-common/src/models/user/search.rs
@@ -1,9 +1,10 @@
-use super::{UserDetails, USER_DELETED_SENTINEL};
+use super::UserDetails;
 use crate::db::kv::RedisResult;
 use crate::db::RedisOps;
 use crate::models::create_zero_score_tuples;
 use crate::models::traits::Collection;
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 use utoipa::ToSchema;
 
 pub const USER_NAME_KEY_PARTS: [&str; 2] = ["Users", "Name"];
@@ -85,7 +86,8 @@ impl UserSearch {
     ///
     /// This method takes a list of `UserDetails` and adds them all to the sorted set at once.
     pub async fn put_to_index(details_list: &[&UserDetails]) -> RedisResult<()> {
-        // ensure existing records are deleted
+        // put_to_graph already wrote the NEW name; only the cache knows the stale member.
+        // Unresolved ids are ignored: a first-time index has no prior name to remove.
         Self::delete_existing_records(
             details_list
                 .iter()
@@ -99,10 +101,9 @@ impl UserSearch {
         let mut pairs: Vec<String> = Vec::with_capacity(details_list.len());
         let mut ids: Vec<String> = Vec::with_capacity(details_list.len());
 
-        for details in details_list
-            .iter()
-            .filter(|d| d.name != USER_DELETED_SENTINEL)
-        {
+        // Tombstoned users are removed from the index by `delete`; never re-add them
+        // here, or the next cache-miss read would resurrect the entry.
+        for details in details_list.iter().filter(|d| !d.deleted) {
             // Convert the username to lowercase before storing
             let username = details.name.to_lowercase();
             let user_id = &details.id;
@@ -118,28 +119,36 @@ impl UserSearch {
     }
 
     pub async fn delete(user_id: &str) -> RedisResult<()> {
-        Self::delete_existing_records(&[user_id]).await
+        for id in Self::delete_existing_records(&[user_id]).await? {
+            warn!(user_id = %id, "no cached name at delete; Users:Name member may leak if the user was still indexed")
+        }
+        Ok(())
     }
 
-    async fn delete_existing_records(user_ids: &[&str]) -> RedisResult<()> {
+    /// Removes the cached index members for `user_ids`, returning the ids whose
+    /// name could not be resolved from the JSON cache.
+    async fn delete_existing_records(user_ids: &[&str]) -> RedisResult<Vec<String>> {
         if user_ids.is_empty() {
-            return Ok(());
+            return Ok(Vec::new());
         }
-        let mut records_to_delete: Vec<String> = Vec::with_capacity(user_ids.len());
+        // Resolve names from Redis JSON cache.
         let keys: Vec<Vec<&str>> = user_ids.iter().map(|&id| vec![id]).collect();
-        let users = UserDetails::get_from_index(keys.iter().map(|item| item.as_slice()).collect())
-            .await?
-            .into_iter()
-            .flatten()
-            .collect::<Vec<UserDetails>>();
-        for user_id in user_ids {
-            let existing_username = users
-                .iter()
-                .find(|user| user.id.to_string() == *user_id)
-                .map(|user| user.name.to_lowercase());
-            if let Some(existing_record) = existing_username {
-                let search_key = format!("{existing_record}:{user_id}");
-                records_to_delete.push(search_key);
+        let cached_users =
+            UserDetails::get_from_index(keys.iter().map(|item| item.as_slice()).collect())
+                .await?
+                .into_iter()
+                .flatten()
+                .collect::<Vec<UserDetails>>();
+
+        let mut records_to_delete: Vec<String> = Vec::with_capacity(user_ids.len());
+        let mut unresolved: Vec<String> = Vec::new();
+        for id in user_ids {
+            match cached_users.iter().find(|u| u.id.to_string() == *id) {
+                Some(user) => {
+                    let name = user.name.to_lowercase();
+                    records_to_delete.push(format!("{name}:{id}"));
+                }
+                None => unresolved.push((*id).to_string()),
             }
         }
 
@@ -152,6 +161,8 @@ impl UserSearch {
                 .collect::<Vec<&str>>(),
         )
         .await?;
-        Self::remove_from_index_sorted_set(None, &USER_ID_KEY_PARTS, user_ids).await
+        Self::remove_from_index_sorted_set(None, &USER_ID_KEY_PARTS, user_ids).await?;
+
+        Ok(unresolved)
     }
 }

--- a/nexus-common/src/models/user/search.rs
+++ b/nexus-common/src/models/user/search.rs
@@ -156,7 +156,7 @@ impl UsersByTagSearch {
             &[user_id, label],
             &[&TAG_GLOBAL_USER_TAGGERS[..], &[label]].concat(),
             user_id,
-            Some((&details_key, "$.deleted")),
+            Some((&details_key, "$.deleted", "true")),
         )
         .await
     }

--- a/nexus-common/src/models/user/stream.rs
+++ b/nexus-common/src/models/user/stream.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use super::{Influencers, UserCounts, UserDetails, UserSearch, UserView, USER_DELETED_SENTINEL};
+use super::{Influencers, UserCounts, UserDetails, UserSearch, UserView};
 
 use crate::db::kv::{sets, RedisError, RedisResult, SortOrder};
 use crate::db::{fetch_all_rows_from_graph, queries, RedisOps};
@@ -155,7 +155,7 @@ impl UserStream {
 
             for (id, details) in cached_ids.into_iter().zip(details_list) {
                 match details {
-                    Some(ref d) if d.name != USER_DELETED_SENTINEL => filtered_ids.push(id),
+                    Some(ref d) if !d.deleted => filtered_ids.push(id),
                     _ => deleted_ids.push(id),
                 }
             }
@@ -177,13 +177,9 @@ impl UserStream {
         let mut user_ids = Vec::new();
 
         for row in rows {
-            let maybe_rec_user_id = row.get::<Option<String>>("recommended_user_id")?;
-            let maybe_rec_user_name = row.get::<Option<String>>("recommended_user_name")?;
-
-            if let (Some(user_id), Some(user_name)) = (maybe_rec_user_id, maybe_rec_user_name) {
-                if user_name != USER_DELETED_SENTINEL {
-                    user_ids.push(user_id);
-                }
+            // Deleted users are filtered in Cypher; only the user ID is projected.
+            if let Some(uid) = row.get::<Option<String>>("recommended_user_id")? {
+                user_ids.push(uid);
             }
         }
 
@@ -266,7 +262,7 @@ impl UserStream {
 
         for ((id, _score), details) in set.into_iter().zip(details_list) {
             match details {
-                Some(ref d) if d.name != USER_DELETED_SENTINEL => filtered_ids.push(id),
+                Some(ref d) if !d.deleted => filtered_ids.push(id),
                 _ => deleted_ids.push(id),
             }
         }

--- a/nexus-watcher/src/events/handlers/user.rs
+++ b/nexus-watcher/src/events/handlers/user.rs
@@ -21,13 +21,15 @@ pub async fn sync_put(user: PubkyAppUser, user_id: PubkyId) -> Result<(), EventP
     // Step 2: Save to graph
     user_details.put_to_graph().await?;
 
-    // Step 3: Run in parallel the cache process: SAVE TO INDEX
+    // Step 3: Reindex search BEFORE refreshing the details cache. `put_to_index`
+    // resolves the stale `name:id` member from the cached JSON, so a concurrent
+    // `UserDetails::put_to_index` could overwrite it with the new name first and
+    // leak the old member forever.
+    UserSearch::put_to_index(&[&user_details]).await?;
+
+    // Step 4: Run in parallel the remaining cache writes: SAVE TO INDEX
     let indexing_results = nexus_common::traced_join!(
         tracing::info_span!("index.write");
-        async {
-            UserSearch::put_to_index(&[&user_details]).await?;
-            Ok::<(), EventProcessorError>(())
-        },
         async {
             // TODO: Use SCARD on a set for unique tag count to avoid race conditions in parallel processing
             // If new user (no existing counts), save a new `UserCounts`
@@ -45,7 +47,6 @@ pub async fn sync_put(user: PubkyAppUser, user_id: PubkyId) -> Result<(), EventP
 
     indexing_results.0?;
     indexing_results.1?;
-    indexing_results.2?;
     Ok(())
 }
 

--- a/nexus-watcher/src/events/handlers/user.rs
+++ b/nexus-watcher/src/events/handlers/user.rs
@@ -6,7 +6,7 @@ use nexus_common::db::{
 };
 use nexus_common::models::{
     traits::Collection,
-    user::{UserCounts, UserDetails, UserSearch, USER_DELETED_SENTINEL},
+    user::{UserCounts, UserDetails, UserSearch},
 };
 use pubky_app_specs::{PubkyAppUser, PubkyId};
 use tracing::debug;
@@ -56,10 +56,9 @@ pub async fn del(user_id: PubkyId) -> Result<(), EventProcessorError> {
     // 1. Graph query to check if there is any edge at all to this user.
     let query = user_is_safe_to_delete(&user_id);
 
-    // 2. If there is no relationships (OperationOutcome::CreatedOrDeleted), delete from graph and redis.
-    // 3. But if there is any relationship (OperationOutcome::Updated), then we simply update the user with empty profile
-    // and keyword username [DELETED].
-    // A deleted user is a user whose profile is empty and has username `"[DELETED]"`
+    // 2. If there are no relationships (OperationOutcome::CreatedOrDeleted), delete from graph and redis.
+    // 3. If there are relationships (OperationOutcome::Updated), overwrite the node with a cleared
+    // profile carrying `deleted = true`. The node survives so its edges stay intact.
     match execute_graph_operation(query).await? {
         OperationOutcome::CreatedOrDeleted => {
             // 1. UserSearch reads UserDetails — must run before UserDetails Redis is removed
@@ -81,15 +80,20 @@ pub async fn del(user_id: PubkyId) -> Result<(), EventProcessorError> {
             exec_single_row(queries::del::delete_user(&user_id)).await?;
         }
         OperationOutcome::Updated => {
-            let deleted_user = PubkyAppUser {
-                name: USER_DELETED_SENTINEL.to_string(),
-                bio: None,
-                status: None,
-                links: None,
-                image: None,
-            };
+            // 1. UserSearch resolves the indexed name from UserDetails — must run
+            // before the profile is wiped, or the stale entry cannot be removed.
+            UserSearch::delete(&user_id).await?;
 
-            sync_put(deleted_user, user_id).await?;
+            // 2. Graph-first: write the tombstone before invalidating the cache.
+            // Collection::get_by_ids repopulates the cache from the graph on a miss,
+            // so invalidating first would let a concurrent read cache the live profile
+            // again — and nothing would invalidate it a second time.
+            UserDetails::tombstone(&user_id).put_to_graph().await?;
+
+            // 3. Invalidate cached UserDetails JSON so subsequent reads see the tombstone.
+            let key_parts: &[&str] = &[user_id.as_ref()];
+            let key_parts_list = [key_parts];
+            UserDetails::remove_from_index_multiple_json(&key_parts_list).await?;
         }
         OperationOutcome::MissingDependency => return Err(EventProcessorError::SkipIndexing),
     }

--- a/nexus-watcher/tests/event_processor/users/del_with_relations.rs
+++ b/nexus-watcher/tests/event_processor/users/del_with_relations.rs
@@ -4,7 +4,8 @@ use crate::{
 };
 use anyhow::Result;
 use chrono::Utc;
-use nexus_common::models::user::{UserCounts, UserStream, UserView, USER_DELETED_SENTINEL};
+use nexus_common::models::traits::Collection;
+use nexus_common::models::user::{UserCounts, UserDetails, UserSearch, UserStream, UserView};
 use pubky::Keypair;
 use pubky_app_specs::{
     traits::{HasIdPath, HashId},
@@ -40,24 +41,19 @@ async fn test_delete_user_with_relationships() -> Result<()> {
     // Delete the user
     test.cleanup_user(&user_kp).await?;
 
-    // Fetch user details; should be updated to "[DELETED]"
+    // Fetch user details; the profile must be wiped and the deleted flag set.
     let user_details = find_user_details(&user_id).await?;
-    assert_eq!(
-        user_details.name, USER_DELETED_SENTINEL,
-        "User name should be '[DELETED]' after deletion"
+    assert!(
+        user_details.deleted,
+        "User should be marked as deleted after deletion with relationships"
     );
     assert_eq!(
-        user_details.bio, None,
-        "User bio should be 'null' after deletion.",
+        user_details.name, "",
+        "User name should be cleared after deletion"
     );
-    assert_eq!(
-        user_details.status, None,
-        "User status should be None after deletion"
-    );
-    assert_eq!(
-        user_details.image, None,
-        "User image should be None after deletion"
-    );
+    assert_eq!(user_details.bio, None, "User bio should be cleared");
+    assert_eq!(user_details.status, None, "User status should be cleared");
+    assert_eq!(user_details.image, None, "User image should be cleared");
 
     // User counts should still exist
     let user_counts = find_user_counts(&user_id).await;
@@ -73,9 +69,13 @@ async fn test_delete_user_with_relationships() -> Result<()> {
         "User view should be present after deletion"
     );
     let user_view = user_view.unwrap();
+    assert!(
+        user_view.details.deleted,
+        "User view should report deleted: true after tombstoning"
+    );
     assert_eq!(
-        user_view.details.name, USER_DELETED_SENTINEL,
-        "User view name should be '[DELETED]' after deletion"
+        user_view.details.name, "",
+        "User view name should be cleared after deletion"
     );
 
     // Now delete the user's post
@@ -163,23 +163,22 @@ async fn test_delete_user_with_relationships() -> Result<()> {
     // Delete the user
     test.cleanup_user(&user_with_kp).await?;
 
-    // Fetch user details; should be updated to "[DELETED]"
+    // Fetch user details; the profile must be wiped and the deleted flag set.
     let user_details = find_user_details(&user_with_id).await?;
-    assert_eq!(
-        user_details.name, USER_DELETED_SENTINEL,
-        "User name should be '[DELETED]' after deletion"
+    assert!(
+        user_details.deleted,
+        "User should be marked as deleted after deletion with relationships"
     );
     assert_eq!(
-        user_details.bio, None,
-        "User bio should be 'null' after deletion.",
+        user_details.name, "",
+        "User name should be cleared after deletion"
     );
-    assert_eq!(
-        user_details.status, None,
-        "User status should be None after deletion"
-    );
-    assert_eq!(
-        user_details.image, None,
-        "User image should be None after deletion"
+    assert_eq!(user_details.bio, None, "User bio should be cleared");
+    assert_eq!(user_details.status, None, "User status should be cleared");
+    assert_eq!(user_details.image, None, "User image should be cleared");
+    assert!(
+        user_details.links.is_none(),
+        "User links should be cleared after deletion"
     );
 
     // User counts should still exist
@@ -199,8 +198,12 @@ async fn test_delete_user_with_relationships() -> Result<()> {
     );
     let user_view = user_view.unwrap();
     assert_eq!(
-        user_view.details.name, USER_DELETED_SENTINEL,
-        "User view name should be '[DELETED]' after deletion"
+        user_view.details.name, "",
+        "User view name should be cleared after deletion"
+    );
+    assert!(
+        user_view.details.deleted,
+        "User view should report deleted: true after tombstoning"
     );
 
     // Now delete the user's post
@@ -297,6 +300,210 @@ async fn test_delete_recommended_user() -> Result<()> {
     let alice_recommended_ids_res_2 = UserStream::get_recommended_ids(&alice_id, None).await;
     let alice_recommended_ids_2 = alice_recommended_ids_res_2.unwrap();
     assert_eq!(alice_recommended_ids_2, None);
+
+    Ok(())
+}
+
+/// Resurrection: delete a user with relationships, re-PUT a profile, assert deleted == false
+/// and that the user is visible again in streams.
+#[tokio_shared_rt::test(shared)]
+async fn test_user_resurrection() -> Result<()> {
+    let mut test = WatcherTest::setup(None).await?;
+
+    // Create a user
+    let user_kp = Keypair::random();
+    let user = PubkyAppUser {
+        bio: Some("Resurrection test user".to_string()),
+        image: None,
+        links: None,
+        name: "Watcher:UserResurrection:User".to_string(),
+        status: None,
+    };
+    let user_id = test.create_user(&user_kp, &user).await?;
+
+    // Create a post to establish a relationship
+    let post = PubkyAppPost {
+        content: "User's post before deletion".to_string(),
+        kind: PubkyAppPostKind::Short,
+        parent: None,
+        embed: None,
+        attachments: None,
+        lock: None,
+    };
+    test.create_post(&user_kp, &post).await?;
+
+    // Delete the user (tombstone with relationships)
+    test.cleanup_user(&user_kp).await?;
+
+    // Verify deleted flag is set
+    let user_details = find_user_details(&user_id).await?;
+    assert!(
+        user_details.deleted,
+        "User should be marked as deleted after tombstoning"
+    );
+
+    // Re-PUT a profile (resurrection)
+    let revived_user = PubkyAppUser {
+        bio: Some("Revived!".to_string()),
+        image: None,
+        links: None,
+        name: "Watcher:UserResurrection:User".to_string(),
+        status: None,
+    };
+    test.create_profile(&user_kp, &revived_user).await?;
+
+    // Verify deleted flag is cleared — create_user always sets deleted: false
+    let user_details = find_user_details(&user_id).await?;
+    assert!(
+        !user_details.deleted,
+        "User should NOT be deleted after re-PUTting their profile (resurrection)"
+    );
+    assert_eq!(user_details.name, "Watcher:UserResurrection:User");
+    assert_eq!(user_details.bio, Some("Revived!".to_string()));
+
+    // User should be visible in search
+    let search_result =
+        nexus_common::models::user::UserSearch::get_by_name("Watcher:UserResurrection", None, None)
+            .await?;
+    assert!(
+        search_result.is_some(),
+        "Resurrected user should be visible in name search"
+    );
+    let search_ids = search_result.unwrap().0;
+    assert!(
+        search_ids.contains(&user_id),
+        "Resurrected user ID should appear in search results"
+    );
+
+    Ok(())
+}
+
+/// A tombstoned user must drop out of both search indexes, and stay out: the
+/// `deleted` filter in `put_to_index` stops a cache-miss read from re-adding them.
+#[tokio_shared_rt::test(shared)]
+async fn test_deleted_user_removed_from_search() -> Result<()> {
+    let mut test = WatcherTest::setup(None).await?;
+
+    // Create a user
+    let user_kp = Keypair::random();
+    let user = PubkyAppUser {
+        bio: None,
+        image: None,
+        links: None,
+        name: "Watcher:DeletedInSearch:User".to_string(),
+        status: None,
+    };
+    let user_id = test.create_user(&user_kp, &user).await?;
+
+    // Create a post so the user has relationships and will be tombstoned
+    let post = PubkyAppPost {
+        content: "A post".to_string(),
+        kind: PubkyAppPostKind::Short,
+        parent: None,
+        embed: None,
+        attachments: None,
+        lock: None,
+    };
+    test.create_post(&user_kp, &post).await?;
+
+    // Delete the user
+    test.cleanup_user(&user_kp).await?;
+
+    // Verify deleted flag
+    let user_details = find_user_details(&user_id).await?;
+    assert!(user_details.deleted, "User should be marked as deleted");
+
+    // The old name must no longer resolve to this user
+    let search_ids =
+        nexus_common::models::user::UserSearch::get_by_name("Watcher:DeletedInSearch", None, None)
+            .await?
+            .map(|s| s.0)
+            .unwrap_or_default();
+    assert!(
+        !search_ids.contains(&user_id),
+        "Deleted user should be removed from name search"
+    );
+
+    // ...nor should the ID index still carry them
+    let id_search_ids = nexus_common::models::user::UserSearch::get_by_id(
+        user_id.chars().take(10).collect::<String>().as_str(),
+        None,
+        None,
+    )
+    .await?
+    .map(|s| s.0)
+    .unwrap_or_default();
+    assert!(
+        !id_search_ids.contains(&user_id),
+        "Deleted user should be removed from ID search"
+    );
+
+    Ok(())
+}
+
+/// Regression: a user node whose name is the literal "[DELETED]" must report
+/// deleted: false and stay visible in name search — deletion is the flag, never
+/// the name. The old sentinel-name scheme was deliberate, but it conflated a
+/// legitimate name with a tombstone, which is why the flag replaced it.
+///
+/// `PubkyAppUser::sanitize` rewrites that name to "anonymous", so the shape is
+/// unreachable through a profile.json event and only exists for rows written
+/// before the flag. The test reproduces it by ingesting normally and then
+/// renaming through the model, below the sanitize boundary.
+#[tokio_shared_rt::test(shared)]
+async fn test_live_user_with_sentinel_name_is_not_tombstoned() -> Result<()> {
+    let mut test = WatcherTest::setup(None).await?;
+
+    let user_kp = Keypair::random();
+    let user = PubkyAppUser {
+        bio: Some("I chose this name intentionally".to_string()),
+        image: None,
+        links: None,
+        name: "Watcher:SentinelName".to_string(),
+        status: None,
+    };
+    let user_id = test.create_user(&user_kp, &user).await?;
+
+    // Rename to the legacy sentinel while staying live.
+    let mut user_details = find_user_details(&user_id).await?;
+    user_details.name = "[DELETED]".to_string();
+    user_details.put_to_graph().await?;
+
+    // Order matters: `UserSearch::put_to_index` drops the stale `name:id` member
+    // by resolving the OLD name from the cached JSON, so refresh that cache only
+    // afterwards — `UserDetails::put_to_index` writes it before reindexing search.
+    UserSearch::put_to_index(&[&user_details]).await?;
+    UserDetails::put_to_index(&[&user_details.id], vec![Some(user_details.clone())]).await?;
+
+    // The node keeps the sentinel name and is still live
+    let stored = find_user_details(&user_id).await?;
+    assert_eq!(stored.name, "[DELETED]");
+    assert!(
+        !stored.deleted,
+        "A live user with name '[DELETED]' should NOT be treated as deleted"
+    );
+
+    // User should be visible in search under the sentinel name
+    let search_result = UserSearch::get_by_name("[DELETED]", None, None).await?;
+    assert!(
+        search_result.is_some(),
+        "User with name '[DELETED]' should appear in name search"
+    );
+    let search_ids = search_result.unwrap().0;
+    assert!(
+        search_ids.contains(&user_id),
+        "User with name '[DELETED]' should be visible in name search"
+    );
+
+    // ...and the pre-rename name must no longer resolve to them
+    let stale_ids = UserSearch::get_by_name("Watcher:SentinelName", None, None)
+        .await?
+        .map(|s| s.0)
+        .unwrap_or_default();
+    assert!(
+        !stale_ids.contains(&user_id),
+        "Renamed user should be dropped from the old name index"
+    );
 
     Ok(())
 }

--- a/nexus-watcher/tests/event_processor/users/del_with_relations.rs
+++ b/nexus-watcher/tests/event_processor/users/del_with_relations.rs
@@ -4,12 +4,13 @@ use crate::{
 };
 use anyhow::Result;
 use chrono::Utc;
-use nexus_common::models::traits::Collection;
-use nexus_common::models::user::{UserCounts, UserDetails, UserSearch, UserStream, UserView};
+use nexus_common::models::user::{UserCounts, UserSearch, UserStream, UserView};
+use nexus_watcher::events::handlers;
 use pubky::Keypair;
 use pubky_app_specs::{
     traits::{HasIdPath, HashId},
     PubkyAppBlob, PubkyAppFile, PubkyAppPost, PubkyAppPostKind, PubkyAppUser, PubkyAppUserLink,
+    PubkyId,
 };
 
 #[tokio_shared_rt::test(shared)]
@@ -449,7 +450,7 @@ async fn test_deleted_user_removed_from_search() -> Result<()> {
 /// `PubkyAppUser::sanitize` rewrites that name to "anonymous", so the shape is
 /// unreachable through a profile.json event and only exists for rows written
 /// before the flag. The test reproduces it by ingesting normally and then
-/// renaming through the model, below the sanitize boundary.
+/// calling `user::sync_put` directly, below the sanitize boundary.
 #[tokio_shared_rt::test(shared)]
 async fn test_live_user_with_sentinel_name_is_not_tombstoned() -> Result<()> {
     let mut test = WatcherTest::setup(None).await?;
@@ -463,17 +464,15 @@ async fn test_live_user_with_sentinel_name_is_not_tombstoned() -> Result<()> {
         status: None,
     };
     let user_id = test.create_user(&user_kp, &user).await?;
-
-    // Rename to the legacy sentinel while staying live.
-    let mut user_details = find_user_details(&user_id).await?;
-    user_details.name = "[DELETED]".to_string();
-    user_details.put_to_graph().await?;
-
-    // Order matters: `UserSearch::put_to_index` drops the stale `name:id` member
-    // by resolving the OLD name from the cached JSON, so refresh that cache only
-    // afterwards — `UserDetails::put_to_index` writes it before reindexing search.
-    UserSearch::put_to_index(&[&user_details]).await?;
-    UserDetails::put_to_index(&[&user_details.id], vec![Some(user_details.clone())]).await?;
+    
+    // Rename to the legacy sentinel while staying live. Goes through the real
+    // handler so graph and both indexes are written in production order.
+    let renamed = PubkyAppUser {
+        name: "[DELETED]".to_string(),
+        ..user
+    };
+    let user_pubky_id = PubkyId::try_from(user_id.as_str()).map_err(anyhow::Error::msg)?;
+    handlers::user::sync_put(renamed, user_pubky_id).await?;
 
     // The node keeps the sentinel name and is still live
     let stored = find_user_details(&user_id).await?;

--- a/nexus-watcher/tests/event_processor/users/del_with_relations.rs
+++ b/nexus-watcher/tests/event_processor/users/del_with_relations.rs
@@ -464,7 +464,7 @@ async fn test_live_user_with_sentinel_name_is_not_tombstoned() -> Result<()> {
         status: None,
     };
     let user_id = test.create_user(&user_kp, &user).await?;
-    
+
     // Rename to the legacy sentinel while staying live. Goes through the real
     // handler so graph and both indexes are written in production order.
     let renamed = PubkyAppUser {

--- a/nexus-watcher/tests/event_processor/users/moderated.rs
+++ b/nexus-watcher/tests/event_processor/users/moderated.rs
@@ -78,6 +78,8 @@ async fn test_moderated_user_lifecycle() -> Result<()> {
     // 9. Confirm the user does exist but the profile has been cleaned
     let details = find_user_details(&target_id).await?;
     assert_eq!(details.bio, None);
+    assert_eq!(details.name, "");
+    assert!(details.deleted, "Moderated user should be flagged deleted");
 
     Ok(())
 }

--- a/nexus-watcher/tests/service/event_processor_prioritization.rs
+++ b/nexus-watcher/tests/service/event_processor_prioritization.rs
@@ -172,6 +172,7 @@ async fn create_active_user_on_homeserver(hs_id: &PubkyId) -> Result<(), DynErro
         links: None,
         image: None,
         indexed_at: Utc::now().timestamp_millis(),
+        deleted: false,
     };
 
     user.put_to_graph().await?;

--- a/nexus-watcher/tests/service/hs_event_processor.rs
+++ b/nexus-watcher/tests/service/hs_event_processor.rs
@@ -34,6 +34,7 @@ async fn create_user_hosted_on(user_id: &str, hs_id: Option<&str>) {
         links: None,
         image: None,
         indexed_at: Utc::now().timestamp_millis(),
+        deleted: false,
     };
     exec_single_row(queries::put::create_user(&user).expect("create_user query"))
         .await

--- a/nexus-watcher/tests/service/key_based_event_processor.rs
+++ b/nexus-watcher/tests/service/key_based_event_processor.rs
@@ -624,6 +624,7 @@ async fn create_user_on_homeserver(homeserver: &Homeserver) -> Result<String, Dy
         links: None,
         image: None,
         indexed_at: Utc::now().timestamp_millis(),
+        deleted: false,
     };
 
     user.put_to_graph().await?;
@@ -659,6 +660,7 @@ fn test_user_details(user_id: &str) -> Result<UserDetails, DynError> {
         links: None,
         image: None,
         indexed_at: Utc::now().timestamp_millis(),
+        deleted: false,
     })
 }
 

--- a/nexus-watcher/tests/service/utils/processor.rs
+++ b/nexus-watcher/tests/service/utils/processor.rs
@@ -102,6 +102,7 @@ pub async fn create_random_homeservers_and_persist(
                 links: None,
                 image: None,
                 indexed_at: Utc::now().timestamp_millis(),
+                deleted: false,
             };
             user.put_to_graph().await.unwrap();
             set_user_homeserver(&user_id, &homeserver_id).await.unwrap();

--- a/nexus-webapi/benches/avatar.rs
+++ b/nexus-webapi/benches/avatar.rs
@@ -75,6 +75,7 @@ impl AvatarBenchSetup {
             status: None,
             image: Some(avatar_uri.clone()),
             indexed_at: 1_724_134_095_000,
+            deleted: false,
         };
 
         UserDetails::put_to_index(&[USER_PUBKY], vec![Some(user)])

--- a/nexus-webapi/tests/user/views.rs
+++ b/nexus-webapi/tests/user/views.rs
@@ -181,3 +181,34 @@ async fn test_get_details() -> Result<()> {
 
     Ok(())
 }
+
+/// Assert that the `deleted` field appears on both the `/details` and `/user` (view)
+/// responses and is serialized as a plain bool.
+#[tokio_shared_rt::test(shared)]
+async fn test_deleted_flag_in_details_and_view() -> Result<()> {
+    let user_id = "4snwyct86m383rsduhw5xgcxpw7c63j3pq8x4ycqikxgik8y64ro";
+
+    // /v0/user/{id}/details
+    let details = get_request(&format!("/v0/user/{user_id}/details")).await?;
+    assert!(
+        details["deleted"].is_boolean(),
+        "details response must serialize deleted as a boolean"
+    );
+    assert_eq!(
+        details["deleted"], false,
+        "live user must report deleted: false"
+    );
+
+    // /v0/user/{id} (UserView embeds UserDetails)
+    let view = get_request(&format!("/v0/user/{user_id}")).await?;
+    assert!(
+        view["details"]["deleted"].is_boolean(),
+        "view response must serialize deleted as a boolean"
+    );
+    assert_eq!(
+        view["details"]["deleted"], false,
+        "live user must report deleted: false in view response"
+    );
+
+    Ok(())
+}

--- a/nexusd/src/migrations/migrations_list/mod.rs
+++ b/nexusd/src/migrations/migrations_list/mod.rs
@@ -3,4 +3,5 @@ pub mod post_content_index_author_setup_1780531200;
 pub mod post_content_index_setup_1780444800;
 pub mod remove_muted_1771718400;
 pub mod resource_node_setup_1774000000;
+pub mod user_deleted_flag_1780617600;
 pub mod users_by_pk_reindex_1751635096;

--- a/nexusd/src/migrations/migrations_list/user_deleted_flag_1780617600.rs
+++ b/nexusd/src/migrations/migrations_list/user_deleted_flag_1780617600.rs
@@ -1,0 +1,144 @@
+use crate::migrations::manager::Migration;
+use async_trait::async_trait;
+use futures::StreamExt;
+use nexus_common::db::graph::Query;
+use nexus_common::db::{get_neo4j_graph, RedisOps};
+use nexus_common::models::user::UserDetails;
+use nexus_common::types::DynError;
+use tracing::info;
+
+/// Migrate from the `[DELETED]` name sentinel to a boolean `deleted` property.
+///
+/// # What this does
+/// - Sets `u.deleted = true` where `name = '[DELETED]'`, `false` everywhere else, so the
+///   property is present on every `:User` (enables dropping `coalesce()` later).
+/// - Invalidates cached tombstone JSON per page. Live users' pre-migration entries lack
+///   the key and deserialize to `false`, which is already correct.
+///
+/// # Batching
+/// Nothing indexes `:User(deleted)` or `:User(name)`, so the backfill scans once and lets
+/// the server commit per batch via `IN TRANSACTIONS`, instead of re-scanning per batch.
+/// Tombstone IDs use keyset pagination over the `uniqueUserId` index; `SKIP`/`LIMIT`
+/// replans as a label scan with `Limit $limit + $skip`, re-reading every earlier row.
+///
+/// # Idempotency
+/// Safe to re-run: the `SET` falsifies the `WHERE`. `is_multi_staged()` is `false`, so the
+/// manager marks this Done after one backfill; re-running needs the id in
+/// `migrations_backfill_ready`. The second disjunct
+/// (`u.name = '[DELETED]' AND u.deleted = false`) re-catches users tombstoned by
+/// pre-cutover code. `IN TRANSACTIONS` commits per batch, so a mid-run failure leaves the
+/// backfill partial and not Done, as the old client loop did; re-running finishes it.
+///
+/// # Rollback caveat
+/// New-code tombstones leave `name` empty, not `'[DELETED]'`. Rolling back to code that
+/// filters by the sentinel name makes them appear live, with an empty profile.
+///
+/// # Deploy ordering
+/// Hard cutover: stop every pre-cutover instance (nexus-watcher is the only tombstone
+/// writer), run `nexusd db migration run`, then start the new binaries. The first two
+/// steps must not overlap — old code tombstones via the sentinel name without touching
+/// `deleted`, so one written after the backfill drains reads as LIVE permanently,
+/// recoverable only by a re-run. Between the last two both readers are consistent: the
+/// backfill leaves `name` intact.
+pub struct UserDeletedFlag1780617600;
+
+/// Tombstone IDs invalidated per keyset page.
+const TOMBSTONE_PAGE_SIZE: usize = 10_000;
+
+#[async_trait]
+impl Migration for UserDeletedFlag1780617600 {
+    fn id(&self) -> &'static str {
+        "UserDeletedFlag1780617600"
+    }
+
+    fn is_multi_staged(&self) -> bool {
+        false
+    }
+
+    async fn dual_write(_data: Box<dyn std::any::Any + Send + 'static>) -> Result<(), DynError> {
+        Ok(())
+    }
+
+    async fn backfill(&self) -> Result<(), DynError> {
+        let graph = get_neo4j_graph()?;
+
+        // MATCH stays outside the subquery so IN TRANSACTIONS batches the rows it feeds in;
+        // the trailing count forces the batches to run. Drain predicate: see # Idempotency.
+        let query = Query::new(
+            "user_deleted_flag_backfill",
+            "MATCH (u:User)
+             WHERE u.deleted IS NULL OR (u.name = '[DELETED]' AND u.deleted = false)
+             CALL (u) {
+                 SET u.deleted = coalesce(u.name = '[DELETED]', false)
+             } IN TRANSACTIONS OF 10000 ROWS
+             RETURN count(u) AS processed",
+        );
+
+        let mut result = graph.execute(query).await?;
+        let processed: i64 = match result.next().await {
+            Some(Ok(row)) => row.get::<i64>("processed")?,
+            Some(Err(e)) => return Err(e.into()),
+            None => 0,
+        };
+        info!("UserDeletedFlag migration: {} users backfilled", processed);
+
+        // Tombstones only: live users' missing key already deserializes to false.
+        let mut cursor = String::new();
+        let mut total_tombstoned: usize = 0;
+
+        loop {
+            let page = Query::new(
+                "user_deleted_flag_tombstones",
+                "MATCH (u:User)
+                 WHERE u.deleted = true AND u.id > $cursor
+                 RETURN u.id AS id
+                 ORDER BY id
+                 LIMIT $limit",
+            )
+            .param("cursor", cursor.clone())
+            .param("limit", TOMBSTONE_PAGE_SIZE as i64);
+
+            let mut rows = graph.execute(page).await?;
+            let mut ids: Vec<String> = Vec::with_capacity(TOMBSTONE_PAGE_SIZE);
+            while let Some(row) = rows.next().await {
+                ids.push(row?.get::<String>("id")?);
+            }
+
+            // Empty page: past the last tombstone.
+            let Some(last_id) = ids.last().cloned() else {
+                break;
+            };
+            cursor = last_id;
+
+            let owned: Vec<Vec<&str>> = ids.iter().map(|id| vec![id.as_str()]).collect();
+            let key_parts_list: Vec<&[&str]> = owned.iter().map(|k| k.as_slice()).collect();
+            UserDetails::remove_from_index_multiple_json(&key_parts_list).await?;
+
+            total_tombstoned += ids.len();
+            info!(
+                "UserDeletedFlag migration: invalidated {} tombstone cache entries ({} total)",
+                ids.len(),
+                total_tombstoned
+            );
+
+            if ids.len() < TOMBSTONE_PAGE_SIZE {
+                break;
+            }
+        }
+
+        info!(
+            "UserDeletedFlag migration: complete — {} users backfilled, {} tombstones marked and cache-invalidated",
+            processed, total_tombstoned
+        );
+
+        Ok(())
+    }
+
+    async fn cutover(&self) -> Result<(), DynError> {
+        Ok(())
+    }
+
+    async fn cleanup(&self) -> Result<(), DynError> {
+        Ok(())
+    }
+}

--- a/nexusd/src/migrations/migrations_list/user_deleted_flag_1780617600.rs
+++ b/nexusd/src/migrations/migrations_list/user_deleted_flag_1780617600.rs
@@ -10,8 +10,12 @@ use tracing::info;
 /// Migrate from the `[DELETED]` name sentinel to a boolean `deleted` property.
 ///
 /// # What this does
-/// - Sets `u.deleted = true` where `name = '[DELETED]'`. Live users are left untouched, so
-///   `deleted IS NULL` stays a normal permanent state: every reader treats absent as live,
+/// - Sets `u.deleted = true` and clears `u.name` where `name = '[DELETED]'`, converging old
+///   tombstones on the shape `UserDetails::tombstone` writes. Old ones already had
+///   `bio`/`status`/`links`/`image` wiped by the pre-cutover `sync_put`, so `name` was the
+///   only field that still differed. Clients that display the name no longer see two shapes.
+/// - Live users are left untouched, so `deleted IS NULL` stays a normal permanent state:
+///   every reader treats absent as live,
 ///   Cypher via `NOT coalesce(u.deleted, false)` and Rust via `deserialize_user_deleted`.
 ///   The filters keep their `coalesce()` — dropping it would make a missing property read
 ///   as deleted, which silently drops the user from `get_active_users_by_homeserver` and
@@ -25,17 +29,26 @@ use tracing::info;
 /// Tombstone IDs use keyset pagination over the `uniqueUserId` index; `SKIP`/`LIMIT`
 /// replans as a label scan with `Limit $limit + $skip`, re-reading every earlier row.
 ///
+/// # Why the name is authoritative here
+/// Only for the legacy rows this runs against: `PubkyAppUser::sanitize` rewrites a
+/// `[DELETED]` name to "anonymous", so no live user can reach that shape through a
+/// profile.json event, and every sentinel-named row predates the flag. The codebase
+/// otherwise treats the flag as the only signal — a live user renamed below the sanitize
+/// boundary (`test_live_user_with_sentinel_name_is_not_tombstoned`) must stay live, and a
+/// re-run would tombstone them and destroy the name irreversibly.
+///
 /// # Idempotency
-/// Safe to re-run: the `SET` falsifies the `WHERE`. `is_multi_staged()` is `false`, so the
-/// manager marks this Done after one backfill; re-running needs the id in
-/// `migrations_backfill_ready`. `coalesce()` in the predicate makes it match both an
-/// unmigrated tombstone (no property at all) and one written by pre-cutover code after the
-/// scan. `IN TRANSACTIONS` commits per batch, so a mid-run failure leaves the
-/// backfill partial and not Done, as the old client loop did; re-running finishes it.
+/// Safe to re-run: clearing `name` falsifies the `WHERE`. `is_multi_staged()` is `false`, so
+/// the manager marks this Done after one backfill; re-running needs the id in
+/// `migrations_backfill_ready`. `IN TRANSACTIONS` commits per batch, so a mid-run failure
+/// leaves the backfill partial and not Done, as the old client loop did; re-running
+/// finishes it.
 ///
 /// # Rollback caveat
-/// New-code tombstones leave `name` empty, not `'[DELETED]'`. Rolling back to code that
-/// filters by the sentinel name makes them appear live, with an empty profile.
+/// After this runs, *no* tombstone carries `'[DELETED]'` any more — the sentinel is gone
+/// from the graph entirely. Rolling back to code that filters by the sentinel name makes
+/// every tombstone appear live, with an empty profile, not just the ones written post-
+/// cutover. Only the flag distinguishes them, so a rollback needs the flag-aware readers.
 ///
 /// # Deploy ordering
 /// Hard cutover: stop every pre-cutover instance (nexus-watcher is the only tombstone
@@ -43,8 +56,10 @@ use tracing::info;
 /// steps must not overlap — old code tombstones via the sentinel name without touching
 /// `deleted`, so one written after the backfill drains reads as LIVE permanently,
 /// recoverable only by a re-run. The post-backfill verify catches such a write if it lands
-/// before the check, but it is a guard, not a guarantee. Between the last two both readers
-/// are consistent: the backfill leaves `name` intact.
+/// before the check, but it is a guard, not a guarantee. Clearing `name` also removes the
+/// old margin for error on the last step: a pre-cutover instance left running past the
+/// migration now sees every tombstone as a live user with an empty profile, where it used
+/// to still filter them by name.
 pub struct UserDeletedFlag1780617600;
 
 /// Tombstone IDs invalidated per keyset page.
@@ -72,9 +87,9 @@ impl Migration for UserDeletedFlag1780617600 {
         let query = Query::new(
             "user_deleted_flag_backfill",
             "MATCH (u:User)
-             WHERE u.name = '[DELETED]' AND coalesce(u.deleted, false) = false
+             WHERE u.name = '[DELETED]'
              CALL (u) {
-                 SET u.deleted = true
+                 SET u.deleted = true, u.name = ''
              } IN TRANSACTIONS OF 10000 ROWS
              RETURN count(u) AS processed",
         );
@@ -86,17 +101,17 @@ impl Migration for UserDeletedFlag1780617600 {
             None => 0,
         };
         info!(
-            "UserDeletedFlag migration: {} tombstones flagged",
+            "UserDeletedFlag migration: {} tombstones flagged and names cleared",
             processed
         );
 
-        // Re-run the drain predicate: a leftover row means either the batches did not all
-        // commit, or a pre-cutover writer tombstoned a user after the scan (see # Deploy
-        // ordering). Erroring here leaves the migration not Done, so a re-run is required.
+        // Re-run the drain predicate: a surviving sentinel name means either the batches did
+        // not all commit, or a pre-cutover writer tombstoned a user after the scan (see
+        // # Deploy ordering). Erroring here leaves the migration not Done, forcing a re-run.
         let verify = Query::new(
             "user_deleted_flag_verify",
             "MATCH (u:User)
-             WHERE u.name = '[DELETED]' AND coalesce(u.deleted, false) = false
+             WHERE u.name = '[DELETED]'
              RETURN count(u) AS remaining",
         );
 
@@ -108,14 +123,15 @@ impl Migration for UserDeletedFlag1780617600 {
         };
         if remaining != 0 {
             return Err(format!(
-                "UserDeletedFlag migration: backfill did not drain — {remaining} tombstones \
-                 still unflagged. Confirm every pre-cutover instance is stopped, then re-run \
-                 the migration before starting the new binaries."
+                "UserDeletedFlag migration: backfill did not drain — {remaining} users still \
+                 named '[DELETED]'. Confirm every pre-cutover instance is stopped, then \
+                 re-run the migration before starting the new binaries."
             )
             .into());
         }
 
-        // Tombstones only: live users' missing key already deserializes to false.
+        // Tombstones only: live users' missing key already deserializes to false. This pass
+        // is also what propagates the cleared name — cached JSON still holds '[DELETED]'.
         let mut cursor = String::new();
         let mut total_tombstoned: usize = 0;
 
@@ -160,7 +176,7 @@ impl Migration for UserDeletedFlag1780617600 {
         }
 
         info!(
-            "UserDeletedFlag migration: complete — {} tombstones flagged, {} tombstones marked and cache-invalidated",
+            "UserDeletedFlag migration: complete — {} tombstones flagged and cleared, {} cache entries invalidated",
             processed, total_tombstoned
         );
 

--- a/nexusd/src/migrations/migrations_list/user_deleted_flag_1780617600.rs
+++ b/nexusd/src/migrations/migrations_list/user_deleted_flag_1780617600.rs
@@ -10,8 +10,12 @@ use tracing::info;
 /// Migrate from the `[DELETED]` name sentinel to a boolean `deleted` property.
 ///
 /// # What this does
-/// - Sets `u.deleted = true` where `name = '[DELETED]'`, `false` everywhere else, so the
-///   property is present on every `:User` (enables dropping `coalesce()` later).
+/// - Sets `u.deleted = true` where `name = '[DELETED]'`. Live users are left untouched, so
+///   `deleted IS NULL` stays a normal permanent state: every reader treats absent as live,
+///   Cypher via `NOT coalesce(u.deleted, false)` and Rust via `deserialize_user_deleted`.
+///   The filters keep their `coalesce()` — dropping it would make a missing property read
+///   as deleted, which silently drops the user from `get_active_users_by_homeserver` and
+///   stops the watcher indexing them.
 /// - Invalidates cached tombstone JSON per page. Live users' pre-migration entries lack
 ///   the key and deserialize to `false`, which is already correct.
 ///
@@ -24,9 +28,9 @@ use tracing::info;
 /// # Idempotency
 /// Safe to re-run: the `SET` falsifies the `WHERE`. `is_multi_staged()` is `false`, so the
 /// manager marks this Done after one backfill; re-running needs the id in
-/// `migrations_backfill_ready`. The second disjunct
-/// (`u.name = '[DELETED]' AND u.deleted = false`) re-catches users tombstoned by
-/// pre-cutover code. `IN TRANSACTIONS` commits per batch, so a mid-run failure leaves the
+/// `migrations_backfill_ready`. `coalesce()` in the predicate makes it match both an
+/// unmigrated tombstone (no property at all) and one written by pre-cutover code after the
+/// scan. `IN TRANSACTIONS` commits per batch, so a mid-run failure leaves the
 /// backfill partial and not Done, as the old client loop did; re-running finishes it.
 ///
 /// # Rollback caveat
@@ -38,8 +42,9 @@ use tracing::info;
 /// writer), run `nexusd db migration run`, then start the new binaries. The first two
 /// steps must not overlap — old code tombstones via the sentinel name without touching
 /// `deleted`, so one written after the backfill drains reads as LIVE permanently,
-/// recoverable only by a re-run. Between the last two both readers are consistent: the
-/// backfill leaves `name` intact.
+/// recoverable only by a re-run. The post-backfill verify catches such a write if it lands
+/// before the check, but it is a guard, not a guarantee. Between the last two both readers
+/// are consistent: the backfill leaves `name` intact.
 pub struct UserDeletedFlag1780617600;
 
 /// Tombstone IDs invalidated per keyset page.
@@ -67,9 +72,9 @@ impl Migration for UserDeletedFlag1780617600 {
         let query = Query::new(
             "user_deleted_flag_backfill",
             "MATCH (u:User)
-             WHERE u.deleted IS NULL OR (u.name = '[DELETED]' AND u.deleted = false)
+             WHERE u.name = '[DELETED]' AND coalesce(u.deleted, false) = false
              CALL (u) {
-                 SET u.deleted = coalesce(u.name = '[DELETED]', false)
+                 SET u.deleted = true
              } IN TRANSACTIONS OF 10000 ROWS
              RETURN count(u) AS processed",
         );
@@ -80,7 +85,35 @@ impl Migration for UserDeletedFlag1780617600 {
             Some(Err(e)) => return Err(e.into()),
             None => 0,
         };
-        info!("UserDeletedFlag migration: {} users backfilled", processed);
+        info!(
+            "UserDeletedFlag migration: {} tombstones flagged",
+            processed
+        );
+
+        // Re-run the drain predicate: a leftover row means either the batches did not all
+        // commit, or a pre-cutover writer tombstoned a user after the scan (see # Deploy
+        // ordering). Erroring here leaves the migration not Done, so a re-run is required.
+        let verify = Query::new(
+            "user_deleted_flag_verify",
+            "MATCH (u:User)
+             WHERE u.name = '[DELETED]' AND coalesce(u.deleted, false) = false
+             RETURN count(u) AS remaining",
+        );
+
+        let mut result = graph.execute(verify).await?;
+        let remaining: i64 = match result.next().await {
+            Some(Ok(row)) => row.get::<i64>("remaining")?,
+            Some(Err(e)) => return Err(e.into()),
+            None => return Err("UserDeletedFlag migration: verify query returned no rows".into()),
+        };
+        if remaining != 0 {
+            return Err(format!(
+                "UserDeletedFlag migration: backfill did not drain — {remaining} tombstones \
+                 still unflagged. Confirm every pre-cutover instance is stopped, then re-run \
+                 the migration before starting the new binaries."
+            )
+            .into());
+        }
 
         // Tombstones only: live users' missing key already deserializes to false.
         let mut cursor = String::new();
@@ -127,7 +160,7 @@ impl Migration for UserDeletedFlag1780617600 {
         }
 
         info!(
-            "UserDeletedFlag migration: complete — {} users backfilled, {} tombstones marked and cache-invalidated",
+            "UserDeletedFlag migration: complete — {} tombstones flagged, {} tombstones marked and cache-invalidated",
             processed, total_tombstoned
         );
 

--- a/nexusd/src/migrations/mod.rs
+++ b/nexusd/src/migrations/mod.rs
@@ -13,6 +13,7 @@ use crate::migrations::migrations_list::post_content_index_author_setup_17805312
 use crate::migrations::migrations_list::post_content_index_setup_1780444800::PostContentIndexSetup1780444800;
 use crate::migrations::migrations_list::remove_muted_1771718400::RemoveMuted1771718400;
 use crate::migrations::migrations_list::resource_node_setup_1774000000::ResourceNodeSetup1774000000;
+use crate::migrations::migrations_list::user_deleted_flag_1780617600::UserDeletedFlag1780617600;
 use crate::migrations::migrations_list::users_by_pk_reindex_1751635096::UsersByPkReindex1751635096;
 /// Registers migrations with the `MigrationManager`
 ///
@@ -47,6 +48,7 @@ pub fn import_migrations(migration_manager: &mut MigrationManager) {
         Box::new(ResourceNodeSetup1774000000),
         Box::new(PostContentIndexSetup1780444800),
         Box::new(PostContentIndexAuthorSetup1780531200),
+        Box::new(UserDeletedFlag1780617600),
     ];
     for migration in migrations {
         migration_manager.register(migration);


### PR DESCRIPTION
Tombstoned users get `deleted = true` instead of having their name overwritten, so a live user named "[DELETED]" is no longer treated as deleted.

 New-code tombstones leave `name` empty, not `'[DELETED]'`. Rolling back to code that filters by the sentinel name makes them appear live, with an empty profile.