### PR TITLE
fix: correct own-post visibility across Reach filters

### DIFF
--- a/docker/test-graph/mocks/posts.cypher
+++ b/docker/test-graph/mocks/posts.cypher
@@ -234,6 +234,12 @@ MERGE (p:Post {id: "SIJW1TGL5BKG9"}) SET p.content = "LINK post, pubky H", p.kin
 MATCH (u:User {id: $eixample}), (p:Post {id: "SIJW1TGL5BKG9"}) MERGE (u)-[:AUTHORED]->(p);
 MATCH (reply:Post {id: "SIJW1TGL5BKG9" }), (parent:Post {id: "SIJW1TGL5BKG8" }) MERGE (reply)-[:REPLIED]->(parent);
 
+// Graph-path friends regression: Eixample's self-follow makes its own tagged
+// post a candidate, while Detroit's tagged post is the valid friend result.
+// The source query must return only Detroit's post.
+MATCH (tagger:User {id: $amsterdam}), (post:Post {id: "4ZCW1TGL5BKG7"}) MERGE (tagger)-[:TAGGED {label: "reach-self-follow", id: "REACHSELFTAG1", indexed_at: 1224534096400}]->(post);
+MATCH (tagger:User {id: $amsterdam}), (post:Post {id: "00000039YD9CY"}) MERGE (tagger)-[:TAGGED {label: "reach-self-follow", id: "REACHSELFTAG2", indexed_at: 1224534096401}]->(post);
+
 // ###############################
 // ##### Collection posts ########
 // ###############################

--- a/docker/test-graph/mocks/posts.cypher
+++ b/docker/test-graph/mocks/posts.cypher
@@ -32,6 +32,11 @@ MATCH (u1:User {id: $detroit}), (u2:User {id: $cairo}) MERGE (u1)-[:FOLLOWS {ind
 MATCH (u1:User {id: $detroit}), (u2:User {id: $eixample}) MERGE (u1)-[:FOLLOWS {indexed_at: 1730475900000, id: "P73K44JG5SZT7"}]->(u2);
 MATCH (u1:User {id: $eixample}), (u2:User {id: $detroit}) MERGE (u1)-[:FOLLOWS {indexed_at: 1730475940000, id: "P73K85JG5DZT7"}]->(u2);
 
+// Historical self-follows exercise defensive filtering in all reach backends.
+MATCH (u:User {id: $amsterdam}) MERGE (u)-[:FOLLOWS {indexed_at: 1730475950000, id: "P73K85JGSELF1"}]->(u);
+MATCH (u:User {id: $bogota}) MERGE (u)-[:FOLLOWS {indexed_at: 1730475950001, id: "P73K85JGSELF2"}]->(u);
+MATCH (u:User {id: $eixample}) MERGE (u)-[:FOLLOWS {indexed_at: 1730475950002, id: "P73K85JGSELF3"}]->(u);
+
 // ###############################
 // ##### Posts related tags ######
 // ###############################

--- a/docker/test-graph/mocks/posts.cypher
+++ b/docker/test-graph/mocks/posts.cypher
@@ -147,6 +147,12 @@ MERGE (p:Post {id: "4ZCW1TGL5BKG6"}) SET p.content = "Long post, article F", p.k
 MATCH (u:User {id: $bogota}), (p:Post {id: "4ZCW1TGL5BKG6"}) MERGE (u)-[:AUTHORED]->(p);
 MERGE (p:Post {id: "4ZCW1TGL5BKG7"}) SET p.content = "Long post, article G", p.kind = "long", p.indexed_at = 1819477230350;
 MATCH (u:User {id: $eixample}), (p:Post {id: "4ZCW1TGL5BKG7"}) MERGE (u)-[:AUTHORED]->(p);
+// Graph-path friends regression: unique label on an existing Eixample parent.
+// Eixample's self-follow would make this post a friends candidate unless the
+// query excludes the observer. Unique label (not `opensource`) so we do not
+// bump engagement on the opensource ranking fixtures; 2008 tag timestamp
+// keeps it out of hot-tags windows.
+MATCH (tagger:User {id: $amsterdam}), (post:Post {id: "4ZCW1TGL5BKG7"}) MERGE (tagger)-[:TAGGED {label: "reach-self-follow", id: "REACHSELFTAG1", indexed_at: 1224534096400}]->(post);
 MERGE (p:Post {id: "4ZCW1TGL5BKG8"}) SET p.content = "Long post, article H", p.kind = "long", p.indexed_at = 1819477230360;
 MATCH (u:User {id: $eixample}), (p:Post {id: "4ZCW1TGL5BKG8"}) MERGE (u)-[:AUTHORED]->(p);
 // Image posts
@@ -233,12 +239,6 @@ MATCH (u:User {id: $eixample}), (p:Post {id: "SIJW1TGL5BKG8"}) MERGE (u)-[:AUTHO
 MERGE (p:Post {id: "SIJW1TGL5BKG9"}) SET p.content = "LINK post, pubky H", p.kind = "link", p.indexed_at = 1980477299378;
 MATCH (u:User {id: $eixample}), (p:Post {id: "SIJW1TGL5BKG9"}) MERGE (u)-[:AUTHORED]->(p);
 MATCH (reply:Post {id: "SIJW1TGL5BKG9" }), (parent:Post {id: "SIJW1TGL5BKG8" }) MERGE (reply)-[:REPLIED]->(parent);
-
-// Graph-path friends regression: Eixample's self-follow makes its own tagged
-// post a candidate, while Detroit's tagged post is the valid friend result.
-// The source query must return only Detroit's post.
-MATCH (tagger:User {id: $amsterdam}), (post:Post {id: "4ZCW1TGL5BKG7"}) MERGE (tagger)-[:TAGGED {label: "reach-self-follow", id: "REACHSELFTAG1", indexed_at: 1224534096400}]->(post);
-MATCH (tagger:User {id: $amsterdam}), (post:Post {id: "00000039YD9CY"}) MERGE (tagger)-[:TAGGED {label: "reach-self-follow", id: "REACHSELFTAG2", indexed_at: 1224534096401}]->(post);
 
 // ###############################
 // ##### Collection posts ########

--- a/docker/test-graph/mocks/wot.cypher
+++ b/docker/test-graph/mocks/wot.cypher
@@ -111,7 +111,8 @@ MATCH (u:User {id: $d1b}), (p:Post {id: "WOTPOSTTAGS01"}) MERGE (u)-[:TAGGED {la
 MATCH (u:User {id: $modbot}), (p:Post {id: "WOTPOSTTAGS01"}) MERGE (u)-[:TAGGED {label: "wotflag", id: "WOTTAGFLAG001", indexed_at: 1224534096000}]->(p);
 
 // Regression fixture for the O->D1->O follow cycle. O tags this deep reply
-// directly, but returning to O through the cycle must not make O a trusted tagger.
+// directly; returning to O through the cycle must not make O a trusted tagger.
+// Nested under WOTPOSTTAGS01 so it stays out of parent streams and engagement.
 MERGE (p:Post {id: "WOTPOSTCYCLE1"}) SET p.content = "follow-cycle tag fixture", p.kind = "short", p.indexed_at = 1650000000008;
 MATCH (u:User {id: $d2}), (p:Post {id: "WOTPOSTCYCLE1"}) MERGE (u)-[:AUTHORED]->(p);
 MATCH (parent:Post {id: "WOTPOSTTAGS01"}), (reply:Post {id: "WOTPOSTCYCLE1"}) MERGE (reply)-[:REPLIED]->(parent);

--- a/docker/test-graph/mocks/wot.cypher
+++ b/docker/test-graph/mocks/wot.cypher
@@ -126,12 +126,14 @@ MATCH (from:User {id: $d2}), (to:User {id: $btc4}) MERGE (from)-[:TAGGED {label:
 // empty, so only its own TAGGED edges count).
 MATCH (from:User {id: $spammer}), (to:User {id: $btc5}) MERGE (from)-[:TAGGED {label: $bitcoiner_tag, id: "WOTTAGBTC0006", indexed_at: 1224534095600}]->(to);
 MATCH (from:User {id: $spammer}), (to:User {id: $artist1}) MERGE (from)-[:TAGGED {label: $artist_tag, id: "WOTTAGART0001", indexed_at: 1224534095700}]->(to);
-// SPAMMER self-tags as bitcoiner: its own post must still be excluded from its
-// own depth-0 feed (self-exclusion applies to the "Me" trust set too).
+// SPAMMER self-tags as bitcoiner: its own post qualifies for its depth-0
+// Tagged-as feed.
 MATCH (from:User {id: $spammer}), (to:User {id: $spammer}) MERGE (from)-[:TAGGED {label: $bitcoiner_tag, id: "WOTTAGSELF002", indexed_at: 1224534096300}]->(to);
-// Self-endorsement: D1 (in O's WoT) tags the OBSERVER as bitcoiner. O's own posts
-// must still be excluded from O's wot_domain feed (self-exclusion, like `wot`).
+// D1 (in O's WoT) tags the OBSERVER as bitcoiner, so O's own posts qualify for
+// O's network Tagged-as feed.
 MATCH (from:User {id: $d1}), (to:User {id: $o_obs}) MERGE (from)-[:TAGGED {label: $bitcoiner_tag, id: "WOTTAGSELF001", indexed_at: 1224534096100}]->(to);
+// O's direct tag must not leak into network depth through the O->D1->O cycle.
+MATCH (from:User {id: $o_obs}), (to:User {id: $artist1}) MERGE (from)-[:TAGGED {label: $artist_tag, id: "WOTTAGCYCLE01", indexed_at: 1224534096200}]->(to);
 
 // ##################################
 // ##### WoT post-tag pagination ####

--- a/docker/test-graph/mocks/wot.cypher
+++ b/docker/test-graph/mocks/wot.cypher
@@ -110,6 +110,13 @@ MATCH (u:User {id: $d1}), (p:Post {id: "WOTPOSTTAGS01"}) MERGE (u)-[:TAGGED {lab
 MATCH (u:User {id: $d1b}), (p:Post {id: "WOTPOSTTAGS01"}) MERGE (u)-[:TAGGED {label: "wotreview", id: "WOTTAGREV0002", indexed_at: 1224534095900}]->(p);
 MATCH (u:User {id: $modbot}), (p:Post {id: "WOTPOSTTAGS01"}) MERGE (u)-[:TAGGED {label: "wotflag", id: "WOTTAGFLAG001", indexed_at: 1224534096000}]->(p);
 
+// Regression fixture for the O->D1->O follow cycle. O tags this deep reply
+// directly, but returning to O through the cycle must not make O a trusted tagger.
+MERGE (p:Post {id: "WOTPOSTCYCLE1"}) SET p.content = "follow-cycle tag fixture", p.kind = "short", p.indexed_at = 1650000000008;
+MATCH (u:User {id: $d2}), (p:Post {id: "WOTPOSTCYCLE1"}) MERGE (u)-[:AUTHORED]->(p);
+MATCH (parent:Post {id: "WOTPOSTTAGS01"}), (reply:Post {id: "WOTPOSTCYCLE1"}) MERGE (reply)-[:REPLIED]->(parent);
+MATCH (from:User {id: $o_obs}), (to:Post {id: "WOTPOSTCYCLE1"}) MERGE (from)-[:TAGGED {label: "cycle-only", id: "WOTTAGCYCLE02", indexed_at: 1224534096201}]->(to);
+
 // ##############################
 // ##### Domain user->user tags #
 // ##############################

--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -524,9 +524,8 @@ pub fn get_viewer_trusted_network_tags(user_id: &str, viewer_id: &str, depth: Wo
 /// existing post always returns one row with `tags` (`[]` when no trusted tagger
 /// tagged it, or when the viewer is unknown) for an empty/normal 200; only a
 /// missing post returns zero rows (404). Labels are ordered by tagger count and
-/// paginated with
-/// `skip_tags`/`limit_tags`; each label's taggers are capped at `limit_taggers`,
-/// mirroring the global tag endpoint so the response stays bounded.
+/// paginated with `skip_tags`/`limit_tags`; each label's taggers are capped at
+/// `limit_taggers`, mirroring the global tag endpoint so the response stays bounded.
 pub fn get_viewer_trusted_network_post_tags(
     author_id: &str,
     post_id: &str,

--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -481,10 +481,12 @@ pub fn get_active_users_by_homeserver(hs_id: &str) -> Query {
 }
 
 /// Tags on a user applied by users in the viewer's Web of Trust (transitive
-/// FOLLOWS, 1..=depth). User existence is the anchor: the user is matched first
-/// and the viewer with `OPTIONAL MATCH`, so an existing user always returns one
-/// row with `tags` (`[]` when no trusted tagger tagged them, or the viewer is
-/// unknown) for an empty/normal 200; only a missing user returns zero rows (404).
+/// FOLLOWS, 1..=depth). A follow cycle that reaches the viewer again does not add
+/// the viewer to the trusted tagger set. User existence is the anchor: the user
+/// is matched first and the viewer with `OPTIONAL MATCH`, so an existing user
+/// always returns one row with `tags` (`[]` when no trusted tagger tagged them,
+/// or the viewer is unknown) for an empty/normal 200; only a missing user returns
+/// zero rows (404).
 /// Mirrors `get_viewer_trusted_network_post_tags`.
 pub fn get_viewer_trusted_network_tags(user_id: &str, viewer_id: &str, depth: WotDepth) -> Query {
     let graph_query = format!(
@@ -497,6 +499,7 @@ pub fn get_viewer_trusted_network_tags(user_id: &str, viewer_id: &str, depth: Wo
         CALL {{
             WITH viewer, tagged
             MATCH (viewer)-[:FOLLOWS*1..{depth}]->(tagger:User)-[tag:TAGGED]->(tagged)
+            WHERE tagger.id <> viewer.id
             WITH tag.label AS label, collect(DISTINCT tagger.id) AS taggerIds
             RETURN collect({{
                 label: label,
@@ -515,11 +518,13 @@ pub fn get_viewer_trusted_network_tags(user_id: &str, viewer_id: &str, depth: Wo
 }
 
 /// Tags on a single post applied by users in the viewer's Web of Trust
-/// (transitive FOLLOWS, 1..=depth). Post existence is the anchor: the post is
-/// matched first and the viewer with `OPTIONAL MATCH`, so an existing post always
-/// returns one row with `tags` (`[]` when no trusted tagger tagged it, or when the
-/// viewer is unknown) for an empty/normal 200; only a missing post returns zero
-/// rows (404). Labels are ordered by tagger count and paginated with
+/// (transitive FOLLOWS, 1..=depth). A follow cycle that reaches the viewer again
+/// does not add the viewer to the trusted tagger set. Post existence is the
+/// anchor: the post is matched first and the viewer with `OPTIONAL MATCH`, so an
+/// existing post always returns one row with `tags` (`[]` when no trusted tagger
+/// tagged it, or when the viewer is unknown) for an empty/normal 200; only a
+/// missing post returns zero rows (404). Labels are ordered by tagger count and
+/// paginated with
 /// `skip_tags`/`limit_tags`; each label's taggers are capped at `limit_taggers`,
 /// mirroring the global tag endpoint so the response stays bounded.
 pub fn get_viewer_trusted_network_post_tags(
@@ -538,6 +543,7 @@ pub fn get_viewer_trusted_network_post_tags(
         CALL {{
             WITH viewer, p
             MATCH (viewer)-[:FOLLOWS*1..{depth}]->(tagger:User)-[tag:TAGGED]->(p)
+            WHERE tagger.id <> viewer.id
             WITH tag.label AS label, collect(DISTINCT tagger.id) AS taggerIds
             WITH label, taggerIds, SIZE(taggerIds) AS taggersCount
             ORDER BY taggersCount DESC, label ASC
@@ -1348,6 +1354,29 @@ mod tests {
             assert!(
                 dedup < posts,
                 "author dedup must precede the posts MATCH:\n{cypher}"
+            );
+        }
+    }
+
+    #[test]
+    fn trusted_network_tag_queries_exclude_viewer_reached_through_cycle() {
+        let user_tags = get_viewer_trusted_network_tags("user", "viewer", WotDepth::default())
+            .to_cypher_populated();
+        let post_tags = get_viewer_trusted_network_post_tags(
+            "author",
+            "post",
+            "viewer",
+            WotDepth::default(),
+            0,
+            10,
+            10,
+        )
+        .to_cypher_populated();
+
+        for cypher in [user_tags, post_tags] {
+            assert!(
+                cypher.contains("WHERE tagger.id <> viewer.id"),
+                "trusted-network tag queries must exclude a viewer reached through a follow cycle:\n{cypher}"
             );
         }
     }

--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -896,23 +896,24 @@ pub fn post_stream(
     // it after the posts MATCH re-runs the reach traversal for every post in the
     // graph.
     //
-    // The WoT arms filter and dedupe (WITH DISTINCT author) before the posts
-    // MATCH: a variable-length traversal yields one row per path, and expanding
-    // each path row to the author's posts multiplies rows the terminal DISTINCT
-    // would only dedupe after paying for them. Their trust filters (author is
-    // not the observer, since a trusted path can loop back to them; endorsement
-    // label in the domain) must move up here with them, before `endorsement`
-    // and the path row multiplicity leave scope.
+    // The WoT arms bind, filter, and dedupe authors before the posts MATCH.
+    // Variable-length traversals yield one row per path, so expanding posts first
+    // would multiply work that a later DISTINCT could only remove afterward.
+    // Keep each source's filters in its arm; WITH DISTINCT drops path-specific
+    // variables from scope and carries only the qualified authors forward.
     match &source {
-        StreamSource::Following { .. } => {
-            cypher.push_str("MATCH (observer)-[:FOLLOWS]->(author)\n")
-        }
-        StreamSource::Followers { .. } => {
-            cypher.push_str("MATCH (observer)<-[:FOLLOWS]-(author)\n")
-        }
-        StreamSource::Friends { .. } => {
-            cypher.push_str("MATCH (observer)-[:FOLLOWS]->(author)-[:FOLLOWS]->(observer)\n")
-        }
+        StreamSource::Following { .. } => cypher.push_str(
+            "MATCH (observer)-[:FOLLOWS]->(author)\n\
+             WHERE author.id <> $observer_id\n",
+        ),
+        StreamSource::Followers { .. } => cypher.push_str(
+            "MATCH (observer)<-[:FOLLOWS]-(author)\n\
+             WHERE author.id <> $observer_id\n",
+        ),
+        StreamSource::Friends { .. } => cypher.push_str(
+            "MATCH (observer)-[:FOLLOWS]->(author)-[:FOLLOWS]->(observer)\n\
+             WHERE author.id <> $observer_id\n",
+        ),
         StreamSource::Bookmarks { .. } => cypher.push_str("MATCH (observer)-[:BOOKMARKED]->(p)\n"),
         StreamSource::Wot { depth, .. } => cypher.push_str(&format!(
             "MATCH (observer)-[:FOLLOWS*1..{depth}]->(author:User)\n\
@@ -920,23 +921,26 @@ pub fn post_stream(
              WITH DISTINCT author\n"
         )),
         // Me (depth-0): the observer is the sole tagger, so match their TAGGED
-        // edge directly, no traversal and no CALL. Cheaper than the network path.
+        // edge directly. A matching self-endorsement may qualify the observer as
+        // an author; no traversal or CALL is needed.
         StreamSource::WotDomain {
             trust: DomainTrust::Me,
             ..
         } => cypher.push_str(
             "MATCH (observer)-[endorsement:TAGGED]->(author:User)\n\
-             WHERE endorsement.label IN $domain_tags AND author.id <> $observer_id\n\
+             WHERE endorsement.label IN $domain_tags\n\
              WITH DISTINCT author\n",
         ),
-        // Network: CALL collapses the trust reach to distinct taggers before the tag join.
+        // Network: collapse the trust reach to distinct taggers before the tag
+        // join. A follow cycle must not make the observer a network tagger, but
+        // a trusted tagger may still qualify the observer as an author.
         StreamSource::WotDomain {
             trust: DomainTrust::Network(depth),
             ..
         } => cypher.push_str(&format!(
-            "CALL {{ WITH observer MATCH (observer)-[:FOLLOWS*1..{depth}]->(tagger:User) RETURN DISTINCT tagger }}\n\
+            "CALL {{ WITH observer MATCH (observer)-[:FOLLOWS*1..{depth}]->(tagger:User) WHERE tagger.id <> observer.id RETURN DISTINCT tagger }}\n\
              MATCH (tagger)-[endorsement:TAGGED]->(author:User)\n\
-             WHERE endorsement.label IN $domain_tags AND author.id <> $observer_id\n\
+             WHERE endorsement.label IN $domain_tags\n\
              WITH DISTINCT author\n"
         )),
         _ => {}

--- a/nexus-common/src/models/post/stream.rs
+++ b/nexus-common/src/models/post/stream.rs
@@ -531,6 +531,7 @@ impl PostStream {
         limit: Option<usize>,
     ) -> ModelResult<PostKeyStream> {
         let custom_limit = Some(200);
+        let observer_id = source.get_observer();
         let user_ids = match &source {
             StreamSource::Following { observer_id } => {
                 Following::get_by_id(observer_id, None, custom_limit)
@@ -551,7 +552,10 @@ impl PostStream {
                     .0
             }
             _ => vec![],
-        };
+        }
+        .into_iter()
+        .filter(|user_id| Some(user_id.as_str()) != observer_id)
+        .collect::<Vec<_>>();
 
         if !user_ids.is_empty() {
             let post_keys = Self::get_posts_for_user_ids(

--- a/nexus-common/src/models/post/stream.rs
+++ b/nexus-common/src/models/post/stream.rs
@@ -62,6 +62,7 @@ pub enum StreamSource {
     },
     /// Posts by users whom the observer's Web of Trust has tagged with a `domain_tags` label.
     /// `trust = Me` restricts the taggers to the observer alone (depth-0 self set).
+    /// Includes the observer's own posts when they themselves carry a matching label.
     WotDomain {
         observer_id: String,
         trust: DomainTrust,
@@ -530,7 +531,7 @@ impl PostStream {
         limit: Option<usize>,
     ) -> ModelResult<PostKeyStream> {
         let custom_limit = Some(200);
-        let mut user_ids = match &source {
+        let user_ids = match &source {
             StreamSource::Following { observer_id } => {
                 Following::get_by_id(observer_id, None, custom_limit)
                     .await?
@@ -553,11 +554,6 @@ impl PostStream {
         };
 
         if !user_ids.is_empty() {
-            // Include the observer in the post stream
-            if let Some(observer_id) = source.get_observer() {
-                user_ids.push(observer_id.to_string());
-            }
-
             let post_keys = Self::get_posts_for_user_ids(
                 &user_ids.iter().map(AsRef::as_ref).collect::<Vec<_>>(),
                 order,

--- a/nexus-watcher/src/events/handlers/follow.rs
+++ b/nexus-watcher/src/events/handlers/follow.rs
@@ -16,6 +16,11 @@ pub async fn sync_put(
     followee_id: PubkyId,
     ingestor: &UserIngestor,
 ) -> Result<(), EventProcessorError> {
+    if follower_id == followee_id {
+        debug!("Ignoring self-follow");
+        return Ok(());
+    }
+
     debug!("Indexing follow");
     // SAVE TO GRAPH
     // (follower_id)-[:FOLLOWS]->(followee_id)

--- a/nexus-watcher/tests/event_processor/follows/put.rs
+++ b/nexus-watcher/tests/event_processor/follows/put.rs
@@ -94,3 +94,41 @@ async fn test_homeserver_put_follow() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio_shared_rt::test(shared)]
+async fn test_homeserver_ignores_self_follow() -> Result<()> {
+    let mut test = WatcherTest::setup(None).await?;
+    let user_kp = Keypair::random();
+    let user = PubkyAppUser {
+        bio: Some("test_homeserver_self_follow".to_string()),
+        image: None,
+        links: None,
+        name: "Watcher:Follow:Self".to_string(),
+        status: None,
+    };
+    let user_id = test.create_user(&user_kp, &user).await?;
+
+    test.create_follow(&user_kp, &user_id).await?;
+
+    assert!(
+        !find_follow_relationship(&user_id, &user_id).await?,
+        "Self-follow should not be created in the graph"
+    );
+    let (_, is_follower) = Followers::check_set_member(&[&user_id], &user_id).await?;
+    assert!(
+        !is_follower,
+        "Self-follow should not be added to the followers index"
+    );
+    let (_, is_following) = Following::check_set_member(&[&user_id], &user_id).await?;
+    assert!(
+        !is_following,
+        "Self-follow should not be added to the following index"
+    );
+
+    let counts = find_user_counts(&user_id).await;
+    assert_eq!(counts.followers, 0);
+    assert_eq!(counts.following, 0);
+
+    test.cleanup_user(&user_kp).await?;
+    Ok(())
+}

--- a/nexus-webapi/src/routes/v0/stream/posts.rs
+++ b/nexus-webapi/src/routes/v0/stream/posts.rs
@@ -300,7 +300,8 @@ impl PostStreamQuery {
 
 
 The `source` parameter determines the type of stream. Depending on the `source`, certain parameters are required:
-- *following*, *followers*, *friends*, *bookmarks*: Requires **observer_id**.
+- *following*, *followers*, *friends*: Require **observer_id** and exclude posts authored by the observer.
+- *bookmarks*: Requires **observer_id**.
 - *post_replies*: Requires **author_id** and **post_id** to filter replies to a specific post.
 - *author*:  Requires  **author_id** to filter posts by a specific author.
 - *author_replies*:  Requires  **author_id** to filter replies by a specific author.
@@ -371,7 +372,8 @@ pub async fn stream_posts_handler(
     description = r#"Stream Post Keys: Retrieve a stream of post keys
 
 The `source` parameter determines the type of stream. Depending on the `source`, certain parameters are required:
-- *following*, *followers*, *friends*, *bookmarks*: Requires **observer_id**.
+- *following*, *followers*, *friends*: Require **observer_id** and exclude posts authored by the observer.
+- *bookmarks*: Requires **observer_id**.
 - *post_replies*: Requires **author_id** and **post_id** to filter replies to a specific post.
 - *author*:  Requires  **author_id** to filter posts by a specific author.
 - *author_replies*:  Requires  **author_id** to filter replies by a specific author.

--- a/nexus-webapi/src/routes/v0/stream/posts.rs
+++ b/nexus-webapi/src/routes/v0/stream/posts.rs
@@ -307,7 +307,7 @@ The `source` parameter determines the type of stream. Depending on the `source`,
 - *author_replies*:  Requires  **author_id** to filter replies by a specific author.
 - *collection*: Requires **author_id** and **post_id** of the Collection post; items are returned in curator order.
 
-- *wot*: Requires **observer_id**. Posts from users in the observer's Web of Trust (transitive follows, `depth` 1-3, default 2).
+- *wot*: Requires **observer_id**. Posts from users in the observer's Web of Trust (transitive follows, `depth` 1-3, default 2). Excludes the observer's own posts, including when a follow cycle reaches the observer again.
 - *wot_domain*: Requires **observer_id** and **domain_tags**. Posts by authors whom the observer's Web of Trust has tagged with any of `domain_tags`, all of those authors' posts, not only topic-tagged ones; combine with `tags=` for topic-scoped posts. With `depth=0` the trust set is the observer alone ("Me"): posts by authors the observer tagged directly. Includes the observer's own posts when they themselves are tagged with a matching label.
 
 Ensure that you provide the necessary parameters based on the selected `source`. If a required parameter is missing, a 400 Bad Request error will be returned."#
@@ -379,7 +379,7 @@ The `source` parameter determines the type of stream. Depending on the `source`,
 - *author_replies*:  Requires  **author_id** to filter replies by a specific author.
 - *collection*: Requires **author_id** and **post_id** of the Collection post; keys are returned in curator order.
 
-- *wot*: Requires **observer_id**. Posts from users in the observer's Web of Trust (transitive follows, `depth` 1-3, default 2).
+- *wot*: Requires **observer_id**. Posts from users in the observer's Web of Trust (transitive follows, `depth` 1-3, default 2). Excludes the observer's own posts, including when a follow cycle reaches the observer again.
 - *wot_domain*: Requires **observer_id** and **domain_tags**. Posts by authors whom the observer's Web of Trust has tagged with any of `domain_tags`, all of those authors' posts, not only topic-tagged ones; combine with `tags=` for topic-scoped posts. With `depth=0` the trust set is the observer alone ("Me"): posts by authors the observer tagged directly. Includes the observer's own posts when they themselves are tagged with a matching label.
 
 Ensure that you provide the necessary parameters based on the selected `source`. If a required parameter is missing, a 400 Bad Request error will be returned."#

--- a/nexus-webapi/src/routes/v0/stream/posts.rs
+++ b/nexus-webapi/src/routes/v0/stream/posts.rs
@@ -307,7 +307,7 @@ The `source` parameter determines the type of stream. Depending on the `source`,
 - *collection*: Requires **author_id** and **post_id** of the Collection post; items are returned in curator order.
 
 - *wot*: Requires **observer_id**. Posts from users in the observer's Web of Trust (transitive follows, `depth` 1-3, default 2).
-- *wot_domain*: Requires **observer_id** and **domain_tags**. Posts by authors whom the observer's Web of Trust has tagged with any of `domain_tags`, all of those authors' posts, not only topic-tagged ones; combine with `tags=` for topic-scoped posts. With `depth=0` the trust set is the observer alone ("Me"): posts by authors the observer tagged directly.
+- *wot_domain*: Requires **observer_id** and **domain_tags**. Posts by authors whom the observer's Web of Trust has tagged with any of `domain_tags`, all of those authors' posts, not only topic-tagged ones; combine with `tags=` for topic-scoped posts. With `depth=0` the trust set is the observer alone ("Me"): posts by authors the observer tagged directly. Includes the observer's own posts when they themselves are tagged with a matching label.
 
 Ensure that you provide the necessary parameters based on the selected `source`. If a required parameter is missing, a 400 Bad Request error will be returned."#
 )]
@@ -378,7 +378,7 @@ The `source` parameter determines the type of stream. Depending on the `source`,
 - *collection*: Requires **author_id** and **post_id** of the Collection post; keys are returned in curator order.
 
 - *wot*: Requires **observer_id**. Posts from users in the observer's Web of Trust (transitive follows, `depth` 1-3, default 2).
-- *wot_domain*: Requires **observer_id** and **domain_tags**. Posts by authors whom the observer's Web of Trust has tagged with any of `domain_tags`, all of those authors' posts, not only topic-tagged ones; combine with `tags=` for topic-scoped posts. With `depth=0` the trust set is the observer alone ("Me"): posts by authors the observer tagged directly.
+- *wot_domain*: Requires **observer_id** and **domain_tags**. Posts by authors whom the observer's Web of Trust has tagged with any of `domain_tags`, all of those authors' posts, not only topic-tagged ones; combine with `tags=` for topic-scoped posts. With `depth=0` the trust set is the observer alone ("Me"): posts by authors the observer tagged directly. Includes the observer's own posts when they themselves are tagged with a matching label.
 
 Ensure that you provide the necessary parameters based on the selected `source`. If a required parameter is missing, a 400 Bad Request error will be returned."#
 )]

--- a/nexus-webapi/tests/stream/post/reach/timeline.rs
+++ b/nexus-webapi/tests/stream/post/reach/timeline.rs
@@ -1,6 +1,6 @@
 use super::utils::test_reach_filter_with_posts;
 use crate::{
-    stream::post::{AMSTERDAM, BOGOTA, ROOT_PATH, TAG_LABEL_2, USER_ID},
+    stream::post::{AMSTERDAM, BOGOTA, ROOT_PATH, TAG_LABEL_2},
     utils::get_request,
 };
 use anyhow::Result;
@@ -8,42 +8,71 @@ use anyhow::Result;
 // User from posts.cypher mock
 const EIXAMPLE: &str = "8attbeo9ftu5nztqkcfw3gydksehr7jbspgfi64u4h8eo5e7dbiy";
 
-#[tokio_shared_rt::test(shared)]
-async fn test_stream_posts_following() -> Result<()> {
-    let path = format!("{ROOT_PATH}?observer_id={USER_ID}&source=following");
-    let body = get_request(&path).await?;
-
-    assert!(body.is_array());
-
-    for post in body.as_array().expect("Post stream should be an array") {
-        assert!(
-            post["details"]["author"].is_string(),
-            "author should be a string"
+fn assert_excludes_author(body: &serde_json::Value, observer_id: &str, source: &str) {
+    let posts = body.as_array().expect("Post stream should be an array");
+    assert!(
+        !posts.is_empty(),
+        "{source} regression fixture must return posts"
+    );
+    for post in posts {
+        assert_ne!(
+            post["details"]["author"].as_str(),
+            Some(observer_id),
+            "{source} must not include posts authored by its observer"
         );
     }
-
-    Ok(())
 }
 
-#[tokio_shared_rt::test(shared)]
-async fn test_stream_posts_followers() -> Result<()> {
-    let path = format!("{ROOT_PATH}?observer_id={USER_ID}&source=followers");
-    let body = get_request(&path).await?;
-
-    assert!(body.is_array());
-
-    for post in body.as_array().expect("Post stream should be an array") {
-        assert!(
-            post["details"]["author"].is_string(),
-            "author should be a string"
-        );
-    }
-
-    Ok(())
+fn assert_post_ids(body: &serde_json::Value, expected: &[&str]) {
+    let ids: Vec<&str> = body
+        .as_array()
+        .expect("Post stream should be an array")
+        .iter()
+        .map(|post| {
+            post["details"]["id"]
+                .as_str()
+                .expect("post id should be a string")
+        })
+        .collect();
+    assert_eq!(ids, expected, "post IDs should match exactly");
 }
 
 const START_TIME: usize = 1980477299321;
 const END_TIME: usize = 1980477299312;
+
+#[tokio_shared_rt::test(shared)]
+async fn test_stream_posts_following_excludes_observer_in_matching_window() -> Result<()> {
+    // This window contains Amsterdam's 00000039YD99Y / 00000039YD9B2 posts and
+    // posts by followed users. Before the fix, the observer injection returned
+    // both groups; now only followed-user posts remain.
+    let path = format!(
+        "{ROOT_PATH}?observer_id={AMSTERDAM}&source=following&viewer_id={AMSTERDAM}&start=1720000000000&end=1690000000000&limit=50"
+    );
+    let body = get_request(&path).await?;
+    let ids: Vec<&str> = body
+        .as_array()
+        .expect("Post stream should be an array")
+        .iter()
+        .map(|post| {
+            post["details"]["id"]
+                .as_str()
+                .expect("post id should be a string")
+        })
+        .collect();
+
+    assert_excludes_author(&body, AMSTERDAM, "following");
+    assert!(
+        ids.iter().any(|id| *id == "00000039YD9C0"),
+        "the regression window must retain a known followed-user post, got {ids:?}"
+    );
+    assert!(
+        !ids.iter()
+            .any(|id| matches!(*id, "00000039YD99Y" | "00000039YD9B2")),
+        "the regression window must exclude Amsterdam's posts, got {ids:?}"
+    );
+
+    Ok(())
+}
 
 #[tokio_shared_rt::test(shared)]
 async fn test_stream_posts_following_with_start() -> Result<()> {
@@ -54,30 +83,16 @@ async fn test_stream_posts_following_with_start() -> Result<()> {
 
     assert!(body.is_array());
 
-    let post_array = [
-        "MLOW1TGL5BKH4",
-        "SIJW1TGL5BKG3",
-        "GJMW1TGL5BKG3",
-        "MLOW1TGL5BKH3",
-        "SIJW1TGL5BKG2",
-    ];
-
-    for (index, post) in body
-        .as_array()
-        .expect("Post stream should be an array")
-        .iter()
-        .enumerate()
-    {
-        assert!(
-            post["details"]["author"].is_string(),
-            "author should be a string"
-        );
-
-        assert_eq!(
-            post_array[index], post["details"]["id"],
-            "The post index does not match"
-        )
-    }
+    assert_post_ids(
+        &body,
+        &[
+            "MLOW1TGL5BKH4",
+            "SIJW1TGL5BKG3",
+            "GJMW1TGL5BKG3",
+            "MLOW1TGL5BKH3",
+            "SIJW1TGL5BKG2",
+        ],
+    );
 
     Ok(())
 }
@@ -91,24 +106,7 @@ async fn test_stream_posts_following_with_start_and_end() -> Result<()> {
 
     assert!(body.is_array());
 
-    let post_array = ["MLOW1TGL5BKH4", "SIJW1TGL5BKG3", "GJMW1TGL5BKG3"];
-
-    for (index, post) in body
-        .as_array()
-        .expect("Post stream should be an array")
-        .iter()
-        .enumerate()
-    {
-        assert!(
-            post["details"]["author"].is_string(),
-            "author should be a string"
-        );
-
-        assert_eq!(
-            post_array[index], post["details"]["id"],
-            "The post index does not match"
-        )
-    }
+    assert_post_ids(&body, &["MLOW1TGL5BKH4", "SIJW1TGL5BKG3", "GJMW1TGL5BKG3"]);
 
     Ok(())
 }
@@ -125,24 +123,7 @@ async fn test_stream_posts_followers_with_start() -> Result<()> {
 
     assert!(body.is_array());
 
-    let post_array = ["00000039YD9CE", "00000039YD9CY", "00000039YD9DA"];
-
-    for (index, post) in body
-        .as_array()
-        .expect("Post stream should be an array")
-        .iter()
-        .enumerate()
-    {
-        assert!(
-            post["details"]["author"].is_string(),
-            "author should be a string"
-        );
-
-        assert_eq!(
-            post_array[index], post["details"]["id"],
-            "The post index does not match"
-        )
-    }
+    assert_post_ids(&body, &["00000039YD9CY", "00000039YD9DA"]);
 
     Ok(())
 }
@@ -156,24 +137,7 @@ async fn test_stream_posts_followers_with_start_and_end() -> Result<()> {
 
     assert!(body.is_array());
 
-    let post_array = ["00000039YD9CE", "00000039YD9CY"];
-
-    for (index, post) in body
-        .as_array()
-        .expect("Post stream should be an array")
-        .iter()
-        .enumerate()
-    {
-        assert!(
-            post["details"]["author"].is_string(),
-            "author should be a string"
-        );
-
-        assert_eq!(
-            post_array[index], post["details"]["id"],
-            "The post index does not match"
-        )
-    }
+    assert_post_ids(&body, &["00000039YD9CY"]);
 
     Ok(())
 }
@@ -188,24 +152,7 @@ async fn test_stream_posts_friend_with_start() -> Result<()> {
 
     assert!(body.is_array());
 
-    let post_array = ["4ZCW1TGL5BKG7", "00000039YD9CY", "00000039YD9DA"];
-
-    for (index, post) in body
-        .as_array()
-        .expect("Post stream should be an array")
-        .iter()
-        .enumerate()
-    {
-        assert!(
-            post["details"]["author"].is_string(),
-            "author should be a string"
-        );
-
-        assert_eq!(
-            post_array[index], post["details"]["id"],
-            "The post index does not match"
-        )
-    }
+    assert_post_ids(&body, &["00000039YD9CY", "00000039YD9DA"]);
 
     Ok(())
 }
@@ -220,24 +167,7 @@ async fn test_stream_posts_friend_with_start_and_end() -> Result<()> {
 
     assert!(body.is_array());
 
-    let post_array = ["4ZCW1TGL5BKG7", "00000039YD9CY"];
-
-    for (index, post) in body
-        .as_array()
-        .expect("Post stream should be an array")
-        .iter()
-        .enumerate()
-    {
-        assert!(
-            post["details"]["author"].is_string(),
-            "author should be a string"
-        );
-
-        assert_eq!(
-            post_array[index], post["details"]["id"],
-            "The post index does not match"
-        )
-    }
+    assert_post_ids(&body, &["00000039YD9CY"]);
 
     Ok(())
 }

--- a/nexus-webapi/tests/stream/post/reach/timeline.rs
+++ b/nexus-webapi/tests/stream/post/reach/timeline.rs
@@ -1,41 +1,15 @@
-use super::utils::test_reach_filter_with_posts;
+use super::utils::{assert_excludes_author, test_reach_filter_with_posts};
 use crate::{
-    stream::post::{AMSTERDAM, BOGOTA, ROOT_PATH, TAG_LABEL_2},
+    stream::post::{
+        utils::{ids_in, verify_post_list},
+        AMSTERDAM, BOGOTA, ROOT_PATH, TAG_LABEL_2,
+    },
     utils::get_request,
 };
 use anyhow::Result;
 
 // User from posts.cypher mock
 const EIXAMPLE: &str = "8attbeo9ftu5nztqkcfw3gydksehr7jbspgfi64u4h8eo5e7dbiy";
-
-fn assert_excludes_author(body: &serde_json::Value, observer_id: &str, source: &str) {
-    let posts = body.as_array().expect("Post stream should be an array");
-    assert!(
-        !posts.is_empty(),
-        "{source} regression fixture must return posts"
-    );
-    for post in posts {
-        assert_ne!(
-            post["details"]["author"].as_str(),
-            Some(observer_id),
-            "{source} must not include posts authored by its observer"
-        );
-    }
-}
-
-fn assert_post_ids(body: &serde_json::Value, expected: &[&str]) {
-    let ids: Vec<&str> = body
-        .as_array()
-        .expect("Post stream should be an array")
-        .iter()
-        .map(|post| {
-            post["details"]["id"]
-                .as_str()
-                .expect("post id should be a string")
-        })
-        .collect();
-    assert_eq!(ids, expected, "post IDs should match exactly");
-}
 
 const START_TIME: usize = 1980477299321;
 const END_TIME: usize = 1980477299312;
@@ -49,25 +23,16 @@ async fn test_stream_posts_following_excludes_observer_in_matching_window() -> R
         "{ROOT_PATH}?observer_id={AMSTERDAM}&source=following&viewer_id={AMSTERDAM}&start=1720000000000&end=1690000000000&limit=50"
     );
     let body = get_request(&path).await?;
-    let ids: Vec<&str> = body
-        .as_array()
-        .expect("Post stream should be an array")
-        .iter()
-        .map(|post| {
-            post["details"]["id"]
-                .as_str()
-                .expect("post id should be a string")
-        })
-        .collect();
+    let ids = ids_in(&body);
 
     assert_excludes_author(&body, AMSTERDAM, "following");
     assert!(
-        ids.iter().any(|id| *id == "00000039YD9C0"),
+        ids.iter().any(|id| id == "00000039YD9C0"),
         "the regression window must retain a known followed-user post, got {ids:?}"
     );
     assert!(
         !ids.iter()
-            .any(|id| matches!(*id, "00000039YD99Y" | "00000039YD9B2")),
+            .any(|id| matches!(id.as_str(), "00000039YD99Y" | "00000039YD9B2")),
         "the regression window must exclude Amsterdam's posts, got {ids:?}"
     );
 
@@ -83,15 +48,15 @@ async fn test_stream_posts_following_with_start() -> Result<()> {
 
     assert!(body.is_array());
 
-    assert_post_ids(
-        &body,
-        &[
+    verify_post_list(
+        vec![
             "MLOW1TGL5BKH4",
             "SIJW1TGL5BKG3",
             "GJMW1TGL5BKG3",
             "MLOW1TGL5BKH3",
             "SIJW1TGL5BKG2",
         ],
+        body,
     );
 
     Ok(())
@@ -106,7 +71,10 @@ async fn test_stream_posts_following_with_start_and_end() -> Result<()> {
 
     assert!(body.is_array());
 
-    assert_post_ids(&body, &["MLOW1TGL5BKH4", "SIJW1TGL5BKG3", "GJMW1TGL5BKG3"]);
+    verify_post_list(
+        vec!["MLOW1TGL5BKH4", "SIJW1TGL5BKG3", "GJMW1TGL5BKG3"],
+        body,
+    );
 
     Ok(())
 }
@@ -123,7 +91,7 @@ async fn test_stream_posts_followers_with_start() -> Result<()> {
 
     assert!(body.is_array());
 
-    assert_post_ids(&body, &["00000039YD9CY", "00000039YD9DA"]);
+    verify_post_list(vec!["00000039YD9CY", "00000039YD9DA"], body);
 
     Ok(())
 }
@@ -137,7 +105,7 @@ async fn test_stream_posts_followers_with_start_and_end() -> Result<()> {
 
     assert!(body.is_array());
 
-    assert_post_ids(&body, &["00000039YD9CY"]);
+    verify_post_list(vec!["00000039YD9CY"], body);
 
     Ok(())
 }
@@ -152,7 +120,7 @@ async fn test_stream_posts_friend_with_start() -> Result<()> {
 
     assert!(body.is_array());
 
-    assert_post_ids(&body, &["00000039YD9CY", "00000039YD9DA"]);
+    verify_post_list(vec!["00000039YD9CY", "00000039YD9DA"], body);
 
     Ok(())
 }
@@ -167,7 +135,7 @@ async fn test_stream_posts_friend_with_start_and_end() -> Result<()> {
 
     assert!(body.is_array());
 
-    assert_post_ids(&body, &["00000039YD9CY"]);
+    verify_post_list(vec!["00000039YD9CY"], body);
 
     Ok(())
 }
@@ -395,6 +363,25 @@ async fn test_stream_posts_by_timeline_reach_followers_with_tag_start_and_end() 
 // Post order by timeline
 pub const POST_TA_FR: &str = "00000039YD9CY";
 pub const POST_TB_FR: &str = "00000039YD9DA";
+const SELF_FOLLOW_GRAPH_TAG: &str = "reach-self-follow";
+
+#[tokio_shared_rt::test(shared)]
+async fn test_stream_posts_by_timeline_reach_friends_excludes_observer() -> Result<()> {
+    // Both Eixample and its friend Detroit have a post carrying this tag.
+    // Eixample's self-follow must not make its own post part of the friends stream.
+    test_reach_filter_with_posts(
+        EIXAMPLE,
+        None,
+        "friends",
+        Some(SELF_FOLLOW_GRAPH_TAG),
+        None,
+        None,
+        None,
+        None,
+        &[POST_TA_FR],
+    )
+    .await
+}
 
 #[tokio_shared_rt::test(shared)]
 async fn test_stream_posts_by_timeline_reach_friends_with_tag() -> Result<()> {

--- a/nexus-webapi/tests/stream/post/reach/timeline.rs
+++ b/nexus-webapi/tests/stream/post/reach/timeline.rs
@@ -367,20 +367,18 @@ const SELF_FOLLOW_GRAPH_TAG: &str = "reach-self-follow";
 
 #[tokio_shared_rt::test(shared)]
 async fn test_stream_posts_by_timeline_reach_friends_excludes_observer() -> Result<()> {
-    // Both Eixample and its friend Detroit have a post carrying this tag.
-    // Eixample's self-follow must not make its own post part of the friends stream.
-    test_reach_filter_with_posts(
-        EIXAMPLE,
-        None,
-        "friends",
-        Some(SELF_FOLLOW_GRAPH_TAG),
-        None,
-        None,
-        None,
-        None,
-        &[POST_TA_FR],
-    )
-    .await
+    // Unique tag on Eixample's long post. The self-follow would put that post
+    // in friends unless the observer is excluded. Empty is the expected result;
+    // `test_reach_filter_with_posts` requires a non-empty list.
+    let path =
+        format!("{ROOT_PATH}?observer_id={EIXAMPLE}&source=friends&tags={SELF_FOLLOW_GRAPH_TAG}");
+    let body = get_request(&path).await?;
+    let posts = body.as_array().expect("Post stream should be an array");
+    assert!(
+        posts.is_empty(),
+        "eixample's self-follow must not surface its own tagged post in friends, got {posts:?}"
+    );
+    Ok(())
 }
 
 #[tokio_shared_rt::test(shared)]

--- a/nexus-webapi/tests/stream/post/reach/utils.rs
+++ b/nexus-webapi/tests/stream/post/reach/utils.rs
@@ -4,6 +4,8 @@ use crate::utils::get_request;
 use anyhow::Result;
 use serde_json::Value;
 
+/// Asserts a non-empty stream contains no posts authored by `observer_id`.
+/// An empty body is a failure: it would not exercise the exclusion.
 pub fn assert_excludes_author(body: &Value, observer_id: &str, source: &str) {
     let posts = body.as_array().expect("Post stream should be an array");
     assert!(

--- a/nexus-webapi/tests/stream/post/reach/utils.rs
+++ b/nexus-webapi/tests/stream/post/reach/utils.rs
@@ -2,8 +2,26 @@ use crate::stream::post::utils::{verify_post_list, verify_timeline_post_list};
 use crate::stream::post::ROOT_PATH;
 use crate::utils::get_request;
 use anyhow::Result;
+use serde_json::Value;
 
-/// Test all the reach endpoints that hits the graph
+pub fn assert_excludes_author(body: &Value, observer_id: &str, source: &str) {
+    let posts = body.as_array().expect("Post stream should be an array");
+    assert!(
+        !posts.is_empty(),
+        "{source} regression fixture must return posts"
+    );
+    for post in posts {
+        let author = post["details"]["author"]
+            .as_str()
+            .expect("post author should be a string");
+        assert_ne!(
+            author, observer_id,
+            "{source} must not include posts authored by its observer"
+        );
+    }
+}
+
+/// Tests reach endpoints that use the graph path.
 #[allow(clippy::too_many_arguments)]
 pub async fn test_reach_filter_with_posts(
     user_id: &str,
@@ -43,6 +61,7 @@ pub async fn test_reach_filter_with_posts(
     println!("PATH: {path:?}");
 
     let body = get_request(&path).await?;
+    assert_excludes_author(&body, user_id, source);
 
     if verify_timeline {
         verify_timeline_post_list(expected_posts.to_vec(), body);

--- a/nexus-webapi/tests/stream/post/wot.rs
+++ b/nexus-webapi/tests/stream/post/wot.rs
@@ -94,16 +94,22 @@ async fn test_wot_post_stream_depth_matrix_and_dedup() -> Result<()> {
 
 #[tokio_shared_rt::test(shared)]
 async fn test_wot_domain_post_stream() -> Result<()> {
-    // bitcoiner: 3 endorsed by the observer's WoT; BTC1 endorsed by two raters => once.
+    // bitcoiner: three external authors and the observer are endorsed by the
+    // observer's WoT; BTC1 is endorsed by two raters and must appear once.
     let path = format!(
         "{ROOT_PATH}?source=wot_domain&observer_id={OBSERVER}&depth=2&domain_tags=bitcoiner&limit=30"
     );
     let body = get_request(&path).await?;
-    assert_exact_set(&body, &[P_BTC1, P_BTC2, P_BTC3]);
+    assert_exact_set(&body, &[P_BTC1, P_BTC2, P_BTC3, P_O]);
     assert_eq!(
         count_id(&body, P_BTC1),
         1,
         "P_BTC1 must dedup across endorsers"
+    );
+    assert_eq!(
+        count_id(&body, P_O),
+        1,
+        "the qualified observer's post must appear exactly once"
     );
 
     // btc-dev: only BTC4 (endorsed by depth-2 rater D2).
@@ -118,47 +124,24 @@ async fn test_wot_domain_post_stream() -> Result<()> {
         "{ROOT_PATH}?source=wot_domain&observer_id={OBSERVER}&depth=2&domain_tags=bitcoiner,btc-dev&limit=30"
     );
     let body = get_request(&path).await?;
-    assert_exact_set(&body, &[P_BTC1, P_BTC2, P_BTC3, P_BTC4]);
-
-    // artist is endorsed only by an out-of-WoT user => nothing for this observer.
-    let path = format!(
-        "{ROOT_PATH}?source=wot_domain&observer_id={OBSERVER}&depth=2&domain_tags=artist&limit=30"
-    );
-    let body = get_request(&path).await?;
-    assert!(
-        body.as_array().expect("array").is_empty(),
-        "artist is not endorsed by the observer's WoT"
-    );
+    assert_exact_set(&body, &[P_BTC1, P_BTC2, P_BTC3, P_BTC4, P_O]);
 
     // Backward-compat: omitting `depth` defaults to the depth-2 network reach
-    // (Network(2)), NOT the depth-0 "Me" set. Same result as explicit depth=2.
+    // (Network(2)), not the depth-0 observer-only set. Same result as explicit depth=2.
     let path = format!(
         "{ROOT_PATH}?source=wot_domain&observer_id={OBSERVER}&domain_tags=bitcoiner&limit=30"
     );
     let body = get_request(&path).await?;
-    assert_exact_set(&body, &[P_BTC1, P_BTC2, P_BTC3]);
+    assert_exact_set(&body, &[P_BTC1, P_BTC2, P_BTC3, P_O]);
 
-    Ok(())
-}
-
-#[tokio_shared_rt::test(shared)]
-async fn test_wot_domain_excludes_self_endorsed_observer() -> Result<()> {
-    // D1 (in O's WoT) tags O as bitcoiner, making O a bitcoiner-endorsed author
-    // within their own trust network. O's own posts must still be excluded,
-    // mirroring the `wot` self-exclusion.
-    let path = format!(
-        "{ROOT_PATH}?source=wot_domain&observer_id={OBSERVER}&depth=2&domain_tags=bitcoiner&limit=30"
-    );
-    let body = get_request(&path).await?;
-    assert_excludes(&body, &[P_O]);
     Ok(())
 }
 
 #[tokio_shared_rt::test(shared)]
 async fn test_wot_domain_with_tags_and_engagement_sorting() -> Result<()> {
     // wot_domain combined with a post `tags` filter and TotalEngagement sorting
-    // must produce valid Cypher: the self-exclusion and tag conditions share one
-    // contiguous WHERE/AND chain. No bitcoiner post carries an `opensource`
+    // must produce valid Cypher: the endorsement and post-tag conditions share
+    // one contiguous WHERE/AND chain. No bitcoiner post carries an `opensource`
     // post-tag in the fixture, so the filtered result is exactly empty.
     let path = format!(
         "{ROOT_PATH}?source=wot_domain&observer_id={OBSERVER}&depth=2&domain_tags=bitcoiner&tags=opensource&sorting=total_engagement&limit=30"
@@ -168,29 +151,27 @@ async fn test_wot_domain_with_tags_and_engagement_sorting() -> Result<()> {
     Ok(())
 }
 
-// depth=0 is the "Me" trust set: posts by authors the observer tagged directly,
-// with no follow traversal. SPAMMER has an empty follow-network, so only its own
-// TAGGED edges count. It tagged BTC5 (bitcoiner), ARTIST1 (artist) and self-tagged
-// bitcoiner; the self-tag must not surface SPAMMER's own post.
+// At depth 0 the observer is the only tagger, with no follow traversal. SPAMMER
+// tagged BTC5 (bitcoiner), ARTIST1 (artist), and itself as bitcoiner; the
+// self-tag qualifies SPAMMER's own post for Tagged as.
 #[tokio_shared_rt::test(shared)]
-async fn test_wot_domain_me_self_tagged_and_self_excluded() -> Result<()> {
+async fn test_wot_domain_depth_zero_includes_self_tagged_observer() -> Result<()> {
     let path = format!(
         "{ROOT_PATH}?source=wot_domain&observer_id={SPAMMER}&depth=0&domain_tags=bitcoiner&limit=30"
     );
     let body = get_request(&path).await?;
-    assert_exact_set(&body, &[P_BTC5]);
-    assert_excludes(&body, &[P_S]);
+    assert_exact_set(&body, &[P_BTC5, P_S]);
     Ok(())
 }
 
 #[tokio_shared_rt::test(shared)]
-async fn test_wot_domain_me_or_filter_and_empty() -> Result<()> {
+async fn test_wot_domain_depth_zero_or_filter_and_empty() -> Result<()> {
     // OR over the label list.
     let path = format!(
         "{ROOT_PATH}?source=wot_domain&observer_id={SPAMMER}&depth=0&domain_tags=bitcoiner,artist&limit=30"
     );
     let body = get_request(&path).await?;
-    assert_exact_set(&body, &[P_BTC5, P_ART1]);
+    assert_exact_set(&body, &[P_BTC5, P_ART1, P_S]);
 
     // No self-tag carries this label => empty.
     let path = format!(
@@ -202,30 +183,45 @@ async fn test_wot_domain_me_or_filter_and_empty() -> Result<()> {
 }
 
 #[tokio_shared_rt::test(shared)]
-async fn test_wot_domain_me_uses_only_observer_tags() -> Result<()> {
-    // depth=0 consults only the observer's own tags, never the follow-network. O
-    // has no outgoing TAGGED edges (D1->O is D1 tagging O, not O tagging), so O's
-    // "Me" feed is empty, in contrast to O's depth-2 network feed.
-    let me = format!(
+async fn test_wot_domain_depth_zero_uses_only_observer_tags() -> Result<()> {
+    // depth=0 consults only the observer's own tags, never the follow-network.
+    // D1->O is D1 tagging O, so it cannot make O's observer-only bitcoiner feed non-empty.
+    let observer_only = format!(
         "{ROOT_PATH}?source=wot_domain&observer_id={OBSERVER}&depth=0&domain_tags=bitcoiner&limit=30"
     );
-    let body = get_request(&me).await?;
+    let body = get_request(&observer_only).await?;
     assert_exact_set(&body, &[]);
 
-    let network = format!(
+    // O directly tags ARTIST1. This appears at depth 0.
+    let observer_only = format!(
+        "{ROOT_PATH}?source=wot_domain&observer_id={OBSERVER}&depth=0&domain_tags=artist&limit=30"
+    );
+    let body = get_request(&observer_only).await?;
+    assert_exact_set(&body, &[P_ART1]);
+
+    // At depth 2, O is reachable again through O->D1->O but remains excluded as
+    // a network tagger. SPAMMER is outside the WoT, so neither artist
+    // endorsement qualifies.
+    let network_artist = format!(
+        "{ROOT_PATH}?source=wot_domain&observer_id={OBSERVER}&depth=2&domain_tags=artist&limit=30"
+    );
+    let body = get_request(&network_artist).await?;
+    assert_exact_set(&body, &[]);
+
+    let network_bitcoiner = format!(
         "{ROOT_PATH}?source=wot_domain&observer_id={OBSERVER}&depth=2&domain_tags=bitcoiner&limit=30"
     );
-    let body = get_request(&network).await?;
-    assert_exact_set(&body, &[P_BTC1, P_BTC2, P_BTC3]);
+    let body = get_request(&network_bitcoiner).await?;
+    assert_exact_set(&body, &[P_BTC1, P_BTC2, P_BTC3, P_O]);
     Ok(())
 }
 
 #[tokio_shared_rt::test(shared)]
-async fn test_wot_domain_me_with_topic_tags() -> Result<()> {
+async fn test_wot_domain_depth_zero_with_topic_tags() -> Result<()> {
     // depth=0 combined with a post `tags` filter + engagement sort must build
-    // valid Cypher (direct-tag MATCH + self-exclusion + endorsement + tag
-    // conditions in one WHERE/AND chain). No bitcoiner post carries an
-    // `opensource` tag, so the result is exactly empty.
+    // valid Cypher (direct-tag MATCH + endorsement + post-tag conditions in one
+    // WHERE/AND chain). No bitcoiner post carries an `opensource` tag, so the
+    // result is exactly empty.
     let path = format!(
         "{ROOT_PATH}?source=wot_domain&observer_id={SPAMMER}&depth=0&domain_tags=bitcoiner&tags=opensource&sorting=total_engagement&limit=30"
     );

--- a/nexus-webapi/tests/tags/wot.rs
+++ b/nexus-webapi/tests/tags/wot.rs
@@ -250,11 +250,11 @@ async fn clear_wot_tags_cache() -> Result<(), DynError> {
 const WOT_OBSERVER: &str = "y6apowjmcg8rocmd9jirg95fyf3yykwuhqxozzts4mjipk4n7iao";
 const WOT_REPLY_AUTHOR: &str = "smf4xrqfhx7stnufkjzhbjyu3rbgb3gga64srqmzcyyoyzefse9y";
 const WOT_NON_FOLLOWER: &str = "qdsygndnk45m9ru5jseg3uxk5xg4usj9hrcraqbzgigapzweaa9o";
+const WOT_ARTIST_USER: &str = "w153s1dr9rw6t8s3nd1de6pqquuprb37dwrnwh3nk85jt9ys9k7o";
 const WOT_REPLY_POST: &str = "WOTPOSTREPLY1";
 const NUDITY_TAG: &str = "nudity";
-// D2's parent post: D2 is in the observer's WoT, but no WoT member tagged this post,
-// so its WoT post-tag list is empty (existing post, no trusted tags). 13-char PostId.
-const WOT_UNTAGGED_POST: &str = "WOTPOSTD20004";
+const WOT_CYCLE_TAGGED_POST: &str = "WOTPOSTCYCLE1";
+const CYCLE_ONLY_TAG: &str = "cycle-only";
 // Deep reply tagged by WoT members D1/D1B ('wotreview') and M ('wotflag'); used to
 // check that WoT post-tags honor skip_tags/limit_tags/limit_taggers like the global view.
 const WOT_TAG_LIMIT_POST: &str = "WOTPOSTTAGS01";
@@ -286,18 +286,6 @@ async fn test_wot_post_tags_mod_visibility() -> Result<(), DynError> {
         "a non-follower should not see the mod bot's tag"
     );
 
-    // The observer's WoT is non-empty (follows D1/D1B/M) but none of them tagged this
-    // post: it is a valid post, so the response is an empty list (200), not a 404.
-    let path = format!(
-        "/v0/post/{WOT_REPLY_AUTHOR}/{WOT_UNTAGGED_POST}/tags?viewer_id={WOT_OBSERVER}&depth=2"
-    );
-    let body = get_request(&path).await?;
-    let tags = body.as_array().expect("Tag list should be an array");
-    assert!(
-        tags.is_empty(),
-        "an existing post with no WoT-visible tags should be 200 [], not 404"
-    );
-
     // `viewer_id` without `depth` is the global view, not WoT: the same spammer who
     // saw nothing with depth=2 now sees the mod bot's tag through the global path.
     let path =
@@ -311,6 +299,32 @@ async fn test_wot_post_tags_mod_visibility() -> Result<(), DynError> {
     );
     assert_eq!(tags[0]["label"], NUDITY_TAG);
 
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_wot_post_tags_exclude_viewer_reached_through_cycle() -> Result<(), DynError> {
+    // The global view confirms that O's direct tag exists in the fixture.
+    let base = format!(
+        "/v0/post/{WOT_REPLY_AUTHOR}/{WOT_CYCLE_TAGGED_POST}/tags?viewer_id={WOT_OBSERVER}"
+    );
+    let body = get_request(&base).await?;
+    let tags = body.as_array().expect("Tag list should be an array");
+    assert_eq!(
+        tags.len(),
+        1,
+        "the global view should contain O's direct cycle tag"
+    );
+    assert_eq!(tags[0]["label"], CYCLE_ONLY_TAG);
+
+    // Reaching O again through O->D1->O must not include that tag in the
+    // depth-2 trusted-network view.
+    let body = get_request(&format!("{base}&depth=2")).await?;
+    let tags = body.as_array().expect("Tag list should be an array");
+    assert!(
+        tags.is_empty(),
+        "a follow cycle must not include the viewer's direct post tag, got {tags:?}"
+    );
     Ok(())
 }
 
@@ -394,6 +408,20 @@ async fn test_wot_user_tags_existing_user_without_wot_tags_returns_empty() -> Re
     assert!(
         tags.is_empty(),
         "existing user with no WoT-visible tags should return [], got {tags:?}"
+    );
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_wot_user_tags_exclude_viewer_reached_through_cycle() -> Result<(), DynError> {
+    // O directly tagged ARTIST1. Reaching O again through O->D1->O must not make
+    // O a depth-2 trusted-network tagger.
+    let path = format!("/v0/user/{WOT_ARTIST_USER}/tags?viewer_id={WOT_OBSERVER}&depth=2");
+    let body = get_request(&path).await?;
+    let tags = body.as_array().expect("Tag list should be an array");
+    assert!(
+        tags.is_empty(),
+        "a follow cycle must not include the viewer's direct user tag, got {tags:?}"
     );
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Stop injecting the observer’s posts into Following, Friends, and Followers timelines.
- Allow own posts in `wot_domain` (“Tagged as”) when the observer has a matching network endorsement.
- Prevent follow cycles from treating the observer as a network tagger.
- Update documentation, fixtures, and regression tests.

## Pre-submission Checklist

- [ ] I manually reviewed the PR
- [ ] I asked one or more LLMs to review the PR
- [ ] I asked one or more LLMs to check if this PR can be simplified [^1]
- [ ] If appropriate, I added tests for the changes in this PR
- [ ] If appropriate, I added performance benchmarks for the APIs added in this PR [^2]

[^1]: Sample prompt: "Can this be simplified? Can the code, comments, or logic introduced by these changes be simplfied, clarified or otherwise made more terse, concise and understandable, without affecting functionality?"
[^2]: `cargo bench -p nexus-webapi`
