### PR TITLE
feat(api): search users by profile tags

### DIFF
--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -307,7 +307,9 @@ pub fn search_users_by_tags(labels: &[String], skip: Option<usize>, limit: Optio
         WHERE tag.label IN $labels AND u.name <> $deleted
         WITH u, COUNT(tag) AS score
         RETURN u.id AS user_id, score
-        ORDER BY score DESC, u.id ASC
+        // id DESC matches how Redis breaks equal scores (reverse-lex member
+        // order), keeping pagination windows identical across both paths
+        ORDER BY score DESC, u.id DESC
         ",
     );
 

--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -3,6 +3,7 @@ use crate::db::graph::Query;
 use crate::db::kv::SortOrder;
 use crate::models::post::{KindFilter, StreamSource};
 use crate::models::resource::stream::ResourceSorting;
+use crate::models::user::USER_DELETED_SENTINEL;
 use crate::types::routes::HotTagsInputDTO;
 use crate::types::DomainTrust;
 use crate::types::Pagination;
@@ -273,11 +274,13 @@ pub fn global_tags_by_user() -> Query {
         // create_user_tag MERGEs one TAGGED edge per (tagger, tagged, label),
         // so COUNT(t) is the distinct tagger count.
         MATCH (tagger:User)-[t:TAGGED]->(u:User)
+        WHERE u.name <> $deleted
         WITH t.label AS label, u.id AS user_id, COUNT(t) AS score
         WITH label, COLLECT([toFloat(score), user_id]) AS sorted_set
         RETURN label, sorted_set
         ",
     )
+    .param("deleted", USER_DELETED_SENTINEL)
 }
 
 /// Enumerates the distinct (tagged user, label) pairs carried by user
@@ -288,9 +291,11 @@ pub fn get_user_tag_pairs() -> Query {
         "get_user_tag_pairs",
         "
         MATCH (:User)-[t:TAGGED]->(u:User)
+        WHERE u.name <> $deleted
         RETURN DISTINCT u.id AS user_id, t.label AS label
         ",
     )
+    .param("deleted", USER_DELETED_SENTINEL)
 }
 
 /// Users whose profile carries any of the given tag labels, scored by distinct
@@ -299,7 +304,7 @@ pub fn search_users_by_tags(labels: &[String], skip: Option<usize>, limit: Optio
     let mut cypher = String::from(
         "
         MATCH (tagger:User)-[tag:TAGGED]->(u:User)
-        WHERE tag.label IN $labels
+        WHERE tag.label IN $labels AND u.name <> $deleted
         WITH u, COUNT(tag) AS score
         RETURN u.id AS user_id, score
         ORDER BY score DESC, u.id ASC
@@ -313,7 +318,9 @@ pub fn search_users_by_tags(labels: &[String], skip: Option<usize>, limit: Optio
         cypher.push_str(&format!("LIMIT {}\n", limit.min(MAX_QUERY_LIMIT)));
     }
 
-    Query::new("search_users_by_tags", &cypher).param("labels", labels.to_vec())
+    Query::new("search_users_by_tags", &cypher)
+        .param("labels", labels.to_vec())
+        .param("deleted", USER_DELETED_SENTINEL)
 }
 
 // Retrieve all the tags of the post

--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -264,6 +264,45 @@ pub fn global_tags_by_post_engagement() -> Query {
     )
 }
 
+/// Retrieves unique global tags on user profiles, returning per label the tagged
+/// user ids paired with their distinct tagger counts.
+pub fn global_tags_by_user() -> Query {
+    Query::new(
+        "global_tags_by_user",
+        "
+        // create_user_tag MERGEs one TAGGED edge per (tagger, tagged, label),
+        // so COUNT(t) is the distinct tagger count.
+        MATCH (tagger:User)-[t:TAGGED]->(u:User)
+        WITH t.label AS label, u.id AS user_id, COUNT(t) AS score
+        WITH label, COLLECT([toFloat(score), user_id]) AS sorted_set
+        RETURN label, sorted_set
+        ",
+    )
+}
+
+/// Users whose profile carries any of the given tag labels, scored by distinct
+/// tagger count summed across the searched labels.
+pub fn search_users_by_tags(labels: &[String], skip: Option<usize>, limit: Option<usize>) -> Query {
+    let mut cypher = String::from(
+        "
+        MATCH (tagger:User)-[tag:TAGGED]->(u:User)
+        WHERE tag.label IN $labels
+        WITH u, COUNT(tag) AS score
+        RETURN u.id AS user_id, score
+        ORDER BY score DESC, u.id ASC
+        ",
+    );
+
+    if let Some(skip) = skip {
+        cypher.push_str(&format!("SKIP {}\n", skip.min(MAX_QUERY_SKIP)));
+    }
+    if let Some(limit) = limit {
+        cypher.push_str(&format!("LIMIT {}\n", limit.min(MAX_QUERY_LIMIT)));
+    }
+
+    Query::new("search_users_by_tags", &cypher).param("labels", labels.to_vec())
+}
+
 // Retrieve all the tags of the post
 pub fn post_tags(user_id: &str, post_id: &str) -> Query {
     Query::new(

--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -280,6 +280,19 @@ pub fn global_tags_by_user() -> Query {
     )
 }
 
+/// Enumerates the distinct (tagged user, label) pairs carried by user
+/// profiles, without counts: backfills derive each score from the live
+/// taggers set instead of trusting a snapshot value.
+pub fn get_user_tag_pairs() -> Query {
+    Query::new(
+        "get_user_tag_pairs",
+        "
+        MATCH (:User)-[t:TAGGED]->(u:User)
+        RETURN DISTINCT u.id AS user_id, t.label AS label
+        ",
+    )
+}
+
 /// Users whose profile carries any of the given tag labels, scored by distinct
 /// tagger count summed across the searched labels.
 pub fn search_users_by_tags(labels: &[String], skip: Option<usize>, limit: Option<usize>) -> Query {

--- a/nexus-common/src/db/kv/index/sorted_sets.rs
+++ b/nexus-common/src/db/kv/index/sorted_sets.rs
@@ -1,6 +1,6 @@
 use crate::db::get_redis_conn;
 use crate::db::kv::RedisResult;
-use redis::AsyncCommands;
+use redis::{AsyncCommands, Script};
 use serde::Deserialize;
 use utoipa::ToSchema;
 
@@ -269,5 +269,56 @@ pub async fn del(prefix: &str, key: &str, values: &[&str]) -> RedisResult<()> {
 
     // Remove the elements from the sorted set
     let _: () = redis_conn.zrem(index_key, values).await?;
+    Ok(())
+}
+
+/// Atomically derives a sorted-set member's score from a set's cardinality:
+/// the member's score becomes `SCARD` of the source set, and the member is
+/// removed when the set is empty.
+///
+/// The read and the conditional write run as one Lua script, so concurrent
+/// writers cannot commit a stale cardinality between the two commands.
+///
+/// # Arguments
+///
+/// * `set_prefix` - Prefix of the source set key.
+/// * `set_key` - Key of the source set whose cardinality becomes the score.
+/// * `sorted_set_prefix` - Prefix of the destination sorted set key.
+/// * `sorted_set_key` - Key of the destination sorted set.
+/// * `member` - The sorted-set member to write or remove.
+///
+/// # Errors
+///
+/// Returns an error if the script execution fails.
+pub async fn sync_score_from_set_cardinality(
+    set_prefix: &str,
+    set_key: &str,
+    sorted_set_prefix: &str,
+    sorted_set_key: &str,
+    member: &str,
+) -> RedisResult<()> {
+    let set_index_key = format!("{set_prefix}:{set_key}");
+    let sorted_set_index_key = format!("{sorted_set_prefix}:{sorted_set_key}");
+    let mut redis_conn = get_redis_conn().await?;
+
+    let script = Script::new(
+        r#"
+        local cardinality = redis.call('SCARD', KEYS[1])
+        if cardinality == 0 then
+            redis.call('ZREM', KEYS[2], ARGV[1])
+        else
+            redis.call('ZADD', KEYS[2], cardinality, ARGV[1])
+        end
+        return cardinality
+    "#,
+    );
+
+    let _: i64 = script
+        .key(set_index_key)
+        .key(sorted_set_index_key)
+        .arg(member)
+        .invoke_async(&mut redis_conn)
+        .await?;
+
     Ok(())
 }

--- a/nexus-common/src/db/kv/index/sorted_sets.rs
+++ b/nexus-common/src/db/kv/index/sorted_sets.rs
@@ -286,6 +286,10 @@ pub async fn del(prefix: &str, key: &str, values: &[&str]) -> RedisResult<()> {
 /// * `sorted_set_prefix` - Prefix of the destination sorted set key.
 /// * `sorted_set_key` - Key of the destination sorted set.
 /// * `member` - The sorted-set member to write or remove.
+/// * `removal_guard` - Optional `(json_key, json_path, value)`: when the JSON
+///   document at `json_key` holds `value` at `json_path`, the member is
+///   removed regardless of cardinality. Checked inside the same script, so
+///   the guard cannot race the write.
 ///
 /// # Errors
 ///
@@ -296,13 +300,13 @@ pub async fn sync_score_from_set_cardinality(
     sorted_set_prefix: &str,
     sorted_set_key: &str,
     member: &str,
+    removal_guard: Option<(&str, &str, &str)>,
 ) -> RedisResult<()> {
     let set_index_key = format!("{set_prefix}:{set_key}");
     let sorted_set_index_key = format!("{sorted_set_prefix}:{sorted_set_key}");
     let mut redis_conn = get_redis_conn().await?;
 
-    let script = Script::new(
-        r#"
+    let derive = r#"
         local cardinality = redis.call('SCARD', KEYS[1])
         if cardinality == 0 then
             redis.call('ZREM', KEYS[2], ARGV[1])
@@ -310,15 +314,44 @@ pub async fn sync_score_from_set_cardinality(
             redis.call('ZADD', KEYS[2], cardinality, ARGV[1])
         end
         return cardinality
-    "#,
-    );
+    "#;
 
-    let _: i64 = script
-        .key(set_index_key)
-        .key(sorted_set_index_key)
-        .arg(member)
-        .invoke_async(&mut redis_conn)
-        .await?;
+    let invocation = match removal_guard {
+        Some((json_key, json_path, value)) => {
+            let script = Script::new(&format!(
+                r#"
+                local guarded = redis.call('JSON.GET', KEYS[3], ARGV[2])
+                if guarded then
+                    local decoded = cjson.decode(guarded)
+                    if type(decoded) == 'table' and decoded[1] == ARGV[3] then
+                        redis.call('ZREM', KEYS[2], ARGV[1])
+                        return 0
+                    end
+                end
+                {derive}
+            "#
+            ));
+            script
+                .key(set_index_key)
+                .key(sorted_set_index_key)
+                .key(json_key)
+                .arg(member)
+                .arg(json_path)
+                .arg(value)
+                .invoke_async(&mut redis_conn)
+                .await
+        }
+        None => {
+            let script = Script::new(derive);
+            script
+                .key(set_index_key)
+                .key(sorted_set_index_key)
+                .arg(member)
+                .invoke_async(&mut redis_conn)
+                .await
+        }
+    };
 
+    let _: i64 = invocation?;
     Ok(())
 }

--- a/nexus-common/src/db/kv/traits.rs
+++ b/nexus-common/src/db/kv/traits.rs
@@ -617,6 +617,37 @@ pub trait RedisOps: Serialize + DeserializeOwned + Send + Sync {
         sorted_sets::put_score(SORTED_PREFIX, &key, &member_key, score_mutation).await
     }
 
+    /// Atomically derives a sorted-set member's score from a set's
+    /// cardinality: the score becomes `SCARD` of the source set, and the
+    /// member is removed when the set is empty. Runs as one Lua script, so
+    /// concurrent writers cannot commit a stale cardinality.
+    ///
+    /// # Arguments
+    ///
+    /// * `source_set_prefix` - Prefix of the source set key.
+    /// * `source_set_key_parts` - Key parts of the source set whose cardinality becomes the score.
+    /// * `sorted_set_key_parts` - Key parts of the destination sorted set (under the `Sorted` prefix).
+    /// * `member` - The sorted-set member to write or remove.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the script execution fails.
+    async fn put_cardinality_index_sorted_set(
+        source_set_prefix: &str,
+        source_set_key_parts: &[&str],
+        sorted_set_key_parts: &[&str],
+        member: &str,
+    ) -> RedisResult<()> {
+        sorted_sets::sync_score_from_set_cardinality(
+            source_set_prefix,
+            &source_set_key_parts.join(":"),
+            SORTED_PREFIX,
+            &sorted_set_key_parts.join(":"),
+            member,
+        )
+        .await
+    }
+
     /// Increments the score of a member in a Redis sorted set by 1.0.
     async fn increment_score_index_sorted_set(
         key_parts: &[&str],

--- a/nexus-common/src/db/kv/traits.rs
+++ b/nexus-common/src/db/kv/traits.rs
@@ -628,6 +628,8 @@ pub trait RedisOps: Serialize + DeserializeOwned + Send + Sync {
     /// * `source_set_key_parts` - Key parts of the source set whose cardinality becomes the score.
     /// * `sorted_set_key_parts` - Key parts of the destination sorted set (under the `Sorted` prefix).
     /// * `member` - The sorted-set member to write or remove.
+    /// * `removal_guard` - Optional `(json_key, json_path, value)` that forces
+    ///   removal when the JSON document matches, checked atomically with the write.
     ///
     /// # Errors
     ///
@@ -637,6 +639,7 @@ pub trait RedisOps: Serialize + DeserializeOwned + Send + Sync {
         source_set_key_parts: &[&str],
         sorted_set_key_parts: &[&str],
         member: &str,
+        removal_guard: Option<(&str, &str, &str)>,
     ) -> RedisResult<()> {
         sorted_sets::sync_score_from_set_cardinality(
             source_set_prefix,
@@ -644,6 +647,7 @@ pub trait RedisOps: Serialize + DeserializeOwned + Send + Sync {
             SORTED_PREFIX,
             &sorted_set_key_parts.join(":"),
             member,
+            removal_guard,
         )
         .await
     }

--- a/nexus-common/src/db/reindex.rs
+++ b/nexus-common/src/db/reindex.rs
@@ -9,7 +9,7 @@ use crate::models::tag::stream::HotTags;
 use crate::models::tag::traits::TagCollection;
 use crate::models::tag::user::TagUser;
 use crate::models::traits::Collection;
-use crate::models::user::{Influencers, UserDetails};
+use crate::models::user::{Influencers, UserDetails, UsersByTagSearch};
 use crate::types::DynError;
 use crate::{
     models::post::{PostCounts, PostDetails, PostRelationships},
@@ -79,6 +79,10 @@ pub async fn sync() {
     PostsByTagSearch::reindex()
         .await
         .expect("Failed to store the global post tags");
+
+    UsersByTagSearch::reindex()
+        .await
+        .expect("Failed to store the global user tags");
 
     TagSearch::reindex()
         .await

--- a/nexus-common/src/models/user/mod.rs
+++ b/nexus-common/src/models/user/mod.rs
@@ -15,7 +15,7 @@ pub use details::{set_user_homeserver, set_user_homeserver_stale, UserDetails};
 pub use influencers::Influencers;
 pub use ingestor::UserIngestor;
 pub use relationship::Relationship;
-pub use search::{UserSearch, USER_NAME_KEY_PARTS};
+pub use search::{UserSearch, UsersByTagSearch, TAG_GLOBAL_USER_TAGGERS, USER_NAME_KEY_PARTS};
 pub use stream::{
     UserIdStream, UserStream, UserStreamInput, UserStreamSource, CACHE_USER_RECOMMENDED_KEY_PARTS,
     USER_INFLUENCERS_KEY_PARTS, USER_MOSTFOLLOWED_KEY_PARTS,

--- a/nexus-common/src/models/user/search.rs
+++ b/nexus-common/src/models/user/search.rs
@@ -3,7 +3,7 @@ use crate::db::kv::{RedisResult, SortOrder};
 use crate::db::{fetch_all_rows_from_graph, get_neo4j_graph, queries, GraphError, RedisOps};
 use crate::models::create_zero_score_tuples;
 use crate::models::error::ModelResult;
-use crate::models::tag::user::TagUser;
+use crate::models::tag::user::{TagUser, USER_TAGS_KEY_PARTS};
 use crate::models::traits::Collection;
 use crate::types::Pagination;
 use futures::TryStreamExt;
@@ -14,6 +14,7 @@ use utoipa::ToSchema;
 pub const USER_NAME_KEY_PARTS: [&str; 2] = ["Users", "Name"];
 pub const USER_ID_KEY_PARTS: [&str; 2] = ["Users", "ID"];
 pub const TAG_GLOBAL_USER_TAGGERS: [&str; 4] = ["Tags", "Global", "User", "Taggers"];
+const EVICT_PAGE_SIZE: usize = 500;
 
 /// Represents a single result of a "users by tags" search: a user whose profile
 /// carries at least one of the searched tag labels, and how many distinct
@@ -133,21 +134,62 @@ impl UsersByTagSearch {
 
     /// Syncs the per-label score for a user from the taggers set the tag
     /// handlers already maintain idempotently: the score becomes the set
-    /// cardinality, and the member is removed when the set empties. The read
-    /// and the conditional write run as one Lua script, so concurrent events
-    /// for the same (user, label) cannot commit a stale score, and retries
-    /// converge without gating. Must run after the taggers SADD/SREM settled.
+    /// cardinality, and the member is removed when the set empties or when
+    /// the user's details carry the deleted sentinel. Everything runs as one
+    /// Lua script, so concurrent events for the same (user, label) cannot
+    /// commit a stale score and a concurrent tombstone cannot be raced; the
+    /// callers need no gating and retries converge on their own. Must run
+    /// after the taggers SADD/SREM settled.
     ///
     /// # Errors
     /// Returns an error if the Redis script execution fails.
     pub async fn sync_index_score(user_id: &str, label: &str) -> RedisResult<()> {
+        let details_key = format!("{}:{}", UserDetails::prefix().await, user_id);
         Self::put_cardinality_index_sorted_set(
             &TagUser::prefix().await,
             &[user_id, label],
             &[&TAG_GLOBAL_USER_TAGGERS[..], &[label]].concat(),
             user_id,
+            Some((&details_key, "$.name", USER_DELETED_SENTINEL)),
         )
         .await
+    }
+
+    /// Removes a tombstoned user from every per-label sorted set their
+    /// profile tags placed them in. Each per-label sync re-checks the
+    /// tombstone atomically, so a concurrent tag event cannot re-add them.
+    ///
+    /// # Errors
+    /// Returns an error when reading the user's tag labels or syncing a
+    /// label fails.
+    pub async fn evict_user(user_id: &str) -> RedisResult<()> {
+        let key_parts = [&USER_TAGS_KEY_PARTS[..], &[user_id]].concat();
+        let mut skip = 0;
+        loop {
+            let page = Self::try_from_index_sorted_set(
+                &key_parts,
+                None,
+                None,
+                Some(skip),
+                Some(EVICT_PAGE_SIZE),
+                SortOrder::Descending,
+                None,
+            )
+            .await?;
+            let Some(page) = page else { break };
+            if page.is_empty() {
+                break;
+            }
+            let page_len = page.len();
+            for (label, _) in page {
+                Self::sync_index_score(user_id, &label).await?;
+            }
+            if page_len < EVICT_PAGE_SIZE {
+                break;
+            }
+            skip += page_len;
+        }
+        Ok(())
     }
 
     /// Backfills the index against live data: the graph only enumerates

--- a/nexus-common/src/models/user/search.rs
+++ b/nexus-common/src/models/user/search.rs
@@ -1,6 +1,6 @@
 use super::{UserDetails, USER_DELETED_SENTINEL};
 use crate::db::kv::{RedisResult, SortOrder};
-use crate::db::{fetch_all_rows_from_graph, get_neo4j_graph, queries, GraphError, RedisOps};
+use crate::db::{get_neo4j_graph, queries, GraphError, GraphResult, RedisOps};
 use crate::models::create_zero_score_tuples;
 use crate::models::error::ModelResult;
 use crate::models::tag::user::{TagUser, USER_TAGS_KEY_PARTS};
@@ -38,17 +38,22 @@ impl RedisOps for UsersByTagSearch {}
 
 impl UsersByTagSearch {
     /// Indexes user profile tags into per-label global sorted sets from a
-    /// graph snapshot. Only for full rebuilds over quiescent or empty Redis
-    /// (`db mock`, full reindex); live backfills go through
-    /// [`Self::backfill_from_graph`] instead, which cannot overwrite
-    /// concurrent watcher writes with snapshot state.
+    /// graph snapshot, streaming one label row at a time. Only for full
+    /// rebuilds over quiescent or empty Redis (`db mock`, full reindex); live
+    /// backfills go through the `UsersByTagsIndexBackfill` migration instead,
+    /// which derives every score from live state and cannot overwrite
+    /// concurrent watcher writes.
     ///
     /// # Errors
     /// Returns an error when the graph read or a Redis write fails.
     pub async fn reindex() -> ModelResult<()> {
-        let rows = fetch_all_rows_from_graph(queries::get::global_tags_by_user()).await?;
+        let graph = get_neo4j_graph()?;
+        let mut rows = graph
+            .execute(queries::get::global_tags_by_user())
+            .await
+            .map_err(GraphError::from)?;
 
-        for row in rows {
+        while let Some(row) = rows.try_next().await.map_err(GraphError::from)? {
             let label: &str = row.get("label").unwrap_or("");
             let sorted_set: Vec<(f64, &str)> = row.get("sorted_set").unwrap_or(Vec::new());
             if !label.is_empty() && !sorted_set.is_empty() {
@@ -96,7 +101,9 @@ impl UsersByTagSearch {
             }
             // Union across labels needs an aggregation over multiple sorted sets,
             // so it goes to the graph instead
-            _ => Self::get_from_graph(labels, pagination.skip, pagination.limit).await,
+            _ => Self::get_from_graph(labels, pagination.skip, pagination.limit)
+                .await
+                .map_err(Into::into),
         }
     }
 
@@ -104,7 +111,7 @@ impl UsersByTagSearch {
         labels: &[String],
         skip: Option<usize>,
         limit: Option<usize>,
-    ) -> ModelResult<Vec<UsersByTagSearch>> {
+    ) -> GraphResult<Vec<UsersByTagSearch>> {
         let graph = get_neo4j_graph()?;
         let query = queries::get::search_users_by_tags(labels, skip, limit);
 
@@ -112,7 +119,7 @@ impl UsersByTagSearch {
         // only submits the query and the heavy work (ORDER BY materializes at
         // the first pull) happens while streaming, so a timeout on execute
         // alone lets a slow query run until the HTTP layer's 408.
-        let users = timeout(Duration::from_secs(10), async {
+        timeout(Duration::from_secs(10), async {
             let mut result = graph.execute(query).await?;
 
             let mut users = Vec::new();
@@ -124,12 +131,10 @@ impl UsersByTagSearch {
                     score: score as usize,
                 });
             }
-            Ok::<_, GraphError>(users)
+            Ok(users)
         })
         .await
-        .map_err(|_| GraphError::QueryTimeout)??;
-
-        Ok(users)
+        .map_err(|_| GraphError::QueryTimeout)?
     }
 
     /// Syncs the per-label score for a user from the taggers set the tag

--- a/nexus-common/src/models/user/search.rs
+++ b/nexus-common/src/models/user/search.rs
@@ -61,8 +61,8 @@ impl UsersByTagSearch {
 
     /// Searches users by profile tag labels with union semantics: any user
     /// whose profile carries at least one of the labels is returned, scored
-    /// by the summed distinct-tagger counts, descending. Tie order between
-    /// equal scores is unspecified.
+    /// by the summed distinct-tagger counts, descending. Equal scores break
+    /// ties by user id descending on both serving paths.
     ///
     /// A single label is served from the per-label Redis sorted set; two or
     /// more labels aggregate in the graph under a 10-second budget.
@@ -191,25 +191,6 @@ impl UsersByTagSearch {
                 break;
             }
             skip += page_len;
-        }
-        Ok(())
-    }
-
-    /// Backfills the index against live data: the graph only enumerates
-    /// candidate (user, label) pairs, and every score is derived atomically
-    /// from the current taggers set by [`Self::sync_index_score`]. Events
-    /// landing during the backfill are therefore never overwritten with
-    /// snapshot state; a pair whose tag was deleted mid-backfill derives an
-    /// empty set and stays out of the index.
-    ///
-    /// # Errors
-    /// Returns an error when the graph enumeration or a Redis sync fails.
-    pub async fn backfill_from_graph() -> ModelResult<()> {
-        let rows = fetch_all_rows_from_graph(queries::get::get_user_tag_pairs()).await?;
-        for row in rows {
-            let user_id: String = row.get("user_id")?;
-            let label: String = row.get("label")?;
-            Self::sync_index_score(&user_id, &label).await?;
         }
         Ok(())
     }

--- a/nexus-common/src/models/user/search.rs
+++ b/nexus-common/src/models/user/search.rs
@@ -36,7 +36,14 @@ impl From<(String, f64)> for UsersByTagSearch {
 impl RedisOps for UsersByTagSearch {}
 
 impl UsersByTagSearch {
-    /// Indexes user profile tags into per-label global sorted sets.
+    /// Indexes user profile tags into per-label global sorted sets from a
+    /// graph snapshot. Only for full rebuilds over quiescent or empty Redis
+    /// (`db mock`, full reindex); live backfills go through
+    /// [`Self::backfill_from_graph`] instead, which cannot overwrite
+    /// concurrent watcher writes with snapshot state.
+    ///
+    /// # Errors
+    /// Returns an error when the graph read or a Redis write fails.
     pub async fn reindex() -> ModelResult<()> {
         let rows = fetch_all_rows_from_graph(queries::get::global_tags_by_user()).await?;
 
@@ -51,6 +58,20 @@ impl UsersByTagSearch {
         Ok(())
     }
 
+    /// Searches users by profile tag labels with union semantics: any user
+    /// whose profile carries at least one of the labels is returned, scored
+    /// by the summed distinct-tagger counts, descending. Tie order between
+    /// equal scores is unspecified.
+    ///
+    /// A single label is served from the per-label Redis sorted set; two or
+    /// more labels aggregate in the graph under a 10-second budget.
+    ///
+    /// # Errors
+    /// Returns [`crate::models::error::ModelError::KvOperationFailed`] on
+    /// Redis failures and
+    /// [`crate::models::error::ModelError::GraphOperationFailed`] on graph
+    /// failures, including `GraphError::QueryTimeout` when the graph path
+    /// exceeds its budget.
     pub async fn get_by_labels(
         labels: &[String],
         pagination: Pagination,
@@ -111,19 +132,41 @@ impl UsersByTagSearch {
     }
 
     /// Syncs the per-label score for a user from the taggers set the tag
-    /// handlers already maintain idempotently. Deriving the score instead of
-    /// counting increments means retries converge to the true count, so
-    /// callers need no gating. Must run after the taggers SADD/SREM settled.
-    /// The SCARD-then-ZADD pair is not atomic: concurrent events for the same
-    /// (user, label) on different processor lanes can land a stale score for
-    /// a moment; the next event for that pair rewrites it from the set.
+    /// handlers already maintain idempotently: the score becomes the set
+    /// cardinality, and the member is removed when the set empties. The read
+    /// and the conditional write run as one Lua script, so concurrent events
+    /// for the same (user, label) cannot commit a stale score, and retries
+    /// converge without gating. Must run after the taggers SADD/SREM settled.
+    ///
+    /// # Errors
+    /// Returns an error if the Redis script execution fails.
     pub async fn sync_index_score(user_id: &str, label: &str) -> RedisResult<()> {
-        let taggers = TagUser::get_set_size(&[user_id, label]).await?.unwrap_or(0);
-        let key_parts = [&TAG_GLOBAL_USER_TAGGERS[..], &[label]].concat();
-        match taggers {
-            0 => Self::remove_from_index_sorted_set(None, &key_parts, &[user_id]).await,
-            n => Self::put_index_sorted_set(&key_parts, &[(n as f64, user_id)], None, None).await,
+        Self::put_cardinality_index_sorted_set(
+            &TagUser::prefix().await,
+            &[user_id, label],
+            &[&TAG_GLOBAL_USER_TAGGERS[..], &[label]].concat(),
+            user_id,
+        )
+        .await
+    }
+
+    /// Backfills the index against live data: the graph only enumerates
+    /// candidate (user, label) pairs, and every score is derived atomically
+    /// from the current taggers set by [`Self::sync_index_score`]. Events
+    /// landing during the backfill are therefore never overwritten with
+    /// snapshot state; a pair whose tag was deleted mid-backfill derives an
+    /// empty set and stays out of the index.
+    ///
+    /// # Errors
+    /// Returns an error when the graph enumeration or a Redis sync fails.
+    pub async fn backfill_from_graph() -> ModelResult<()> {
+        let rows = fetch_all_rows_from_graph(queries::get::get_user_tag_pairs()).await?;
+        for row in rows {
+            let user_id: String = row.get("user_id")?;
+            let label: String = row.get("label")?;
+            Self::sync_index_score(&user_id, &label).await?;
         }
+        Ok(())
     }
 }
 

--- a/nexus-common/src/models/user/search.rs
+++ b/nexus-common/src/models/user/search.rs
@@ -1,13 +1,131 @@
 use super::{UserDetails, USER_DELETED_SENTINEL};
-use crate::db::kv::RedisResult;
-use crate::db::RedisOps;
+use crate::db::kv::{RedisResult, SortOrder};
+use crate::db::{fetch_all_rows_from_graph, get_neo4j_graph, queries, GraphError, RedisOps};
 use crate::models::create_zero_score_tuples;
+use crate::models::error::ModelResult;
+use crate::models::tag::user::TagUser;
 use crate::models::traits::Collection;
+use crate::types::Pagination;
+use futures::TryStreamExt;
 use serde::{Deserialize, Serialize};
+use tokio::time::{timeout, Duration};
 use utoipa::ToSchema;
 
 pub const USER_NAME_KEY_PARTS: [&str; 2] = ["Users", "Name"];
 pub const USER_ID_KEY_PARTS: [&str; 2] = ["Users", "ID"];
+pub const TAG_GLOBAL_USER_TAGGERS: [&str; 4] = ["Tags", "Global", "User", "Taggers"];
+
+/// Represents a single result of a "users by tags" search: a user whose profile
+/// carries at least one of the searched tag labels, and how many distinct
+/// taggers applied them (summed across the searched labels).
+#[derive(Serialize, Deserialize, ToSchema, Default)]
+pub struct UsersByTagSearch {
+    pub user_id: String,
+    pub score: usize,
+}
+
+impl From<(String, f64)> for UsersByTagSearch {
+    fn from(tuple: (String, f64)) -> Self {
+        UsersByTagSearch {
+            user_id: tuple.0,
+            score: tuple.1 as usize,
+        }
+    }
+}
+
+impl RedisOps for UsersByTagSearch {}
+
+impl UsersByTagSearch {
+    /// Indexes user profile tags into per-label global sorted sets.
+    pub async fn reindex() -> ModelResult<()> {
+        let rows = fetch_all_rows_from_graph(queries::get::global_tags_by_user()).await?;
+
+        for row in rows {
+            let label: &str = row.get("label").unwrap_or("");
+            let sorted_set: Vec<(f64, &str)> = row.get("sorted_set").unwrap_or(Vec::new());
+            if !label.is_empty() && !sorted_set.is_empty() {
+                let key_parts = [&TAG_GLOBAL_USER_TAGGERS[..], &[label]].concat();
+                Self::put_index_sorted_set(&key_parts, &sorted_set, None, None).await?;
+            }
+        }
+        Ok(())
+    }
+
+    pub async fn get_by_labels(
+        labels: &[String],
+        pagination: Pagination,
+    ) -> ModelResult<Vec<UsersByTagSearch>> {
+        match labels {
+            // Single label: served straight from the per-label sorted set
+            [label] => {
+                let users = Self::try_from_index_sorted_set(
+                    &[&TAG_GLOBAL_USER_TAGGERS[..], &[label.as_str()]].concat(),
+                    None,
+                    None,
+                    pagination.skip,
+                    pagination.limit,
+                    SortOrder::Descending,
+                    None,
+                )
+                .await?;
+                Ok(users
+                    .map(|list| list.into_iter().map(Into::into).collect())
+                    .unwrap_or_default())
+            }
+            // Union across labels needs an aggregation over multiple sorted sets,
+            // so it goes to the graph instead
+            _ => Self::get_from_graph(labels, pagination.skip, pagination.limit).await,
+        }
+    }
+
+    async fn get_from_graph(
+        labels: &[String],
+        skip: Option<usize>,
+        limit: Option<usize>,
+    ) -> ModelResult<Vec<UsersByTagSearch>> {
+        let graph = get_neo4j_graph()?;
+        let query = queries::get::search_users_by_tags(labels, skip, limit);
+
+        // The 10-second budget covers execution AND row streaming: execute()
+        // only submits the query and the heavy work (ORDER BY materializes at
+        // the first pull) happens while streaming, so a timeout on execute
+        // alone lets a slow query run until the HTTP layer's 408.
+        let users = timeout(Duration::from_secs(10), async {
+            let mut result = graph.execute(query).await?;
+
+            let mut users = Vec::new();
+            while let Some(row) = result.try_next().await? {
+                let user_id: String = row.get("user_id")?;
+                let score: i64 = row.get("score")?;
+                users.push(UsersByTagSearch {
+                    user_id,
+                    score: score as usize,
+                });
+            }
+            Ok::<_, GraphError>(users)
+        })
+        .await
+        .map_err(|_| GraphError::QueryTimeout)??;
+
+        Ok(users)
+    }
+
+    /// Syncs the per-label score for a user from the taggers set the tag
+    /// handlers already maintain idempotently. Deriving the score instead of
+    /// counting increments means retries converge to the true count, so
+    /// callers need no gating. Must run after the taggers SADD/SREM settled.
+    /// The SCARD-then-ZADD pair is not atomic: concurrent events for the same
+    /// (user, label) on different processor lanes can land a stale score for
+    /// a moment; the next event for that pair rewrites it from the set.
+    pub async fn sync_index_score(user_id: &str, label: &str) -> RedisResult<()> {
+        let taggers = TagUser::get_set_size(&[user_id, label]).await?.unwrap_or(0);
+        let key_parts = [&TAG_GLOBAL_USER_TAGGERS[..], &[label]].concat();
+        match taggers {
+            0 => Self::remove_from_index_sorted_set(None, &key_parts, &[user_id]).await,
+            n => Self::put_index_sorted_set(&key_parts, &[(n as f64, user_id)], None, None).await,
+        }
+    }
+}
 
 /// List of user IDs
 #[derive(Serialize, Deserialize, ToSchema, Default)]

--- a/nexus-common/src/models/user/search.rs
+++ b/nexus-common/src/models/user/search.rs
@@ -155,14 +155,17 @@ impl UsersByTagSearch {
         .await
     }
 
-    /// Removes a tombstoned user from every per-label sorted set their
-    /// profile tags placed them in. Each per-label sync re-checks the
-    /// tombstone atomically, so a concurrent tag event cannot re-add them.
+    /// Re-derives the user's entry in every per-label sorted set their
+    /// profile tags placed them in: evicts them when their details carry the
+    /// deleted sentinel, restores them when a recreated profile cleared it.
+    /// Each per-label sync checks the tombstone atomically, so concurrent tag
+    /// events cannot race the outcome. Must run after the details write
+    /// settled.
     ///
     /// # Errors
     /// Returns an error when reading the user's tag labels or syncing a
     /// label fails.
-    pub async fn evict_user(user_id: &str) -> RedisResult<()> {
+    pub async fn sync_user_labels(user_id: &str) -> RedisResult<()> {
         let key_parts = [&USER_TAGS_KEY_PARTS[..], &[user_id]].concat();
         let mut skip = 0;
         loop {

--- a/nexus-watcher/src/events/handlers/tag.rs
+++ b/nexus-watcher/src/events/handlers/tag.rs
@@ -11,7 +11,7 @@ use nexus_common::models::tag::post::TagPost;
 use nexus_common::models::tag::search::TagSearch;
 use nexus_common::models::tag::traits::{TagCollection, TaggersCollection};
 use nexus_common::models::tag::user::TagUser;
-use nexus_common::models::user::{UserCounts, UserIngestor};
+use nexus_common::models::user::{UserCounts, UserIngestor, UsersByTagSearch};
 use nexus_common::types::Pagination;
 use nexus_common::universal_tag::normalize::{
     classify_uri, normalize_uri, resource_id, UriCategory,
@@ -348,6 +348,8 @@ async fn put_sync_user(
             );
             idempotent_results.0?;
             idempotent_results.1?;
+
+            UsersByTagSearch::sync_index_score(&tagged_user_id, tag_label).await?;
             Ok(())
         }
         OperationOutcome::MissingDependency => {
@@ -394,6 +396,10 @@ async fn put_sync_user(
             indexing_results.3?;
             indexing_results.4?;
             indexing_results.5?;
+
+            // After the taggers SADD settled: the users-by-tag score is derived
+            // from that set (SCARD), so first attempts and retries converge alike.
+            UsersByTagSearch::sync_index_score(&tagged_user_id, tag_label).await?;
 
             Ok(())
         }
@@ -590,6 +596,10 @@ async fn del_sync_user(
     indexing_results.2?;
     indexing_results.3?;
     indexing_results.4?;
+
+    // After the taggers SREM settled: recompute the derived users-by-tag score,
+    // dropping the member once the last tagger is gone.
+    UsersByTagSearch::sync_index_score(tagged_id, tag_label).await?;
 
     Ok(())
 }

--- a/nexus-watcher/src/events/handlers/user.rs
+++ b/nexus-watcher/src/events/handlers/user.rs
@@ -6,7 +6,7 @@ use nexus_common::db::{
 };
 use nexus_common::models::{
     traits::Collection,
-    user::{UserCounts, UserDetails, UserSearch, USER_DELETED_SENTINEL},
+    user::{UserCounts, UserDetails, UserSearch, UsersByTagSearch, USER_DELETED_SENTINEL},
 };
 use pubky_app_specs::{PubkyAppUser, PubkyId};
 use tracing::debug;
@@ -89,7 +89,12 @@ pub async fn del(user_id: PubkyId) -> Result<(), EventProcessorError> {
                 image: None,
             };
 
-            sync_put(deleted_user, user_id).await?;
+            sync_put(deleted_user, user_id.clone()).await?;
+
+            // After the tombstone settled: drop the user from users-by-tag
+            // search. Each per-label sync re-checks the tombstone atomically,
+            // so a concurrent tag event cannot re-add them.
+            UsersByTagSearch::evict_user(&user_id).await?;
         }
         OperationOutcome::MissingDependency => return Err(EventProcessorError::SkipIndexing),
     }

--- a/nexus-watcher/src/events/handlers/user.rs
+++ b/nexus-watcher/src/events/handlers/user.rs
@@ -46,6 +46,13 @@ pub async fn sync_put(user: PubkyAppUser, user_id: PubkyId) -> Result<(), EventP
     indexing_results.0?;
     indexing_results.1?;
     indexing_results.2?;
+
+    // Profile writes flip the tombstone state in both directions: deletion
+    // writes the sentinel, recreation clears it. Re-derive the user's
+    // per-label search entries afterwards, so tombstones are evicted and
+    // recreated profiles get their retained tags back.
+    UsersByTagSearch::sync_user_labels(&user_id).await?;
+
     Ok(())
 }
 
@@ -89,12 +96,9 @@ pub async fn del(user_id: PubkyId) -> Result<(), EventProcessorError> {
                 image: None,
             };
 
-            sync_put(deleted_user, user_id.clone()).await?;
-
-            // After the tombstone settled: drop the user from users-by-tag
-            // search. Each per-label sync re-checks the tombstone atomically,
-            // so a concurrent tag event cannot re-add them.
-            UsersByTagSearch::evict_user(&user_id).await?;
+            // sync_put re-derives the per-label search entries after writing
+            // the tombstone, which evicts the user from users-by-tag search
+            sync_put(deleted_user, user_id).await?;
         }
         OperationOutcome::MissingDependency => return Err(EventProcessorError::SkipIndexing),
     }

--- a/nexus-watcher/tests/event_processor/tags/mod.rs
+++ b/nexus-watcher/tests/event_processor/tags/mod.rs
@@ -22,4 +22,5 @@ mod user_notification;
 mod user_to_self_put;
 mod user_to_user_del;
 mod user_to_user_put;
+mod users_by_tags_sync;
 pub mod utils;

--- a/nexus-watcher/tests/event_processor/tags/multi_user.rs
+++ b/nexus-watcher/tests/event_processor/tags/multi_user.rs
@@ -1,4 +1,4 @@
-use super::utils::find_user_tag;
+use super::utils::{check_member_user_tag_taggers, find_user_tag};
 use crate::event_processor::users::utils::find_user_counts;
 use crate::event_processor::utils::watcher::{HomeserverHashIdPath, WatcherTest};
 use anyhow::Result;
@@ -130,7 +130,31 @@ async fn test_homeserver_multi_user_tags() -> Result<()> {
     let tagger_c_user_counts = find_user_counts(&tagger_c_id_kp.0).await;
     assert_eq!(tagger_c_user_counts.tagged, 2);
 
+    // Users-by-tag scores follow the taggers sets:
+    // Sorted:Tags:Global:User:Taggers:{label}
+    let wind_score = check_member_user_tag_taggers(tagged_id, label_wind)
+        .await
+        .expect("Failed to check the users-by-tag score");
+    assert_eq!(wind_score, Some(3));
+    let earth_score = check_member_user_tag_taggers(tagged_id, label_earth)
+        .await
+        .expect("Failed to check the users-by-tag score");
+    assert_eq!(earth_score, Some(2));
+
     // Step 4: DEL tag from homeserver
+    // Partial delete first: the member must stay with the remaining taggers count
+    let (first_tag_path, first_tagger_kp) = tag_paths_and_tagger_kps.remove(0);
+    test.del(first_tagger_kp, &first_tag_path).await?;
+
+    let wind_score = check_member_user_tag_taggers(tagged_id, label_wind)
+        .await
+        .expect("Failed to check the users-by-tag score");
+    assert_eq!(
+        wind_score,
+        Some(2),
+        "Partial delete must keep the member with the remaining taggers count"
+    );
+
     for (tag_url, tagger_kp) in tag_paths_and_tagger_kps {
         test.del(tagger_kp, &tag_url).await?;
     }
@@ -169,6 +193,16 @@ async fn test_homeserver_multi_user_tags() -> Result<()> {
             .await
             .unwrap();
     assert!(earth_taggers_result.is_empty());
+
+    // Sorted:Tags:Global:User:Taggers:{label} members must be gone as well
+    let wind_score = check_member_user_tag_taggers(tagged_id, label_wind)
+        .await
+        .expect("Failed to check the users-by-tag score");
+    assert!(wind_score.is_none());
+    let earth_score = check_member_user_tag_taggers(tagged_id, label_earth)
+        .await
+        .expect("Failed to check the users-by-tag score");
+    assert!(earth_score.is_none());
 
     // Check if user counts updated: User:Counts:user_id:post_id
     let user_counts = find_user_counts(tagged_id).await;

--- a/nexus-watcher/tests/event_processor/tags/user_to_user_del.rs
+++ b/nexus-watcher/tests/event_processor/tags/user_to_user_del.rs
@@ -1,4 +1,4 @@
-use super::utils::find_user_tag;
+use super::utils::{check_member_user_tag_taggers, find_user_tag};
 use crate::event_processor::{
     users::utils::{check_member_user_influencer, find_user_counts},
     utils::watcher::{HomeserverHashIdPath, WatcherTest},
@@ -72,6 +72,16 @@ async fn test_homeserver_del_tag_to_another_user() -> Result<()> {
     assert!(
         cache_user_tag.unwrap().is_empty(),
         "The SORTED SET index cannot exist for the tag"
+    );
+
+    // The users-by-tag member must drop with its last tagger:
+    // Sorted:Tags:Global:User:Taggers:{label}
+    let taggers_score = check_member_user_tag_taggers(&tagged_user_id, label)
+        .await
+        .expect("Failed to check the users-by-tag score");
+    assert!(
+        taggers_score.is_none(),
+        "Tagged user cannot stay in the users-by-tag index after the last tagger deletes"
     );
 
     // Check if user counts is updated, User:Counts:user_id

--- a/nexus-watcher/tests/event_processor/tags/user_to_user_put.rs
+++ b/nexus-watcher/tests/event_processor/tags/user_to_user_put.rs
@@ -1,12 +1,14 @@
-use super::utils::find_user_tag;
+use super::utils::{check_member_user_tag_taggers, find_user_tag};
 use crate::event_processor::{
     users::utils::{check_member_user_influencer, find_user_counts},
     utils::watcher::{HomeserverHashIdPath, WatcherTest},
 };
 use anyhow::Result;
 use chrono::Utc;
+use nexus_common::db::RedisOps;
 use nexus_common::models::event::EventLine;
 use nexus_common::models::tag::{traits::TagCollection, user::TagUser};
+use nexus_common::models::user::{UsersByTagSearch, TAG_GLOBAL_USER_TAGGERS};
 use pubky::Keypair;
 use pubky_app_specs::{PubkyAppTag, PubkyAppUser};
 
@@ -100,7 +102,86 @@ async fn test_homeserver_put_tag_user_another() -> Result<()> {
     );
     assert_eq!(influencer_score.unwrap(), 0);
 
+    // Check the users-by-tag search score: Sorted:Tags:Global:User:Taggers:{label}
+    let taggers_score = check_member_user_tag_taggers(&tagged_user_id, label)
+        .await
+        .expect("Failed to check the users-by-tag score");
+    assert!(
+        taggers_score.is_some(),
+        "Tagged user should be a member of the users-by-tag index"
+    );
+    assert_eq!(taggers_score.unwrap(), 1);
+
     // Cleanup user
+    test.cleanup_user(&tagged_kp).await?;
+    test.cleanup_user(&tagger_kp).await?;
+
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_homeserver_user_tag_retry_heals_search_index() -> Result<()> {
+    let mut test = WatcherTest::setup(None).await?;
+
+    let tagged_kp = Keypair::random();
+    let tagged_user = PubkyAppUser {
+        bio: Some("test_homeserver_user_tag_retry_heals_search_index".to_string()),
+        image: None,
+        links: None,
+        name: "Watcher:PutTagRetry:TaggedUser".to_string(),
+        status: None,
+    };
+    let tagged_user_id = test.create_user(&tagged_kp, &tagged_user).await?;
+
+    let tagger_kp = Keypair::random();
+    let tagger_user = PubkyAppUser {
+        bio: Some("test_homeserver_user_tag_retry_heals_search_index".to_string()),
+        image: None,
+        links: None,
+        name: "Watcher:PutTagRetry:TaggerUser".to_string(),
+        status: None,
+    };
+    let _tagger_user_id = test.create_user(&tagger_kp, &tagger_user).await?;
+
+    let label = "selfheal";
+
+    let tag = PubkyAppTag {
+        uri: format!("pubky://{tagged_user_id}/pub/pubky.app/profile.json"),
+        label: label.to_string(),
+        created_at: Utc::now().timestamp_millis(),
+    };
+    let tag_path = tag.hs_path();
+    test.put(&tagger_kp, &tag_path, tag).await?;
+
+    // Simulate the partial failure the Updated branch retries over: the graph
+    // edge exists but the search index write was lost
+    UsersByTagSearch::remove_from_index_sorted_set(
+        None,
+        &[&TAG_GLOBAL_USER_TAGGERS[..], &[label]].concat(),
+        &[tagged_user_id.as_str()],
+    )
+    .await
+    .unwrap();
+
+    // Re-put the same tag: the id hashes (uri, label), so this lands on the
+    // same path and routes the event through the Updated branch, which must
+    // restore the derived score
+    let retry_tag = PubkyAppTag {
+        uri: format!("pubky://{tagged_user_id}/pub/pubky.app/profile.json"),
+        label: label.to_string(),
+        created_at: Utc::now().timestamp_millis(),
+    };
+    test.put(&tagger_kp, &tag_path, retry_tag).await?;
+
+    let taggers_score = check_member_user_tag_taggers(&tagged_user_id, label)
+        .await
+        .expect("Failed to check the users-by-tag score");
+    assert_eq!(
+        taggers_score,
+        Some(1),
+        "The retry path must restore the users-by-tag score from the taggers set"
+    );
+
     test.cleanup_user(&tagged_kp).await?;
     test.cleanup_user(&tagger_kp).await?;
 

--- a/nexus-watcher/tests/event_processor/tags/users_by_tags_sync.rs
+++ b/nexus-watcher/tests/event_processor/tags/users_by_tags_sync.rs
@@ -1,0 +1,119 @@
+use super::utils::check_member_user_tag_taggers;
+use crate::event_processor::utils::watcher::{HomeserverHashIdPath, WatcherTest};
+use anyhow::Result;
+use chrono::Utc;
+use nexus_common::db::{fetch_all_rows_from_graph, queries, RedisOps};
+use nexus_common::models::tag::user::TagUser;
+use nexus_common::models::user::UsersByTagSearch;
+use pubky::Keypair;
+use pubky_app_specs::{PubkyAppTag, PubkyAppUser};
+
+/// The backfill enumerates pairs from a graph snapshot but derives every
+/// score from the live taggers set, so a delete landing after the snapshot
+/// was taken must not be resurrected by the later backfill write.
+#[tokio_shared_rt::test(shared)]
+async fn test_users_by_tags_backfill_does_not_resurrect_deleted_tag() -> Result<()> {
+    let mut test = WatcherTest::setup(None).await?;
+
+    let tagged_kp = Keypair::random();
+    let tagged_user = PubkyAppUser {
+        bio: Some("test_users_by_tags_backfill".to_string()),
+        image: None,
+        links: None,
+        name: "Watcher:BackfillRace:TaggedUser".to_string(),
+        status: None,
+    };
+    let tagged_user_id = test.create_user(&tagged_kp, &tagged_user).await?;
+
+    let tagger_kp = Keypair::random();
+    let tagger_user = PubkyAppUser {
+        bio: Some("test_users_by_tags_backfill".to_string()),
+        image: None,
+        links: None,
+        name: "Watcher:BackfillRace:TaggerUser".to_string(),
+        status: None,
+    };
+    let _tagger_user_id = test.create_user(&tagger_kp, &tagger_user).await?;
+
+    let label = "ghosttag";
+    let tag = PubkyAppTag {
+        uri: format!("pubky://{tagged_user_id}/pub/pubky.app/profile.json"),
+        label: label.to_string(),
+        created_at: Utc::now().timestamp_millis(),
+    };
+    let tag_path = tag.hs_path();
+    test.put(&tagger_kp, &tag_path, tag).await?;
+
+    // Snapshot the pair enumeration exactly as a live backfill would
+    let rows = fetch_all_rows_from_graph(queries::get::get_user_tag_pairs()).await?;
+    let mut snapshot_pairs = Vec::new();
+    for row in rows {
+        let user_id: String = row.get("user_id")?;
+        let pair_label: String = row.get("label")?;
+        if user_id == tagged_user_id {
+            snapshot_pairs.push((user_id, pair_label));
+        }
+    }
+    assert!(
+        snapshot_pairs.contains(&(tagged_user_id.clone(), label.to_string())),
+        "The snapshot must contain the pair before the delete"
+    );
+
+    // The delete lands while the backfill still holds the stale snapshot
+    test.del(&tagger_kp, &tag_path).await?;
+
+    // Replay the backfill writes from the stale snapshot
+    for (user_id, pair_label) in &snapshot_pairs {
+        UsersByTagSearch::sync_index_score(user_id, pair_label).await?;
+    }
+
+    let score = check_member_user_tag_taggers(&tagged_user_id, label)
+        .await
+        .expect("Failed to check the users-by-tag score");
+    assert!(
+        score.is_none(),
+        "A stale backfill snapshot must not resurrect a deleted tag"
+    );
+
+    test.cleanup_user(&tagged_kp).await?;
+    test.cleanup_user(&tagger_kp).await?;
+
+    Ok(())
+}
+
+/// Semantics of the atomic derive: the score equals the taggers set
+/// cardinality, and the member disappears when the set empties.
+#[tokio_shared_rt::test(shared)]
+async fn test_sync_index_score_derives_from_taggers_set() -> Result<()> {
+    // Setup only initializes the shared stack connectors
+    let _test = WatcherTest::setup(None).await?;
+
+    let user_id = "syncscorefixtureuser";
+    let label = "synccheck";
+    let taggers = ["syncscoretaggerone", "syncscoretaggertwo"];
+
+    TagUser::put_index_set(&[user_id, label], &taggers, None, None).await?;
+    UsersByTagSearch::sync_index_score(user_id, label).await?;
+    let score = check_member_user_tag_taggers(user_id, label)
+        .await
+        .expect("Failed to check the users-by-tag score");
+    assert_eq!(
+        score,
+        Some(2),
+        "Score must equal the taggers set cardinality"
+    );
+
+    TagUser(taggers.iter().map(|t| t.to_string()).collect())
+        .remove_from_index_set(&[user_id, label])
+        .await?;
+    UsersByTagSearch::sync_index_score(user_id, label).await?;
+    let score = check_member_user_tag_taggers(user_id, label)
+        .await
+        .expect("Failed to check the users-by-tag score");
+    assert!(
+        score.is_none(),
+        "Member must be removed when the taggers set empties"
+    );
+
+    Ok(())
+}

--- a/nexus-watcher/tests/event_processor/tags/users_by_tags_sync.rs
+++ b/nexus-watcher/tests/event_processor/tags/users_by_tags_sync.rs
@@ -4,9 +4,9 @@ use anyhow::Result;
 use chrono::Utc;
 use nexus_common::db::{fetch_all_rows_from_graph, queries, RedisOps};
 use nexus_common::models::tag::user::TagUser;
-use nexus_common::models::user::UsersByTagSearch;
+use nexus_common::models::user::{UserDetails, UsersByTagSearch, USER_DELETED_SENTINEL};
 use pubky::Keypair;
-use pubky_app_specs::{PubkyAppTag, PubkyAppUser};
+use pubky_app_specs::{PubkyAppTag, PubkyAppUser, PubkyId};
 
 /// The backfill enumerates pairs from a graph snapshot but derives every
 /// score from the live taggers set, so a delete landing after the snapshot
@@ -272,6 +272,76 @@ async fn test_sync_index_score_derives_from_taggers_set() -> Result<()> {
         score.is_none(),
         "Member must be removed when the taggers set empties"
     );
+
+    Ok(())
+}
+
+/// Direct coverage of the removal guard: a `[DELETED]` details document
+/// forces removal regardless of the taggers set cardinality, and clearing it
+/// restores the derive.
+#[tokio_shared_rt::test(shared)]
+async fn test_sync_index_score_removal_guard() -> Result<()> {
+    // Setup only initializes the shared stack connectors
+    let _test = WatcherTest::setup(None).await?;
+
+    // A real key so the details fixture can carry a valid PubkyId
+    let user_id = Keypair::random().public_key().to_z32();
+    let pubky_id =
+        PubkyId::try_from(user_id.as_str()).expect("A random keypair id must parse as PubkyId");
+    let label = "guardcheck";
+    let taggers = ["guardchecktaggerone", "guardchecktaggertwo"];
+
+    TagUser::put_index_set(&[&user_id, label], &taggers, None, None).await?;
+
+    // Guard set: the sentinel wins over a non-empty taggers set
+    let tombstone = UserDetails::from_homeserver(
+        PubkyAppUser {
+            bio: None,
+            image: None,
+            links: None,
+            name: USER_DELETED_SENTINEL.to_string(),
+            status: None,
+        },
+        &pubky_id,
+    );
+    tombstone.put_index_json(&[&user_id], None, None).await?;
+    UsersByTagSearch::sync_index_score(&user_id, label).await?;
+    let score = check_member_user_tag_taggers(&user_id, label)
+        .await
+        .expect("Failed to check the users-by-tag score");
+    assert!(
+        score.is_none(),
+        "The sentinel must force removal even with a non-empty taggers set"
+    );
+
+    // Guard cleared: the derive restores the member from the set cardinality
+    let restored = UserDetails::from_homeserver(
+        PubkyAppUser {
+            bio: None,
+            image: None,
+            links: None,
+            name: "Watcher:GuardCheck:Restored".to_string(),
+            status: None,
+        },
+        &pubky_id,
+    );
+    restored.put_index_json(&[&user_id], None, None).await?;
+    UsersByTagSearch::sync_index_score(&user_id, label).await?;
+    let score = check_member_user_tag_taggers(&user_id, label)
+        .await
+        .expect("Failed to check the users-by-tag score");
+    assert_eq!(
+        score,
+        Some(2),
+        "Clearing the sentinel must restore the derived score"
+    );
+
+    // Cleanup the fixture keys
+    TagUser(taggers.iter().map(|t| t.to_string()).collect())
+        .remove_from_index_set(&[&user_id, label])
+        .await?;
+    UsersByTagSearch::sync_index_score(&user_id, label).await?;
+    UserDetails::remove_from_index_multiple_json(&[&[user_id.as_str()]]).await?;
 
     Ok(())
 }

--- a/nexus-watcher/tests/event_processor/tags/users_by_tags_sync.rs
+++ b/nexus-watcher/tests/event_processor/tags/users_by_tags_sync.rs
@@ -81,6 +81,81 @@ async fn test_users_by_tags_backfill_does_not_resurrect_deleted_tag() -> Result<
     Ok(())
 }
 
+/// Deleting a user with edges tombstones them, and tombstoned users must
+/// leave the users-by-tag index and stay out even when tag events for them
+/// keep arriving.
+#[tokio_shared_rt::test(shared)]
+async fn test_users_by_tags_excludes_deleted_users() -> Result<()> {
+    let mut test = WatcherTest::setup(None).await?;
+
+    let tagged_kp = Keypair::random();
+    let tagged_user = PubkyAppUser {
+        bio: Some("test_users_by_tags_excludes_deleted".to_string()),
+        image: None,
+        links: None,
+        name: "Watcher:DeletedUser:TaggedUser".to_string(),
+        status: None,
+    };
+    let tagged_user_id = test.create_user(&tagged_kp, &tagged_user).await?;
+
+    let tagger_kp = Keypair::random();
+    let tagger_user = PubkyAppUser {
+        bio: Some("test_users_by_tags_excludes_deleted".to_string()),
+        image: None,
+        links: None,
+        name: "Watcher:DeletedUser:TaggerUser".to_string(),
+        status: None,
+    };
+    let _tagger_user_id = test.create_user(&tagger_kp, &tagger_user).await?;
+
+    let label = "deadtag";
+    let tag = PubkyAppTag {
+        uri: format!("pubky://{tagged_user_id}/pub/pubky.app/profile.json"),
+        label: label.to_string(),
+        created_at: Utc::now().timestamp_millis(),
+    };
+    let tag_path = tag.hs_path();
+    test.put(&tagger_kp, &tag_path, tag).await?;
+
+    let score = check_member_user_tag_taggers(&tagged_user_id, label)
+        .await
+        .expect("Failed to check the users-by-tag score");
+    assert_eq!(score, Some(1));
+
+    // The tagged user has a TAGGED edge, so deletion tombstones them and
+    // must evict them from the index
+    test.cleanup_user(&tagged_kp).await?;
+
+    let score = check_member_user_tag_taggers(&tagged_user_id, label)
+        .await
+        .expect("Failed to check the users-by-tag score");
+    assert!(
+        score.is_none(),
+        "A tombstoned user cannot stay in the users-by-tag index"
+    );
+
+    // A tag event arriving after the tombstone cannot resurrect them: the
+    // derive re-checks the tombstone atomically
+    let late_tag = PubkyAppTag {
+        uri: format!("pubky://{tagged_user_id}/pub/pubky.app/profile.json"),
+        label: label.to_string(),
+        created_at: Utc::now().timestamp_millis(),
+    };
+    test.put(&tagger_kp, &tag_path, late_tag).await?;
+
+    let score = check_member_user_tag_taggers(&tagged_user_id, label)
+        .await
+        .expect("Failed to check the users-by-tag score");
+    assert!(
+        score.is_none(),
+        "A tag event after the tombstone cannot re-add the user"
+    );
+
+    test.cleanup_user(&tagger_kp).await?;
+
+    Ok(())
+}
+
 /// Semantics of the atomic derive: the score equals the taggers set
 /// cardinality, and the member disappears when the set empties.
 #[tokio_shared_rt::test(shared)]

--- a/nexus-watcher/tests/event_processor/tags/users_by_tags_sync.rs
+++ b/nexus-watcher/tests/event_processor/tags/users_by_tags_sync.rs
@@ -1,4 +1,4 @@
-use super::utils::check_member_user_tag_taggers;
+use super::utils::{check_member_user_tag_taggers, find_user_tag};
 use crate::event_processor::utils::watcher::{HomeserverHashIdPath, WatcherTest};
 use anyhow::Result;
 use chrono::Utc;
@@ -151,6 +151,89 @@ async fn test_users_by_tags_excludes_deleted_users() -> Result<()> {
         "A tag event after the tombstone cannot re-add the user"
     );
 
+    test.cleanup_user(&tagger_kp).await?;
+
+    Ok(())
+}
+
+/// A tombstoned user who recreates their profile gets their retained tag
+/// entries back: eviction and restoration are the same label sync, decided
+/// by the tombstone state at derive time.
+#[tokio_shared_rt::test(shared)]
+async fn test_users_by_tags_restores_recreated_users() -> Result<()> {
+    let mut test = WatcherTest::setup(None).await?;
+
+    let tagged_kp = Keypair::random();
+    let tagged_user = PubkyAppUser {
+        bio: Some("test_users_by_tags_restores_recreated".to_string()),
+        image: None,
+        links: None,
+        name: "Watcher:RestoredUser:TaggedUser".to_string(),
+        status: None,
+    };
+    let tagged_user_id = test.create_user(&tagged_kp, &tagged_user).await?;
+
+    let tagger_kp = Keypair::random();
+    let tagger_user = PubkyAppUser {
+        bio: Some("test_users_by_tags_restores_recreated".to_string()),
+        image: None,
+        links: None,
+        name: "Watcher:RestoredUser:TaggerUser".to_string(),
+        status: None,
+    };
+    let _tagger_user_id = test.create_user(&tagger_kp, &tagger_user).await?;
+
+    let label = "phoenixtag";
+    let tag = PubkyAppTag {
+        uri: format!("pubky://{tagged_user_id}/pub/pubky.app/profile.json"),
+        label: label.to_string(),
+        created_at: Utc::now().timestamp_millis(),
+    };
+    let tag_path = tag.hs_path();
+    test.put(&tagger_kp, &tag_path, tag).await?;
+
+    let score = check_member_user_tag_taggers(&tagged_user_id, label)
+        .await
+        .expect("Failed to check the users-by-tag score");
+    assert_eq!(score, Some(1));
+
+    // Tombstone the tagged user (the TAGGED edge keeps the node) and verify
+    // the eviction
+    test.cleanup_user(&tagged_kp).await?;
+
+    let score = check_member_user_tag_taggers(&tagged_user_id, label)
+        .await
+        .expect("Failed to check the users-by-tag score");
+    assert!(score.is_none(), "Tombstoned user must be evicted");
+
+    // Recreate the profile without touching the tag: the retained label must
+    // come back with its taggers count
+    let restored_user = PubkyAppUser {
+        bio: Some("test_users_by_tags_restores_recreated".to_string()),
+        image: None,
+        links: None,
+        name: "Watcher:RestoredUser:TaggedUserBack".to_string(),
+        status: None,
+    };
+    test.create_profile(&tagged_kp, &restored_user).await?;
+
+    let score = check_member_user_tag_taggers(&tagged_user_id, label)
+        .await
+        .expect("Failed to check the users-by-tag score");
+    assert_eq!(
+        score,
+        Some(1),
+        "A recreated profile must restore its retained tag entries"
+    );
+
+    // The graph agrees: the retained edge still carries one tagger
+    let graph_tag = find_user_tag(&tagged_user_id, label)
+        .await
+        .unwrap()
+        .expect("Retained tag must exist in the graph");
+    assert_eq!(graph_tag.taggers_count, 1);
+
+    test.cleanup_user(&tagged_kp).await?;
     test.cleanup_user(&tagger_kp).await?;
 
     Ok(())

--- a/nexus-watcher/tests/event_processor/tags/utils.rs
+++ b/nexus-watcher/tests/event_processor/tags/utils.rs
@@ -5,6 +5,7 @@ use nexus_common::{
     models::{
         post::search::{PostsByTagSearch, TAG_GLOBAL_POST_ENGAGEMENT, TAG_GLOBAL_POST_TIMELINE},
         tag::TagDetails,
+        user::{UsersByTagSearch, TAG_GLOBAL_USER_TAGGERS},
     },
 };
 
@@ -38,6 +39,17 @@ pub async fn check_member_total_engagement_post_tag(
     .await
     .unwrap();
     Ok(total_engagement)
+}
+
+pub async fn check_member_user_tag_taggers(user_id: &str, label: &str) -> Result<Option<isize>> {
+    let taggers_count = UsersByTagSearch::check_sorted_set_member(
+        None,
+        &[&TAG_GLOBAL_USER_TAGGERS[..], &[label]].concat(),
+        &[user_id],
+    )
+    .await
+    .unwrap();
+    Ok(taggers_count)
 }
 
 pub async fn check_member_post_tag_global_timeline(

--- a/nexus-webapi/src/routes/v0/endpoints.rs
+++ b/nexus-webapi/src/routes/v0/endpoints.rs
@@ -50,6 +50,7 @@ const SEARCH_PREFIX: &str = concatcp!(VERSION_ROUTE, "/search");
 const SEARCH_USERS_ROUTE: &str = concatcp!(SEARCH_PREFIX, "/users");
 pub const SEARCH_USERS_BY_NAME_ROUTE: &str = concatcp!(SEARCH_USERS_ROUTE, "/by_name/{prefix}");
 pub const SEARCH_USERS_BY_ID_ROUTE: &str = concatcp!(SEARCH_USERS_ROUTE, "/by_id/{prefix}");
+pub const SEARCH_USERS_BY_TAGS_ROUTE: &str = concatcp!(SEARCH_USERS_ROUTE, "/by_tags");
 pub const SEARCH_POSTS_BY_TAG_ROUTE: &str = concatcp!(SEARCH_PREFIX, "/posts/by_tag/{tag}");
 pub const SEARCH_POSTS_BY_CONTENT_ROUTE: &str = concatcp!(SEARCH_PREFIX, "/posts/by_content");
 pub const SEARCH_TAGS_BY_PREFIX_ROUTE: &str = concatcp!(SEARCH_PREFIX, "/tags/by_prefix/{prefix}");

--- a/nexus-webapi/src/routes/v0/search/mod.rs
+++ b/nexus-webapi/src/routes/v0/search/mod.rs
@@ -1,6 +1,6 @@
 use crate::routes::v0::endpoints::{
     SEARCH_POSTS_BY_CONTENT_ROUTE, SEARCH_POSTS_BY_TAG_ROUTE, SEARCH_TAGS_BY_PREFIX_ROUTE,
-    SEARCH_USERS_BY_ID_ROUTE, SEARCH_USERS_BY_NAME_ROUTE,
+    SEARCH_USERS_BY_ID_ROUTE, SEARCH_USERS_BY_NAME_ROUTE, SEARCH_USERS_BY_TAGS_ROUTE,
 };
 use crate::routes::AppState;
 use axum::routing::get;
@@ -29,6 +29,10 @@ pub fn routes() -> Router<AppState> {
         .route(
             SEARCH_USERS_BY_ID_ROUTE,
             get(users::search_users_by_id_handler),
+        )
+        .route(
+            SEARCH_USERS_BY_TAGS_ROUTE,
+            get(users::search_users_by_tags_handler),
         )
         .route(
             SEARCH_POSTS_BY_TAG_ROUTE,

--- a/nexus-webapi/src/routes/v0/search/mod.rs
+++ b/nexus-webapi/src/routes/v0/search/mod.rs
@@ -14,10 +14,17 @@ mod users;
 pub use crate::models::user_id_prefix::USER_ID_SEARCH_MIN_PREFIX_LEN;
 
 pub fn expensive_routes() -> Router<AppState> {
-    Router::new().route(
-        SEARCH_POSTS_BY_CONTENT_ROUTE,
-        get(posts::search_posts_by_content_handler),
-    )
+    Router::new()
+        .route(
+            SEARCH_POSTS_BY_CONTENT_ROUTE,
+            get(posts::search_posts_by_content_handler),
+        )
+        // Multi-label requests aggregate in the graph, so the route starts in
+        // the expensive tier until production metrics justify loosening it
+        .route(
+            SEARCH_USERS_BY_TAGS_ROUTE,
+            get(users::search_users_by_tags_handler),
+        )
 }
 
 pub fn routes() -> Router<AppState> {
@@ -29,10 +36,6 @@ pub fn routes() -> Router<AppState> {
         .route(
             SEARCH_USERS_BY_ID_ROUTE,
             get(users::search_users_by_id_handler),
-        )
-        .route(
-            SEARCH_USERS_BY_TAGS_ROUTE,
-            get(users::search_users_by_tags_handler),
         )
         .route(
             SEARCH_POSTS_BY_TAG_ROUTE,

--- a/nexus-webapi/src/routes/v0/search/users.rs
+++ b/nexus-webapi/src/routes/v0/search/users.rs
@@ -92,7 +92,7 @@ pub struct SearchUsersByTagsQuery {
 #[utoipa::path(
     get,
     path = SEARCH_USERS_BY_TAGS_ROUTE,
-    description = "Search users by profile tags, scored by how many taggers applied the searched labels. Tie order between equal scores is unspecified",
+    description = "Search users by profile tags, scored by how many taggers applied the searched labels. Equal scores break ties by user id descending",
     tag = "Search",
     params(
         ("tags" = Tags, Query, description = "Comma-separated tag labels (1-5). Users tagged with any of them are returned"),

--- a/nexus-webapi/src/routes/v0/search/users.rs
+++ b/nexus-webapi/src/routes/v0/search/users.rs
@@ -1,11 +1,15 @@
-use crate::models::{BoundedLimit, BoundedPagination, BoundedSkip, UserIdPrefix, UsernamePrefix};
-use crate::routes::v0::endpoints::{SEARCH_USERS_BY_ID_ROUTE, SEARCH_USERS_BY_NAME_ROUTE};
+use crate::models::{
+    BoundedLimit, BoundedPagination, BoundedSkip, Tags, UserIdPrefix, UsernamePrefix,
+};
+use crate::routes::v0::endpoints::{
+    SEARCH_USERS_BY_ID_ROUTE, SEARCH_USERS_BY_NAME_ROUTE, SEARCH_USERS_BY_TAGS_ROUTE,
+};
 use crate::routes::v0::search::USER_ID_SEARCH_MIN_PREFIX_LEN;
 use crate::routes::Path;
 use crate::routes::Query;
 use crate::Result;
 use axum::Json;
-use nexus_common::models::user::UserSearch;
+use nexus_common::models::user::{UserSearch, UsersByTagSearch};
 use serde::Deserialize;
 use tracing::debug;
 use utoipa::OpenApi;
@@ -78,9 +82,92 @@ pub async fn search_users_by_id_handler(
     }
 }
 
+#[derive(Deserialize)]
+pub struct SearchUsersByTagsQuery {
+    pub tags: Tags,
+    #[serde(flatten)]
+    pub pagination: BoundedPagination<10_000, 20, 200>,
+}
+
+#[utoipa::path(
+    get,
+    path = SEARCH_USERS_BY_TAGS_ROUTE,
+    description = "Search users by profile tags, scored by how many taggers applied the searched labels. Tie order between equal scores is unspecified",
+    tag = "Search",
+    params(
+        ("tags" = Tags, Query, description = "Comma-separated tag labels (1-5). Users tagged with any of them are returned"),
+        ("skip" = Option<BoundedSkip<10_000>>, Query, description = "Skip N results (max 10000)"),
+        ("limit" = Option<BoundedLimit<20, 200>>, Query, description = "Limit the number of results (1-200, default 20)")
+    ),
+    responses(
+        (status = 200, description = "Search results ordered by tagger count", body = Vec<UsersByTagSearch>),
+        (status = 400, description = "Invalid parameters"),
+        (status = 429, description = "Rate limit exceeded", headers(("Retry-After" = u64, description = "Seconds until retry"))),
+        (status = 500, description = "Internal server error")
+    )
+)]
+pub async fn search_users_by_tags_handler(
+    Query(query): Query<SearchUsersByTagsQuery>,
+) -> Result<Json<Vec<UsersByTagSearch>>> {
+    debug!(
+        "GET {SEARCH_USERS_BY_TAGS_ROUTE} tags:{:?}, skip: {}, limit: {}",
+        query.tags,
+        query.pagination.skip_value(),
+        query.pagination.limit_value()
+    );
+
+    let pagination = query.pagination.to_pagination(None, None);
+
+    let users = UsersByTagSearch::get_by_labels(&query.tags.to_string_vec(), pagination).await?;
+    Ok(Json(users))
+}
+
 #[derive(OpenApi)]
 #[openapi(
-    paths(search_users_by_name_handler, search_users_by_id_handler),
-    components(schemas(UserSearch, UsernamePrefix, UserIdPrefix))
+    paths(
+        search_users_by_name_handler,
+        search_users_by_id_handler,
+        search_users_by_tags_handler
+    ),
+    components(schemas(UserSearch, UsersByTagSearch, Tags, UsernamePrefix, UserIdPrefix))
 )]
 pub struct SearchUsersApiDocs;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_query(
+        s: &str,
+    ) -> std::result::Result<SearchUsersByTagsQuery, serde_urlencoded::de::Error> {
+        serde_urlencoded::from_str(s)
+    }
+
+    #[test]
+    fn tags_csv_parses_and_sanitizes() {
+        let q = parse_query("tags=Dev,%20Free%20").expect("valid tags must parse");
+        assert_eq!(q.tags.to_string_vec(), vec!["dev", "free"]);
+    }
+
+    #[test]
+    fn tags_single_label_parses() {
+        let q = parse_query("tags=synonym").expect("single tag must parse");
+        assert_eq!(q.tags.to_string_vec(), vec!["synonym"]);
+    }
+
+    #[test]
+    fn tags_missing_rejected() {
+        assert!(parse_query("skip=0").is_err());
+    }
+
+    #[test]
+    fn tags_over_five_rejected() {
+        assert!(parse_query("tags=a,b,c,d,e,f").is_err());
+    }
+
+    #[test]
+    fn tags_over_length_label_rejected() {
+        let over_length = "a".repeat(21);
+        assert!(parse_query(&format!("tags={over_length}")).is_err());
+    }
+}

--- a/nexus-webapi/tests/user/mod.rs
+++ b/nexus-webapi/tests/user/mod.rs
@@ -3,4 +3,5 @@ pub mod bootstrap;
 pub mod notifications;
 pub mod reach;
 pub mod search;
+pub mod search_by_tags;
 pub mod views;

--- a/nexus-webapi/tests/user/search_by_tags.rs
+++ b/nexus-webapi/tests/user/search_by_tags.rs
@@ -1,0 +1,140 @@
+use crate::utils::{get_request, invalid_get_request};
+use anyhow::Result;
+use axum::http::StatusCode;
+use nexus_webapi::routes::v0::endpoints::SEARCH_USERS_BY_TAGS_ROUTE;
+use serde_json::Value;
+use std::collections::HashMap;
+
+// User-profile tag fixtures from docker/test-graph/mocks/tags.cypher
+const AURELIO: &str = "c4yotzcb76d31y44jsymtdcowqg7oyqej46jty3yy7ybtzt9x41o";
+const ARST: &str = "5f4e8eoogmkhqeyo5ijdix3ma6rw9byj8m36yrjp78pnxxc379to";
+const PETER: &str = "db6w58pd5h63fbhtd88y8zz7pai9rkjwqt9omg6i7dz31dynrgcy";
+
+fn search_users_by_tags(query: &str) -> String {
+    format!("{SEARCH_USERS_BY_TAGS_ROUTE}?{query}")
+}
+
+fn result_rows(body: &Value) -> &Vec<Value> {
+    body.as_array().expect("Search results should be an array")
+}
+
+fn scores_by_user(body: &Value) -> HashMap<String, u64> {
+    result_rows(body)
+        .iter()
+        .map(|row| {
+            (
+                row["user_id"]
+                    .as_str()
+                    .expect("user_id should be a string")
+                    .to_string(),
+                row["score"].as_u64().expect("score should be a number"),
+            )
+        })
+        .collect()
+}
+
+fn assert_scores_descending(body: &Value) {
+    let scores: Vec<u64> = result_rows(body)
+        .iter()
+        .map(|row| row["score"].as_u64().expect("score should be a number"))
+        .collect();
+    assert!(
+        scores.windows(2).all(|w| w[0] >= w[1]),
+        "Scores should be descending: {scores:?}"
+    );
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_user_search_by_single_tag() -> Result<()> {
+    // 5 taggers applied 'now' to aurelio (mocks/tags.cypher WoT block)
+    let body = get_request(&search_users_by_tags("tags=now")).await?;
+    let scores = scores_by_user(&body);
+    assert_eq!(scores.get(AURELIO), Some(&5));
+
+    let body = get_request(&search_users_by_tags("tags=pubky")).await?;
+    assert_scores_descending(&body);
+    let scores = scores_by_user(&body);
+    assert_eq!(scores.get(ARST), Some(&3));
+    assert_eq!(scores.get(PETER), Some(&3));
+
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_user_search_by_tags_union() -> Result<()> {
+    // Two labels take the graph path; scores sum across them (5 'now' + 3 'athens')
+    let body = get_request(&search_users_by_tags("tags=now,athens")).await?;
+    assert_scores_descending(&body);
+    let scores = scores_by_user(&body);
+    assert_eq!(scores.get(AURELIO), Some(&8));
+
+    let occurrences = result_rows(&body)
+        .iter()
+        .filter(|row| row["user_id"] == AURELIO)
+        .count();
+    assert_eq!(occurrences, 1, "A user matching both labels appears once");
+
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_user_search_by_tags_redis_graph_parity() -> Result<()> {
+    // The same label served from the index (single label) and from the graph
+    // (multi label with an unknown second one) must agree on members and
+    // scores. Tie order may differ between paths, so compare as maps.
+    let redis_body = get_request(&search_users_by_tags("tags=pubky&limit=200")).await?;
+    let graph_body =
+        get_request(&search_users_by_tags("tags=pubky,nonexistentzz&limit=200")).await?;
+    assert_eq!(scores_by_user(&redis_body), scores_by_user(&graph_body));
+
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_user_search_by_tags_pagination() -> Result<()> {
+    let full = get_request(&search_users_by_tags("tags=pubky&limit=200")).await?;
+    let full = result_rows(&full).clone();
+    assert!(
+        full.len() >= 3,
+        "Fixture should have at least 3 tagged users"
+    );
+
+    let page = get_request(&search_users_by_tags("tags=pubky&skip=1&limit=2")).await?;
+    assert_eq!(result_rows(&page).as_slice(), &full[1..3]);
+
+    let beyond = get_request(&search_users_by_tags("tags=pubky&skip=9999")).await?;
+    assert!(result_rows(&beyond).is_empty());
+
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_user_search_by_tags_unknown_label() -> Result<()> {
+    let body = get_request(&search_users_by_tags("tags=nonexistentzz")).await?;
+    assert!(result_rows(&body).is_empty());
+
+    Ok(())
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn test_user_search_by_tags_rejects_invalid() -> Result<()> {
+    // More than 5 labels
+    invalid_get_request(
+        &search_users_by_tags("tags=a,b,c,d,e,f"),
+        StatusCode::BAD_REQUEST,
+    )
+    .await?;
+
+    // Over-length label
+    let over_length = "a".repeat(21);
+    invalid_get_request(
+        &search_users_by_tags(&format!("tags={over_length}")),
+        StatusCode::BAD_REQUEST,
+    )
+    .await?;
+
+    // Missing tags param
+    invalid_get_request(SEARCH_USERS_BY_TAGS_ROUTE, StatusCode::BAD_REQUEST).await?;
+
+    Ok(())
+}

--- a/nexus-webapi/tests/user/search_by_tags.rs
+++ b/nexus-webapi/tests/user/search_by_tags.rs
@@ -80,12 +80,12 @@ async fn test_user_search_by_tags_union() -> Result<()> {
 #[tokio_shared_rt::test(shared)]
 async fn test_user_search_by_tags_redis_graph_parity() -> Result<()> {
     // The same label served from the index (single label) and from the graph
-    // (multi label with an unknown second one) must agree on members and
-    // scores. Tie order may differ between paths, so compare as maps.
+    // (multi label with an unknown second one) must return identical rows in
+    // identical order: both paths break equal scores by user id descending
     let redis_body = get_request(&search_users_by_tags("tags=pubky&limit=200")).await?;
     let graph_body =
         get_request(&search_users_by_tags("tags=pubky,nonexistentzz&limit=200")).await?;
-    assert_eq!(scores_by_user(&redis_body), scores_by_user(&graph_body));
+    assert_eq!(result_rows(&redis_body), result_rows(&graph_body));
 
     Ok(())
 }

--- a/nexusd/src/migrations/migrations_list/mod.rs
+++ b/nexusd/src/migrations/migrations_list/mod.rs
@@ -4,3 +4,4 @@ pub mod post_content_index_setup_1780444800;
 pub mod remove_muted_1771718400;
 pub mod resource_node_setup_1774000000;
 pub mod users_by_pk_reindex_1751635096;
+pub mod users_by_tags_index_backfill_1786924800;

--- a/nexusd/src/migrations/migrations_list/users_by_tags_index_backfill_1786924800.rs
+++ b/nexusd/src/migrations/migrations_list/users_by_tags_index_backfill_1786924800.rs
@@ -1,7 +1,16 @@
 use async_trait::async_trait;
+use futures::TryStreamExt;
+use std::time::Instant;
+use tracing::info;
 
 use crate::migrations::manager::Migration;
-use nexus_common::{models::user::UsersByTagSearch, types::DynError};
+use nexus_common::{
+    db::{get_neo4j_graph, queries},
+    models::user::UsersByTagSearch,
+    types::DynError,
+};
+
+const PROGRESS_LOG_EVERY: u64 = 500;
 
 pub struct UsersByTagsIndexBackfill1786924800;
 
@@ -20,13 +29,39 @@ impl Migration for UsersByTagsIndexBackfill1786924800 {
     }
 
     async fn backfill(&self) -> Result<(), DynError> {
-        // Run after the new watcher is live. The graph snapshot only
-        // enumerates candidate (user, label) pairs; every score is derived
-        // atomically from the live taggers set, so events landing during the
-        // backfill are never overwritten with snapshot state.
-        UsersByTagSearch::backfill_from_graph()
-            .await
-            .map_err(Into::into)
+        // Run after the new watcher is live. The graph only enumerates
+        // candidate (user, label) pairs, streamed to keep memory flat; every
+        // score is derived atomically from the live taggers set, so events
+        // landing during the backfill are never overwritten with snapshot
+        // state, and a failed run can simply be re-run.
+        let graph = get_neo4j_graph()?;
+        let mut rows = graph.execute(queries::get::get_user_tag_pairs()).await?;
+
+        let started = Instant::now();
+        let mut processed: u64 = 0;
+        while let Some(row) = rows.try_next().await? {
+            let user_id: String = row.get("user_id")?;
+            let label: String = row.get("label")?;
+            UsersByTagSearch::sync_index_score(&user_id, &label).await?;
+
+            processed += 1;
+            if processed.is_multiple_of(PROGRESS_LOG_EVERY) {
+                let elapsed = started.elapsed().as_secs_f64();
+                info!(
+                    processed,
+                    elapsed_secs = format!("{elapsed:.1}"),
+                    pairs_per_sec = format!("{:.0}", processed as f64 / elapsed),
+                    "UsersByTagsIndexBackfill progress"
+                );
+            }
+        }
+
+        info!(
+            processed,
+            elapsed_secs = format!("{:.1}", started.elapsed().as_secs_f64()),
+            "UsersByTagsIndexBackfill completed"
+        );
+        Ok(())
     }
 
     async fn cutover(&self) -> Result<(), DynError> {

--- a/nexusd/src/migrations/migrations_list/users_by_tags_index_backfill_1786924800.rs
+++ b/nexusd/src/migrations/migrations_list/users_by_tags_index_backfill_1786924800.rs
@@ -20,12 +20,13 @@ impl Migration for UsersByTagsIndexBackfill1786924800 {
     }
 
     async fn backfill(&self) -> Result<(), DynError> {
-        // Build the per-label users-by-tag sorted sets from a graph snapshot,
-        // run after the new watcher is live. Puts overwritten mid-backfill are
-        // safe; a delete landing between the graph read and the ZADD can be
-        // resurrected and stays until the next event for that (user, label).
-        // Same accepted race class as PostsByTagSearch::reindex.
-        UsersByTagSearch::reindex().await.map_err(Into::into)
+        // Run after the new watcher is live. The graph snapshot only
+        // enumerates candidate (user, label) pairs; every score is derived
+        // atomically from the live taggers set, so events landing during the
+        // backfill are never overwritten with snapshot state.
+        UsersByTagSearch::backfill_from_graph()
+            .await
+            .map_err(Into::into)
     }
 
     async fn cutover(&self) -> Result<(), DynError> {

--- a/nexusd/src/migrations/migrations_list/users_by_tags_index_backfill_1786924800.rs
+++ b/nexusd/src/migrations/migrations_list/users_by_tags_index_backfill_1786924800.rs
@@ -1,0 +1,38 @@
+use async_trait::async_trait;
+
+use crate::migrations::manager::Migration;
+use nexus_common::{models::user::UsersByTagSearch, types::DynError};
+
+pub struct UsersByTagsIndexBackfill1786924800;
+
+#[async_trait]
+impl Migration for UsersByTagsIndexBackfill1786924800 {
+    fn id(&self) -> &'static str {
+        "UsersByTagsIndexBackfill1786924800"
+    }
+
+    fn is_multi_staged(&self) -> bool {
+        false
+    }
+
+    async fn dual_write(_data: Box<dyn std::any::Any + Send + 'static>) -> Result<(), DynError> {
+        Ok(())
+    }
+
+    async fn backfill(&self) -> Result<(), DynError> {
+        // Build the per-label users-by-tag sorted sets from a graph snapshot,
+        // run after the new watcher is live. Puts overwritten mid-backfill are
+        // safe; a delete landing between the graph read and the ZADD can be
+        // resurrected and stays until the next event for that (user, label).
+        // Same accepted race class as PostsByTagSearch::reindex.
+        UsersByTagSearch::reindex().await.map_err(Into::into)
+    }
+
+    async fn cutover(&self) -> Result<(), DynError> {
+        Ok(())
+    }
+
+    async fn cleanup(&self) -> Result<(), DynError> {
+        Ok(())
+    }
+}

--- a/nexusd/src/migrations/mod.rs
+++ b/nexusd/src/migrations/mod.rs
@@ -14,6 +14,7 @@ use crate::migrations::migrations_list::post_content_index_setup_1780444800::Pos
 use crate::migrations::migrations_list::remove_muted_1771718400::RemoveMuted1771718400;
 use crate::migrations::migrations_list::resource_node_setup_1774000000::ResourceNodeSetup1774000000;
 use crate::migrations::migrations_list::users_by_pk_reindex_1751635096::UsersByPkReindex1751635096;
+use crate::migrations::migrations_list::users_by_tags_index_backfill_1786924800::UsersByTagsIndexBackfill1786924800;
 /// Registers migrations with the `MigrationManager`
 ///
 /// # Description
@@ -47,6 +48,7 @@ pub fn import_migrations(migration_manager: &mut MigrationManager) {
         Box::new(ResourceNodeSetup1774000000),
         Box::new(PostContentIndexSetup1780444800),
         Box::new(PostContentIndexAuthorSetup1780531200),
+        Box::new(UsersByTagsIndexBackfill1786924800),
     ];
     for migration in migrations {
         migration_manager.register(migration);


### PR DESCRIPTION
Closes #1030

BE support for the search redesign People section (pubky/pubky-app#1841). FE gets user ids + scores and hydrates with the existing `POST /v0/stream/users/by_ids`.

```
GET /v0/search/users/by_tags?tags=synonym,rust&skip=0&limit=20
-> [ { "user_id": "pxnu3...", "score": 12 }, ... ]
```

- `tags`: 1 to 5 labels, union semantics. `score`: how many taggers applied the label to the user, with multiple tags the sum. Descending, tie order unspecified.
- 1 label reads a new Redis index `Sorted:Tags:Global:User:Taggers:<label>`, 2 to 5 labels fall back to a Cypher query, same split the post streams do. The graph path stays in the default rate-limit tier like `/stream/posts?tags=`, we can move it to the expensive tier later if it shows up in metrics.
- The index score is derived from the `User:Taggers:{user}:{label}` set instead of counting increments, and the derive runs as one Lua script (SCARD + conditional ZADD/ZREM), so concurrent events can't commit a stale score and watcher retries converge on their own, no drift and no gating.
- `db mock` builds the index, and there is a `UsersByTagsIndexBackfill` migration for live deploys. The backfill only enumerates (user, label) pairs from the graph and derives every score from the live taggers sets, so it can't overwrite concurrent watcher writes with snapshot state.

Deploy note: after the new watcher is live, add `UsersByTagsIndexBackfill1786924800` to `backfill_ready` in the deployed config and run `nexusd db migration run`.

Deleted users are excluded: every profile write re-derives the user's per-label entries, so a tombstone evicts them and a recreated profile restores their retained tags. The derive re-checks the tombstone in the same Lua script so late tag events can't resurrect them, and the graph path filters the `[DELETED]` sentinel.
