### PR TITLE
fix: preserve key-based indexing progress on timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3064,7 +3064,7 @@ dependencies = [
  "redis",
  "serde",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-shared-rt",
  "tracing",

--- a/nexus-watcher/src/events/retry/processor.rs
+++ b/nexus-watcher/src/events/retry/processor.rs
@@ -14,7 +14,7 @@ use super::IndexKey;
 use super::RetryEvent;
 use super::RetryScheduler;
 use crate::events::{DefaultEventHandler, EventHandler};
-use crate::service::indexer::TEventProcessor;
+use crate::service::indexer::{ProcessorResult, RunCompletion, RunContext, TEventProcessor};
 
 /// Maximum number of retry events to fetch per batch to avoid memory spikes
 const RETRY_BATCH_SIZE: usize = 100;
@@ -43,7 +43,7 @@ impl TEventProcessor for RetryProcessor {
         None
     }
 
-    async fn run_internal(self: Arc<Self>) -> Result<(), EventProcessorError> {
+    async fn run_internal(self: Arc<Self>, _context: RunContext) -> ProcessorResult {
         let now = Utc::now().timestamp_millis();
 
         loop {
@@ -51,7 +51,7 @@ impl TEventProcessor for RetryProcessor {
 
             if events.is_empty() {
                 debug!("No more events ready for retry");
-                return Ok(());
+                return Ok(RunCompletion::Completed);
             }
 
             info!("Processing batch of {} retry events", events.len());
@@ -59,7 +59,7 @@ impl TEventProcessor for RetryProcessor {
             for (index_key, retry_event) in events {
                 if *self.shutdown_rx.borrow() {
                     debug!("Shutdown detected; exiting retry processing loop");
-                    return Ok(());
+                    return Ok(RunCompletion::Completed);
                 }
 
                 self.process_retry_event(&index_key, retry_event).await?;

--- a/nexus-watcher/src/service/indexer/homeserver.rs
+++ b/nexus-watcher/src/service/indexer/homeserver.rs
@@ -1,4 +1,4 @@
-use super::TEventProcessor;
+use super::{ProcessorResult, RunCompletion, RunContext, TEventProcessor};
 use crate::errors::EventProcessorError;
 use crate::events::retry::RetryScheduler;
 use crate::events::{read_stream_capped, Event, EventHandler, MAX_EVENTS_BODY};
@@ -194,7 +194,7 @@ impl TEventProcessor for HsEventProcessor {
         }
     }
 
-    async fn run_internal(self: Arc<Self>) -> Result<(), EventProcessorError> {
+    async fn run_internal(self: Arc<Self>, _context: RunContext) -> ProcessorResult {
         let maybe_event_lines = self
             .poll_events()
             .await
@@ -208,7 +208,7 @@ impl TEventProcessor for HsEventProcessor {
             }
         }
 
-        Ok(())
+        Ok(RunCompletion::Completed)
     }
 }
 

--- a/nexus-watcher/src/service/indexer/key_based.rs
+++ b/nexus-watcher/src/service/indexer/key_based.rs
@@ -17,13 +17,56 @@ use pubky_app_specs::PubkyId;
 use tokio::sync::watch::Receiver;
 use tracing::{debug, error, info, warn};
 
-use super::TEventProcessor;
+use super::{ProcessorResult, RunCompletion, RunContext, TEventProcessor, TimeoutPolicy};
 use crate::events::retry::RetryScheduler;
 use crate::events::EventHandler;
 use crate::service::runner::UserNotFoundBackoff;
 use crate::service::user_hs_resolver;
 
 const FETCH_EVENTS_429_BACKOFF_SECS: [u64; 3] = [1, 2, 3];
+const CURSOR_PERSIST_BACKOFF_MS: [u64; 2] = [100, 250];
+const KEY_BASED_TIMEOUT_GRACE: Duration = Duration::from_secs(10);
+
+/// Controls whether homeserver indexing continues after processing one user.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ProcessingControl {
+    /// Continue with the next user.
+    Continue,
+    /// End the run and report cooperative budget exhaustion.
+    StopOnBudgetExhaustion,
+}
+
+/// Progress from processing one user's events, before cursor persistence.
+struct EventProgress {
+    latest_cursor: Option<u64>,
+    result: Result<ProcessingControl, EventProcessorError>,
+}
+
+impl EventProgress {
+    /// Keep going; persist `latest_cursor` if any.
+    fn continuing(latest_cursor: Option<u64>) -> Self {
+        Self {
+            latest_cursor,
+            result: Ok(ProcessingControl::Continue),
+        }
+    }
+
+    /// Budget exhausted; persist `latest_cursor` if any, then stop.
+    fn stop_on_budget_exhaustion(latest_cursor: Option<u64>) -> Self {
+        Self {
+            latest_cursor,
+            result: Ok(ProcessingControl::StopOnBudgetExhaustion),
+        }
+    }
+
+    /// Handler or validation failed; persist `latest_cursor` if any, then return the error.
+    fn failed(latest_cursor: Option<u64>, error: EventProcessorError) -> Self {
+        Self {
+            latest_cursor,
+            result: Err(error),
+        }
+    }
+}
 
 /// Counter for per-user stream events an External HS returned at or below the
 /// ordering floor — a replay of already-indexed data, or a regression against an
@@ -149,7 +192,13 @@ impl TEventProcessor for KeyBasedEventProcessor {
         Some(Duration::from_mins(8))
     }
 
-    async fn run_internal(self: Arc<Self>) -> Result<(), EventProcessorError> {
+    fn timeout_policy(&self) -> TimeoutPolicy {
+        TimeoutPolicy::Cooperative {
+            grace: KEY_BASED_TIMEOUT_GRACE,
+        }
+    }
+
+    async fn run_internal(self: Arc<Self>, context: RunContext) -> ProcessorResult {
         let hs_id = self.homeserver_id.to_string();
 
         // Blacklisted HSs must never be indexed. The runner already excludes
@@ -168,7 +217,7 @@ impl TEventProcessor for KeyBasedEventProcessor {
 
         if users.is_empty() {
             debug!("No users, skipping");
-            return Ok(());
+            return Ok(RunCompletion::Completed);
         }
 
         info!(user_count = users.len(), "Found users");
@@ -177,6 +226,10 @@ impl TEventProcessor for KeyBasedEventProcessor {
             if *self.shutdown_rx.borrow() {
                 debug!("Shutdown detected; stopping user iteration");
                 break;
+            }
+            if context.is_budget_exhausted() {
+                debug!("Run budget exhausted; stopping user iteration");
+                return Ok(RunCompletion::BudgetExhausted);
             }
             let user_id = user_pk.z32();
 
@@ -190,8 +243,14 @@ impl TEventProcessor for KeyBasedEventProcessor {
                 continue;
             }
 
-            match self.process_user(&hs_pk, user_pk, *cursor).await {
-                Ok(()) => self.user_not_found_backoff.record_success(user_pk).await,
+            match self.process_user(&hs_pk, user_pk, *cursor, &context).await {
+                Ok(control) => {
+                    self.user_not_found_backoff.record_success(user_pk).await;
+
+                    if control == ProcessingControl::StopOnBudgetExhaustion {
+                        return Ok(RunCompletion::BudgetExhausted);
+                    }
+                }
                 Err(err) => {
                     if err.should_not_retry_now() {
                         error!(
@@ -217,7 +276,7 @@ impl TEventProcessor for KeyBasedEventProcessor {
             }
         }
 
-        Ok(())
+        Ok(RunCompletion::Completed)
     }
 }
 
@@ -262,27 +321,65 @@ impl KeyBasedEventProcessor {
         hs_pk: &PublicKey,
         user_pk: &PublicKey,
         cursor: EventCursor,
-    ) -> Result<(), EventProcessorError> {
+        context: &RunContext,
+    ) -> Result<ProcessingControl, EventProcessorError> {
         let hs_id: &str = self.homeserver_id.as_ref();
         let stream_events = self
             .fetch_user_events_with_429_backoff(hs_pk, user_pk, cursor)
             .await?;
 
         let user_id = user_pk.z32();
-        let (latest_cursor, result) = self
-            .process_user_events(hs_id, &user_id, cursor.id(), stream_events)
+        let EventProgress {
+            latest_cursor,
+            result,
+        } = self
+            .process_user_events(hs_id, &user_id, cursor.id(), stream_events, context)
             .await;
 
-        if let Some(cursor_val) = latest_cursor {
-            if let Err(write_err) = UserHsCursor::write(&user_id, hs_id, cursor_val).await {
-                error!(
-                    %user_id, %cursor_val, ?write_err,
-                    "Best-effort cursor persist failed; events may be re-processed on next run",
-                );
-            }
+        if let Some(cursor_to_persist) = latest_cursor {
+            Self::persist_user_cursor(&user_id, hs_id, cursor_to_persist).await?;
         }
 
         result
+    }
+
+    /// Writes the user's homeserver cursor to Redis. On write failure, retries
+    /// with [`CURSOR_PERSIST_BACKOFF_MS`], then returns the last error.
+    async fn persist_user_cursor(
+        user_id: &str,
+        hs_id: &str,
+        cursor: u64,
+    ) -> Result<(), EventProcessorError> {
+        let mut retry_index = 0;
+
+        loop {
+            match UserHsCursor::write(user_id, hs_id, cursor).await {
+                Ok(()) => return Ok(()),
+                Err(error) => {
+                    let Some(&backoff_ms) = CURSOR_PERSIST_BACKOFF_MS.get(retry_index) else {
+                        error!(
+                            %user_id,
+                            %cursor,
+                            attempts = retry_index + 1,
+                            ?error,
+                            "Failed to persist user cursor after retries",
+                        );
+                        return Err(error.into());
+                    };
+
+                    warn!(
+                        %user_id,
+                        %cursor,
+                        attempt = retry_index + 1,
+                        retry_after_ms = backoff_ms,
+                        ?error,
+                        "Failed to persist user cursor; retrying",
+                    );
+                    tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
+                    retry_index += 1;
+                }
+            }
+        }
     }
 
     async fn fetch_user_events_with_429_backoff(
@@ -335,26 +432,32 @@ impl KeyBasedEventProcessor {
         user_id: &str,
         persisted_cursor: u64,
         stream_events: Vec<StreamEvent>,
-    ) -> (Option<u64>, Result<(), EventProcessorError>) {
+        context: &RunContext,
+    ) -> EventProgress {
         if *self.shutdown_rx.borrow() {
             debug!(%user_id, "Shutdown detected; exiting event loop");
-            return (None, Ok(()));
+            return EventProgress::continuing(None);
+        }
+        if context.is_budget_exhausted() {
+            debug!(%user_id, "Run budget exhausted; exiting event loop");
+            return EventProgress::stop_on_budget_exhaustion(None);
         }
 
         let mut cursor_floor = persisted_cursor;
+
         for stream_event in &stream_events {
             let cursor_id = stream_event.cursor.id();
             if cursor_id <= cursor_floor {
                 OUT_OF_ORDER_CURSOR_EXTERNAL_HS
                     .add(1, &[KeyValue::new("hs_id", hs_id.to_string())]);
-                return (
+                return EventProgress::failed(
                     None,
-                    Err(EventProcessorError::EventCursorOutOfOrder {
+                    EventProcessorError::EventCursorOutOfOrder {
                         hs_id: hs_id.into(),
                         user_id: user_id.into(),
                         cursor: cursor_id,
                         cursor_floor,
-                    }),
+                    },
                 );
             }
             cursor_floor = cursor_id;
@@ -367,6 +470,10 @@ impl KeyBasedEventProcessor {
                 debug!(%user_id, "Shutdown detected; exiting event loop");
                 break;
             }
+            if context.is_budget_exhausted() {
+                debug!(%user_id, "Run budget exhausted; exiting event loop");
+                return EventProgress::stop_on_budget_exhaustion(latest_cursor);
+            }
 
             let cursor_id = stream_event.cursor.id();
 
@@ -375,13 +482,13 @@ impl KeyBasedEventProcessor {
             // because a foreign user PK with an unsupported path would
             // return Ok(None) thus skipping but also advancing latest_cursor.
             if let Err(err) = Self::validate_user_id(hs_id, &stream_event, user_id) {
-                return (latest_cursor, Err(err));
+                return EventProgress::failed(latest_cursor, err);
             }
 
             match Event::from_stream_event(&stream_event) {
                 Ok(Some(event)) => {
                     if let Err(err) = self.handle_event(&event).await {
-                        return (latest_cursor, Err(err));
+                        return EventProgress::failed(latest_cursor, err);
                     }
                 }
                 Ok(None) => { /* resource not handled by Nexus, skip */ }
@@ -399,9 +506,14 @@ impl KeyBasedEventProcessor {
             // logged parse errors. UserIdMismatch and handler errors return
             // before this point, so their cursor is not persisted.
             latest_cursor = Some(cursor_id);
+
+            if context.is_budget_exhausted() {
+                debug!(%user_id, %cursor_id, "Run budget exhausted after event");
+                return EventProgress::stop_on_budget_exhaustion(latest_cursor);
+            }
         }
 
-        (latest_cursor, Ok(()))
+        EventProgress::continuing(latest_cursor)
     }
 
     fn validate_user_id(

--- a/nexus-watcher/src/service/indexer/mod.rs
+++ b/nexus-watcher/src/service/indexer/mod.rs
@@ -90,22 +90,25 @@ pub trait TEventProcessor: Send + Sync + 'static {
             service = %instance_name,
             homeserver,
         );
-        let handle = tokio::spawn(self.run_internal().instrument(span));
+        let mut handle = tokio::spawn(self.run_internal().instrument(span));
 
-        let join_result = tokio::time::timeout(timeout, handle)
-            .await
-            .inspect_err(
-                |_| error!(service = %instance_name, homeserver, "Event processor timed out"),
-            )
-            .map_err(|_| RunError::TimedOut)?;
+        let join_result = match tokio::time::timeout(timeout, &mut handle).await {
+            Ok(result) => result,
+            Err(_) => {
+                error!(service = %instance_name, homeserver, "Event processor timed out");
+                handle.abort();
+                let _ = handle.await;
+                return Err(RunError::TimedOut);
+            }
+        };
 
         // The JoinError can be:
         // - join_error.is_panic() => panic by the inner future
         // - join_error.is_cancelled() => inner future was abruptly interrupted, for example
         //   - JoinHandle::abort() is called on the handle
         //   - the Tokio runtime is shut down
-        // In our model, we don't trigger such interruptions. Instead we use the shutdown signal
-        // to gracefully stop the event processing loop. Therefore we consider all JoinErrors as panics.
+        // Timeout cancellation is handled above. Any JoinError reaching this point is unexpected,
+        // so we treat it as a panic.
         let run_internal_result = join_result
             .inspect_err(|je| {
                 error!(

--- a/nexus-watcher/src/service/indexer/mod.rs
+++ b/nexus-watcher/src/service/indexer/mod.rs
@@ -1,10 +1,13 @@
 mod homeserver;
 mod key_based;
+mod processor_run;
 
 pub use homeserver::HsEventProcessor;
 pub use key_based::{KeyBasedEventProcessor, KeyBasedEventSource, PubkyKeyBasedEventSource};
+pub use processor_run::{ProcessorResult, RunCompletion, RunContext, RunError, TimeoutPolicy};
 
-use std::{fmt::Display, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
+use tokio::task::JoinHandle;
 
 use crate::errors::EventProcessorError;
 use crate::events::retry::RetryScheduler;
@@ -16,46 +19,52 @@ use tracing::{debug, error, trace, warn, Instrument};
 /// OpenTelemetry meter name shared by all watcher indexer metrics.
 pub(super) const METER_NAME: &str = "nexus.watcher";
 
-/// Possible error types of an event processor run
-#[derive(Debug)]
-pub enum RunError {
-    Internal(EventProcessorError),
-    Panicked,
-    TimedOut,
-}
-
-impl RunError {
-    pub fn is_panic(&self) -> bool {
-        matches!(self, RunError::Panicked)
-    }
-
-    pub fn is_timeout(&self) -> bool {
-        matches!(self, RunError::TimedOut)
-    }
-}
-
-impl std::error::Error for RunError {}
-
-impl Display for RunError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            RunError::Internal(err) => write!(f, "Internal error: {err}"),
-            RunError::Panicked => write!(f, "Execution panicked"),
-            RunError::TimedOut => write!(f, "Execution timed out"),
+fn resolve_processor_task_result(
+    result: Result<ProcessorResult, tokio::task::JoinError>,
+    instance_name: &str,
+    homeserver_id: Option<&str>,
+) -> Result<RunCompletion, RunError> {
+    let homeserver = homeserver_id.map(tracing::field::display);
+    match result {
+        Ok(Ok(completion)) => Ok(completion),
+        Ok(Err(error)) => {
+            error!(
+                service = %instance_name,
+                homeserver,
+                ?error,
+                "Event processor failed"
+            );
+            Err(RunError::Internal(error))
+        }
+        Err(error) => {
+            error!(
+                service = %instance_name,
+                homeserver,
+                ?error,
+                "Event processor task failed"
+            );
+            Err(RunError::Panicked)
         }
     }
 }
 
+async fn force_abort_processor_task(
+    handle: &mut JoinHandle<ProcessorResult>,
+) -> Result<RunCompletion, RunError> {
+    handle.abort();
+    // TODO: Bound this wait and fence unfinished tasks so later processor runs cannot overlap.
+    let _ = handle.await;
+    Err(RunError::TimedOut)
+}
+
 /// Asynchronous event processor interface for the Watcher service.
 ///
-/// This trait represents a component that can process events asynchronously and can be
-/// gracefully shut down through a watch channel.
+/// Processors support watcher-wide shutdown and may also observe a run-scoped
+/// budget through [`RunContext`].
 ///
 /// # Implementation Notes
-/// - Implementors should regularly check the `shutdown_rx` channel for shutdown signals
-///   and terminate gracefully when received
-/// - The method returns an `EventProcessorError` to allow for typed error handling across
-///   different processor implementations
+/// - Check watcher shutdown at safe processing boundaries.
+/// - Processors using cooperative timeouts should also check [`RunContext::is_budget_exhausted`].
 #[async_trait::async_trait]
 pub trait TEventProcessor: Send + Sync + 'static {
     /// Returns the event handler used to process events.
@@ -77,7 +86,7 @@ pub trait TEventProcessor: Send + Sync + 'static {
         None
     }
 
-    async fn run(self: Arc<Self>) -> Result<(), RunError> {
+    async fn run(self: Arc<Self>) -> Result<RunCompletion, RunError> {
         let timeout = self
             .custom_timeout()
             .unwrap_or(Duration::from_secs(PROCESSING_TIMEOUT_SECS));
@@ -85,57 +94,65 @@ pub trait TEventProcessor: Send + Sync + 'static {
         let instance_name = self.instance_name();
         let homeserver_id = self.homeserver_id().map(str::to_owned);
         let homeserver = homeserver_id.as_deref().map(tracing::field::display);
+        let timeout_policy = self.timeout_policy();
+
         let span = tracing::info_span!(
             "event_processor.run",
             service = %instance_name,
             homeserver,
         );
-        let mut handle = tokio::spawn(self.run_internal().instrument(span));
 
-        let join_result = match tokio::time::timeout(timeout, &mut handle).await {
-            Ok(result) => result,
-            Err(_) => {
-                error!(service = %instance_name, homeserver, "Event processor timed out");
-                handle.abort();
-                let _ = handle.await;
-                return Err(RunError::TimedOut);
+        let (budget_exhaustion_tx, context) = RunContext::with_budget_signal();
+        let mut handle = tokio::spawn(self.run_internal(context).instrument(span));
+
+        match tokio::time::timeout(timeout, &mut handle).await {
+            Ok(join_result) => {
+                resolve_processor_task_result(join_result, instance_name, homeserver_id.as_deref())
             }
-        };
+            Err(_) => match timeout_policy {
+                TimeoutPolicy::HardAbort => {
+                    error!(service = %instance_name, homeserver, "Event processor timed out");
+                    force_abort_processor_task(&mut handle).await
+                }
+                TimeoutPolicy::Cooperative { grace } => {
+                    debug!(
+                        service = %instance_name,
+                        homeserver,
+                        ?grace,
+                        "Event processor budget exhausted; requesting cooperative stop"
+                    );
+                    budget_exhaustion_tx.send_replace(true);
 
-        // The JoinError can be:
-        // - join_error.is_panic() => panic by the inner future
-        // - join_error.is_cancelled() => inner future was abruptly interrupted, for example
-        //   - JoinHandle::abort() is called on the handle
-        //   - the Tokio runtime is shut down
-        // Timeout cancellation is handled above. Any JoinError reaching this point is unexpected,
-        // so we treat it as a panic.
-        let run_internal_result = join_result
-            .inspect_err(|je| {
-                error!(
-                    service = %instance_name,
-                    homeserver,
-                    error = ?je,
-                    "Event processor JoinError"
-                )
-            })
-            .map_err(|_| RunError::Panicked)?;
-
-        run_internal_result
-            .inspect_err(|e| {
-                error!(
-                    service = %instance_name,
-                    homeserver,
-                    error = ?e,
-                    "Event processor failed"
-                )
-            })
-            .map_err(RunError::Internal)
+                    match tokio::time::timeout(grace, &mut handle).await {
+                        Ok(join_result) => resolve_processor_task_result(
+                            join_result,
+                            instance_name,
+                            homeserver_id.as_deref(),
+                        ),
+                        Err(_) => {
+                            error!(
+                                service = %instance_name,
+                                homeserver,
+                                ?grace,
+                                "Event processor did not stop within grace period"
+                            );
+                            force_abort_processor_task(&mut handle).await
+                        }
+                    }
+                }
+            },
+        }
     }
 
     /// Runs the event processor asynchronously.
     ///
-    /// Returns `Ok(())` on a clean exit, or `Err(EventProcessorError)` on failure.
-    async fn run_internal(self: Arc<Self>) -> Result<(), EventProcessorError>;
+    /// Returns the completion reason on a clean exit, or an error on failure.
+    async fn run_internal(self: Arc<Self>, context: RunContext) -> ProcessorResult;
+
+    /// Selects immediate hard abort or cooperative cancellation after a timeout.
+    fn timeout_policy(&self) -> TimeoutPolicy {
+        TimeoutPolicy::HardAbort
+    }
 
     /// Optional custom timeout for this event processor.
     ///

--- a/nexus-watcher/src/service/indexer/processor_run.rs
+++ b/nexus-watcher/src/service/indexer/processor_run.rs
@@ -1,0 +1,77 @@
+//! Types that control and describe a single event processor run.
+
+use std::time::Duration;
+
+use tokio::sync::watch;
+
+use crate::errors::EventProcessorError;
+
+/// Successful outcome of one event processor invocation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RunCompletion {
+    /// The processor finished normally.
+    Completed,
+    /// The processor stopped cooperatively after exhausting its run budget.
+    BudgetExhausted,
+}
+
+/// Timeout behavior for an event processor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TimeoutPolicy {
+    HardAbort,
+    Cooperative { grace: Duration },
+}
+
+/// State scoped to one invocation of an event processor.
+#[derive(Clone)]
+pub struct RunContext {
+    budget_exhaustion_rx: watch::Receiver<bool>,
+}
+
+impl RunContext {
+    /// Creates a run context and the sender used to signal budget exhaustion.
+    pub fn with_budget_signal() -> (watch::Sender<bool>, Self) {
+        let (budget_exhaustion_tx, budget_exhaustion_rx) = watch::channel(false);
+        (
+            budget_exhaustion_tx,
+            Self {
+                budget_exhaustion_rx,
+            },
+        )
+    }
+
+    /// Creates a context that never receives a budget-expiry signal.
+    pub fn inactive() -> Self {
+        Self::with_budget_signal().1
+    }
+
+    /// Returns whether the run budget expired and requested a cooperative stop.
+    ///
+    /// This check is non-blocking and should be called at safe processing boundaries.
+    pub fn is_budget_exhausted(&self) -> bool {
+        *self.budget_exhaustion_rx.borrow()
+    }
+}
+
+pub type ProcessorResult = Result<RunCompletion, EventProcessorError>;
+
+/// Possible error types of an event processor run.
+#[derive(Debug, thiserror::Error)]
+pub enum RunError {
+    #[error("Internal error: {0}")]
+    Internal(EventProcessorError),
+    #[error("Execution panicked")]
+    Panicked,
+    #[error("Execution timed out")]
+    TimedOut,
+}
+
+impl RunError {
+    pub fn is_panic(&self) -> bool {
+        matches!(self, RunError::Panicked)
+    }
+
+    pub fn is_timeout(&self) -> bool {
+        matches!(self, RunError::TimedOut)
+    }
+}

--- a/nexus-watcher/src/service/mod.rs
+++ b/nexus-watcher/src/service/mod.rs
@@ -7,7 +7,10 @@ pub mod user_hs_resolver;
 
 /// Module exports
 pub use constants::{PROCESSING_TIMEOUT_SECS, WATCHER_CONFIG_FILE_NAME};
-pub use indexer::{HsEventProcessor, KeyBasedEventProcessor, RunError, TEventProcessor};
+pub use indexer::{
+    HsEventProcessor, KeyBasedEventProcessor, ProcessorResult, RunCompletion, RunContext, RunError,
+    TEventProcessor, TimeoutPolicy,
+};
 pub use runner::{HsEventProcessorRunner, KeyBasedEventProcessorRunner, TEventProcessorRunner};
 pub(crate) use task_runner::{run_periodic_tasks, PeriodicTask};
 pub use user_hs_resolver::UserHsResolverRunner;
@@ -131,7 +134,7 @@ impl NexusWatcher {
             }),
             PeriodicTask::new("retry-processor", retry_processor_interval_ms, move || {
                 let processor = retry_processor.clone();
-                async move { processor.run().await.map_err(DynError::from) }
+                async move { processor.run().await.map(|_| ()).map_err(DynError::from) }
             }),
         ];
 

--- a/nexus-watcher/src/service/runner/key_based.rs
+++ b/nexus-watcher/src/service/runner/key_based.rs
@@ -112,10 +112,11 @@ impl TEventProcessorRunner for KeyBasedEventProcessorRunner {
 
     async fn backoff_hs_record_result(&self, hs_id: &str, status: &ProcessorRunStatus) {
         let mut backoff = self.backoff.lock().await;
-        if *status == ProcessorRunStatus::Ok {
-            backoff.record_success(hs_id);
-        } else {
-            backoff.record_failure(hs_id);
+        match status {
+            ProcessorRunStatus::Ok | ProcessorRunStatus::BudgetExhausted => {
+                backoff.record_success(hs_id)
+            }
+            _ => backoff.record_failure(hs_id),
         }
     }
 
@@ -128,6 +129,7 @@ impl TEventProcessorRunner for KeyBasedEventProcessorRunner {
         }
 
         let count_ok = stats.count_ok();
+        let count_budget_exhausted = stats.count_budget_exhausted();
         let count_error = stats.count_error();
         let count_panic = stats.count_panic();
         let count_timeout = stats.count_timeout();
@@ -151,12 +153,51 @@ impl TEventProcessorRunner for KeyBasedEventProcessorRunner {
                 hs_skipped = count_skipped,
                 "Key-based indexing finished; some homeservers skipped (backoff)"
             );
-        } else if count_ok == 0 {
+        } else if count_ok == 0 && count_budget_exhausted == 0 {
             info!("Key-based indexing finished: no external homeservers");
         } else {
-            info!(hs_ok = count_ok, "Key-based indexing finished");
+            info!(
+                hs_ok = count_ok,
+                hs_budget_exhausted = count_budget_exhausted,
+                "Key-based indexing finished"
+            );
         }
 
         ProcessedStats(stats)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn runner() -> KeyBasedEventProcessorRunner {
+        let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        KeyBasedEventProcessorRunner::from_config(&WatcherConfig::default(), shutdown_rx)
+    }
+
+    #[tokio::test]
+    async fn budget_exhaustion_resets_homeserver_backoff() {
+        let runner = runner();
+
+        runner.backoff.lock().await.record_failure("hs1");
+        assert!(runner.backoff.lock().await.should_skip("hs1"));
+
+        runner
+            .backoff_hs_record_result("hs1", &ProcessorRunStatus::BudgetExhausted)
+            .await;
+
+        assert!(!runner.backoff.lock().await.should_skip("hs1"));
+    }
+
+    #[tokio::test]
+    async fn forced_timeout_triggers_homeserver_backoff() {
+        let runner = runner();
+
+        runner
+            .backoff_hs_record_result("hs1", &ProcessorRunStatus::Timeout)
+            .await;
+
+        assert!(runner.backoff.lock().await.should_skip("hs1"));
     }
 }

--- a/nexus-watcher/src/service/runner/mod.rs
+++ b/nexus-watcher/src/service/runner/mod.rs
@@ -16,13 +16,14 @@ use tokio::sync::watch::Receiver;
 use tracing::{debug, error, info};
 
 use crate::service::{
-    indexer::{RunError, TEventProcessor},
+    indexer::{RunCompletion, RunError, TEventProcessor},
     stats::{ProcessedStats, ProcessorRunStatus, RunAllProcessorsStats},
 };
 
-pub fn status_from_run_result(result: Result<(), RunError>) -> ProcessorRunStatus {
+pub fn status_from_run_result(result: Result<RunCompletion, RunError>) -> ProcessorRunStatus {
     match result {
-        Ok(_) => ProcessorRunStatus::Ok,
+        Ok(RunCompletion::Completed) => ProcessorRunStatus::Ok,
+        Ok(RunCompletion::BudgetExhausted) => ProcessorRunStatus::BudgetExhausted,
         Err(RunError::Internal(_)) => ProcessorRunStatus::Error,
         Err(RunError::Panicked) => ProcessorRunStatus::Panic,
         Err(RunError::TimedOut) => ProcessorRunStatus::Timeout,
@@ -113,4 +114,23 @@ pub trait TEventProcessorRunner: Send + Sync {
     ///
     /// No-op default implementation. Runners that use backoff should overwrite as needed.
     async fn backoff_hs_record_result(&self, _hs_id: &str, _status: &ProcessorRunStatus) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn budget_completion_maps_to_budget_exhausted_status() {
+        let status = status_from_run_result(Ok(RunCompletion::BudgetExhausted));
+        assert_eq!(status, ProcessorRunStatus::BudgetExhausted);
+    }
+
+    #[test]
+    fn timeout_error_maps_to_timeout_status() {
+        assert_eq!(
+            status_from_run_result(Err(RunError::TimedOut)),
+            ProcessorRunStatus::Timeout
+        );
+    }
 }

--- a/nexus-watcher/src/service/stats.rs
+++ b/nexus-watcher/src/service/stats.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 pub enum ProcessorRunStatus {
     FailedToBuild,
     Ok,
+    BudgetExhausted,
     Error,
     Panic,
     Timeout,
@@ -45,6 +46,11 @@ impl RunAllProcessorsStats {
         self.count(ProcessorRunStatus::Ok)
     }
 
+    /// Number of homeservers that stopped cleanly after using their run budget.
+    pub fn count_budget_exhausted(&self) -> usize {
+        self.count(ProcessorRunStatus::BudgetExhausted)
+    }
+
     /// Number of homeservers where processing failed with Err
     pub fn count_error(&self) -> usize {
         self.count(ProcessorRunStatus::Error)
@@ -73,3 +79,27 @@ impl RunAllProcessorsStats {
 
 /// Wrapper around `RunAllProcessorsStats` which indicates they've been processed
 pub struct ProcessedStats(pub RunAllProcessorsStats);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn budget_exhaustion_is_counted_separately_from_timeout() {
+        let mut stats = RunAllProcessorsStats::default();
+        stats.add_run_result(
+            "budgeted".into(),
+            Duration::ZERO,
+            ProcessorRunStatus::BudgetExhausted,
+        );
+        stats.add_run_result(
+            "timed-out".into(),
+            Duration::ZERO,
+            ProcessorRunStatus::Timeout,
+        );
+
+        assert_eq!(stats.count_budget_exhausted(), 1);
+        assert_eq!(stats.count_timeout(), 1);
+        assert_eq!(stats.count_ok(), 0);
+    }
+}

--- a/nexus-watcher/tests/service/key_based_event_processor.rs
+++ b/nexus-watcher/tests/service/key_based_event_processor.rs
@@ -15,7 +15,9 @@ use nexus_watcher::errors::EventProcessorError;
 use nexus_watcher::events::retry::{InitialBackoff, RetryScheduler};
 use nexus_watcher::events::Event;
 use nexus_watcher::events::EventHandler;
-use nexus_watcher::service::indexer::{KeyBasedEventProcessor, RunError, TEventProcessor};
+use nexus_watcher::service::indexer::{
+    KeyBasedEventProcessor, RunCompletion, RunContext, RunError, TEventProcessor,
+};
 use nexus_watcher::service::runner::UserNotFoundBackoff;
 use nexus_watcher::service::{KeyBasedEventProcessorRunner, TEventProcessorRunner};
 use pubky::{Event as StreamEvent, EventCursor, EventType, Keypair, PubkyResource, PublicKey};
@@ -769,7 +771,7 @@ async fn key_based_processor_stops_current_and_next_users_after_shutdown() -> Re
         ),
     ]));
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let handler = Arc::new(ShutdownOnFirstHandle::new(shutdown_tx));
+    let handler = Arc::new(SignalOnFirstHandle::new(shutdown_tx));
     let processor =
         processor_with_shutdown(homeserver, handler.clone(), source.clone(), shutdown_rx);
 
@@ -779,6 +781,44 @@ async fn key_based_processor_stops_current_and_next_users_after_shutdown() -> Re
     assert_eq!(calls.len(), 1);
     assert_eq!(handler.handle_count(), 1);
     assert_eq!(user_cursor(&calls[0], &hs_id).await?, Some(1));
+
+    Ok(())
+}
+
+/// Verifies budget exhaustion waits for the current event, persists its cursor,
+/// and stops before another event or user.
+#[tokio_shared_rt::test(shared)]
+async fn key_based_processor_persists_cursor_before_budget_stop() -> Result<(), DynError> {
+    setup().await?;
+
+    let (_hs_keypair, homeserver) = create_homeserver().await?;
+    let hs_id = homeserver.id.to_string();
+    let user_a_id = create_user_on_homeserver(&homeserver).await?;
+    let user_b_id = create_user_on_homeserver(&homeserver).await?;
+    let source = Arc::new(MockKeyBasedEventSource::default().with_user_events(vec![
+        (
+            user_a_id.clone(),
+            vec![
+                stream_event(1, &user_a_id, "/pub/pubky.app/profile.json")?,
+                stream_event(2, &user_a_id, "/pub/pubky.app/profile.json")?,
+            ],
+        ),
+        (
+            user_b_id.clone(),
+            vec![stream_event(1, &user_b_id, "/pub/pubky.app/profile.json")?],
+        ),
+    ]));
+    let (budget_exhaustion_tx, context) = RunContext::with_budget_signal();
+    let handler = Arc::new(SignalOnFirstHandle::new(budget_exhaustion_tx));
+    let processor = processor(homeserver, handler.clone(), source.clone());
+
+    let completion = processor.run_internal(context).await?;
+    let calls = source.calls().await;
+
+    assert_eq!(calls.len(), 1);
+    assert_eq!(handler.handle_count(), 1);
+    assert_eq!(user_cursor(&calls[0], &hs_id).await?, Some(1));
+    assert_eq!(completion, RunCompletion::BudgetExhausted);
 
     Ok(())
 }
@@ -1057,15 +1097,15 @@ fn assert_internal_event_cursor_out_of_order(err: RunError) {
 ///
 /// This lets shutdown-path tests verify that the processor persists the first
 /// safe cursor, stops the current user stream, and does not fetch later users.
-struct ShutdownOnFirstHandle {
-    shutdown_tx: watch::Sender<bool>,
+struct SignalOnFirstHandle {
+    signal_tx: watch::Sender<bool>,
     handle_count: AtomicUsize,
 }
 
-impl ShutdownOnFirstHandle {
-    fn new(shutdown_tx: watch::Sender<bool>) -> Self {
+impl SignalOnFirstHandle {
+    fn new(signal_tx: watch::Sender<bool>) -> Self {
         Self {
-            shutdown_tx,
+            signal_tx,
             handle_count: AtomicUsize::new(0),
         }
     }
@@ -1076,10 +1116,10 @@ impl ShutdownOnFirstHandle {
 }
 
 #[async_trait::async_trait]
-impl EventHandler for ShutdownOnFirstHandle {
+impl EventHandler for SignalOnFirstHandle {
     async fn handle(&self, _event: &Event) -> Result<(), EventProcessorError> {
         if self.handle_count.fetch_add(1, Ordering::SeqCst) == 0 {
-            let _ = self.shutdown_tx.send(true);
+            self.signal_tx.send_replace(true);
         }
 
         Ok(())

--- a/nexus-watcher/tests/service/mock_event_processor.rs
+++ b/nexus-watcher/tests/service/mock_event_processor.rs
@@ -1,7 +1,13 @@
+use crate::service::utils::create_mock_handler;
 use crate::service::utils::{create_mock_event_processors, MockEventProcessorRunner, HS_IDS};
 use anyhow::Result;
 use nexus_common::types::DynError;
+use nexus_watcher::errors::EventProcessorError;
+use nexus_watcher::events::EventHandler;
+use nexus_watcher::service::TEventProcessor;
 use nexus_watcher::service::TEventProcessorRunner;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
 const TIMEOUT: Duration = Duration::from_secs(2);
@@ -37,4 +43,59 @@ async fn test_mock_event_processors() -> Result<(), DynError> {
     );
 
     Ok(())
+}
+
+/// Verifies that `run` waits for its timed-out task to be cancelled.
+#[tokio_shared_rt::test(shared)]
+async fn processor_run_aborts_spawned_task_on_timeout() -> Result<(), DynError> {
+    let task_dropped = Arc::new(AtomicBool::new(false));
+    let processor = Arc::new(AbortTrackingProcessor {
+        task_dropped: task_dropped.clone(),
+        event_handler: create_mock_handler(Ok(()), None),
+        timeout: Duration::from_millis(50),
+    });
+
+    let err = processor.run().await.unwrap_err();
+    assert!(err.is_timeout(), "expected timeout, got {err:?}");
+    assert!(
+        task_dropped.load(Ordering::SeqCst),
+        "run should await cancellation of the timed-out task"
+    );
+
+    Ok(())
+}
+
+struct AbortTrackingProcessor {
+    task_dropped: Arc<AtomicBool>,
+    event_handler: Arc<dyn EventHandler>,
+    timeout: Duration,
+}
+
+struct TaskDropGuard(Arc<AtomicBool>);
+
+impl Drop for TaskDropGuard {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::SeqCst);
+    }
+}
+
+#[async_trait::async_trait]
+impl TEventProcessor for AbortTrackingProcessor {
+    fn event_handler(&self) -> &Arc<dyn EventHandler> {
+        &self.event_handler
+    }
+
+    fn instance_name(&self) -> &'static str {
+        "AbortTrackingProcessor"
+    }
+
+    fn custom_timeout(&self) -> Option<Duration> {
+        Some(self.timeout)
+    }
+
+    async fn run_internal(self: Arc<Self>) -> Result<(), EventProcessorError> {
+        let _guard = TaskDropGuard(self.task_dropped.clone());
+        std::future::pending::<()>().await;
+        Ok(())
+    }
 }

--- a/nexus-watcher/tests/service/mock_event_processor.rs
+++ b/nexus-watcher/tests/service/mock_event_processor.rs
@@ -2,10 +2,11 @@ use crate::service::utils::create_mock_handler;
 use crate::service::utils::{create_mock_event_processors, MockEventProcessorRunner, HS_IDS};
 use anyhow::Result;
 use nexus_common::types::DynError;
-use nexus_watcher::errors::EventProcessorError;
 use nexus_watcher::events::EventHandler;
-use nexus_watcher::service::TEventProcessor;
-use nexus_watcher::service::TEventProcessorRunner;
+use nexus_watcher::service::{
+    ProcessorResult, RunCompletion, RunContext, TEventProcessor, TEventProcessorRunner,
+    TimeoutPolicy,
+};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -53,6 +54,7 @@ async fn processor_run_aborts_spawned_task_on_timeout() -> Result<(), DynError> 
         task_dropped: task_dropped.clone(),
         event_handler: create_mock_handler(Ok(()), None),
         timeout: Duration::from_millis(50),
+        timeout_policy: TimeoutPolicy::HardAbort,
     });
 
     let err = processor.run().await.unwrap_err();
@@ -65,10 +67,43 @@ async fn processor_run_aborts_spawned_task_on_timeout() -> Result<(), DynError> 
     Ok(())
 }
 
+#[tokio_shared_rt::test(shared)]
+async fn processor_run_stops_cooperatively_after_budget_exhaustion() -> Result<(), DynError> {
+    let result = Arc::new(CooperativeProcessor {
+        event_handler: create_mock_handler(Ok(()), None),
+        timeout: Duration::from_millis(50),
+        grace: Duration::from_millis(500),
+    })
+    .run()
+    .await?;
+
+    assert_eq!(result, RunCompletion::BudgetExhausted);
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn processor_run_aborts_after_cooperative_grace_expires() -> Result<(), DynError> {
+    let task_dropped = Arc::new(AtomicBool::new(false));
+    let processor = Arc::new(AbortTrackingProcessor {
+        task_dropped: task_dropped.clone(),
+        event_handler: create_mock_handler(Ok(()), None),
+        timeout: Duration::from_millis(50),
+        timeout_policy: TimeoutPolicy::Cooperative {
+            grace: Duration::from_millis(50),
+        },
+    });
+
+    let err = processor.run().await.unwrap_err();
+    assert!(err.is_timeout(), "expected timeout, got {err:?}");
+    assert!(task_dropped.load(Ordering::SeqCst));
+    Ok(())
+}
+
 struct AbortTrackingProcessor {
     task_dropped: Arc<AtomicBool>,
     event_handler: Arc<dyn EventHandler>,
     timeout: Duration,
+    timeout_policy: TimeoutPolicy,
 }
 
 struct TaskDropGuard(Arc<AtomicBool>);
@@ -93,9 +128,45 @@ impl TEventProcessor for AbortTrackingProcessor {
         Some(self.timeout)
     }
 
-    async fn run_internal(self: Arc<Self>) -> Result<(), EventProcessorError> {
+    fn timeout_policy(&self) -> TimeoutPolicy {
+        self.timeout_policy
+    }
+
+    async fn run_internal(self: Arc<Self>, _context: RunContext) -> ProcessorResult {
         let _guard = TaskDropGuard(self.task_dropped.clone());
         std::future::pending::<()>().await;
-        Ok(())
+        Ok(RunCompletion::Completed)
+    }
+}
+
+struct CooperativeProcessor {
+    event_handler: Arc<dyn EventHandler>,
+    timeout: Duration,
+    grace: Duration,
+}
+
+#[async_trait::async_trait]
+impl TEventProcessor for CooperativeProcessor {
+    fn event_handler(&self) -> &Arc<dyn EventHandler> {
+        &self.event_handler
+    }
+
+    fn instance_name(&self) -> &'static str {
+        "CooperativeProcessor"
+    }
+
+    fn custom_timeout(&self) -> Option<Duration> {
+        Some(self.timeout)
+    }
+
+    fn timeout_policy(&self) -> TimeoutPolicy {
+        TimeoutPolicy::Cooperative { grace: self.grace }
+    }
+
+    async fn run_internal(self: Arc<Self>, context: RunContext) -> ProcessorResult {
+        while !context.is_budget_exhausted() {
+            tokio::task::yield_now().await;
+        }
+        Ok(RunCompletion::BudgetExhausted)
     }
 }

--- a/nexus-watcher/tests/service/retry_processor.rs
+++ b/nexus-watcher/tests/service/retry_processor.rs
@@ -11,7 +11,7 @@ use nexus_watcher::events::retry::{
 };
 use nexus_watcher::events::EventHandler;
 use nexus_watcher::events::EventType;
-use nexus_watcher::service::TEventProcessor;
+use nexus_watcher::service::{RunContext, TEventProcessor};
 use pubky_app_specs::post_uri_builder;
 use std::sync::Arc;
 use tokio::sync::watch;
@@ -113,7 +113,7 @@ async fn test_backoff_first_retry_uses_initial_value() -> Result<()> {
     );
 
     // Process through the public API
-    let _ = processor.run_internal().await;
+    let _ = processor.run_internal(RunContext::inactive()).await;
 
     // Verify event was re-queued with backoff
     let updated_event = store
@@ -172,7 +172,7 @@ async fn test_backoff_exponential_growth() -> Result<()> {
     );
 
     // Process through the public API
-    let _ = processor.run_internal().await;
+    let _ = processor.run_internal(RunContext::inactive()).await;
 
     // Verify event was re-queued with exponential backoff
     let updated_event = store
@@ -237,7 +237,7 @@ async fn test_infrastructure_error_at_max_retries_does_not_dead_letter() -> Resu
     );
 
     // Process through the public API — should_not_retry_now error must NOT dead-letter
-    let result = processor.run_internal().await;
+    let result = processor.run_internal(RunContext::inactive()).await;
     assert!(
         result.is_err(),
         "Should-not-retry-now error should propagate, not dead-letter"
@@ -300,7 +300,7 @@ async fn test_backoff_capped_at_max() -> Result<()> {
     );
 
     // Process through the public API
-    let _ = processor.run_internal().await;
+    let _ = processor.run_internal(RunContext::inactive()).await;
 
     // Verify event was re-queued with capped backoff
     let updated_event = store
@@ -362,7 +362,7 @@ async fn test_retry_success_removes_from_queue() -> Result<()> {
     );
 
     // Process through the public API
-    let _ = processor.run_internal().await;
+    let _ = processor.run_internal(RunContext::inactive()).await;
 
     // Verify event was removed from index after processing
     assert!(
@@ -412,7 +412,7 @@ async fn test_retry_404_removes_from_queue() -> Result<()> {
     );
 
     // Process through the public API
-    let _ = processor.run_internal().await;
+    let _ = processor.run_internal(RunContext::inactive()).await;
 
     // Verify event was removed from index (404 means content is gone)
     assert!(
@@ -466,7 +466,7 @@ async fn test_transient_error_schedules_retry() -> Result<()> {
     );
 
     // Process through the public API - this will propagate the should_not_retry_now error
-    let result = processor.run_internal().await;
+    let result = processor.run_internal(RunContext::inactive()).await;
     assert!(
         result.is_err(),
         "Should-not-retry-now error should propagate"
@@ -537,7 +537,7 @@ async fn test_missing_dependency_schedules_retry() -> Result<()> {
     );
 
     // Process through the public API
-    let _ = processor.run_internal().await;
+    let _ = processor.run_internal(RunContext::inactive()).await;
 
     // Verify event was re-queued with incremented retry_count
     let updated_event = store
@@ -618,7 +618,7 @@ async fn test_dead_letter_after_max_transient_retries() -> Result<()> {
     );
 
     // Process through the public API — event should be dead-lettered
-    let _ = processor.run_internal().await;
+    let _ = processor.run_internal(RunContext::inactive()).await;
 
     // Verify event was removed from index (dead-lettered)
     assert!(
@@ -674,7 +674,7 @@ async fn test_dead_letter_after_max_dependency_retries() -> Result<()> {
     );
 
     // Process through the public API
-    let _ = processor.run_internal().await;
+    let _ = processor.run_internal(RunContext::inactive()).await;
 
     // Verify event was removed from index (dead-lettered)
     assert!(
@@ -780,7 +780,7 @@ async fn test_shutdown_interrupts_batch() -> Result<()> {
     shutdown_tx.send(true)?;
 
     // Run the processor - should return Ok(()) immediately due to shutdown
-    let result: Result<(), EventProcessorError> = processor.run_internal().await;
+    let result = processor.run_internal(RunContext::inactive()).await;
 
     assert!(
         result.is_ok(),
@@ -856,7 +856,7 @@ async fn test_infrastructure_error_stops_batch() -> Result<()> {
     );
 
     // Run the processor - should propagate should_not_retry_now error
-    let result: Result<(), EventProcessorError> = processor.run_internal().await;
+    let result = processor.run_internal(RunContext::inactive()).await;
 
     // Verify the error propagated up
     assert!(
@@ -936,7 +936,7 @@ async fn test_empty_batch_returns_ok() -> Result<()> {
     );
 
     // No events in queue - should return Ok(())
-    let result: Result<(), EventProcessorError> = processor.run_internal().await;
+    let result = processor.run_internal(RunContext::inactive()).await;
     assert!(result.is_ok(), "Empty batch should return Ok(())");
 
     // No events, handler must never be called.
@@ -978,7 +978,7 @@ async fn test_del_event_retry_success() -> Result<()> {
         shutdown_rx,
     );
 
-    let _ = processor.run_internal().await;
+    let _ = processor.run_internal(RunContext::inactive()).await;
 
     // Handler called once for the DEL event.
     assert_eq!(
@@ -1030,7 +1030,7 @@ async fn test_non_retryable_error_removes_event() -> Result<()> {
         shutdown_rx,
     );
 
-    let result = processor.run_internal().await;
+    let result = processor.run_internal(RunContext::inactive()).await;
     assert!(result.is_ok(), "Non-retryable error should not propagate");
 
     // Handler called once for the event before dead-lettering.
@@ -1105,7 +1105,7 @@ async fn test_batch_continues_after_single_failure() -> Result<()> {
         shutdown_rx,
     );
 
-    let result = processor.run_internal().await;
+    let result = processor.run_internal(RunContext::inactive()).await;
     assert!(
         result.is_ok(),
         "Retryable application error must not stop the batch"
@@ -1179,7 +1179,7 @@ async fn test_future_events_not_picked_up() -> Result<()> {
         shutdown_rx,
     );
 
-    let result = processor.run_internal().await;
+    let result = processor.run_internal(RunContext::inactive()).await;
     assert!(result.is_ok(), "Should return Ok when no ready events");
 
     // Handler must never be called — no ready events in the batch.

--- a/nexus-watcher/tests/service/utils/processor.rs
+++ b/nexus-watcher/tests/service/utils/processor.rs
@@ -9,7 +9,7 @@ use nexus_common::models::user::{set_user_homeserver, UserDetails};
 use nexus_watcher::errors::EventProcessorError;
 use nexus_watcher::events::retry::RetryScheduler;
 use nexus_watcher::events::EventHandler;
-use nexus_watcher::service::TEventProcessor;
+use nexus_watcher::service::{ProcessorResult, RunCompletion, RunContext, TEventProcessor};
 use pubky::Keypair;
 use pubky_app_specs::PubkyId;
 use tokio::sync::watch::Receiver;
@@ -48,21 +48,20 @@ impl TEventProcessor for MockEventProcessor {
         None
     }
 
-    async fn run_internal(self: Arc<Self>) -> Result<(), EventProcessorError> {
-        // Simulate a long-running task if needed, but be responsive to shutdown
-        // This simulates the processing of event lines, which can take a while but can be interrupted by the shutdown signal
+    async fn run_internal(self: Arc<Self>, _context: RunContext) -> ProcessorResult {
+        // Simulate long-running work while remaining responsive to shutdown.
         if let Some(sleep_duration) = self.sleep_duration {
             let mut shutdown_rx = self.shutdown_rx.clone();
             tokio::select! {
                 _ = tokio::time::sleep(sleep_duration) => {},
                 _ = shutdown_rx.changed() => {
-                    return Ok(());
+                    return Ok(RunCompletion::Completed);
                 }
             }
         }
 
         match &self.processor_status {
-            MockEventProcessorResult::Success => Ok(()),
+            MockEventProcessorResult::Success => Ok(RunCompletion::Completed),
             MockEventProcessorResult::Error(e) => Err(EventProcessorError::Generic(e.clone())),
             MockEventProcessorResult::Panic => panic!("Event processor panicked: unknown error"),
         }


### PR DESCRIPTION
### Summary
Adds cooperative timeout handling for key-based indexing. When its processing budget expires, the processor finishes the current event, retries cursor persistence, and stops before processing another event or user.

Budget exhaustion is tracked separately from forced timeouts and resets homeserver backoff. Other processors retain their existing hard-timeout behavior, with aborted tasks awaited to prevent overlapping runs.

### Pre-submission Checklist

- [x] I manually reviewed and tested the PR 
- [ ] I asked one or more LLMs to review the PR
- [ ] I asked one or more LLMs to check if this PR can be simplified [^1]
- [ ] If appropriate, I added tests for the changes in this PR
- [ ] If appropriate, I added performance benchmarks for the APIs added in this PR [^2]

[^1]: Sample prompt: "Can this be simplified? Can the code, comments, or logic introduced by these changes be simplfied, clarified or otherwise made more terse, concise and understandable, without affecting functionality?"
[^2]: `cargo bench -p nexus-webapi`
