### PR TITLE
 fix: default `max_file_size` to the `pubky-app-specs` blob cap (existing `config.toml` keeps its value)

### DIFF
--- a/nexus-common/default.config.toml
+++ b/nexus-common/default.config.toml
@@ -45,11 +45,12 @@ initial_backoff_secs = 60
 # Maximum backoff duration (in seconds) for a failing homeserver
 max_backoff_secs = 3600
 retry_processor_interval_ms = 10000
-# Maximum allowed file size (in bytes) for ingested files. Default: 52428800 (50 MiB).
+# Maximum allowed file size (in bytes) for ingested files.
+# Unset, it defaults to the blob size cap declared by pubky-app-specs.
 # Responses with Content-Length exceeding this are rejected immediately.
 # Responses without a header are streamed with a running byte-count and aborted past the cap.
 # Rejected files are treated as permanent failures (not retried).
-max_file_size = 52428800
+# max_file_size = 104857600
 # User public key to trust for moderating content (test user key, change as needed)
 moderation_id = "uo7jgkykft4885n8cruizwy6khw71mnu5pq3ay9i8pw1ymcn85ko"
 # Tags on content to de-index when placed by the trusted moderator above

--- a/nexus-common/default.config.toml
+++ b/nexus-common/default.config.toml
@@ -46,11 +46,11 @@ initial_backoff_secs = 60
 max_backoff_secs = 3600
 retry_processor_interval_ms = 10000
 # Maximum allowed file size (in bytes) for ingested files.
-# Unset, it defaults to the blob size cap declared by pubky-app-specs.
 # Responses with Content-Length exceeding this are rejected immediately.
 # Responses without a header are streamed with a running byte-count and aborted past the cap.
 # Rejected files are treated as permanent failures (not retried).
-# max_file_size = 104857600
+# Unset, it defaults to the blob size cap declared by pubky-app-specs.
+# max_file_size = <bytes>
 # User public key to trust for moderating content (test user key, change as needed)
 moderation_id = "uo7jgkykft4885n8cruizwy6khw71mnu5pq3ay9i8pw1ymcn85ko"
 # Tags on content to de-index when placed by the trusted moderator above

--- a/nexus-common/src/config/daemon.rs
+++ b/nexus-common/src/config/daemon.rs
@@ -66,7 +66,9 @@ mod tests {
 
     use crate::config::file::{reader::DEFAULT_CONFIG_TOML, ConfigLoader};
     use crate::{
-        config::watcher::DEFAULT_MODERATION_ID, file::validate_and_expand_path, DaemonConfig, Level,
+        config::watcher::{DEFAULT_MAX_FILE_SIZE, DEFAULT_MODERATION_ID},
+        file::validate_and_expand_path,
+        DaemonConfig, Level,
     };
 
     #[tokio_shared_rt::test(shared)]
@@ -91,6 +93,7 @@ mod tests {
         assert_eq!(c.watcher.external_hs_monitoring_interval_ms, 5_000);
         assert_eq!(c.watcher.hs_resolver_interval_ms, 10_000);
         assert_eq!(c.watcher.retry_processor_interval_ms, 10_000);
+        assert_eq!(c.watcher.max_file_size, DEFAULT_MAX_FILE_SIZE);
         assert_eq!(
             c.watcher.moderation_id,
             PubkyId::try_from(DEFAULT_MODERATION_ID).unwrap()

--- a/nexus-common/src/config/watcher.rs
+++ b/nexus-common/src/config/watcher.rs
@@ -1,7 +1,7 @@
 use super::file::ConfigLoader;
 use super::{default_stack, DaemonConfig, StackConfig};
 use async_trait::async_trait;
-use pubky_app_specs::PubkyId;
+use pubky_app_specs::{PubkyId, VALIDATION_LIMITS};
 use serde::{de::Error, Deserialize, Deserializer, Serialize};
 use std::fmt::Debug;
 
@@ -32,8 +32,8 @@ pub const DEFAULT_MAX_BACKOFF_SECS: u64 = 3_600;
 pub const MAX_EVENTS_LIMIT: u16 = 1_000;
 /// Extra-safety check: Upper bound for [WatcherConfig::key_based_events_limit]
 pub const MAX_KEY_BASED_EVENTS_LIMIT: u16 = 100;
-/// Default for [WatcherConfig::max_file_size] — 50 MiB
-pub const DEFAULT_MAX_FILE_SIZE: u64 = 50 * 1024 * 1024;
+/// Default for [WatcherConfig::max_file_size] — the blob size cap from pubky-app-specs
+pub const DEFAULT_MAX_FILE_SIZE: u64 = VALIDATION_LIMITS.max_blob_size_bytes as u64;
 
 // Retry configuration defaults
 /// Default for [EventRetryConfig::max_retries]
@@ -159,7 +159,7 @@ pub struct WatcherConfig {
     pub retry_processor_interval_ms: u64,
 
     /// Max file size in bytes (Content-Length check + streaming enforcement).
-    /// Rejected files are permanent failures (not retried). Default: 50 MiB.
+    /// Rejected files are permanent failures (not retried). Defaults to the pubky-app-specs blob cap.
     #[serde(default = "default_max_file_size")]
     pub max_file_size: u64,
 


### PR DESCRIPTION
Previous default value was not matching the specs. 
By default nexus should use value from `pubky-app-specs` with an option for overwritting it.