### PR TITLE
chore: log primary homeserver run duration

### DIFF
--- a/nexus-watcher/src/service/runner/homeserver.rs
+++ b/nexus-watcher/src/service/runner/homeserver.rs
@@ -2,12 +2,14 @@ use super::TEventProcessorRunner;
 use crate::events::retry::RetryScheduler;
 use crate::events::{DefaultEventHandler, EventHandler};
 use crate::service::indexer::{HsEventProcessor, TEventProcessor};
+use crate::service::stats::{ProcessedStats, RunAllProcessorsStats};
 use nexus_common::models::homeserver::Homeserver;
 use nexus_common::types::DynError;
 use nexus_common::WatcherConfig;
 use pubky_app_specs::PubkyId;
 use std::sync::Arc;
 use tokio::sync::watch::Receiver;
+use tracing::debug;
 
 pub struct HsEventProcessorRunner {
     /// See [WatcherConfig::events_limit]
@@ -65,5 +67,16 @@ impl TEventProcessorRunner for HsEventProcessorRunner {
 
     async fn pre_run(&self) -> Result<Vec<String>, DynError> {
         Ok(vec![self.primary_homeserver.to_string()])
+    }
+
+    async fn post_run(&self, stats: RunAllProcessorsStats) -> ProcessedStats {
+        for individual_run_stat in &stats.stats {
+            let hs_id = &individual_run_stat.hs_id;
+            let duration = individual_run_stat.duration;
+            let status = &individual_run_stat.status;
+            debug!(homeserver = %hs_id, ?duration, ?status, "Primary homeserver run completed");
+        }
+
+        ProcessedStats(stats)
     }
 }


### PR DESCRIPTION
## Summary
- Log `duration` and `status` after each primary homeserver indexing tick, matching the key-based runner.
- Use a distinct message (`Primary homeserver run completed`) so it is easy to filter separately from `Event processor run completed`.

### Related log
```bash
2026-08-14T10:33:19.032960Z DEBUG nexus_watcher::service::runner::homeserver:77: Primary homeserver run completed homeserver=8um71us3fyw6h8wbcxb5ar3rwusy1a6u49956ikzojg3gcwd1dty duration=4.892990708s status=Ok
```

## Pre-submission Checklist

- [ ] I manually reviewed the PR
- [ ] I asked one or more LLMs to review the PR
- [ ] I asked one or more LLMs to check if this PR can be simplified [^1]
- [ ] If appropriate, I added tests for the changes in this PR
- [ ] If appropriate, I added performance benchmarks for the APIs added in this PR [^2]

[^1]: Sample prompt: "Can this be simplified? Can the code, comments, or logic introduced by these changes be simplfied, clarified or otherwise made more terse, concise and understandable, without affecting functionality?"
[^2]: `cargo bench -p nexus-webapi`
