### PR TITLE
chore: reduce watcher log noise

### DIFF
--- a/nexus-common/src/db/kv/index/json.rs
+++ b/nexus-common/src/db/kv/index/json.rs
@@ -3,7 +3,7 @@ use crate::db::kv::error::{RedisError, RedisResult};
 use deadpool_redis::redis::Script;
 use deadpool_redis::redis::{AsyncCommands, JsonAsyncCommands};
 use serde::{de::DeserializeOwned, Serialize};
-use tracing::{debug, warn};
+use tracing::{trace, warn};
 
 #[derive(Clone, Debug)]
 pub enum JsonAction {
@@ -59,7 +59,7 @@ pub async fn put<T: Serialize + Send + Sync>(
         }
     }
 
-    debug!(
+    trace!(
         "Set key: {} with optional expiration: {:?}",
         index_key, expiration
     );
@@ -144,7 +144,7 @@ pub async fn modify_json_field(
     "#,
     );
 
-    debug!(
+    trace!(
         "Modifiying field: {} in key: {} by {}",
         field, index_key, amount
     );

--- a/nexus-common/src/db/kv/index/json.rs
+++ b/nexus-common/src/db/kv/index/json.rs
@@ -61,7 +61,8 @@ pub async fn put<T: Serialize + Send + Sync>(
 
     trace!(
         "Set key: {} with optional expiration: {:?}",
-        index_key, expiration
+        index_key,
+        expiration
     );
     Ok(())
 }
@@ -146,7 +147,9 @@ pub async fn modify_json_field(
 
     trace!(
         "Modifiying field: {} in key: {} by {}",
-        field, index_key, amount
+        field,
+        index_key,
+        amount
     );
 
     let _: i64 = script

--- a/nexus-common/src/stack.rs
+++ b/nexus-common/src/stack.rs
@@ -62,13 +62,27 @@ impl StackManager {
     }
 
     /// Builds an [`EnvFilter`] at the given level with directives to suppress noisy dependencies.
+    ///
+    /// HTTP/TLS crates are always capped. Discovery crates (`mainline`, `pkarr`, `pubky`) are
+    /// capped unless the global level is [`Level::Trace`], so their detail only appears when
+    /// explicitly tracing.
     fn env_filter(log_level: Level) -> EnvFilter {
         EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-            EnvFilter::new(log_level.as_str())
+            let mut filter = EnvFilter::new(log_level.as_str())
                 .add_directive("opentelemetry=error".parse().unwrap())
                 .add_directive("h2=error".parse().unwrap())
                 .add_directive("tower=info".parse().unwrap())
-                .add_directive("mainline=info".parse().unwrap())
+                .add_directive("reqwest=warn".parse().unwrap())
+                .add_directive("hyper_util=warn".parse().unwrap())
+                .add_directive("rustls=warn".parse().unwrap());
+
+            if log_level != Level::Trace {
+                for directive in ["mainline=info", "pkarr=warn", "pubky=warn"] {
+                    filter = filter.add_directive(directive.parse().unwrap());
+                }
+            }
+
+            filter
         })
     }
 

--- a/nexus-watcher/src/events/event.rs
+++ b/nexus-watcher/src/events/event.rs
@@ -106,14 +106,14 @@ impl Event {
         let event_type: EventType = stream_event.event_type.clone().into();
 
         let uri = stream_event.resource.to_pubky_url();
-        debug!("New stream event: {event_type} {uri}");
+        debug!(%event_type, %uri, "New stream event");
 
         let event_line = format!("{event_type} {uri}");
         match Self::parse_event_parts(event_type, uri, event_line)? {
             ParseResult::Parsed(event) => Ok(Some(event)),
             ParseResult::Skipped => Ok(None),
             ParseResult::UnrecognizedUri { reason, .. } => {
-                warn!("Unrecognized event URI: {reason}");
+                warn!(%reason, "Unrecognized event URI");
                 Ok(None)
             }
         }

--- a/nexus-watcher/src/events/event.rs
+++ b/nexus-watcher/src/events/event.rs
@@ -77,7 +77,6 @@ pub struct Event {
 impl Event {
     /// Parse event from a line returned by the homeserver's `/events` endpoint.
     pub fn parse_event(line: &str) -> Result<ParseResult, EventProcessorError> {
-        debug!("New event: {}", line);
         let parts: Vec<&str> = line.split(' ').collect();
         if parts.len() != 2 {
             return Err(EventProcessorError::InvalidEventLine(format!(

--- a/nexus-watcher/src/events/handlers/bookmark.rs
+++ b/nexus-watcher/src/events/handlers/bookmark.rs
@@ -14,7 +14,7 @@ pub async fn sync_put(
     bookmark: PubkyAppBookmark,
     id: String,
 ) -> Result<(), EventProcessorError> {
-    debug!("Indexing new bookmark: {} -> {}", user_id, id);
+    debug!("Indexing bookmark");
     // Parse the URI to extract author_id and post_id using the updated parse_post_uri
     let parsed_uri =
         ParsedUri::try_from(bookmark.uri.as_str()).map_err(EventProcessorError::generic)?;
@@ -61,7 +61,7 @@ pub async fn sync_put(
 
 #[tracing::instrument(name = "bookmark.del", skip_all, fields(user_id = %user_id, bookmark_id = %bookmark_id))]
 pub async fn del(user_id: PubkyId, bookmark_id: String) -> Result<(), EventProcessorError> {
-    debug!("Deleting bookmark: {} -> {}", user_id, bookmark_id);
+    debug!("Deleting bookmark");
     sync_del(user_id, bookmark_id).await
 }
 

--- a/nexus-watcher/src/events/handlers/file.rs
+++ b/nexus-watcher/src/events/handlers/file.rs
@@ -24,7 +24,7 @@ pub async fn sync_put(
     max_file_size: u64,
     ingestor: &UserIngestor,
 ) -> Result<(), EventProcessorError> {
-    debug!("Indexing new file resource at {}/{}", user_id, file_id);
+    debug!("Indexing file");
 
     let file_meta = ingest(
         &user_id,
@@ -111,7 +111,7 @@ pub async fn del(
     file_id: String,
     files_path: &Path,
 ) -> Result<(), EventProcessorError> {
-    debug!("Deleting File resource at {}/{}", user_id, file_id);
+    debug!("Deleting file");
     let result = FileDetails::get_by_ids(&[&[user_id, &file_id]]).await?;
 
     if result.is_empty() {

--- a/nexus-watcher/src/events/handlers/follow.rs
+++ b/nexus-watcher/src/events/handlers/follow.rs
@@ -16,7 +16,7 @@ pub async fn sync_put(
     followee_id: PubkyId,
     ingestor: &UserIngestor,
 ) -> Result<(), EventProcessorError> {
-    debug!("Indexing new follow: {} -> {}", follower_id, followee_id);
+    debug!("Indexing follow");
     // SAVE TO GRAPH
     // (follower_id)-[:FOLLOWS]->(followee_id)
     match Followers::put_to_graph(&follower_id, &followee_id).await? {
@@ -85,7 +85,7 @@ pub async fn sync_put(
 
 #[tracing::instrument(name = "follow.del", skip_all, fields(follower_id = %follower_id, followee_id = %followee_id))]
 pub async fn del(follower_id: PubkyId, followee_id: PubkyId) -> Result<(), EventProcessorError> {
-    debug!("Deleting follow: {} -> {}", follower_id, followee_id);
+    debug!("Deleting follow");
     // Maybe we could do it here but lets follow the naming convention
     sync_del(follower_id, followee_id).await
 }

--- a/nexus-watcher/src/events/handlers/post.rs
+++ b/nexus-watcher/src/events/handlers/post.rs
@@ -23,7 +23,7 @@ pub async fn sync_put(
     post_id: String,
     ingestor: &UserIngestor,
 ) -> Result<(), EventProcessorError> {
-    debug!("Indexing new post: {}/{}", author_id, post_id);
+    debug!("Indexing post");
     // Create PostDetails object
     let post_details = PostDetails::from_homeserver(post.clone(), &author_id, &post_id);
     // We avoid indexing replies into global feed sorted sets
@@ -315,10 +315,7 @@ async fn recover_post_index_state(
     author_id: &PubkyId,
     post_id: &str,
 ) -> Result<(), EventProcessorError> {
-    debug!(
-        "Recovering post index state from graph: {}/{}",
-        author_id, post_id
-    );
+    debug!("Recovering post index state from graph");
 
     // Fetch post details from the graph once — used both to drive mention
     // edge recovery (needs the content) and to re-populate the PostDetails
@@ -549,7 +546,7 @@ pub async fn del(
     post_id: String,
     ingestor: &UserIngestor,
 ) -> Result<(), EventProcessorError> {
-    debug!("Deleting post: {}/{}", author_id, post_id);
+    debug!("Deleting post");
 
     // Graph query to check if there is any edge at all to this post other than AUTHORED, is a reply or is a repost.
     let query = post_is_safe_to_delete(&author_id, &post_id);

--- a/nexus-watcher/src/events/handlers/tag.rs
+++ b/nexus-watcher/src/events/handlers/tag.rs
@@ -37,7 +37,7 @@ pub async fn sync_put(
     tag_id: String,
     ingestor: &UserIngestor,
 ) -> Result<(), EventProcessorError> {
-    debug!("Indexing new tag: {} -> {}", tagger_id, tag_id);
+    debug!("Indexing tag");
 
     // Parse the embeded URI to extract author_id and post_id using parse_tagged_post_uri
     let parsed_uri = ParsedUri::try_from(tag.uri.as_str()).map_err(EventProcessorError::generic)?;
@@ -76,7 +76,7 @@ pub async fn sync_put_resource(
     app: String,
     ingestor: &UserIngestor,
 ) -> Result<(), EventProcessorError> {
-    debug!("Indexing resource tag: {tagger_id} -> {tag_id} (app={app})",);
+    debug!(%app, "Indexing resource tag");
 
     match classify_uri(&tag.uri) {
         UriCategory::InternalKnown => {
@@ -409,7 +409,7 @@ pub async fn del(tag_uri: &str) -> Result<(), EventProcessorError> {
     let arg_tag_id = tag_storage_uri.tag_id;
     let arg_app = tag_storage_uri.app;
 
-    debug!("Deleting tag: {arg_user_id} -> {arg_tag_id} (app={arg_app:?})");
+    debug!("Deleting tag");
 
     // 1. Read target from graph WITHOUT deleting the edge
     let row = match fetch_row_from_graph(queries::get::get_tag_target(

--- a/nexus-watcher/src/events/handlers/user.rs
+++ b/nexus-watcher/src/events/handlers/user.rs
@@ -13,7 +13,7 @@ use tracing::debug;
 
 #[tracing::instrument(name = "user.put", skip_all, fields(user_id = %user_id))]
 pub async fn sync_put(user: PubkyAppUser, user_id: PubkyId) -> Result<(), EventProcessorError> {
-    debug!("Indexing new user profile: {}", user_id);
+    debug!("Indexing user profile");
 
     // Step 1: Create `UserDetails` object
     let user_details = UserDetails::from_homeserver(user, &user_id);
@@ -51,7 +51,7 @@ pub async fn sync_put(user: PubkyAppUser, user_id: PubkyId) -> Result<(), EventP
 
 #[tracing::instrument(name = "user.del", skip_all, fields(user_id = %user_id))]
 pub async fn del(user_id: PubkyId) -> Result<(), EventProcessorError> {
-    debug!("Deleting user profile:  {}", user_id);
+    debug!("Deleting user profile");
 
     // 1. Graph query to check if there is any edge at all to this user.
     let query = user_is_safe_to_delete(&user_id);

--- a/nexus-watcher/src/events/mod.rs
+++ b/nexus-watcher/src/events/mod.rs
@@ -177,7 +177,7 @@ pub async fn handle_put_event(
             )
             .await?
         }
-        other => debug!("Event type not handled, Resource: {other:?}"),
+        other => debug!(?other, "Event type not handled"),
     }
     Ok(())
 }
@@ -188,8 +188,6 @@ pub async fn handle_del_event(
     files_path: &Path,
     ingestor: Arc<UserIngestor>,
 ) -> Result<(), EventProcessorError> {
-    debug!("Handling DEL event for URI: {}", event.uri);
-
     let user_id = event.parsed_uri.user_id().clone();
     match event.parsed_uri.resource() {
         Resource::User => handlers::user::del(user_id).await?,
@@ -205,7 +203,7 @@ pub async fn handle_del_event(
         Resource::File(file_id) => {
             handlers::file::del(&user_id, file_id.clone(), files_path).await?
         }
-        other => debug!("DEL event type not handled for resource: {other:?}"),
+        other => debug!(?other, "DEL event type not handled"),
     }
     Ok(())
 }

--- a/nexus-watcher/src/events/mod.rs
+++ b/nexus-watcher/src/events/mod.rs
@@ -99,8 +99,6 @@ pub async fn handle_put_event(
     moderation: Arc<Moderation>,
     ingestor: Arc<UserIngestor>,
 ) -> Result<(), EventProcessorError> {
-    debug!("Handling PUT event for URI: {}", event.uri);
-
     let pubky = PubkyConnector::get()?;
     let response = pubky.public_storage().get(&event.uri).await?;
 

--- a/nexus-watcher/src/events/retry/processor.rs
+++ b/nexus-watcher/src/events/retry/processor.rs
@@ -35,8 +35,8 @@ impl TEventProcessor for RetryProcessor {
         &self.event_handler
     }
 
-    fn instance_name(&self) -> String {
-        "RetryProcessor".to_string()
+    fn instance_name(&self) -> &'static str {
+        "RetryProcessor"
     }
 
     fn retry_scheduler(&self) -> Option<&Arc<RetryScheduler>> {

--- a/nexus-watcher/src/service/indexer/homeserver.rs
+++ b/nexus-watcher/src/service/indexer/homeserver.rs
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, LazyLock};
 use tokio::sync::watch::Receiver;
 use tokio::sync::Mutex;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info, trace, warn};
 
 /// OpenTelemetry meter name for all watcher metrics.
 const METER_NAME: &str = "nexus.watcher";
@@ -69,7 +69,7 @@ impl TEventProcessor for HsEventProcessor {
     }
 
     fn instance_name(&self) -> String {
-        format!("HsEventProcessor with HS ID: {}", self.homeserver.id)
+        "HsEventProcessor".into()
     }
 
     fn retry_scheduler(&self) -> Option<&Arc<RetryScheduler>> {
@@ -173,9 +173,9 @@ impl HsEventProcessor {
     /// using the current cursor and a specified limit. It retrieves new event
     /// URIs in a newline-separated format, processes it into a vector of strings,
     /// and returns the result.
-    #[tracing::instrument(name = "events.poll", skip_all, fields(homeserver = %self.homeserver.id))]
+    #[tracing::instrument(name = "events.poll", skip_all)]
     async fn poll_events(&self) -> Result<Option<Vec<String>>, EventProcessorError> {
-        debug!("Polling new events from homeserver");
+        debug!(cursor = %self.homeserver.cursor, "Polling events");
 
         let response_text = {
             let pubky = PubkyConnector::get()?;
@@ -206,7 +206,7 @@ impl HsEventProcessor {
         };
 
         let lines: Vec<String> = response_text.trim().lines().map(String::from).collect();
-        debug!("Homeserver response lines {:?}", lines);
+        trace!("Homeserver response lines {:?}", lines);
 
         if lines.is_empty() || (lines.len() == 1 && lines[0].is_empty()) {
             return Ok(None);

--- a/nexus-watcher/src/service/indexer/homeserver.rs
+++ b/nexus-watcher/src/service/indexer/homeserver.rs
@@ -123,12 +123,12 @@ impl TEventProcessor for HsEventProcessor {
         let maybe_event_lines = self
             .poll_events()
             .await
-            .inspect_err(|e| error!("Error polling events: {e:?}"))?;
+            .inspect_err(|e| error!(error = ?e, "Error polling events"))?;
 
         match maybe_event_lines {
             None => debug!("No new events"),
             Some(event_lines) => {
-                info!("Processing {} event lines", event_lines.len());
+                info!(event_lines = event_lines.len(), "Processing event lines");
                 self.process_event_lines(event_lines).await?;
             }
         }
@@ -206,7 +206,7 @@ impl HsEventProcessor {
         };
 
         let lines: Vec<String> = response_text.trim().lines().map(String::from).collect();
-        trace!("Homeserver response lines {:?}", lines);
+        trace!(?lines, "Homeserver response lines");
 
         if lines.is_empty() || (lines.len() == 1 && lines[0].is_empty()) {
             return Ok(None);
@@ -229,15 +229,15 @@ impl HsEventProcessor {
     pub async fn process_event_lines(&self, lines: Vec<String>) -> Result<(), EventProcessorError> {
         for line in &lines {
             if *self.shutdown_rx.borrow() {
-                debug!(hs_id = %self.homeserver.id, "Shutdown detected; exiting event processing loop");
+                debug!("Shutdown detected; exiting event processing loop");
                 return Ok(());
             }
 
             if let Some(cursor) = line.strip_prefix("cursor: ") {
-                info!("Received cursor for the next request: {cursor}");
+                info!(%cursor, "Received cursor for the next request");
                 match Homeserver::try_from_cursor(self.homeserver.id.clone(), cursor) {
                     Ok(hs) => hs.put_to_index().await?,
-                    Err(e) => warn!("{e}"),
+                    Err(e) => warn!(error = %e, "Failed to persist homeserver cursor"),
                 }
                 continue;
             }

--- a/nexus-watcher/src/service/indexer/homeserver.rs
+++ b/nexus-watcher/src/service/indexer/homeserver.rs
@@ -68,8 +68,8 @@ impl TEventProcessor for HsEventProcessor {
         &self.event_handler
     }
 
-    fn instance_name(&self) -> String {
-        "HsEventProcessor".into()
+    fn instance_name(&self) -> &'static str {
+        "HsEventProcessor"
     }
 
     fn retry_scheduler(&self) -> Option<&Arc<RetryScheduler>> {

--- a/nexus-watcher/src/service/indexer/homeserver.rs
+++ b/nexus-watcher/src/service/indexer/homeserver.rs
@@ -99,7 +99,6 @@ impl TEventProcessor for HsEventProcessor {
                 warn!(
                     event.uri = %event.uri,
                     user_id = %user_id,
-                    processor_homeserver = %self.homeserver.id,
                     "User's homeserver mapping is stale; skipping event"
                 );
                 Ok(false)
@@ -110,7 +109,6 @@ impl TEventProcessor for HsEventProcessor {
                 warn!(
                     event.uri = %event.uri,
                     user_id = %user_id,
-                    processor_homeserver = %self.homeserver.id,
                     user_homeserver = %hs_id,
                     "User is hosted on a different homeserver; skipping event"
                 );

--- a/nexus-watcher/src/service/indexer/key_based.rs
+++ b/nexus-watcher/src/service/indexer/key_based.rs
@@ -117,8 +117,8 @@ impl TEventProcessor for KeyBasedEventProcessor {
         &self.event_handler
     }
 
-    fn instance_name(&self) -> String {
-        "KeyBasedEventProcessor".into()
+    fn instance_name(&self) -> &'static str {
+        "KeyBasedEventProcessor"
     }
 
     fn retry_scheduler(&self) -> Option<&Arc<RetryScheduler>> {
@@ -142,7 +142,7 @@ impl TEventProcessor for KeyBasedEventProcessor {
         let hs_pk = self.homeserver_id.to_public_key();
 
         let users = self
-            .resolve_users_with_cursors(&hs_id)
+            .resolve_users_with_cursors()
             .await
             .inspect_err(|e| error!(error = ?e, "Failed to resolve users"))?;
 
@@ -170,7 +170,7 @@ impl TEventProcessor for KeyBasedEventProcessor {
                 continue;
             }
 
-            match self.process_user(&hs_pk, &hs_id, user_pk, *cursor).await {
+            match self.process_user(&hs_pk, user_pk, *cursor).await {
                 Ok(()) => self.user_not_found_backoff.record_success(user_pk).await,
                 Err(err) => {
                     if err.should_not_retry_now() {
@@ -206,8 +206,8 @@ impl KeyBasedEventProcessor {
     #[tracing::instrument(name = "dx.users.resolve", skip_all)]
     async fn resolve_users_with_cursors(
         &self,
-        hs_id: &str,
     ) -> Result<Vec<(PublicKey, EventCursor)>, EventProcessorError> {
+        let hs_id: &str = self.homeserver_id.as_ref();
         let user_ids = user_hs_resolver::get_user_ids_by_homeserver(hs_id).await?;
         debug!(user_count = user_ids.len(), "Resolved users");
 
@@ -240,10 +240,10 @@ impl KeyBasedEventProcessor {
     async fn process_user(
         &self,
         hs_pk: &PublicKey,
-        hs_id: &str,
         user_pk: &PublicKey,
         cursor: EventCursor,
     ) -> Result<(), EventProcessorError> {
+        let hs_id: &str = self.homeserver_id.as_ref();
         let stream_events = self
             .fetch_user_events_with_429_backoff(hs_pk, user_pk, cursor)
             .await?;

--- a/nexus-watcher/src/service/indexer/key_based.rs
+++ b/nexus-watcher/src/service/indexer/key_based.rs
@@ -59,7 +59,7 @@ impl KeyBasedEventSource for PubkyKeyBasedEventSource {
                 }
                 error => error.into(),
             })
-            .inspect_err(|e| error!("Failed to subscribe to event stream: {e:?}"))?;
+            .inspect_err(|e| error!(error = ?e, "Failed to subscribe to event stream"))?;
 
         // The HS is asked for at most `limit` events, but a misbehaving one could return more
         let limit = limit as usize;
@@ -68,8 +68,10 @@ impl KeyBasedEventSource for PubkyKeyBasedEventSource {
             // Read at most `limit` events. If the stream still has more, log an error and drop the rest.
             if events.len() >= limit {
                 error!(
-                    "Event stream for user {user_pk} on HS {hs_pk} returned more than the \
-                     requested limit of {limit} events; ignoring the excess"
+                    %user_pk,
+                    %hs_pk,
+                    limit,
+                    "Event stream returned more than the requested limit; ignoring the excess"
                 );
                 break;
             }
@@ -142,14 +144,14 @@ impl TEventProcessor for KeyBasedEventProcessor {
         let users = self
             .resolve_users_with_cursors(&hs_id)
             .await
-            .inspect_err(|e| error!("Failed to resolve users: {e:?}"))?;
+            .inspect_err(|e| error!(error = ?e, "Failed to resolve users"))?;
 
         if users.is_empty() {
             debug!("No users, skipping");
             return Ok(());
         }
 
-        info!("Found {} users", users.len());
+        info!(user_count = users.len(), "Found users");
 
         for (user_pk, cursor) in &users {
             if *self.shutdown_rx.borrow() {
@@ -207,12 +209,12 @@ impl KeyBasedEventProcessor {
         hs_id: &str,
     ) -> Result<Vec<(PublicKey, EventCursor)>, EventProcessorError> {
         let user_ids = user_hs_resolver::get_user_ids_by_homeserver(hs_id).await?;
-        debug!("Resolved {} user(s)", user_ids.len());
+        debug!(user_count = user_ids.len(), "Resolved users");
 
         let mut valid_users: Vec<(PublicKey, &str)> = Vec::with_capacity(user_ids.len());
         for user_id in &user_ids {
             let Ok(user_pk) = user_id.parse::<PublicKey>() else {
-                warn!("Invalid user public key '{user_id}', skipping");
+                warn!(%user_id, "Invalid user public key, skipping");
                 continue;
             };
             valid_users.push((user_pk, user_id.as_str()));
@@ -313,7 +315,7 @@ impl KeyBasedEventProcessor {
 
         for stream_event in stream_events {
             if *self.shutdown_rx.borrow() {
-                debug!(hs_id = %hs_id, user = %user_id, "Shutdown detected; exiting event loop");
+                debug!(%hs_id, %user_id, "Shutdown detected; exiting event loop");
                 break;
             }
 
@@ -332,7 +334,13 @@ impl KeyBasedEventProcessor {
                 }
                 Ok(None) => { /* resource not handled by Nexus, skip */ }
                 Err(e) => {
-                    error!(%hs_id, %user_id, %cursor_id, "Skipping unparseable stream event: {e}");
+                    error!(
+                        %hs_id,
+                        %user_id,
+                        %cursor_id,
+                        error = %e,
+                        "Skipping unparseable stream event"
+                    );
                 }
             }
 

--- a/nexus-watcher/src/service/indexer/key_based.rs
+++ b/nexus-watcher/src/service/indexer/key_based.rs
@@ -135,7 +135,7 @@ impl TEventProcessor for KeyBasedEventProcessor {
         // Blacklisted HSs must never be indexed. The runner already excludes
         // them from `pre_run`, so reaching here is unexpected.
         if self.hs_blacklist.is_blacklisted(&hs_id) {
-            error!(%hs_id, action = "abort_hs", "Refusing to process blacklisted HS");
+            error!(action = "abort_hs", "Refusing to process blacklisted HS");
             return Err(EventProcessorError::HsBlacklisted { hs_id });
         }
 
@@ -164,7 +164,7 @@ impl TEventProcessor for KeyBasedEventProcessor {
             // increasing number of runs (see `UserNotFoundBackoff`).
             if self.user_not_found_backoff.consume_skip(user_pk).await {
                 debug!(
-                    %hs_id, %user_id, action = "skip_user",
+                    %user_id, action = "skip_user",
                     "Skipping user due to prior 404 (NotFound404) backoff",
                 );
                 continue;
@@ -175,7 +175,7 @@ impl TEventProcessor for KeyBasedEventProcessor {
                 Err(err) => {
                     if err.should_not_retry_now() {
                         error!(
-                            %hs_id, %user_id, action = "abort_hs", ?err,
+                            %user_id, action = "abort_hs", ?err,
                             "Got should-not-retry-now error while processing user; aborting homeserver run",
                         );
                         return Err(err);
@@ -184,12 +184,12 @@ impl TEventProcessor for KeyBasedEventProcessor {
                     if err.is_not_found() {
                         self.user_not_found_backoff.record_failure(user_pk).await;
                         warn!(
-                            %hs_id, %user_id, action = "skip_user", ?err,
+                            %user_id, action = "skip_user", ?err,
                             "User event fetch returned 404; backing off this user for future runs",
                         );
                     } else {
                         error!(
-                            %hs_id, %user_id, action = "skip_user", ?err,
+                            %user_id, action = "skip_user", ?err,
                             "Got error while processing user; continuing with next user",
                         );
                     }
@@ -245,7 +245,7 @@ impl KeyBasedEventProcessor {
         cursor: EventCursor,
     ) -> Result<(), EventProcessorError> {
         let stream_events = self
-            .fetch_user_events_with_429_backoff(hs_pk, hs_id, user_pk, cursor)
+            .fetch_user_events_with_429_backoff(hs_pk, user_pk, cursor)
             .await?;
 
         let user_id = user_pk.z32();
@@ -256,7 +256,7 @@ impl KeyBasedEventProcessor {
         if let Some(cursor_val) = latest_cursor {
             if let Err(write_err) = UserHsCursor::write(&user_id, hs_id, cursor_val).await {
                 error!(
-                    %hs_id, %user_id, %cursor_val, ?write_err,
+                    %user_id, %cursor_val, ?write_err,
                     "Best-effort cursor persist failed; events may be re-processed on next run",
                 );
             }
@@ -268,7 +268,6 @@ impl KeyBasedEventProcessor {
     async fn fetch_user_events_with_429_backoff(
         &self,
         hs_pk: &PublicKey,
-        hs_id: &str,
         user_pk: &PublicKey,
         cursor: EventCursor,
     ) -> Result<Vec<StreamEvent>, EventProcessorError> {
@@ -288,7 +287,7 @@ impl KeyBasedEventProcessor {
                     };
 
                     warn!(
-                        %hs_id, %user_id, retry_after_secs = *backoff_secs,
+                        %user_id, retry_after_secs = *backoff_secs,
                         "Homeserver rate-limited user event fetch; retrying",
                     );
 
@@ -315,7 +314,7 @@ impl KeyBasedEventProcessor {
 
         for stream_event in stream_events {
             if *self.shutdown_rx.borrow() {
-                debug!(%hs_id, %user_id, "Shutdown detected; exiting event loop");
+                debug!(%user_id, "Shutdown detected; exiting event loop");
                 break;
             }
 
@@ -335,7 +334,6 @@ impl KeyBasedEventProcessor {
                 Ok(None) => { /* resource not handled by Nexus, skip */ }
                 Err(e) => {
                     error!(
-                        %hs_id,
                         %user_id,
                         %cursor_id,
                         error = %e,

--- a/nexus-watcher/src/service/indexer/key_based.rs
+++ b/nexus-watcher/src/service/indexer/key_based.rs
@@ -116,7 +116,7 @@ impl TEventProcessor for KeyBasedEventProcessor {
     }
 
     fn instance_name(&self) -> String {
-        format!("KeyBasedEventProcessor with HS ID: {}", self.homeserver_id)
+        "KeyBasedEventProcessor".into()
     }
 
     fn retry_scheduler(&self) -> Option<&Arc<RetryScheduler>> {
@@ -201,7 +201,7 @@ impl TEventProcessor for KeyBasedEventProcessor {
 
 impl KeyBasedEventProcessor {
     /// Resolves monitored users on this homeserver and reads their cursors from Redis.
-    #[tracing::instrument(name = "dx.users.resolve", skip_all, fields(homeserver = %hs_id))]
+    #[tracing::instrument(name = "dx.users.resolve", skip_all)]
     async fn resolve_users_with_cursors(
         &self,
         hs_id: &str,
@@ -234,10 +234,7 @@ impl KeyBasedEventProcessor {
     ///
     /// Each user gets their own `limit` budget, ensuring fair progress regardless
     /// of how many events other users have produced.
-    #[tracing::instrument(name = "dx.user_events.process", skip_all, fields(
-        homeserver = %hs_id,
-        user = %user_pk.z32(),
-    ))]
+    #[tracing::instrument(name = "dx.user_events.process", skip_all, fields(user_id = %user_pk.z32()))]
     async fn process_user(
         &self,
         hs_pk: &PublicKey,

--- a/nexus-watcher/src/service/indexer/mod.rs
+++ b/nexus-watcher/src/service/indexer/mod.rs
@@ -5,11 +5,10 @@ pub use homeserver::HsEventProcessor;
 pub use key_based::{KeyBasedEventProcessor, KeyBasedEventSource, PubkyKeyBasedEventSource};
 use std::{fmt::Display, sync::Arc, time::Duration};
 
-use tracing::{Instrument, trace};
+use tracing::{debug, error, trace, warn, Instrument};
 
 use crate::errors::EventProcessorError;
 use crate::events::{Event, ParseResult};
-use tracing::{debug, error, warn};
 
 use crate::events::retry::RetryScheduler;
 use crate::events::EventHandler;
@@ -63,7 +62,7 @@ pub trait TEventProcessor: Send + Sync + 'static {
     fn event_handler(&self) -> &Arc<dyn EventHandler>;
 
     /// Returns a short service label for monitoring and tracing spans (e.g. `HsEventProcessor`).
-    fn instance_name(&self) -> String;
+    fn instance_name(&self) -> &'static str;
 
     /// Returns the retry scheduler used by [`Self::handle_error`] to enqueue failed
     /// events for later retry.  Returns `None` when the processor bypasses

--- a/nexus-watcher/src/service/indexer/mod.rs
+++ b/nexus-watcher/src/service/indexer/mod.rs
@@ -81,24 +81,19 @@ pub trait TEventProcessor: Send + Sync + 'static {
             .unwrap_or(Duration::from_secs(PROCESSING_TIMEOUT_SECS));
 
         let instance_name = self.instance_name();
-        let homeserver = self.homeserver_id().map(str::to_owned);
-        let span = match homeserver.as_deref() {
-            Some(hs_id) => tracing::info_span!(
-                "event_processor.run",
-                service = %instance_name,
-                homeserver = %hs_id,
-            ),
-            None => tracing::info_span!("event_processor.run", service = %instance_name),
-        };
+        let homeserver_id = self.homeserver_id().map(str::to_owned);
+        let homeserver = homeserver_id.as_deref().map(tracing::field::display);
+        let span = tracing::info_span!(
+            "event_processor.run",
+            service = %instance_name,
+            homeserver,
+        );
         let handle = tokio::spawn(self.run_internal().instrument(span));
 
         let join_result = tokio::time::timeout(timeout, handle)
             .await
-            .inspect_err(|_| match homeserver.as_deref() {
-                Some(hs_id) => {
-                    error!(service = %instance_name, homeserver = %hs_id, "Event processor timed out")
-                }
-                None => error!(service = %instance_name, "Event processor timed out"),
+            .inspect_err(|_| {
+                error!(service = %instance_name, homeserver, "Event processor timed out")
             })
             .map_err(|_| RunError::TimedOut)?;
 
@@ -110,20 +105,24 @@ pub trait TEventProcessor: Send + Sync + 'static {
         // In our model, we don't trigger such interruptions. Instead we use the shutdown signal
         // to gracefully stop the event processing loop. Therefore we consider all JoinErrors as panics.
         let run_internal_result = join_result
-            .inspect_err(|je| match homeserver.as_deref() {
-                Some(hs_id) => {
-                    error!(service = %instance_name, homeserver = %hs_id, error = ?je, "Event processor JoinError")
-                }
-                None => error!(service = %instance_name, error = ?je, "Event processor JoinError"),
+            .inspect_err(|je| {
+                error!(
+                    service = %instance_name,
+                    homeserver,
+                    error = ?je,
+                    "Event processor JoinError"
+                )
             })
             .map_err(|_| RunError::Panicked)?;
 
         run_internal_result
-            .inspect_err(|e| match homeserver.as_deref() {
-                Some(hs_id) => {
-                    error!(service = %instance_name, homeserver = %hs_id, error = ?e, "Event processor failed")
-                }
-                None => error!(service = %instance_name, error = ?e, "Event processor failed"),
+            .inspect_err(|e| {
+                error!(
+                    service = %instance_name,
+                    homeserver,
+                    error = ?e,
+                    "Event processor failed"
+                )
             })
             .map_err(RunError::Internal)
     }

--- a/nexus-watcher/src/service/indexer/mod.rs
+++ b/nexus-watcher/src/service/indexer/mod.rs
@@ -92,9 +92,9 @@ pub trait TEventProcessor: Send + Sync + 'static {
 
         let join_result = tokio::time::timeout(timeout, handle)
             .await
-            .inspect_err(|_| {
-                error!(service = %instance_name, homeserver, "Event processor timed out")
-            })
+            .inspect_err(
+                |_| error!(service = %instance_name, homeserver, "Event processor timed out"),
+            )
             .map_err(|_| RunError::TimedOut)?;
 
         // The JoinError can be:

--- a/nexus-watcher/src/service/indexer/mod.rs
+++ b/nexus-watcher/src/service/indexer/mod.rs
@@ -147,13 +147,13 @@ pub trait TEventProcessor: Send + Sync + 'static {
     async fn process_event_line(&self, line: &str) -> Result<(), EventProcessorError> {
         match Event::parse_event(line) {
             // Invalid event lines come from untrusted homeservers; treat as bad peer data, not Nexus errors.
-            Err(e) => warn!("{e}"),
+            Err(e) => warn!(error = %e, "Invalid event line"),
             Ok(ParseResult::Skipped) => {}
             Ok(ParseResult::UnrecognizedUri { reason, .. }) => {
-                warn!("Unrecognized event URI: {reason}");
+                warn!(%reason, "Unrecognized event URI");
             }
             Ok(ParseResult::Parsed(event)) => {
-                trace!("Processing event: {:?}", event);
+                trace!(?event, "Processing event");
                 self.handle_event(&event).await?;
             }
         }
@@ -175,14 +175,15 @@ pub trait TEventProcessor: Send + Sync + 'static {
         error: EventProcessorError,
     ) -> Result<(), EventProcessorError> {
         if error.should_not_retry_now() {
-            warn!("Got should-not-retry-now error, stopping batch: {error}");
+            warn!(error = %error, "Got should-not-retry-now error, stopping batch");
             return Err(error);
         }
 
         if !RetryScheduler::should_enqueue_related_event(&error) {
             debug!(
-                "Error not worth retrying, skipping event {}: {error}",
-                event.uri
+                event.uri = %event.uri,
+                error = %error,
+                "Error not worth retrying, skipping event"
             );
             return Ok(());
         }
@@ -193,8 +194,8 @@ pub trait TEventProcessor: Send + Sync + 'static {
 
         let Some(homeserver_id) = self.homeserver_id() else {
             warn!(
-                "Retryable error but no origin homeserver to persist; skipping retry for {}",
-                event.uri
+                event.uri = %event.uri,
+                "Retryable error but no origin homeserver to persist; skipping retry"
             );
             return Ok(());
         };
@@ -202,7 +203,7 @@ pub trait TEventProcessor: Send + Sync + 'static {
         if error.is_missing_dependency() {
             scheduler.queue_missing_dep(event, homeserver_id).await
         } else {
-            warn!("Transient error, queuing event for retry: {error}");
+            warn!(error = %error, "Transient error, queuing event for retry");
             scheduler.queue_transient(event, homeserver_id).await
         }
     }

--- a/nexus-watcher/src/service/indexer/mod.rs
+++ b/nexus-watcher/src/service/indexer/mod.rs
@@ -5,7 +5,7 @@ pub use homeserver::HsEventProcessor;
 pub use key_based::{KeyBasedEventProcessor, KeyBasedEventSource, PubkyKeyBasedEventSource};
 use std::{fmt::Display, sync::Arc, time::Duration};
 
-use tracing::Instrument;
+use tracing::{Instrument, trace};
 
 use crate::errors::EventProcessorError;
 use crate::events::{Event, ParseResult};
@@ -62,9 +62,7 @@ pub trait TEventProcessor: Send + Sync + 'static {
     /// This allows for flexible event handling implementations, including mocked versions for testing.
     fn event_handler(&self) -> &Arc<dyn EventHandler>;
 
-    /// Returns the instance name of the event processor, used in the monitoring and tracing spans.
-    ///
-    /// For instances mapped to a specific HS, this should include the HS ID.
+    /// Returns a short service label for monitoring and tracing spans (e.g. `HsEventProcessor`).
     fn instance_name(&self) -> String;
 
     /// Returns the retry scheduler used by [`Self::handle_error`] to enqueue failed
@@ -84,12 +82,25 @@ pub trait TEventProcessor: Send + Sync + 'static {
             .unwrap_or(Duration::from_secs(PROCESSING_TIMEOUT_SECS));
 
         let instance_name = self.instance_name();
-        let span = tracing::info_span!("event_processor.run", service = %instance_name);
+        let homeserver = self.homeserver_id().map(str::to_owned);
+        let span = match homeserver.as_deref() {
+            Some(hs_id) => tracing::info_span!(
+                "event_processor.run",
+                service = %instance_name,
+                homeserver = %hs_id,
+            ),
+            None => tracing::info_span!("event_processor.run", service = %instance_name),
+        };
         let handle = tokio::spawn(self.run_internal().instrument(span));
 
         let join_result = tokio::time::timeout(timeout, handle)
             .await
-            .inspect_err(|_| error!("Event processor timed out for {instance_name}"))
+            .inspect_err(|_| match homeserver.as_deref() {
+                Some(hs_id) => {
+                    error!(service = %instance_name, homeserver = %hs_id, "Event processor timed out")
+                }
+                None => error!(service = %instance_name, "Event processor timed out"),
+            })
             .map_err(|_| RunError::TimedOut)?;
 
         // The JoinError can be:
@@ -100,11 +111,21 @@ pub trait TEventProcessor: Send + Sync + 'static {
         // In our model, we don't trigger such interruptions. Instead we use the shutdown signal
         // to gracefully stop the event processing loop. Therefore we consider all JoinErrors as panics.
         let run_internal_result = join_result
-            .inspect_err(|je| error!("JoinError by event processor for {instance_name}: {je:?}"))
+            .inspect_err(|je| match homeserver.as_deref() {
+                Some(hs_id) => {
+                    error!(service = %instance_name, homeserver = %hs_id, error = ?je, "Event processor JoinError")
+                }
+                None => error!(service = %instance_name, error = ?je, "Event processor JoinError"),
+            })
             .map_err(|_| RunError::Panicked)?;
 
         run_internal_result
-            .inspect_err(|e| error!("Event processor failed for {instance_name}: {e:?}"))
+            .inspect_err(|e| match homeserver.as_deref() {
+                Some(hs_id) => {
+                    error!(service = %instance_name, homeserver = %hs_id, error = ?e, "Event processor failed")
+                }
+                None => error!(service = %instance_name, error = ?e, "Event processor failed"),
+            })
             .map_err(RunError::Internal)
     }
 
@@ -132,7 +153,7 @@ pub trait TEventProcessor: Send + Sync + 'static {
                 warn!("Unrecognized event URI: {reason}");
             }
             Ok(ParseResult::Parsed(event)) => {
-                debug!("Processing event: {:?}", event);
+                trace!("Processing event: {:?}", event);
                 self.handle_event(&event).await?;
             }
         }
@@ -206,7 +227,6 @@ pub trait TEventProcessor: Send + Sync + 'static {
             event.r#type = %event.event_type,
             event.user_id = %event.parsed_uri.user_id(),
             event.resource_id = event.parsed_uri.resource().id().unwrap_or_default(),
-            instance = %self.instance_name(),
             otel.status_code = tracing::field::Empty,
             otel.status_message = tracing::field::Empty,
         )

--- a/nexus-watcher/src/service/runner/key_based.rs
+++ b/nexus-watcher/src/service/runner/key_based.rs
@@ -124,7 +124,7 @@ impl TEventProcessorRunner for KeyBasedEventProcessorRunner {
             let hs_id = &individual_run_stat.hs_id;
             let duration = individual_run_stat.duration;
             let status = &individual_run_stat.status;
-            info!(%hs_id, ?duration, ?status, "Event processor run completed");
+            info!(homeserver = %hs_id, ?duration, ?status, "Event processor run completed");
         }
 
         let count_ok = stats.count_ok();

--- a/nexus-watcher/src/service/runner/key_based.rs
+++ b/nexus-watcher/src/service/runner/key_based.rs
@@ -12,7 +12,7 @@ use nexus_common::WatcherConfig;
 use pubky_app_specs::PubkyId;
 use std::sync::Arc;
 use tokio::sync::{watch::Receiver, Mutex};
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 
 /// Runner for [KeyBasedEventProcessor]
 pub struct KeyBasedEventProcessorRunner {
@@ -124,7 +124,7 @@ impl TEventProcessorRunner for KeyBasedEventProcessorRunner {
             let hs_id = &individual_run_stat.hs_id;
             let duration = individual_run_stat.duration;
             let status = &individual_run_stat.status;
-            debug!(%hs_id, ?duration, ?status, "Event processor run completed");
+            info!(%hs_id, ?duration, ?status, "Event processor run completed");
         }
 
         let count_ok = stats.count_ok();
@@ -136,11 +136,25 @@ impl TEventProcessorRunner for KeyBasedEventProcessorRunner {
         let had_issues = count_error + count_panic + count_timeout + count_failed_to_build > 0;
 
         if had_issues {
-            warn!("Run result: {count_ok} ok, {count_skipped} skipped (backoff), {count_failed_to_build} failed to build, {count_error} error, {count_panic} panic, {count_timeout} timeout");
+            warn!(
+                hs_ok = count_ok,
+                hs_skipped = count_skipped,
+                hs_failed_to_build = count_failed_to_build,
+                hs_error = count_error,
+                hs_panic = count_panic,
+                hs_timeout = count_timeout,
+                "Key-based indexing finished with issues"
+            );
         } else if count_skipped > 0 {
-            info!("Run result: {count_ok} ok, {count_skipped} skipped (backoff)");
+            warn!(
+                ok = count_ok,
+                skipped = count_skipped,
+                "Key-based indexing (per hs) finished; some skipped (backoff)"
+            );
+        } else if count_ok == 0 {
+            info!("Key-based indexing finished: no external homeservers");
         } else {
-            debug!("Run result: {count_ok} ok");
+            info!(ok = count_ok, "Key-based indexing (per hs) finished");
         }
 
         ProcessedStats(stats)

--- a/nexus-watcher/src/service/runner/key_based.rs
+++ b/nexus-watcher/src/service/runner/key_based.rs
@@ -12,7 +12,7 @@ use nexus_common::WatcherConfig;
 use pubky_app_specs::PubkyId;
 use std::sync::Arc;
 use tokio::sync::{watch::Receiver, Mutex};
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 /// Runner for [KeyBasedEventProcessor]
 pub struct KeyBasedEventProcessorRunner {
@@ -124,7 +124,7 @@ impl TEventProcessorRunner for KeyBasedEventProcessorRunner {
             let hs_id = &individual_run_stat.hs_id;
             let duration = individual_run_stat.duration;
             let status = &individual_run_stat.status;
-            info!(homeserver = %hs_id, ?duration, ?status, "Event processor run completed");
+            debug!(homeserver = %hs_id, ?duration, ?status, "Event processor run completed");
         }
 
         let count_ok = stats.count_ok();
@@ -147,14 +147,14 @@ impl TEventProcessorRunner for KeyBasedEventProcessorRunner {
             );
         } else if count_skipped > 0 {
             warn!(
-                ok = count_ok,
-                skipped = count_skipped,
-                "Key-based indexing (per hs) finished; some skipped (backoff)"
+                hs_ok = count_ok,
+                hs_skipped = count_skipped,
+                "Key-based indexing finished; some homeservers skipped (backoff)"
             );
         } else if count_ok == 0 {
             info!("Key-based indexing finished: no external homeservers");
         } else {
-            info!(ok = count_ok, "Key-based indexing (per hs) finished");
+            info!(hs_ok = count_ok, "Key-based indexing finished");
         }
 
         ProcessedStats(stats)

--- a/nexus-watcher/src/service/runner/key_based_hs_backoff.rs
+++ b/nexus-watcher/src/service/runner/key_based_hs_backoff.rs
@@ -56,7 +56,7 @@ impl HomeserverBackoff {
         entry.backoff_until = Instant::now() + Duration::from_secs(backoff_secs);
         entry.next_backoff_secs = (backoff_secs * 2).min(max);
 
-        info!("Homeserver {hs_id} backed off for {backoff_secs}s");
+        info!(homeserver = %hs_id, backoff_secs, "Homeserver backed off");
     }
 }
 

--- a/nexus-watcher/src/service/runner/mod.rs
+++ b/nexus-watcher/src/service/runner/mod.rs
@@ -74,12 +74,12 @@ pub trait TEventProcessorRunner: Send + Sync {
 
         for hs_id in hs_ids {
             if *self.shutdown_rx().borrow() {
-                info!(hs_id = %hs_id, "Shutdown detected; exiting run loop");
+                info!(homeserver = %hs_id, "Shutdown detected; exiting run loop");
                 break;
             }
 
             if self.backoff_hs_should_skip(&hs_id).await {
-                debug!(%hs_id, "Skipping homeserver in backoff");
+                debug!(homeserver = %hs_id, "Skipping homeserver in backoff");
                 run_stats.add_run_result(hs_id, Duration::ZERO, ProcessorRunStatus::Skipped);
                 continue;
             }
@@ -88,7 +88,7 @@ pub trait TEventProcessorRunner: Send + Sync {
             let status = match self.build(&hs_id).await {
                 Ok(event_processor) => status_from_run_result(event_processor.run().await),
                 Err(e) => {
-                    error!(hs_id = %hs_id, error = %e, "Failed to build event processor");
+                    error!(homeserver = %hs_id, error = %e, "Failed to build event processor");
                     ProcessorRunStatus::FailedToBuild
                 }
             };

--- a/nexus-watcher/src/service/user_hs_resolver.rs
+++ b/nexus-watcher/src/service/user_hs_resolver.rs
@@ -209,7 +209,7 @@ async fn resolve_user(
 
         (None, Some(resolved_hs_id)) => {
             set_user_homeserver(&user_id, resolved_hs_id).await?;
-            debug!("User {user_id} -> HS {resolved_hs_id}");
+            debug!(%user_id, homeserver = %resolved_hs_id, "HS mapping created");
         }
 
         // Already bound to a HS: toggle the stale flag instead of switching.

--- a/nexus-watcher/src/service/user_hs_resolver.rs
+++ b/nexus-watcher/src/service/user_hs_resolver.rs
@@ -87,7 +87,7 @@ pub async fn run(
             // For the user_ids that fail to convert, we log an error message and skip them
             user_id
                 .parse::<PublicKey>()
-                .map_err(|e| error!("Failed to parse user_id {user_id}: {e}"))
+                .map_err(|e| error!(%user_id, error = %e, "Failed to parse user_id"))
                 .ok()
         })
         .collect();
@@ -99,7 +99,7 @@ pub async fn run(
     }
 
     let total = user_pks.len() as u64;
-    debug!("Resolving homeservers for {} users", total);
+    debug!(user_count = total, "Resolving homeservers");
 
     let mut failed = 0u64;
     let mut processed = 0u64;
@@ -121,7 +121,7 @@ pub async fn run(
         tokio::select! {
             biased;
             _ = shutdown_rx.changed() => {
-                info!("Shutdown detected; HS resolver stopping after {processed}/{total} users");
+                info!(processed, total, "Shutdown detected; HS resolver stopping");
                 break;
             }
             result = resolve_user(resolver, &user_pk) => {
@@ -205,7 +205,7 @@ async fn resolve_user(
     let maybe_stored_hs_id = get_user_homeserver(&user_id).await?;
 
     match (&maybe_stored_hs_id, &maybe_resolved_hs_id) {
-        (None, None) => warn!("User {user_id} has no published homeserver"),
+        (None, None) => warn!(%user_id, "User has no published homeserver"),
 
         (None, Some(resolved_hs_id)) => {
             set_user_homeserver(&user_id, resolved_hs_id).await?;
@@ -215,15 +215,16 @@ async fn resolve_user(
         // Already bound to a HS: toggle the stale flag instead of switching.
         (Some(stored_hs_id), Some(resolved_hs_id)) if resolved_hs_id.as_ref() == stored_hs_id => {
             set_user_homeserver_stale(&user_id, false).await?;
-            debug!("User {user_id} still hosted on {stored_hs_id}, mapping active");
+            debug!(%user_id, homeserver = %stored_hs_id, "HS mapping still active");
         }
 
         // HS switching is not fully implemented, so the bound HS is never changed once set
         (Some(stored_hs_id), _) => {
             set_user_homeserver_stale(&user_id, true).await?;
             warn!(
-                "User {user_id} homeserver changed or was removed (stored {stored_hs_id}); \
-                 switching unsupported, mapping marked stale and indexing paused"
+                %user_id,
+                stored_homeserver = %stored_hs_id,
+                "User homeserver changed or was removed; switching unsupported, mapping marked stale"
             );
         }
     }

--- a/nexus-watcher/tests/service/utils/processor.rs
+++ b/nexus-watcher/tests/service/utils/processor.rs
@@ -37,7 +37,7 @@ impl TEventProcessor for MockEventProcessor {
     }
 
     fn instance_name(&self) -> String {
-        format!("MockEventProcessor for HS ID: {}", self.homeserver_id)
+        "MockEventProcessor".into()
     }
 
     fn homeserver_id(&self) -> Option<&str> {

--- a/nexus-watcher/tests/service/utils/processor.rs
+++ b/nexus-watcher/tests/service/utils/processor.rs
@@ -36,8 +36,8 @@ impl TEventProcessor for MockEventProcessor {
         self.custom_timeout
     }
 
-    fn instance_name(&self) -> String {
-        "MockEventProcessor".into()
+    fn instance_name(&self) -> &'static str {
+        "MockEventProcessor"
     }
 
     fn homeserver_id(&self) -> Option<&str> {


### PR DESCRIPTION
## Summary

Improves watcher and stack logging so `DEBUG` is usable day-to-day, without changing indexing behavior.

- **Span identity** — Attach `homeserver` once on the `event_processor.run` span. Keep `instance_name()` as a short static label (`HsEventProcessor`, `RetryProcessor`, …) instead of baking the HS ID into every log line.
- **Structured fields** — Prefer tracing fields over string interpolation, and use a single `homeserver` field name (replacing mixed `hs_id` / `processor_homeserver`).
- **Less DEBUG noise** — Remove logs that only repeat span data. Move high-volume detail to `TRACE` (KV writes, full HS responses, parsed event dumps). Keep handler DEBUG as short verbs when IDs are already on the span.
- **Quieter defaults** — Cap noisy HTTP/TLS crates at `warn`, and discovery crates (`mainline`, `pkarr`, `pubky`) unless the global level is `TRACE`.


## Pre-submission Checklist

- [ ] I manually reviewed the PR
- [ ] I asked one or more LLMs to review the PR
- [ ] I asked one or more LLMs to check if this PR can be simplified [^1]
- [ ] If appropriate, I added tests for the changes in this PR
- [ ] If appropriate, I added performance benchmarks for the APIs added in this PR [^2]

[^1]: Sample prompt: "Can this be simplified? Can the code, comments, or logic introduced by these changes be simplfied, clarified or otherwise made more terse, concise and understandable, without affecting functionality?"
[^2]: `cargo bench -p nexus-webapi`
