### PR TITLE
deps: bump pubky to 0.10 and adapt call sites

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3895,8 +3895,9 @@ dependencies = [
 
 [[package]]
 name = "pubky-app-specs"
-version = "0.7.1"
-source = "git+https://github.com/pubky/pubky-app-specs?branch=bump%2Fdependencies#753ab6ba533e395704a091801eeba665e28dd120"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e3f048c60ac2f9176d26cbbb82789193d454d90ae3cb3bb8333972e2f02a53c"
 dependencies = [
  "base32",
  "blake3",
@@ -5535,7 +5536,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -6514,7 +6515,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,16 +189,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
-name = "assert-json-diff"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "async-compat"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,45 +214,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-dropper"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d901072ae4dcdca2201b98beb02d31fb4b6b2472fbd0e870b12ec15b8b35b2d2"
-dependencies = [
- "async-dropper-derive",
- "async-dropper-simple",
- "async-trait",
- "futures",
- "tokio",
-]
-
-[[package]]
-name = "async-dropper-derive"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35cf17a37761f1c88b8e770b5956820fe84c12854165b6f930c604ea186e47e"
-dependencies = [
- "async-trait",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
- "tokio",
-]
-
-[[package]]
-name = "async-dropper-simple"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c4748dfe8cd3d625ec68fc424fa80c134319881185866f9e173af9e5d8add8"
-dependencies = [
- "async-scoped",
- "async-trait",
- "futures",
- "rustc_version",
- "tokio",
-]
-
-[[package]]
 name = "async-lock"
 version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,17 +222,6 @@ dependencies = [
  "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
-]
-
-[[package]]
-name = "async-scoped"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4042078ea593edffc452eef14e99fdb2b120caa4ad9618bcdeabc4a023b98740"
-dependencies = [
- "futures",
- "pin-project",
- "tokio",
 ]
 
 [[package]]
@@ -340,12 +280,6 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
-name = "auto-future"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c1e7e457ea78e524f48639f551fd79703ac3f2237f5ecccdf4708f8a75ad373"
 
 [[package]]
 name = "autocfg"
@@ -488,36 +422,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "axum-test"
-version = "17.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eb1dfb84bd48bad8e4aa1acb82ed24c2bb5e855b659959b4e03b4dca118fcac"
-dependencies = [
- "anyhow",
- "assert-json-diff",
- "auto-future",
- "axum",
- "bytes",
- "bytesize",
- "cookie",
- "http",
- "http-body-util",
- "hyper",
- "hyper-util",
- "mime",
- "pretty_assertions",
- "reserve-port",
- "rust-multipart-rfc7578_2",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "smallvec",
- "tokio",
- "tower",
- "url",
-]
-
-[[package]]
 name = "backoff"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,6 +445,12 @@ dependencies = [
  "gloo-timers",
  "tokio",
 ]
+
+[[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
 
 [[package]]
 name = "base32"
@@ -653,12 +563,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bytesize"
-version = "2.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d7c8918969267b2932ffd5655509bbbea0833823058c378876953217f5fc50e"
-
-[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -717,8 +621,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -1172,12 +1078,12 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "5.0.0-pre.6"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335f1947f241137a14106b6f5acc5918a5ede29c9d71d3f2cb1678d5075d9fc3"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
  "digest 0.11.3",
  "fiat-crypto",
@@ -1409,12 +1315,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab03c107fafeb3ee9f5925686dbb7a73bc76e3932abb0d2b365cb64b169cf04c"
 
 [[package]]
-name = "diff"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1507,20 +1407,20 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ed25519"
-version = "3.0.0-rc.4"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e914c7c52decb085cea910552e24c63ac019e3ab8bf001ff736da9a9d9d890"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
 dependencies = [
- "pkcs8 0.11.0-rc.11",
- "serde",
+ "pkcs8 0.11.0",
+ "serdect",
  "signature 3.0.0",
 ]
 
 [[package]]
 name = "ed25519-dalek"
-version = "3.0.0-pre.6"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053618a4c3d3bc24f188aa660ae75a46eeab74ef07fb415c61431e5e7cd4749b"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -1678,7 +1578,6 @@ checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
- "nanorand",
  "spin 0.9.8",
 ]
 
@@ -2723,6 +2622,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "konst"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2861,9 +2775,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mainline"
-version = "6.2.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25fd96e1eb0cff23f7048801d1561336c2e3c9f2b468d0271f27ad3463f583bf"
+checksum = "6dfad9601b9117218868271c05403853593d4817e7abeab5c95e11eee16382bb"
 dependencies = [
  "crc",
  "document-features",
@@ -2953,15 +2867,6 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -3571,6 +3476,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3671,9 +3586,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkarr"
-version = "6.0.1"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51c6a54ffd41eaecab1c5736251f48f229638430939fcf1e02a22ddc632471be"
+checksum = "0b8d06aecdd0cb2166c14af7abf72a8e2f125e04071bbed81b69c9b802c2a50a"
 dependencies = [
  "async-compat",
  "base32",
@@ -3682,7 +3597,6 @@ dependencies = [
  "cfg_aliases",
  "document-features",
  "dyn-clone",
- "ed25519",
  "ed25519-dalek",
  "futures-buffered",
  "futures-lite",
@@ -3694,7 +3608,6 @@ dependencies = [
  "mainline",
  "ntimestamp",
  "page_size",
- "pkcs8 0.11.0-rc.11",
  "reqwest 0.13.4",
  "rustls",
  "rustls-webpki",
@@ -3706,14 +3619,13 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
 name = "pkarr-relay"
-version = "0.12.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "344ea7c879bddcca7efe61229bdbdeaa544db3e686a056e81d600ef83266f7b1"
+checksum = "7b81df71b61bf03d17c6f8b54c34a78cc8af6e784309983517d61597db024b4a"
 dependencies = [
  "anyhow",
  "axum",
@@ -3757,9 +3669,9 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.11.0-rc.11"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12922b6296c06eb741b02d7b5161e3aaa22864af38dfa025a1a3ba3f68c84577"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
  "der 0.8.1",
  "spki 0.8.0",
@@ -3860,43 +3772,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "pretty_assertions"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
-dependencies = [
- "diff",
- "yansi",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit 0.25.12+spec-1.1.0",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
 ]
 
 [[package]]
@@ -3983,10 +3864,11 @@ checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
 name = "pubky"
-version = "0.9.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dabfa82f58ad04e2b65fcecc02ca953dec608533dfa820b03ee174b2593e8af"
+checksum = "773c09666db817b1d2cf13866e053b790e95ec99c78385b86fa848d23bb36e70"
 dependencies = [
+ "async-trait",
  "base64",
  "cookie",
  "eventsource-stream",
@@ -3995,11 +3877,13 @@ dependencies = [
  "futures-util",
  "httpdate",
  "log",
+ "percent-encoding",
  "pkarr",
  "pubky-common",
  "reqwest 0.13.4",
  "rustls",
  "serde",
+ "serde_json",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -4011,9 +3895,8 @@ dependencies = [
 
 [[package]]
 name = "pubky-app-specs"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f6eccc1430eb48d63632d14fe47d051b6d12ca688bed9ac11678f8dc14e8f8a"
+version = "0.7.1"
+source = "git+https://github.com/pubky/pubky-app-specs?branch=bump%2Fdependencies#753ab6ba533e395704a091801eeba665e28dd120"
 dependencies = [
  "base32",
  "blake3",
@@ -4032,43 +3915,43 @@ dependencies = [
 
 [[package]]
 name = "pubky-common"
-version = "0.9.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7115f4177712ffb1d261e93a9a4992ef12da80c4b70decb1395bf8ac919c24c"
+checksum = "e772ea228e1d7be7590c7a15ce975605df30e257ddeb272be8d6c0c23c98f57c"
 dependencies = [
  "argon2",
- "base32",
+ "base64",
  "blake3",
  "crypto_secretbox",
  "ed25519-dalek",
- "js-sys",
- "once_cell",
+ "percent-encoding",
  "pkarr",
  "postcard",
  "pubky-timestamp",
  "rand 0.10.2",
  "serde",
+ "serde_json",
  "thiserror 2.0.19",
  "url",
 ]
 
 [[package]]
 name = "pubky-homeserver"
-version = "0.9.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e315ea8b80adef1089d7e42b45ddc820671054b7a23f0f31a6c469dbfab9159"
+checksum = "63a6206797063a121ae225db5114804626d5773d8484c0a12422b42a5625a087"
 dependencies = [
  "anyhow",
- "async-dropper",
  "async-stream",
  "async-trait",
  "axum",
  "axum-extra",
  "axum-server",
- "axum-test",
+ "backon",
  "base32",
  "base64",
  "bytes",
+ "chrono",
  "clap",
  "dashmap",
  "dav-server",
@@ -4076,14 +3959,13 @@ dependencies = [
  "dirs",
  "dyn-clone",
  "fast-glob",
- "flume 0.11.1",
  "futures-lite",
  "futures-util",
  "governor",
- "hex",
  "hostname-validator",
  "httpdate",
  "infer",
+ "jsonwebtoken",
  "mime_guess",
  "opendal",
  "opentelemetry 0.29.1",
@@ -4094,12 +3976,14 @@ dependencies = [
  "prometheus",
  "pubky-common",
  "pubky_test_utils",
+ "rand 0.10.2",
  "reqwest 0.13.4",
  "sea-query",
  "sea-query-binder",
  "serde",
  "serde_json",
  "serde_valid",
+ "sha2 0.10.9",
  "sqlx",
  "tempfile",
  "thiserror 2.0.19",
@@ -4108,7 +3992,7 @@ dependencies = [
  "toml 0.8.23",
  "tower",
  "tower-cookies",
- "tower-http 0.6.11",
+ "tower-http 0.7.0",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -4117,16 +4001,13 @@ dependencies = [
 
 [[package]]
 name = "pubky-testnet"
-version = "0.9.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1c662f45e102c01454c80859f3354a30e6e88fe7412dd1f6a61c7983a1558fe"
+checksum = "217af1f61b33e0c0c63093b407f7a77ff22e6e1ea6b2252987807fd4b2f4a57f"
 dependencies = [
  "anyhow",
  "clap",
- "dirs",
  "http-relay",
- "mainline",
- "once_cell",
  "pkarr",
  "pkarr-relay",
  "pubky",
@@ -4616,15 +4497,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reserve-port"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71ea98a177596a4579881992bd2bd4af27772fc95d0e5f5668a8f9535eca6380"
-dependencies = [
- "thiserror 2.0.19",
-]
-
-[[package]]
 name = "retain_mut"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4711,21 +4583,6 @@ checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
 dependencies = [
  "sha2 0.11.0",
  "walkdir",
-]
-
-[[package]]
-name = "rust-multipart-rfc7578_2"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c839d037155ebc06a571e305af66ff9fd9063a6e662447051737e1ac75beea41"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-util",
- "http",
- "mime",
- "rand 0.9.5",
- "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5118,15 +4975,14 @@ dependencies = [
 
 [[package]]
 name = "serde_valid"
-version = "1.0.5"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b615bed66931a7a9809b273937adc8a402d038b1e509d027fcaf62f084d33d1"
+checksum = "4b441ba4464f0faf811267a3392ff53e2d9a2f8c4f23941b62ec7c452dd80451"
 dependencies = [
  "indexmap",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "num-traits",
  "once_cell",
- "paste",
  "regex",
  "serde",
  "serde_json",
@@ -5138,13 +4994,11 @@ dependencies = [
 
 [[package]]
 name = "serde_valid_derive"
-version = "1.0.5"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fa1a5a21ea5aab06d2e6a6b59837d450fb2be9695be97735a711edfbe79ea07"
+checksum = "5cd65e72e4b76575cde962665a131c1c83c2fe1c328c27e2f036a16567fe59af"
 dependencies = [
- "itertools 0.13.0",
- "paste",
- "proc-macro-error2",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "strsim",
@@ -5153,12 +5007,21 @@ dependencies = [
 
 [[package]]
 name = "serde_valid_literal"
-version = "1.0.5"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd07331596ea967dccf9a35bde71ecd757490e09827b938a5c6226c648e3a25e"
+checksum = "3728389b4f730ec97f933664f5db0731f80b64c3b23ff904a5dec5f93f205ce9"
 dependencies = [
- "paste",
  "regex",
+]
+
+[[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct",
+ "serde",
 ]
 
 [[package]]
@@ -5270,6 +5133,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a75cbde1bf934313596a004973e462f9a82caa814dcf1a5f507bdf51597eeb4"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.19",
+ "time",
 ]
 
 [[package]]
@@ -5660,7 +5535,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -6116,6 +5991,7 @@ dependencies = [
  "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -6638,7 +6514,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6966,12 +6842,6 @@ name = "xxhash-rust"
 version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d93c89cdc2d3a63c3ec48ffe926931bdc069eafa8e4402fe6d8f790c9d1e576"
-
-[[package]]
-name = "yansi"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ redis = "1.0.4"
 opentelemetry = "0.32"
 opentelemetry_sdk = { version = "0.32", features = ["rt-tokio"] }
 pubky = "0.10.0"
-pubky-app-specs = { git = "https://github.com/pubky/pubky-app-specs", branch = "bump/dependencies", features = ["openapi"] }
+pubky-app-specs = { version = "0.8.0", features = ["openapi"] }
 pubky-testnet = "0.10.0"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.149"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,9 @@ neo4rs = "0.8.0"
 redis = "1.0.4"
 opentelemetry = "0.32"
 opentelemetry_sdk = { version = "0.32", features = ["rt-tokio"] }
-pubky = "0.9.3"
-pubky-app-specs = { version = "0.7.0", features = ["openapi"] }
-pubky-testnet = "0.9.3"
+pubky = "0.10.0"
+pubky-app-specs = { git = "https://github.com/pubky/pubky-app-specs", branch = "bump/dependencies", features = ["openapi"] }
+pubky-testnet = "0.10.0"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.149"
 tempfile = "3.25"

--- a/nexus-common/src/db/connectors/pubky.rs
+++ b/nexus-common/src/db/connectors/pubky.rs
@@ -83,7 +83,12 @@ impl PubkyConnector {
                         .testnet_with_host(host)
                         // Force pkarr/mainline DHT to bind an ephemeral local port instead of default behavior
                         // We do this to prevent the client DHT from competing with `StaticTestnet` for port 6881
-                        .pkarr(|p| p.dht(|d| d.port(0)))
+                        .pkarr(|p| {
+                            p.dht(|c| {
+                                c.port = Some(0);
+                                c
+                            })
+                        })
                         .build(),
                     None => PubkyHttpClient::new(),
                 }

--- a/nexus-common/src/models/user/ingestor.rs
+++ b/nexus-common/src/models/user/ingestor.rs
@@ -55,11 +55,15 @@ impl UserIngestor {
 
         let pubky = PubkyConnector::get().map_err(ModelError::from_generic)?;
 
-        let Some(hs_pk) = pubky.get_homeserver_of(&user_id.to_public_key()).await else {
+        let Some(hs_pk) = pubky
+            .get_homeserver_of(&user_id.to_public_key())
+            .await
+            .map_err(ModelError::from_generic)?
+        else {
             return Ok(None);
         };
 
-        let hs_id = hs_pk.into_inner().to_z32();
+        let hs_id = hs_pk.to_z32();
         if self.hs_blacklist.is_blacklisted(&hs_id) {
             return Err(ModelError::HsBlacklisted { hs_id });
         }

--- a/nexus-watcher/src/service/user_hs_resolver.rs
+++ b/nexus-watcher/src/service/user_hs_resolver.rs
@@ -36,10 +36,7 @@ pub struct PubkyConnectorResolver;
 impl PkdnsHomeserverResolver for PubkyConnectorResolver {
     async fn resolve_homeserver(&self, user_pk: &PublicKey) -> PubkyClientResult<Option<PubkyId>> {
         let pubky = PubkyConnector::get()?;
-        Ok(pubky
-            .get_homeserver_of(user_pk)
-            .await?
-            .map(PubkyId::from))
+        Ok(pubky.get_homeserver_of(user_pk).await?.map(PubkyId::from))
     }
 }
 

--- a/nexus-watcher/src/service/user_hs_resolver.rs
+++ b/nexus-watcher/src/service/user_hs_resolver.rs
@@ -36,10 +36,10 @@ pub struct PubkyConnectorResolver;
 impl PkdnsHomeserverResolver for PubkyConnectorResolver {
     async fn resolve_homeserver(&self, user_pk: &PublicKey) -> PubkyClientResult<Option<PubkyId>> {
         let pubky = PubkyConnector::get()?;
-        match pubky.get_homeserver_of(user_pk).await {
-            Some(hs_pk) => Ok(Some(PubkyId::from(hs_pk))),
-            None => Ok(None),
-        }
+        Ok(pubky
+            .get_homeserver_of(user_pk)
+            .await?
+            .map(PubkyId::from))
     }
 }
 

--- a/nexus-watcher/tests/event_processor/utils/watcher.rs
+++ b/nexus-watcher/tests/event_processor/utils/watcher.rs
@@ -17,6 +17,7 @@ use nexus_watcher::events::{DefaultEventHandler, EventHandler};
 use nexus_watcher::events::{Event, ParseResult};
 use nexus_watcher::service::HsEventProcessorRunner;
 use nexus_watcher::service::TEventProcessorRunner;
+use pubky::ClientId;
 use pubky::Keypair;
 use pubky::PublicKey;
 use pubky::ResourcePath;
@@ -35,6 +36,11 @@ use tempfile::TempDir;
 use tracing::debug;
 
 static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Client ID used for grant-based test sessions (pubky 0.10+).
+fn test_client_id() -> ClientId {
+    ClientId::new("nexus-watcher.test").expect("static test client id is valid")
+}
 
 /// Generate a unique post ID for tests.
 /// Uses PID-based offset for inter-process uniqueness and atomic counter
@@ -212,7 +218,7 @@ impl WatcherTest {
         let pubky = PubkyConnector::get()?;
 
         let signer = pubky.signer(user_keypair.clone());
-        let session = signer.signin().await?;
+        let session = signer.signin(test_client_id()).await?;
         session
             .storage()
             .put(hs_path, serde_json::to_string(&object)?)
@@ -235,7 +241,7 @@ impl WatcherTest {
         let pubky = PubkyConnector::get()?;
 
         let signer = pubky.signer(user_keypair.clone());
-        let session = signer.signin().await?;
+        let session = signer.signin(test_client_id()).await?;
         session.storage().delete(hs_path).await?;
         self.ensure_event_processing_complete().await?;
         Ok(())
@@ -338,7 +344,7 @@ impl WatcherTest {
         let pubky = PubkyConnector::get()?;
 
         let signer = pubky.signer(user_kp.clone());
-        let session = signer.signin().await?;
+        let session = signer.signin(test_client_id()).await?;
         session.storage().put(homeserver_uri, object).await?;
         Ok(())
     }

--- a/nexus-webapi/benches/avatar.rs
+++ b/nexus-webapi/benches/avatar.rs
@@ -13,6 +13,7 @@ use nexus_common::models::{
     traits::Collection,
     user::UserDetails,
 };
+use nexus_common::utils::test_utils::default_ingestor_tests;
 use nexus_webapi::{
     models::PubkyId,
     routes::{r#static::user_avatar_handler, AppState, Path},
@@ -55,6 +56,7 @@ impl AvatarBenchSetup {
             _temp_dir: temp_dir,
             app_state: AppState {
                 files_path: Arc::new(files_path),
+                ingestor: default_ingestor_tests(),
             },
             user_id,
         };

--- a/nexus-webapi/src/key_republisher.rs
+++ b/nexus-webapi/src/key_republisher.rs
@@ -45,13 +45,19 @@ impl KeyRepublisher {
         client: &pkarr::Client,
         signed_packet: &SignedPacket,
     ) -> Result<(), PublishError> {
-        let res = client.publish(signed_packet, None).await;
-        if let Err(e) = &res {
-            tracing::warn!("Failed to publish the service's pkarr packet to the DHT: {e}");
-        } else {
-            tracing::info!("Published the service's pkarr packet to the DHT.");
+        match client.publish(signed_packet).await {
+            Ok(stored_on) => {
+                tracing::info!(
+                    stored_on,
+                    "Published the service's pkarr packet to the DHT."
+                );
+                Ok(())
+            }
+            Err(e) => {
+                tracing::warn!("Failed to publish the service's pkarr packet to the DHT: {e}");
+                Err(e)
+            }
         }
-        res
     }
 
     /// Start the periodic republish task which will republish the server packet to the DHT every hour.


### PR DESCRIPTION
## Summary
- Bump `pubky` / `pubky-testnet` to `0.10.0`.
- Temporarily pin `pubky-app-specs` to the `bump/dependencies` branch ([pubky-app-specs#153](https://github.com/pubky/pubky-app-specs/pull/153)) until `0.7.1` is published.
- Adapt call sites for breaking 0.10 APIs:
  - DHT ephemeral port via `mainline::Config.port`
  - `get_homeserver_of` → `Result<Option<PublicKey>>`
  - grant `signin(ClientId)` in watcher tests
  - pkarr `publish` (single-arg, returns stored-node count)
  - avatar bench `AppState.ingestor`

## Pre-submission Checklist

- [ ] I manually reviewed the PR
- [ ] I asked one or more LLMs to review the PR
- [ ] I asked one or more LLMs to check if this PR can be simplified [^1]
- [ ] If appropriate, I added tests for the changes in this PR
- [ ] If appropriate, I added performance benchmarks for the APIs added in this PR [^2]

[^1]: Sample prompt: "Can this be simplified? Can the code, comments, or logic introduced by these changes be simplfied, clarified or otherwise made more terse, concise and understandable, without affecting functionality?"
[^2]: `cargo bench -p nexus-webapi`
