### PR TITLE
fix(watcher): configure a global Pubky HTTP request timeout

### DIFF
--- a/nexus-common/default.config.toml
+++ b/nexus-common/default.config.toml
@@ -87,6 +87,9 @@ testnet = false
 # testnet host, leave as "localhost" for local development. Change only if the
 # testnet homeserver/relay are on another machine (e.g. Docker setups).
 testnet_host = "localhost"
+# Total request timeout in seconds for all HTTP requests made by the shared Pubky client.
+# This includes response-body reads and should accommodate max_file_size blob downloads.
+pubky_http_request_timeout = 30
 # External HS PKs which are forbidden from being indexed
 external_hs_pk_blacklist = []
 

--- a/nexus-common/default.config.toml
+++ b/nexus-common/default.config.toml
@@ -90,7 +90,7 @@ testnet = false
 testnet_host = "localhost"
 # Total request timeout in seconds for all HTTP requests made by the shared Pubky client.
 # This includes response-body reads and should accommodate max_file_size blob downloads.
-pubky_http_request_timeout = 30
+pubky_http_request_timeout_secs = 30
 # External HS PKs which are forbidden from being indexed
 external_hs_pk_blacklist = []
 

--- a/nexus-common/default.config.toml
+++ b/nexus-common/default.config.toml
@@ -90,7 +90,7 @@ testnet = false
 testnet_host = "localhost"
 # Total request timeout in seconds for all HTTP requests made by the shared Pubky client.
 # This includes response-body reads and should accommodate max_file_size blob downloads.
-pubky_http_request_timeout_secs = 30
+pubky_http_request_timeout_secs = 300
 # External HS PKs which are forbidden from being indexed
 external_hs_pk_blacklist = []
 

--- a/nexus-common/src/config/daemon.rs
+++ b/nexus-common/src/config/daemon.rs
@@ -69,7 +69,7 @@ impl ConfigLoader<DaemonConfig> for DaemonConfig {}
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, net::SocketAddr, path::PathBuf, str::FromStr};
+    use std::{collections::HashMap, net::SocketAddr, path::PathBuf, str::FromStr, time::Duration};
 
     use pubky_app_specs::PubkyId;
 
@@ -118,6 +118,11 @@ mod tests {
             ]
         );
         assert!(c.stack.net.external_hs_pk_blacklist.is_empty());
+        assert_eq!(c.stack.net.pubky_http_request_timeout, 30);
+        assert_eq!(
+            c.stack.net.pubky_client_http_request_timeout(),
+            Duration::from_secs(30)
+        );
 
         assert_eq!(c.stack.log_level, Level::Info);
         assert_eq!(
@@ -371,6 +376,29 @@ mod tests {
             DaemonConfig::try_from_str(&toml).is_err(),
             "an invalid public key in the blacklist must fail config parsing"
         );
+    }
+
+    #[test]
+    fn test_pubky_http_request_timeout_rejects_zero() {
+        let toml = DEFAULT_CONFIG_TOML.replace(
+            "pubky_http_request_timeout = 30",
+            "pubky_http_request_timeout = 0",
+        );
+
+        assert!(
+            DaemonConfig::try_from_str(&toml).is_err(),
+            "pubky_http_request_timeout must be at least 1 second"
+        );
+    }
+
+    #[test]
+    fn test_pubky_http_request_timeout_defaults_when_omitted() {
+        let toml = DEFAULT_CONFIG_TOML.replace("pubky_http_request_timeout = 30\n", "");
+
+        let config = DaemonConfig::try_from_str(&toml)
+            .expect("config without pubky_http_request_timeout should use the default");
+
+        assert_eq!(config.stack.net.pubky_http_request_timeout, 30);
     }
 
     /// Legacy `watcher_sleep` / `hs_resolver_sleep` field names (renamed to

--- a/nexus-common/src/config/daemon.rs
+++ b/nexus-common/src/config/daemon.rs
@@ -121,10 +121,10 @@ mod tests {
             ]
         );
         assert!(c.stack.net.external_hs_pk_blacklist.is_empty());
-        assert_eq!(c.stack.net.pubky_http_request_timeout_secs, 30);
+        assert_eq!(c.stack.net.pubky_http_request_timeout_secs, 300);
         assert_eq!(
             c.stack.net.pubky_client_http_request_timeout(),
-            Duration::from_secs(30)
+            Duration::from_secs(300)
         );
 
         assert_eq!(c.stack.log_level, Level::Info);
@@ -384,7 +384,7 @@ mod tests {
     #[test]
     fn test_pubky_http_request_timeout_secs_rejects_zero() {
         let toml = DEFAULT_CONFIG_TOML.replace(
-            "pubky_http_request_timeout_secs = 30",
+            "pubky_http_request_timeout_secs = 300",
             "pubky_http_request_timeout_secs = 0",
         );
 
@@ -396,12 +396,12 @@ mod tests {
 
     #[test]
     fn test_pubky_http_request_timeout_secs_defaults_when_omitted() {
-        let toml = DEFAULT_CONFIG_TOML.replace("pubky_http_request_timeout_secs = 30\n", "");
+        let toml = DEFAULT_CONFIG_TOML.replace("pubky_http_request_timeout_secs = 300\n", "");
 
         let config = DaemonConfig::try_from_str(&toml)
             .expect("config without pubky_http_request_timeout_secs should use the default");
 
-        assert_eq!(config.stack.net.pubky_http_request_timeout_secs, 30);
+        assert_eq!(config.stack.net.pubky_http_request_timeout_secs, 300);
     }
 
     /// Legacy `watcher_sleep` / `hs_resolver_sleep` field names (renamed to

--- a/nexus-common/src/config/daemon.rs
+++ b/nexus-common/src/config/daemon.rs
@@ -121,7 +121,7 @@ mod tests {
             ]
         );
         assert!(c.stack.net.external_hs_pk_blacklist.is_empty());
-        assert_eq!(c.stack.net.pubky_http_request_timeout, 30);
+        assert_eq!(c.stack.net.pubky_http_request_timeout_secs, 30);
         assert_eq!(
             c.stack.net.pubky_client_http_request_timeout(),
             Duration::from_secs(30)
@@ -382,26 +382,26 @@ mod tests {
     }
 
     #[test]
-    fn test_pubky_http_request_timeout_rejects_zero() {
+    fn test_pubky_http_request_timeout_secs_rejects_zero() {
         let toml = DEFAULT_CONFIG_TOML.replace(
-            "pubky_http_request_timeout = 30",
-            "pubky_http_request_timeout = 0",
+            "pubky_http_request_timeout_secs = 30",
+            "pubky_http_request_timeout_secs = 0",
         );
 
         assert!(
             DaemonConfig::try_from_str(&toml).is_err(),
-            "pubky_http_request_timeout must be at least 1 second"
+            "pubky_http_request_timeout_secs must be at least 1 second"
         );
     }
 
     #[test]
-    fn test_pubky_http_request_timeout_defaults_when_omitted() {
-        let toml = DEFAULT_CONFIG_TOML.replace("pubky_http_request_timeout = 30\n", "");
+    fn test_pubky_http_request_timeout_secs_defaults_when_omitted() {
+        let toml = DEFAULT_CONFIG_TOML.replace("pubky_http_request_timeout_secs = 30\n", "");
 
         let config = DaemonConfig::try_from_str(&toml)
-            .expect("config without pubky_http_request_timeout should use the default");
+            .expect("config without pubky_http_request_timeout_secs should use the default");
 
-        assert_eq!(config.stack.net.pubky_http_request_timeout, 30);
+        assert_eq!(config.stack.net.pubky_http_request_timeout_secs, 30);
     }
 
     /// Legacy `watcher_sleep` / `hs_resolver_sleep` field names (renamed to

--- a/nexus-common/src/config/net.rs
+++ b/nexus-common/src/config/net.rs
@@ -1,7 +1,14 @@
+use std::time::Duration;
+
 use pubky_app_specs::PubkyId;
-use serde::{Deserialize, Serialize};
+use serde::{de::Error, Deserialize, Deserializer, Serialize};
 
 const DEFAULT_TESTNET_HOST: &str = "localhost";
+const DEFAULT_PUBKY_HTTP_REQUEST_TIMEOUT_SECS: u64 = 30;
+
+const fn default_pubky_http_request_timeout() -> u64 {
+    DEFAULT_PUBKY_HTTP_REQUEST_TIMEOUT_SECS
+}
 
 /// Shared Pubky network settings for the Nexus stack (`[stack.net]`).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -13,6 +20,14 @@ pub struct NetConfig {
     /// Only used when [Self::testnet] is true.
     #[serde(default = "NetConfig::default_testnet_host")]
     pub testnet_host: String,
+    /// Total request timeout in seconds for every HTTP request made by the shared Pubky client.
+    /// This includes reading the complete response body, so the default accommodates
+    /// downloads up to [`crate::DEFAULT_MAX_FILE_SIZE`].
+    #[serde(
+        default = "default_pubky_http_request_timeout",
+        deserialize_with = "deserialize_nonzero_pubky_http_request_timeout"
+    )]
+    pub pubky_http_request_timeout: u64,
     /// External HS PKs which are forbidden from being indexed.
     #[serde(default)]
     pub external_hs_pk_blacklist: Vec<PubkyId>,
@@ -23,8 +38,21 @@ impl Default for NetConfig {
         Self {
             testnet: false,
             testnet_host: Self::default_testnet_host(),
+            pubky_http_request_timeout: DEFAULT_PUBKY_HTTP_REQUEST_TIMEOUT_SECS,
             external_hs_pk_blacklist: Vec::new(),
         }
+    }
+}
+
+fn deserialize_nonzero_pubky_http_request_timeout<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    match u64::deserialize(deserializer)? {
+        0 => Err(D::Error::custom(
+            "pubky_http_request_timeout must be at least 1 second",
+        )),
+        timeout => Ok(timeout),
     }
 }
 
@@ -36,5 +64,10 @@ impl NetConfig {
     /// Returns the testnet relay hostname for [`PubkyConnector::initialise`]
     pub fn pubky_client_testnet_host(&self) -> Option<&str> {
         self.testnet.then_some(self.testnet_host.as_str())
+    }
+
+    /// Returns the total request deadline used to initialize the shared Pubky client.
+    pub fn pubky_client_http_request_timeout(&self) -> Duration {
+        Duration::from_secs(self.pubky_http_request_timeout)
     }
 }

--- a/nexus-common/src/config/net.rs
+++ b/nexus-common/src/config/net.rs
@@ -4,7 +4,7 @@ use pubky_app_specs::PubkyId;
 use serde::{de::Error, Deserialize, Deserializer, Serialize};
 
 const DEFAULT_TESTNET_HOST: &str = "localhost";
-const DEFAULT_PUBKY_HTTP_REQUEST_TIMEOUT_SECS: u64 = 30;
+const DEFAULT_PUBKY_HTTP_REQUEST_TIMEOUT_SECS: u64 = 300;
 
 const fn default_pubky_http_request_timeout_secs() -> u64 {
     DEFAULT_PUBKY_HTTP_REQUEST_TIMEOUT_SECS

--- a/nexus-common/src/config/net.rs
+++ b/nexus-common/src/config/net.rs
@@ -6,7 +6,7 @@ use serde::{de::Error, Deserialize, Deserializer, Serialize};
 const DEFAULT_TESTNET_HOST: &str = "localhost";
 const DEFAULT_PUBKY_HTTP_REQUEST_TIMEOUT_SECS: u64 = 30;
 
-const fn default_pubky_http_request_timeout() -> u64 {
+const fn default_pubky_http_request_timeout_secs() -> u64 {
     DEFAULT_PUBKY_HTTP_REQUEST_TIMEOUT_SECS
 }
 
@@ -24,10 +24,10 @@ pub struct NetConfig {
     /// This includes reading the complete response body, so the default accommodates
     /// downloads up to [`crate::DEFAULT_MAX_FILE_SIZE`].
     #[serde(
-        default = "default_pubky_http_request_timeout",
-        deserialize_with = "deserialize_nonzero_pubky_http_request_timeout"
+        default = "default_pubky_http_request_timeout_secs",
+        deserialize_with = "deserialize_nonzero_pubky_http_request_timeout_secs"
     )]
-    pub pubky_http_request_timeout: u64,
+    pub pubky_http_request_timeout_secs: u64,
     /// External HS PKs which are forbidden from being indexed.
     #[serde(default)]
     pub external_hs_pk_blacklist: Vec<PubkyId>,
@@ -38,19 +38,21 @@ impl Default for NetConfig {
         Self {
             testnet: false,
             testnet_host: Self::default_testnet_host(),
-            pubky_http_request_timeout: DEFAULT_PUBKY_HTTP_REQUEST_TIMEOUT_SECS,
+            pubky_http_request_timeout_secs: DEFAULT_PUBKY_HTTP_REQUEST_TIMEOUT_SECS,
             external_hs_pk_blacklist: Vec::new(),
         }
     }
 }
 
-fn deserialize_nonzero_pubky_http_request_timeout<'de, D>(deserializer: D) -> Result<u64, D::Error>
+fn deserialize_nonzero_pubky_http_request_timeout_secs<'de, D>(
+    deserializer: D,
+) -> Result<u64, D::Error>
 where
     D: Deserializer<'de>,
 {
     match u64::deserialize(deserializer)? {
         0 => Err(D::Error::custom(
-            "pubky_http_request_timeout must be at least 1 second",
+            "pubky_http_request_timeout_secs must be at least 1 second",
         )),
         timeout => Ok(timeout),
     }
@@ -68,6 +70,6 @@ impl NetConfig {
 
     /// Returns the total request deadline used to initialize the shared Pubky client.
     pub fn pubky_client_http_request_timeout(&self) -> Duration {
-        Duration::from_secs(self.pubky_http_request_timeout)
+        Duration::from_secs(self.pubky_http_request_timeout_secs)
     }
 }

--- a/nexus-common/src/db/connectors/pubky.rs
+++ b/nexus-common/src/db/connectors/pubky.rs
@@ -1,6 +1,6 @@
 use pubky::errors::{AuthError, BuildError, PkarrError, RequestError};
 use pubky::{Pubky, PubkyHttpClient, StatusCode};
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 use thiserror::Error;
 use tokio::sync::OnceCell;
 use tracing::debug;
@@ -70,16 +70,26 @@ impl PubkyConnector {
     ///
     /// - For mainnet, pass `None`.
     /// - For testnet, pass `Some(hostname)` (e.g., "localhost" or "homeserver").
-    pub async fn initialise(testnet_host: Option<&str>) -> PubkyClientResult<()> {
+    /// - `http_request_timeout` bounds every Pubky HTTP request, including response-body reads.
+    pub async fn initialise(
+        testnet_host: Option<&str>,
+        http_request_timeout: Duration,
+    ) -> PubkyClientResult<()> {
         PUBKY_SINGLETON
             .get_or_try_init(|| async {
                 let mode = testnet_host
                     .map(|host| format!("testnet with host '{host}'"))
                     .unwrap_or_else(|| "mainnet".to_string());
-                debug!("Initialising Pubky singleton in {mode} mode");
+                debug!(
+                    ?http_request_timeout,
+                    "Initialising Pubky singleton in {mode} mode"
+                );
 
-                let client = match testnet_host {
-                    Some(host) => PubkyHttpClient::builder()
+                let mut client_builder = PubkyHttpClient::builder();
+                client_builder.request_timeout(http_request_timeout);
+
+                if let Some(host) = testnet_host {
+                    client_builder
                         .testnet_with_host(host)
                         // Force pkarr/mainline DHT to bind an ephemeral local port instead of default behavior
                         // We do this to prevent the client DHT from competing with `StaticTestnet` for port 6881
@@ -88,11 +98,12 @@ impl PubkyConnector {
                                 c.port = Some(0);
                                 c
                             })
-                        })
-                        .build(),
-                    None => PubkyHttpClient::new(),
+                        });
                 }
-                .map_err(|e| PubkyClientError::from(pubky::Error::from(e)))?;
+
+                let client = client_builder
+                    .build()
+                    .map_err(|e| PubkyClientError::from(pubky::Error::from(e)))?;
                 Ok(Arc::new(Pubky::with_client(client)))
             })
             .await

--- a/nexus-watcher/src/builder.rs
+++ b/nexus-watcher/src/builder.rs
@@ -64,7 +64,11 @@ impl NexusWatcherBuilder {
         StackManager::setup(&self.0.stack).await?;
         let shutdown_rx = shutdown_rx.unwrap_or_else(create_shutdown_rx);
 
-        let _ = PubkyConnector::initialise(self.0.stack.net.pubky_client_testnet_host()).await;
+        PubkyConnector::initialise(
+            self.0.stack.net.pubky_client_testnet_host(),
+            self.0.stack.net.pubky_client_http_request_timeout(),
+        )
+        .await?;
 
         NexusWatcher::start(shutdown_rx, self.0).await
     }


### PR DESCRIPTION
This PR adds a configurable total HTTP request timeout to the shared Pubky client.

Note this is not a connection timeout, but a request timeout. This means the entire request, including receiving the response body, has to complete within this time.

In more detail:

- Adds `[stack.net].pubky_http_request_timeout` to `config.toml`, defaulting to **30 seconds**.
  - The deadline includes response-body reads.
  - Value of `0` is rejected during config parsing.
- Uses the same configured singleton for both mainnet and testnet clients.

---

# Pre-submission Checklist

- [x] I manually reviewed the PR
- [x] I asked one or more LLMs to review the PR
- [x] I asked one or more LLMs to check if this PR can be simplified [^1]
- [ ] If appropriate, I added tests for the changes in this PR
- [ ] If appropriate, I added performance benchmarks for the APIs added in this PR [^2]

[^1]: Sample prompt: "Can this be simplified? Can the code, comments, or logic introduced by these changes be simplfied, clarified or otherwise made more terse, concise and understandable, without affecting functionality?"
[^2]: `cargo bench -p nexus-webapi`
