### PR TITLE
feat: local OTEL compose + resource attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,12 +91,29 @@ cargo run -p nexusd -- api
 
 ## 📈 Observability
 
-If you want to enable observability in Nexus, you can connect it to an OpenTelemetry exporter. Follow these steps:
+Nexus exports telemetry over OTLP. For local development, use either the bundled observability stack or a separately installed SigNoz instance.
 
-1. Install Signoz locally – Follow the Signoz installation [guide](https://signoz.io/docs/install)
-2. Configure the connection – In _config.toml_, set the `endpoint` under `[stack.otlp]` to point Nexus to the Signoz endpoint
-3. Run Nexus – Start nexusd using the configured settings
-4. Access the Signoz dashboard – Open http://localhost:3301 in your browser (allow some time for data to populate).
+Configure the OTLP endpoint in _config.toml_:
+
+```toml
+[stack.otlp]
+name = "nexusd"
+endpoint = "http://localhost:4317"
+```
+
+OTLP export is disabled when `endpoint` is omitted. When configured, Nexus exports logs, traces, and metrics using `name` as the OpenTelemetry `service.name`.
+
+### Local observability stack
+
+The bundled stack runs independently of the database services and combines the OpenTelemetry Collector with Grafana, Tempo, Prometheus, and Loki.
+
+```bash
+docker compose -f docker/docker-compose.observability.yml up -d
+```
+
+### SigNoz
+
+SigNoz remains supported as an alternative OpenTelemetry backend. Follow the [SigNoz installation guide](https://signoz.io/docs/install), then replace the local endpoint above with the SigNoz OTLP endpoint. Its local dashboard is available at [http://localhost:3301](http://localhost:3301).
 
 ## 📦 Data Migrations
 

--- a/docker/docker-compose.observability.yml
+++ b/docker/docker-compose.observability.yml
@@ -1,4 +1,4 @@
-name: pubky-nexus-otel-local
+name: pubky-nexus-observability
 
 x-logging: &default-logging
   driver: json-file

--- a/docker/docker-compose.observability.yml
+++ b/docker/docker-compose.observability.yml
@@ -1,5 +1,11 @@
 name: pubky-nexus-otel-local
 
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "3"
+
 services:
   otel-collector:
     image: otel/opentelemetry-collector-contrib:0.115.1
@@ -11,9 +17,13 @@ services:
       - 127.0.0.1:4317:4317
       - 127.0.0.1:4318:4318
     depends_on:
-      - tempo
-      - prometheus
-      - loki
+      tempo:
+        condition: service_healthy
+      prometheus:
+        condition: service_healthy
+      loki:
+        condition: service_healthy
+    logging: *default-logging
     restart: unless-stopped
 
   tempo:
@@ -23,6 +33,13 @@ services:
     volumes:
       - ./otel/tempo.yaml:/etc/tempo.yaml:ro
       - tempo_data:/var/tempo
+    healthcheck:
+      test: ["CMD", "/usr/bin/wget", "-qO-", "http://localhost:3200/ready"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
+    logging: *default-logging
     restart: unless-stopped
 
   prometheus:
@@ -31,12 +48,20 @@ services:
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.path=/prometheus'
+      - '--storage.tsdb.retention.time=24h'
       - '--web.enable-remote-write-receiver'
     volumes:
       - ./otel/prometheus.yaml:/etc/prometheus/prometheus.yml:ro
       - prometheus_data:/prometheus
     ports:
       - 127.0.0.1:9090:9090
+    healthcheck:
+      test: ["CMD", "/bin/wget", "-qO-", "http://localhost:9090/-/ready"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
+    logging: *default-logging
     restart: unless-stopped
 
   loki:
@@ -48,6 +73,13 @@ services:
       - loki_data:/loki
     ports:
       - 127.0.0.1:3100:3100
+    healthcheck:
+      test: ["CMD", "/busybox/wget", "-qO-", "http://localhost:3100/ready"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
+    logging: *default-logging
     restart: unless-stopped
 
   grafana:
@@ -62,10 +94,7 @@ services:
       - grafana_data:/var/lib/grafana
     ports:
       - 127.0.0.1:3000:3000
-    depends_on:
-      - prometheus
-      - tempo
-      - loki
+    logging: *default-logging
     restart: unless-stopped
 
 volumes:

--- a/docker/docker-compose.otel-local.yml
+++ b/docker/docker-compose.otel-local.yml
@@ -1,0 +1,75 @@
+name: pubky-nexus-otel-local
+
+services:
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.115.1
+    container_name: otel-collector
+    command: ["--config=/etc/otelcol/config.yaml"]
+    volumes:
+      - ./otel/collector-config.yaml:/etc/otelcol/config.yaml:ro
+    ports:
+      - 127.0.0.1:4317:4317
+      - 127.0.0.1:4318:4318
+    depends_on:
+      - tempo
+      - prometheus
+      - loki
+    restart: unless-stopped
+
+  tempo:
+    image: grafana/tempo:2.6.1
+    container_name: tempo
+    command: ["-config.file=/etc/tempo.yaml"]
+    volumes:
+      - ./otel/tempo.yaml:/etc/tempo.yaml:ro
+      - tempo_data:/var/tempo
+    restart: unless-stopped
+
+  prometheus:
+    image: prom/prometheus:v2.55.1
+    container_name: prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.enable-remote-write-receiver'
+    volumes:
+      - ./otel/prometheus.yaml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    ports:
+      - 127.0.0.1:9090:9090
+    restart: unless-stopped
+
+  loki:
+    image: grafana/loki:3.3.0
+    container_name: loki
+    command: ["-config.file=/etc/loki/config.yaml"]
+    volumes:
+      - ./otel/loki.yaml:/etc/loki/config.yaml:ro
+      - loki_data:/loki
+    ports:
+      - 127.0.0.1:3100:3100
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:11.4.0
+    container_name: grafana
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
+    volumes:
+      - ./otel/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml:ro
+      - grafana_data:/var/lib/grafana
+    ports:
+      - 127.0.0.1:3000:3000
+    depends_on:
+      - prometheus
+      - tempo
+      - loki
+    restart: unless-stopped
+
+volumes:
+  tempo_data:
+  prometheus_data:
+  loki_data:
+  grafana_data:

--- a/docker/otel/collector-config.yaml
+++ b/docker/otel/collector-config.yaml
@@ -1,7 +1,3 @@
-# OpenTelemetry Collector - single OTLP entry point for local nexus testing.
-# Receives traces, logs and metrics over OTLP and fans each signal out to its
-# backend (Tempo / Prometheus / Loki).
-
 receivers:
   otlp:
     protocols:
@@ -35,7 +31,6 @@ exporters:
       insecure: true
 
   # Mirror everything to stdout for a quick sanity check:
-  #   docker compose -f docker/docker-compose.otel-local.yml logs -f otel-collector
   debug:
     verbosity: normal
 

--- a/docker/otel/collector-config.yaml
+++ b/docker/otel/collector-config.yaml
@@ -1,0 +1,55 @@
+# OpenTelemetry Collector - single OTLP entry point for local nexus testing.
+# Receives traces, logs and metrics over OTLP and fans each signal out to its
+# backend (Tempo / Prometheus / Loki).
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch: {}
+
+exporters:
+  # Traces -> Tempo (OTLP/gRPC)
+  otlp/tempo:
+    endpoint: tempo:4317
+    tls:
+      insecure: true
+
+  # Metrics -> Prometheus (remote-write receiver, enabled via compose command)
+  prometheusremotewrite:
+    endpoint: http://prometheus:9090/api/v1/write
+    tls:
+      insecure: true
+    resource_to_telemetry_conversion:
+      enabled: true   # service.name etc. become metric labels
+
+  # Logs -> Loki (native OTLP ingestion endpoint; exporter appends /v1/logs)
+  otlphttp/loki:
+    endpoint: http://loki:3100/otlp
+    tls:
+      insecure: true
+
+  # Mirror everything to stdout for a quick sanity check:
+  #   docker compose -f docker/docker-compose.otel-local.yml logs -f otel-collector
+  debug:
+    verbosity: normal
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp/tempo, debug]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [prometheusremotewrite, debug]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlphttp/loki, debug]

--- a/docker/otel/grafana-datasources.yaml
+++ b/docker/otel/grafana-datasources.yaml
@@ -1,0 +1,23 @@
+# Auto-provisioned Grafana datasources for the three signals.
+
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+
+  - name: Tempo
+    type: tempo
+    uid: tempo
+    access: proxy
+    url: http://tempo:3200
+
+  - name: Loki
+    type: loki
+    uid: loki
+    access: proxy
+    url: http://loki:3100

--- a/docker/otel/grafana-datasources.yaml
+++ b/docker/otel/grafana-datasources.yaml
@@ -1,5 +1,3 @@
-# Auto-provisioned Grafana datasources for the three signals.
-
 apiVersion: 1
 
 datasources:

--- a/docker/otel/loki.yaml
+++ b/docker/otel/loki.yaml
@@ -1,0 +1,34 @@
+# Minimal single-binary Loki config with native OTLP log ingestion enabled.
+
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+# Required so OTLP resource/scope attributes can be stored as structured metadata
+limits_config:
+  allow_structured_metadata: true
+  volume_enabled: true

--- a/docker/otel/loki.yaml
+++ b/docker/otel/loki.yaml
@@ -26,6 +26,12 @@ schema_config:
         prefix: index_
         period: 24h
 
+compactor:
+  working_directory: /loki/compactor
+  retention_enabled: true
+  delete_request_store: filesystem
+
 limits_config:
   allow_structured_metadata: true
   volume_enabled: true
+  retention_period: 24h

--- a/docker/otel/loki.yaml
+++ b/docker/otel/loki.yaml
@@ -1,5 +1,3 @@
-# Minimal single-binary Loki config with native OTLP log ingestion enabled.
-
 auth_enabled: false
 
 server:
@@ -28,7 +26,6 @@ schema_config:
         prefix: index_
         period: 24h
 
-# Required so OTLP resource/scope attributes can be stored as structured metadata
 limits_config:
   allow_structured_metadata: true
   volume_enabled: true

--- a/docker/otel/prometheus.yaml
+++ b/docker/otel/prometheus.yaml
@@ -1,0 +1,12 @@
+# Prometheus receives metrics pushed by the collector via remote write
+# (see --web.enable-remote-write-receiver in the compose command).
+# It also scrapes itself so the target list is never empty.
+
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ["localhost:9090"]

--- a/docker/otel/prometheus.yaml
+++ b/docker/otel/prometheus.yaml
@@ -1,7 +1,3 @@
-# Prometheus receives metrics pushed by the collector via remote write
-# (see --web.enable-remote-write-receiver in the compose command).
-# It also scrapes itself so the target list is never empty.
-
 global:
   scrape_interval: 15s
   evaluation_interval: 15s

--- a/docker/otel/tempo.yaml
+++ b/docker/otel/tempo.yaml
@@ -1,0 +1,26 @@
+# Minimal single-binary Tempo config for local trace storage.
+
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+
+ingester:
+  max_block_duration: 5m
+
+compactor:
+  compaction:
+    block_retention: 24h
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /var/tempo/blocks
+    wal:
+      path: /var/tempo/wal

--- a/docker/otel/tempo.yaml
+++ b/docker/otel/tempo.yaml
@@ -1,5 +1,3 @@
-# Minimal single-binary Tempo config for local trace storage.
-
 server:
   http_listen_port: 3200
 

--- a/examples/api/api-config.toml
+++ b/examples/api/api-config.toml
@@ -33,8 +33,13 @@ external_hs_pk_blacklist = []
 [stack.otlp]
 # Service name used for tracing, logging, and metrics in OpenTelemetry
 name = "nexus.example.api"
-# OTLP endpoint is not set by default. If you want to enable tracing, set it to the OpenTelemetry Collector endpoint
+# OTLP endpoint is not set by default. To export logs, traces, and metrics,
+# set it to an OpenTelemetry Collector endpoint.
 #endpoint = "http://localhost:4317"
+# Optional resource attributes attached to all OTLP signals
+# [stack.otlp.resource_attributes]
+# "host.name" = "nexus-1"
+# "deployment.environment.name" = "local"
 
 [stack.db]
 redis = "redis://127.0.0.1:6379"

--- a/examples/watcher/watcher-config.toml
+++ b/examples/watcher/watcher-config.toml
@@ -47,8 +47,13 @@ external_hs_pk_blacklist = []
 [stack.otlp]
 # Service name used for tracing, logging, and metrics in OpenTelemetry
 name = "nexus.example.watcher"
-# OTLP endpoint is not set by default. If you want to enable tracing, set it to the OpenTelemetry Collector endpoint
+# OTLP endpoint is not set by default. To export logs, traces, and metrics,
+# set it to an OpenTelemetry Collector endpoint.
 #endpoint = "http://localhost:4317"
+# Optional resource attributes attached to all OTLP signals
+# [stack.otlp.resource_attributes]
+# "host.name" = "nexus-1"
+# "deployment.environment.name" = "local"
 
 [stack.db]
 redis = "redis://localhost:6379"

--- a/nexus-common/default.config.toml
+++ b/nexus-common/default.config.toml
@@ -95,6 +95,11 @@ external_hs_pk_blacklist = []
 name = "nexusd"
 # OTLP endpoint is not set by default. If you want to enable tracing, set it to the OpenTelemetry Collector endpoint
 #endpoint = "http://localhost:4317"
+# Optional. Arbitrary key/value resource attributes attached to all OTLP signals
+# (e.g. host, env, region, …) so shared collectors can label and filter by source.
+# [stack.otlp.resource_attributes]
+# host = "nexus-1"
+# env = "prod"
 
 [stack.db]
 redis = "redis://127.0.0.1:6379"

--- a/nexus-common/default.config.toml
+++ b/nexus-common/default.config.toml
@@ -93,13 +93,13 @@ external_hs_pk_blacklist = []
 [stack.otlp]
 # Service name used for tracing, logging, and metrics in OpenTelemetry
 name = "nexusd"
-# OTLP endpoint is not set by default. If you want to enable tracing, set it to the OpenTelemetry Collector endpoint
+# OTLP endpoint is not set by default. To export logs, traces, and metrics,
+# set it to an OpenTelemetry Collector endpoint.
 #endpoint = "http://localhost:4317"
-# Optional. Arbitrary key/value resource attributes attached to all OTLP signals
-# (e.g. host, env, region, …) so shared collectors can label and filter by source.
+# Optional resource attributes attached to all OTLP signals
 # [stack.otlp.resource_attributes]
-# host = "nexus-1"
-# env = "prod"
+# "host.name" = "nexus-1"
+# "deployment.environment.name" = "local"
 
 [stack.db]
 redis = "redis://127.0.0.1:6379"

--- a/nexus-common/src/config/daemon.rs
+++ b/nexus-common/src/config/daemon.rs
@@ -60,7 +60,7 @@ impl ConfigLoader<DaemonConfig> for DaemonConfig {}
 
 #[cfg(test)]
 mod tests {
-    use std::{net::SocketAddr, path::PathBuf, str::FromStr};
+    use std::{collections::HashMap, net::SocketAddr, path::PathBuf, str::FromStr};
 
     use pubky_app_specs::PubkyId;
 
@@ -116,8 +116,38 @@ mod tests {
         );
         assert_eq!(c.stack.otlp.name, "nexusd");
         assert!(c.stack.otlp.endpoint.is_none());
+        assert!(c.stack.otlp.resource_attributes.is_empty());
         assert_eq!(c.stack.db.redis, "redis://127.0.0.1:6379");
         assert_eq!(c.stack.db.neo4j.uri, "bolt://localhost:7687");
+    }
+
+    /// Optional `[stack.otlp.resource_attributes]` parses into a string map.
+    #[test]
+    fn test_otlp_resource_attributes_parsing() {
+        let toml = format!(
+            "{DEFAULT_CONFIG_TOML}\n\
+             [stack.otlp.resource_attributes]\n\
+             host = \"nexus-1\"\n\
+             env = \"prod\"\n\
+             region = \"eu-central\"\n\
+             \"deployment.environment\" = \"production\"\n\
+             \"service.instance.id\" = \"nexusd-01\"\n"
+        );
+
+        let c = DaemonConfig::try_from_str(&toml)
+            .expect("config with otlp resource_attributes should parse");
+
+        let expected = HashMap::from([
+            ("host".to_string(), "nexus-1".to_string()),
+            ("env".to_string(), "prod".to_string()),
+            ("region".to_string(), "eu-central".to_string()),
+            (
+                "deployment.environment".to_string(),
+                "production".to_string(),
+            ),
+            ("service.instance.id".to_string(), "nexusd-01".to_string()),
+        ]);
+        assert_eq!(c.stack.otlp.resource_attributes, expected);
     }
 
     /// A populated `external_hs_pk_blacklist` is parsed into the expected

--- a/nexus-common/src/config/stack.rs
+++ b/nexus-common/src/config/stack.rs
@@ -1,5 +1,6 @@
 use crate::{db::DatabaseConfig, get_files_dir_pathbuf};
 use serde::{Deserialize, Deserializer, Serialize};
+use std::collections::HashMap;
 use std::{fmt::Debug, path::PathBuf};
 
 use super::net::NetConfig;
@@ -20,6 +21,11 @@ pub struct OtlpConfig {
     pub name: String,
     /// OTLP endpoint. When set, enables export of traces, logs, and metrics
     pub endpoint: Option<String>,
+    /// Extra resource attributes attached to all traces, metrics, and logs
+    /// from this process (e.g. `host`, `env`) so shared collectors can
+    /// distinguish sources.
+    #[serde(default)]
+    pub resource_attributes: HashMap<String, String>,
 }
 
 impl Default for OtlpConfig {
@@ -27,6 +33,7 @@ impl Default for OtlpConfig {
         Self {
             name: String::from("nexus"),
             endpoint: None,
+            resource_attributes: HashMap::new(),
         }
     }
 }

--- a/nexus-common/src/stack.rs
+++ b/nexus-common/src/stack.rs
@@ -1,3 +1,4 @@
+use crate::config::OtlpConfig;
 use crate::db::kv::search::set_ft_search_timeout_ms;
 use crate::db::{Neo4jConnector, RedisConnector};
 use crate::types::DynError;
@@ -31,9 +32,8 @@ impl StackManager {
     pub async fn setup(config: &StackConfig) -> Result<(), DynError> {
         let stored = STACK_CONFIG
             .get_or_try_init(|| async {
-                Self::setup_logging(&config.otlp.name, &config.otlp.endpoint, config.log_level)
-                    .await;
-                Self::setup_metrics(&config.otlp.name, &config.otlp.endpoint).await;
+                Self::setup_logging(&config.otlp, config.log_level).await;
+                Self::setup_metrics(&config.otlp).await;
 
                 RedisConnector::init(&config.db.redis).await?;
                 Neo4jConnector::init(&config.db.neo4j).await?;
@@ -49,15 +49,13 @@ impl StackManager {
         Ok(())
     }
 
-    async fn setup_logging(service_name: &str, otel_endpoint: &Option<String>, log_level: Level) {
-        match otel_endpoint {
+    async fn setup_logging(otlp: &OtlpConfig, log_level: Level) {
+        match &otlp.endpoint {
             None => Self::setup_local_logging(log_level),
-            Some(endpoint) => {
-                match Self::setup_otlp_logging(service_name, endpoint, log_level).await {
-                    Ok(()) => info!("OpenTelemetry Logging initialized for {service_name} service"),
-                    Err(e) => error!("Failed to initialize OpenTelemetry Logging: {:?}", e),
-                }
-            }
+            Some(_) => match Self::setup_otlp_logging(otlp, log_level).await {
+                Ok(()) => info!("OpenTelemetry Logging initialized for {} service", otlp.name),
+                Err(e) => error!("Failed to initialize OpenTelemetry Logging: {:?}", e),
+            },
         }
     }
 
@@ -105,10 +103,14 @@ impl StackManager {
     }
 
     async fn setup_otlp_logging(
-        service_name: &str,
-        otel_endpoint: &str,
+        otlp: &OtlpConfig,
         log_level: Level,
     ) -> Result<(), Box<dyn std::error::Error>> {
+        let otel_endpoint = otlp
+            .endpoint
+            .as_deref()
+            .expect("OTLP endpoint must be set in [stack.otlp]");
+
         // TODO: Add local tracer, https://github.com/pubky/pubky-nexus/issues/356
         // Set up OpenTelemetry Tracer (Spans)
         let tracing_exporter = SpanExporter::builder()
@@ -120,7 +122,7 @@ impl StackManager {
 
         // Collects spans in memory and sends them in batches
         let tracer_provider = SdkTracerProvider::builder()
-            .with_resource(Self::create_resource(service_name))
+            .with_resource(Self::create_resource(otlp))
             .with_batch_exporter(tracing_exporter)
             .build();
 
@@ -137,7 +139,7 @@ impl StackManager {
             .map_err(|e| format!("OTLP Logging Exporter Error: {e}"))?;
 
         let logging_provider = SdkLoggerProvider::builder()
-            .with_resource(Self::create_resource(service_name))
+            .with_resource(Self::create_resource(otlp))
             .with_batch_exporter(logging_exporter)
             .build();
 
@@ -156,7 +158,7 @@ impl StackManager {
         // This allows #[instrument] and info_span!() to produce OTel spans
         // that are exported alongside manually-created OTel spans.
         let otel_trace_layer =
-            OpenTelemetryLayer::new(tracer_provider.tracer(service_name.to_string()))
+            OpenTelemetryLayer::new(tracer_provider.tracer(otlp.name.clone()))
                 .with_filter(Self::env_filter(log_level));
 
         // Creates a tracing subscriber
@@ -178,8 +180,8 @@ impl StackManager {
         Ok(())
     }
 
-    async fn setup_metrics(service_name: &str, otel_endpoint: &Option<String>) {
-        match otel_endpoint {
+    async fn setup_metrics(otlp: &OtlpConfig) {
+        match &otlp.endpoint {
             None => info!("Metrics collection is disabled. No metrics will be exported"),
             Some(endpoint) => {
                 // Configure the exporter to collect and send metrics to an OTLP
@@ -192,29 +194,73 @@ impl StackManager {
 
                 // Create a periodic metrics reader that collects and exports metrics at a fixed interval
                 let reader = PeriodicReader::builder(metric_exporter)
-                    .with_interval(std::time::Duration::from_secs(30))
+                    .with_interval(Duration::from_secs(30))
                     .build();
 
                 // Createa Meter Provider, which is responsible for managing and exporting metrics
                 let provider = SdkMeterProvider::builder()
-                    .with_resource(Self::create_resource(service_name))
+                    .with_resource(Self::create_resource(otlp))
                     .with_reader(reader)
                     .build();
 
                 // Register globally the metrics
                 global::set_meter_provider(provider);
-
-                info!(
-                    "OpenTelemetry Metrics initialized for {} service",
-                    service_name
-                );
+                info!("OpenTelemetry Metrics initialized for {} service", otlp.name);
             }
         }
     }
 
-    fn create_resource(service_name: &str) -> Resource {
+    /// OTEL resource: `resource_attributes`, then `service.name` from `otlp.name` (wins on conflict).
+    fn create_resource(otlp: &OtlpConfig) -> Resource {
         Resource::builder_empty()
-            .with_attribute(KeyValue::new("service.name", String::from(service_name)))
+            .with_attributes(
+                otlp.resource_attributes
+                    .iter()
+                    .map(|(key, value)| KeyValue::new(key.clone(), value.clone())),
+            )
+            .with_service_name(otlp.name.clone())
             .build()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opentelemetry::{Key, Value};
+    use std::collections::HashMap;
+
+    #[test]
+    fn create_resource_applies_attributes_and_service_name() {
+        let otlp = OtlpConfig {
+            name: "nexusd".into(),
+            endpoint: None,
+            resource_attributes: HashMap::from([
+                ("host".into(), "nexus-1".into()),
+                ("env".into(), "prod".into()),
+            ]),
+        };
+        let resource = StackManager::create_resource(&otlp);
+
+        assert_eq!(
+            resource.get(&Key::new("service.name")),
+            Some(Value::from("nexusd"))
+        );
+        assert_eq!(resource.get(&Key::new("host")), Some(Value::from("nexus-1")));
+        assert_eq!(resource.get(&Key::new("env")), Some(Value::from("prod")));
+    }
+
+    #[test]
+    fn create_resource_service_name_wins_over_attribute_map() {
+        let otlp = OtlpConfig {
+            name: "from-config".into(),
+            endpoint: None,
+            resource_attributes: HashMap::from([("service.name".into(), "from-map".into())]),
+        };
+        let resource = StackManager::create_resource(&otlp);
+
+        assert_eq!(
+            resource.get(&Key::new("service.name")),
+            Some(Value::from("from-config"))
+        );
     }
 }

--- a/nexus-common/src/stack.rs
+++ b/nexus-common/src/stack.rs
@@ -53,7 +53,10 @@ impl StackManager {
         match &otlp.endpoint {
             None => Self::setup_local_logging(log_level),
             Some(_) => match Self::setup_otlp_logging(otlp, log_level).await {
-                Ok(()) => info!("OpenTelemetry Logging initialized for {} service", otlp.name),
+                Ok(()) => info!(
+                    "OpenTelemetry Logging initialized for {} service",
+                    otlp.name
+                ),
                 Err(e) => error!("Failed to initialize OpenTelemetry Logging: {:?}", e),
             },
         }
@@ -157,9 +160,8 @@ impl StackManager {
         // Bridge tracing spans into OpenTelemetry trace spans.
         // This allows #[instrument] and info_span!() to produce OTel spans
         // that are exported alongside manually-created OTel spans.
-        let otel_trace_layer =
-            OpenTelemetryLayer::new(tracer_provider.tracer(otlp.name.clone()))
-                .with_filter(Self::env_filter(log_level));
+        let otel_trace_layer = OpenTelemetryLayer::new(tracer_provider.tracer(otlp.name.clone()))
+            .with_filter(Self::env_filter(log_level));
 
         // Creates a tracing subscriber
         let subscriber = Registry::default()
@@ -205,7 +207,10 @@ impl StackManager {
 
                 // Register globally the metrics
                 global::set_meter_provider(provider);
-                info!("OpenTelemetry Metrics initialized for {} service", otlp.name);
+                info!(
+                    "OpenTelemetry Metrics initialized for {} service",
+                    otlp.name
+                );
             }
         }
     }
@@ -245,7 +250,10 @@ mod tests {
             resource.get(&Key::new("service.name")),
             Some(Value::from("nexusd"))
         );
-        assert_eq!(resource.get(&Key::new("host")), Some(Value::from("nexus-1")));
+        assert_eq!(
+            resource.get(&Key::new("host")),
+            Some(Value::from("nexus-1"))
+        );
         assert_eq!(resource.get(&Key::new("env")), Some(Value::from("prod")));
     }
 

--- a/nexusd/src/migrations/default.config.toml
+++ b/nexusd/src/migrations/default.config.toml
@@ -11,8 +11,13 @@ files_path = "./static/files"
 [stack.otlp]
 # Service name used for tracing, logging, and metrics in OpenTelemetry
 name = "nexusd.migration"
-# OTLP endpoint is not set by default. If you want to enable tracing, set it to the OpenTelemetry Collector endpoint
+# OTLP endpoint is not set by default. To export logs, traces, and metrics,
+# set it to an OpenTelemetry Collector endpoint.
 #endpoint = "http://localhost:4317"
+# Optional resource attributes attached to all OTLP signals
+# [stack.otlp.resource_attributes]
+# "host.name" = "nexus-1"
+# "deployment.environment.name" = "local"
 
 [stack.db]
 redis = "redis://localhost:6379"


### PR DESCRIPTION
## Summary
Adds a self-contained local OpenTelemetry stack and optional OTLP resource attributes so Nexus can export identifiable logs, traces, and metrics during local development.
- **Local observability compose**: `docker/docker-compose.observability.yml` runs OTEL Collector, Tempo, Prometheus, Loki, and Grafana (localhost-bound ports), independent of the DB stack
- **Configurable resource attributes**: new optional `[stack.otlp.resource_attributes]` map applied to all OTLP signals; `stack.otlp.name` always wins as `service.name`
- **Docs & examples**: README and default/example configs updated for the bundled stack (SigNoz still supported as an alternative)


## Pre-submission Checklist

- [ ] I manually reviewed the PR
- [ ] I asked one or more LLMs to review the PR
- [ ] I asked one or more LLMs to check if this PR can be simplified [^1]
- [ ] If appropriate, I added tests for the changes in this PR
- [ ] If appropriate, I added performance benchmarks for the APIs added in this PR [^2]

[^1]: Sample prompt: "Can this be simplified? Can the code, comments, or logic introduced by these changes be simplfied, clarified or otherwise made more terse, concise and understandable, without affecting functionality?"
[^2]: `cargo bench -p nexus-webapi`
