### PR TITLE
feat(api): social graph status (trustrank) on the user view

### DIFF
--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -298,6 +298,31 @@ pub fn get_user_tag_pairs() -> Query {
     .param("deleted", USER_DELETED_SENTINEL)
 }
 
+/// Users carrying positive trust, highest first: the ranked population behind
+/// the social graph badge.
+///
+/// `coalesce` rather than `IS NOT NULL` because GDS may write `0.0` or leave
+/// the property unset for a node unreachable from the seed set, and both mean
+/// the same thing. Only positive scores are ranked: everyone at zero shares one
+/// value, so their order would be arbitrary and would reshuffle every run.
+/// Absence from the ranking is what marks them new.
+///
+/// `user_id ASC` breaks score ties deterministically, so two runs over the same
+/// graph agree.
+pub fn get_trust_ranked_user_ids() -> Query {
+    Query::new(
+        "get_trust_ranked_user_ids",
+        "
+        MATCH (u:User)
+        WHERE coalesce(u.trust, 0.0) > 0
+          AND u.name <> $deleted AND NOT coalesce(u.deleted, false)
+        RETURN u.id AS user_id
+        ORDER BY u.trust DESC, user_id ASC
+        ",
+    )
+    .param("deleted", USER_DELETED_SENTINEL)
+}
+
 /// Users whose profile carries any of the given tag labels, scored by distinct
 /// tagger count summed across the searched labels.
 pub fn search_users_by_tags(labels: &[String], skip: Option<usize>, limit: Option<usize>) -> Query {

--- a/nexus-common/src/db/graph/queries/get.rs
+++ b/nexus-common/src/db/graph/queries/get.rs
@@ -301,11 +301,11 @@ pub fn get_user_tag_pairs() -> Query {
 /// Users carrying positive trust, highest first: the ranked population behind
 /// the social graph badge.
 ///
-/// `coalesce` rather than `IS NOT NULL` because GDS may write `0.0` or leave
-/// the property unset for a node unreachable from the seed set, and both mean
-/// the same thing. Only positive scores are ranked: everyone at zero shares one
-/// value, so their order would be arbitrary and would reshuffle every run.
-/// Absence from the ranking is what marks them new.
+/// A node unreachable from the seed set may carry `0.0` or no `trust` property
+/// at all, and `null > 0` is null, so both drop out here. Only positive scores
+/// are ranked: everyone at zero shares one value, so their order would be
+/// arbitrary and would reshuffle every run. Absence from the ranking is what
+/// marks them new.
 ///
 /// `user_id ASC` breaks score ties deterministically, so two runs over the same
 /// graph agree.
@@ -314,7 +314,7 @@ pub fn get_trust_ranked_user_ids() -> Query {
         "get_trust_ranked_user_ids",
         "
         MATCH (u:User)
-        WHERE coalesce(u.trust, 0.0) > 0
+        WHERE u.trust > 0
           AND u.name <> $deleted AND NOT coalesce(u.deleted, false)
         RETURN u.id AS user_id
         ORDER BY u.trust DESC, user_id ASC

--- a/nexus-common/src/db/kv/index/sorted_sets.rs
+++ b/nexus-common/src/db/kv/index/sorted_sets.rs
@@ -107,6 +107,48 @@ pub async fn put(
     Ok(())
 }
 
+/// Replaces a sorted set's entire contents, atomically.
+///
+/// Unlike [`put`], which only adds, this drops members that are no longer
+/// present: use it for a projection rebuilt wholesale from an upstream source.
+/// The `DEL` and the `ZADD` run in one `MULTI`/`EXEC`, so a reader never
+/// observes the set empty or half-written.
+///
+/// Empty `items` deletes the key. For a projection that is the honest result,
+/// since "nothing to rank" and "never built" have to look the same to readers.
+pub async fn replace(
+    prefix: &str,
+    key: &str,
+    items: &[(f64, &str)],
+    expiration: Option<i64>,
+) -> RedisResult<()> {
+    let index_key = format!("{prefix}:{key}");
+    let mut redis_conn = get_redis_conn().await?;
+
+    if items.is_empty() {
+        let _: () = redis_conn.del(&index_key).await?;
+        return Ok(());
+    }
+
+    let mut pipe = redis::pipe();
+    pipe.atomic();
+    pipe.del(&index_key);
+    pipe.zadd_multiple(&index_key, items);
+    if let Some(ttl) = expiration {
+        pipe.expire(&index_key, ttl);
+    }
+    let _: () = pipe.query_async(&mut redis_conn).await?;
+    Ok(())
+}
+
+/// Number of members in a Redis sorted set, or `0` when the key is absent.
+pub async fn card(prefix: &str, key: &str) -> RedisResult<usize> {
+    let index_key = format!("{prefix}:{key}");
+    let mut redis_conn = get_redis_conn().await?;
+    let count: usize = redis_conn.zcard(&index_key).await?;
+    Ok(count)
+}
+
 /// Seeds `member` with `score` only if it is not already in the sorted set.
 ///
 /// `ZADD NX` makes the check and the write one atomic operation, so an existing

--- a/nexus-common/src/db/kv/index/sorted_sets.rs
+++ b/nexus-common/src/db/kv/index/sorted_sets.rs
@@ -141,12 +141,32 @@ pub async fn replace(
     Ok(())
 }
 
-/// Number of members in a Redis sorted set, or `0` when the key is absent.
-pub async fn card(prefix: &str, key: &str) -> RedisResult<usize> {
+/// Reads a sorted set's size and the scores of `members`, from one snapshot.
+///
+/// `MULTI`/`EXEC`, so the count and the scores cannot straddle a concurrent
+/// rewrite of the set. Two independent reads could observe different
+/// generations, which for a ranking means a size from one and positions from
+/// another. Returns `(cardinality, one slot per member)`; an absent key reads
+/// as `0` with every slot `None`.
+pub async fn card_and_members(
+    prefix: &str,
+    key: &str,
+    members: &[&str],
+) -> RedisResult<(usize, Vec<Option<isize>>)> {
     let index_key = format!("{prefix}:{key}");
+
+    let mut pipe = redis::pipe();
+    pipe.atomic();
+    pipe.zcard(&index_key);
+    for member in members {
+        pipe.zscore(&index_key, *member);
+    }
+
     let mut redis_conn = get_redis_conn().await?;
-    let count: usize = redis_conn.zcard(&index_key).await?;
-    Ok(count)
+    let mut replies: Vec<Option<isize>> = pipe.query_async(&mut redis_conn).await?;
+    // The ZCARD reply leads; the rest line up with `members`.
+    let cardinality = replies.remove(0).unwrap_or(0).max(0) as usize;
+    Ok((cardinality, replies))
 }
 
 /// Seeds `member` with `score` only if it is not already in the sorted set.

--- a/nexus-common/src/db/kv/traits.rs
+++ b/nexus-common/src/db/kv/traits.rs
@@ -612,11 +612,16 @@ pub trait RedisOps: Serialize + DeserializeOwned + Send + Sync {
         sorted_sets::replace(prefix, &key, elements, expiration).await
     }
 
-    /// Number of members in a Redis sorted set, `0` when the key is absent.
-    async fn index_sorted_set_card(key_parts: &[&str], prefix: Option<&str>) -> RedisResult<usize> {
+    /// Reads a sorted set's size and the scores of `members` from one snapshot,
+    /// so the two cannot straddle a concurrent rewrite of the set.
+    async fn index_sorted_set_card_and_members(
+        key_parts: &[&str],
+        members: &[&str],
+        prefix: Option<&str>,
+    ) -> RedisResult<(usize, Vec<Option<isize>>)> {
         let prefix = prefix.unwrap_or(SORTED_PREFIX);
         let key = key_parts.join(":");
-        sorted_sets::card(prefix, &key).await
+        sorted_sets::card_and_members(prefix, &key, members).await
     }
 
     /// Seeds a member of a Redis sorted set, leaving an already-present one untouched.

--- a/nexus-common/src/db/kv/traits.rs
+++ b/nexus-common/src/db/kv/traits.rs
@@ -597,6 +597,28 @@ pub trait RedisOps: Serialize + DeserializeOwned + Send + Sync {
         sorted_sets::put(prefix, &key, elements, expiration).await
     }
 
+    /// Rebuilds a Redis sorted set from scratch, atomically.
+    ///
+    /// Unlike [`Self::put_index_sorted_set`], which only adds, this drops
+    /// members that are no longer present. Empty `elements` deletes the key.
+    async fn replace_index_sorted_set(
+        key_parts: &[&str],
+        elements: &[(f64, &str)],
+        prefix: Option<&str>,
+        expiration: Option<i64>,
+    ) -> RedisResult<()> {
+        let prefix = prefix.unwrap_or(SORTED_PREFIX);
+        let key = key_parts.join(":");
+        sorted_sets::replace(prefix, &key, elements, expiration).await
+    }
+
+    /// Number of members in a Redis sorted set, `0` when the key is absent.
+    async fn index_sorted_set_card(key_parts: &[&str], prefix: Option<&str>) -> RedisResult<usize> {
+        let prefix = prefix.unwrap_or(SORTED_PREFIX);
+        let key = key_parts.join(":");
+        sorted_sets::card(prefix, &key).await
+    }
+
     /// Seeds a member of a Redis sorted set, leaving an already-present one untouched.
     ///
     /// Atomic (`ZADD NX`), unlike a `check_sorted_set_member` read followed by

--- a/nexus-common/src/db/reindex.rs
+++ b/nexus-common/src/db/reindex.rs
@@ -9,7 +9,7 @@ use crate::models::tag::stream::HotTags;
 use crate::models::tag::traits::TagCollection;
 use crate::models::tag::user::TagUser;
 use crate::models::traits::Collection;
-use crate::models::user::{Influencers, UserDetails, UsersByTagSearch};
+use crate::models::user::{Influencers, SocialGraphStatus, UserDetails, UsersByTagSearch};
 use crate::types::DynError;
 use crate::{
     models::post::{PostCounts, PostDetails, PostRelationships},
@@ -75,6 +75,10 @@ pub async fn sync() {
     Influencers::reindex()
         .await
         .expect("Failed to reindex influencers");
+
+    SocialGraphStatus::reindex()
+        .await
+        .expect("Failed to reindex the social graph ranking");
 
     PostsByTagSearch::reindex()
         .await

--- a/nexus-common/src/models/user/mod.rs
+++ b/nexus-common/src/models/user/mod.rs
@@ -6,6 +6,7 @@ mod influencers;
 mod ingestor;
 mod relationship;
 mod search;
+mod social_graph;
 mod stream;
 mod view;
 
@@ -16,6 +17,7 @@ pub use influencers::Influencers;
 pub use ingestor::UserIngestor;
 pub use relationship::Relationship;
 pub use search::{UserSearch, UsersByTagSearch, TAG_GLOBAL_USER_TAGGERS, USER_NAME_KEY_PARTS};
+pub use social_graph::{SocialGraphStatus, USER_SOCIAL_GRAPH_KEY_PARTS};
 pub use stream::{
     UserIdStream, UserStream, UserStreamInput, UserStreamSource, CACHE_USER_RECOMMENDED_KEY_PARTS,
     STARTER_PACK_MAX_SKIP, USER_INFLUENCERS_KEY_PARTS, USER_MOSTFOLLOWED_KEY_PARTS,

--- a/nexus-common/src/models/user/social_graph.rs
+++ b/nexus-common/src/models/user/social_graph.rs
@@ -76,10 +76,7 @@ impl SocialGraphStatus {
     ///
     /// An empty ranking means it was never built, which is not the same as
     /// ranking everyone as new, so every slot is `None` and the badge hides.
-    fn classify(
-        population: usize,
-        ranks: &[Option<isize>],
-    ) -> Vec<Option<SocialGraphStatus>> {
+    fn classify(population: usize, ranks: &[Option<isize>]) -> Vec<Option<SocialGraphStatus>> {
         if population == 0 {
             return vec![None; ranks.len()];
         }

--- a/nexus-common/src/models/user/social_graph.rs
+++ b/nexus-common/src/models/user/social_graph.rs
@@ -46,18 +46,15 @@ impl SocialGraphStatus {
             return Ok(Vec::new());
         }
 
-        let members: Vec<[&str; 1]> = user_ids.iter().map(|id| [id.as_ref()]).collect();
-        let pairs: Vec<(&[&str], &[&str])> = members
-            .iter()
-            .map(|member| (USER_SOCIAL_GRAPH_KEY_PARTS.as_slice(), member.as_slice()))
-            .collect();
+        let members: Vec<&str> = user_ids.iter().map(|id| id.as_ref()).collect();
 
-        // The population sizes the `established` cut, so it is read alongside
-        // the ranks rather than baked into them: tuning the cut needs no rebuild.
-        let (population, ranks) = tokio::try_join!(
-            Self::index_sorted_set_card(&USER_SOCIAL_GRAPH_KEY_PARTS, None),
-            Self::check_sorted_set_members(None, &pairs),
-        )?;
+        // The population sizes the `established` cut, so it is read alongside the
+        // ranks rather than baked into them: tuning the cut needs no rebuild. Both
+        // come from one snapshot, or a rebuild landing mid-read could size the cut
+        // from one ranking and place users by another.
+        let (population, ranks) =
+            Self::index_sorted_set_card_and_members(&USER_SOCIAL_GRAPH_KEY_PARTS, &members, None)
+                .await?;
 
         debug_assert_eq!(ranks.len(), user_ids.len());
         Ok(Self::classify(population, &ranks))

--- a/nexus-common/src/models/user/social_graph.rs
+++ b/nexus-common/src/models/user/social_graph.rs
@@ -1,0 +1,208 @@
+use futures::TryStreamExt;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use crate::db::kv::RedisResult;
+use crate::db::{get_neo4j_graph, queries, GraphError, RedisOps};
+use crate::models::error::ModelResult;
+
+/// Redis key parts for the trust ranking projection: `Sorted:Users:SocialGraph`.
+pub const USER_SOCIAL_GRAPH_KEY_PARTS: [&str; 2] = ["Users", "SocialGraph"];
+
+/// Share of the ranked population marked `established`. A placeholder until the
+/// real distribution is known; the ranking stores positions rather than tiers so
+/// that changing this needs no recompute.
+const ESTABLISHED_FRACTION: f64 = 0.05;
+
+/// How established an account is in the follow graph, derived from the seeded
+/// PageRank trust ranking.
+///
+/// Describes position in the graph, not character: it says an account is
+/// expensive to fake, never that it is trustworthy.
+#[derive(Serialize, Deserialize, ToSchema, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SocialGraphStatus {
+    /// No path from the seed set: a brand new account, or a follow farm that
+    /// only follows itself.
+    New,
+    /// Reachable from the seed set.
+    Networked,
+    /// Top slice of the ranking.
+    Established,
+}
+
+impl RedisOps for SocialGraphStatus {}
+
+impl SocialGraphStatus {
+    /// Reads the status of several users.
+    ///
+    /// Returns exactly one slot per requested id on every path, including when
+    /// the ranking is missing: callers zip the result positionally against their
+    /// id list, and a short vec would silently truncate it.
+    pub async fn get_by_ids<T: AsRef<str>>(
+        user_ids: &[T],
+    ) -> RedisResult<Vec<Option<SocialGraphStatus>>> {
+        if user_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let members: Vec<[&str; 1]> = user_ids.iter().map(|id| [id.as_ref()]).collect();
+        let pairs: Vec<(&[&str], &[&str])> = members
+            .iter()
+            .map(|member| (USER_SOCIAL_GRAPH_KEY_PARTS.as_slice(), member.as_slice()))
+            .collect();
+
+        // The population sizes the `established` cut, so it is read alongside
+        // the ranks rather than baked into them: tuning the cut needs no rebuild.
+        let (population, ranks) = tokio::try_join!(
+            Self::index_sorted_set_card(&USER_SOCIAL_GRAPH_KEY_PARTS, None),
+            Self::check_sorted_set_members(None, &pairs),
+        )?;
+
+        debug_assert_eq!(ranks.len(), user_ids.len());
+        Ok(Self::classify(population, &ranks))
+    }
+
+    /// Reads one user's status.
+    pub async fn get_by_id(user_id: &str) -> RedisResult<Option<SocialGraphStatus>> {
+        Ok(Self::get_by_ids(&[user_id])
+            .await?
+            .into_iter()
+            .next()
+            .flatten())
+    }
+
+    /// Maps raw ranks to statuses.
+    ///
+    /// An empty ranking means it was never built, which is not the same as
+    /// ranking everyone as new, so every slot is `None` and the badge hides.
+    fn classify(
+        population: usize,
+        ranks: &[Option<isize>],
+    ) -> Vec<Option<SocialGraphStatus>> {
+        if population == 0 {
+            return vec![None; ranks.len()];
+        }
+        let established_cut = (population as f64 * ESTABLISHED_FRACTION).ceil() as isize;
+
+        ranks
+            .iter()
+            .map(|rank| {
+                Some(match rank {
+                    // Unreachable from the seed set, or created since the last
+                    // rebuild. Both are new.
+                    None => SocialGraphStatus::New,
+                    Some(rank) if *rank <= established_cut => SocialGraphStatus::Established,
+                    Some(_) => SocialGraphStatus::Networked,
+                })
+            })
+            .collect()
+    }
+
+    /// Rebuilds the ranking from the trust scores in the graph. Run by the trust
+    /// recompute job and by a full reindex.
+    ///
+    /// # Errors
+    /// Returns an error when the graph read or the Redis write fails.
+    pub async fn reindex() -> ModelResult<()> {
+        let graph = get_neo4j_graph()?;
+        let mut rows = graph
+            .execute(queries::get::get_trust_ranked_user_ids())
+            .await
+            .map_err(GraphError::from)?;
+
+        // Streamed rather than collected as rows: only the ids are needed.
+        let mut ranked: Vec<String> = Vec::new();
+        while let Some(row) = rows.try_next().await.map_err(GraphError::from)? {
+            ranked.push(row.get("user_id")?);
+        }
+
+        // Empty drops the key, so readers fall back to "unavailable" rather
+        // than "everyone is new".
+        Self::replace_index_sorted_set(
+            &USER_SOCIAL_GRAPH_KEY_PARTS,
+            &Self::rank_elements(&ranked),
+            None,
+            None,
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    /// Turns the ordered ids into the sorted-set payload.
+    ///
+    /// Rank comes from position, never from comparing scores against a cut
+    /// value: seeded PageRank hands identical scores to every spoke of a hub, so
+    /// a `score >= cut` comparison would promote a whole plateau at once.
+    fn rank_elements(ranked: &[String]) -> Vec<(f64, &str)> {
+        ranked
+            .iter()
+            .enumerate()
+            .map(|(index, user_id)| ((index + 1) as f64, user_id.as_str()))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Runs the write and read halves together, so the tests exercise the rank
+    /// encoding end to end without Redis.
+    fn statuses_for(population: usize) -> Vec<SocialGraphStatus> {
+        let ids: Vec<String> = (0..population).map(|i| format!("user{i}")).collect();
+        let ranks: Vec<Option<isize>> = SocialGraphStatus::rank_elements(&ids)
+            .iter()
+            .map(|(rank, _)| Some(*rank as isize))
+            .collect();
+
+        SocialGraphStatus::classify(population, &ranks)
+            .into_iter()
+            .map(|status| status.expect("a built ranking resolves every slot"))
+            .collect()
+    }
+
+    #[test]
+    fn ranks_are_positional() {
+        let ids: Vec<String> = (0..3).map(|i| format!("user{i}")).collect();
+
+        let elements = SocialGraphStatus::rank_elements(&ids);
+
+        assert_eq!(
+            elements,
+            vec![(1.0, "user0"), (2.0, "user1"), (3.0, "user2")]
+        );
+    }
+
+    #[test]
+    fn the_cut_is_inclusive_at_its_boundary() {
+        let statuses = statuses_for(100);
+
+        // ceil(100 * 0.05) == 5, so rank 5 is in and rank 6 is out.
+        assert_eq!(statuses[4], SocialGraphStatus::Established);
+        assert_eq!(statuses[5], SocialGraphStatus::Networked);
+    }
+
+    // The cut rounds up, so a ranking always has an established slice.
+    #[test]
+    fn a_lone_ranked_user_is_established() {
+        assert_eq!(statuses_for(1), vec![SocialGraphStatus::Established]);
+    }
+
+    #[test]
+    fn an_unbuilt_ranking_hides_the_badge() {
+        let statuses = SocialGraphStatus::classify(0, &[Some(1), None, Some(9)]);
+
+        assert_eq!(statuses, vec![None, None, None]);
+    }
+
+    // Absent from a built ranking means unreachable from the seeds, or created
+    // after the last rebuild. Both are new.
+    #[test]
+    fn an_absent_user_in_a_live_ranking_is_new() {
+        let statuses = SocialGraphStatus::classify(100, &[None]);
+
+        assert_eq!(statuses, vec![Some(SocialGraphStatus::New)]);
+    }
+}

--- a/nexus-common/src/models/user/view.rs
+++ b/nexus-common/src/models/user/view.rs
@@ -36,7 +36,11 @@ impl UserView {
             UserCounts::get_by_id(user_id),
             Relationship::get_by_id(user_id, viewer_id),
             // The others surface ModelError; this one is Redis-only.
-            async { SocialGraphStatus::get_by_id(user_id).await.map_err(ModelError::from) },
+            async {
+                SocialGraphStatus::get_by_id(user_id)
+                    .await
+                    .map_err(ModelError::from)
+            },
         )?;
 
         let Some(details) = details else {

--- a/nexus-common/src/models/user/view.rs
+++ b/nexus-common/src/models/user/view.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-use super::{Relationship, UserCounts, UserDetails};
+use super::{Relationship, SocialGraphStatus, UserCounts, UserDetails};
 use crate::db::RedisOps;
 use crate::models::error::{ModelError, ModelResult};
 use crate::models::tag::traits::TagCollection;
@@ -18,6 +18,9 @@ pub struct UserView {
     pub counts: UserCounts,
     pub tags: Vec<TagDetails>,
     pub relationship: Relationship,
+    /// How established the account is in the follow graph. `None` when no
+    /// ranking is available, which is not the same as ranking as new.
+    pub social_graph_status: Option<SocialGraphStatus>,
 }
 
 impl UserView {
@@ -28,10 +31,12 @@ impl UserView {
         depth: Option<u8>,
     ) -> ModelResult<Option<Self>> {
         // Perform all operations concurrently
-        let (details, counts, relationship) = tokio::try_join!(
+        let (details, counts, relationship, social_graph_status) = tokio::try_join!(
             UserDetails::get_by_id(user_id),
             UserCounts::get_by_id(user_id),
             Relationship::get_by_id(user_id, viewer_id),
+            // The others surface ModelError; this one is Redis-only.
+            async { SocialGraphStatus::get_by_id(user_id).await.map_err(ModelError::from) },
         )?;
 
         let Some(details) = details else {
@@ -63,6 +68,7 @@ impl UserView {
             counts,
             relationship,
             tags,
+            social_graph_status,
         }))
     }
 
@@ -75,12 +81,17 @@ impl UserView {
         viewer_id: Option<&str>,
         depth: Option<u8>,
     ) -> ModelResult<Vec<Option<Self>>> {
-        // Use mget to fetch all user details and counts in bulk
-        let (details_list, counts_list): (Vec<Option<UserDetails>>, Vec<Option<UserCounts>>) =
-            tokio::try_join!(UserDetails::mget(user_ids), UserCounts::mget(user_ids))?;
-        // mget returns one slot per id; the positional zip below relies on it.
+        // Use mget to fetch all user details and counts in bulk. The social
+        // graph lookup belongs here, batched, not in the per-user fan-out below.
+        let (details_list, counts_list, social_graph_list) = tokio::try_join!(
+            UserDetails::mget(user_ids),
+            UserCounts::mget(user_ids),
+            SocialGraphStatus::get_by_ids(user_ids),
+        )?;
+        // Each returns one slot per id; the positional zip below relies on it.
         debug_assert_eq!(details_list.len(), user_ids.len());
         debug_assert_eq!(counts_list.len(), user_ids.len());
+        debug_assert_eq!(social_graph_list.len(), user_ids.len());
 
         // Bounded to protect the pool; `buffered` preserves order so results stay
         // aligned with `user_ids`; inputs owned so the future stays `Send`.
@@ -91,7 +102,8 @@ impl UserView {
                 .cloned()
                 .zip(details_list)
                 .zip(counts_list)
-                .map(|((user_id, details), counts)| {
+                .zip(social_graph_list)
+                .map(|(((user_id, details), counts), social_graph_status)| {
                     let viewer_id = viewer_id.clone();
                     async move {
                         let Some(details) = details else {
@@ -124,6 +136,7 @@ impl UserView {
                             counts,
                             relationship,
                             tags,
+                            social_graph_status,
                         }))
                     }
                 }),

--- a/nexus-webapi/src/routes/v0/user/view.rs
+++ b/nexus-webapi/src/routes/v0/user/view.rs
@@ -6,7 +6,7 @@ use crate::routes::Query;
 use crate::{Error, Result};
 use axum::Json;
 use nexus_common::models::tag::TagDetails;
-use nexus_common::models::user::UserView;
+use nexus_common::models::user::{SocialGraphStatus, UserView};
 use serde::Deserialize;
 use tracing::debug;
 use utoipa::OpenApi;
@@ -20,7 +20,13 @@ pub struct ProfileQuery {
 #[utoipa::path(
     get,
     path = USER_ROUTE,
-    description = "User profile",
+    description = "\
+User profile.
+
+**social_graph_status** says how established the account is in the follow graph, from a seeded \
+ranking recomputed on a schedule. `null` means no ranking is available and the badge should be \
+hidden, which is not the same as `new`. It is not an endorsement: a high value means an account is \
+expensive to fake, not that it is trustworthy.",
     tag = "User",
     params(
         ("user_id" = PubkyId, Path, description = "User Pubky ID"),
@@ -55,6 +61,6 @@ pub async fn user_view_handler(
 #[derive(OpenApi)]
 #[openapi(
     paths(user_view_handler),
-    components(schemas(UserView, TagDetails, PubkyId))
+    components(schemas(UserView, SocialGraphStatus, TagDetails, PubkyId))
 )]
 pub struct UserViewApiDoc;

--- a/nexus-webapi/tests/user/views.rs
+++ b/nexus-webapi/tests/user/views.rs
@@ -1,9 +1,14 @@
 use crate::{
     tags::user::PUBKY_PEER,
+    utils::server::TestServiceServer,
     utils::{get_request, invalid_get_request},
 };
 use anyhow::Result;
 use axum::http::StatusCode;
+use deadpool_redis::redis::AsyncCommands;
+use nexus_common::db::get_redis_conn;
+use nexus_common::db::RedisOps;
+use nexus_common::models::user::{SocialGraphStatus, USER_SOCIAL_GRAPH_KEY_PARTS};
 
 #[tokio_shared_rt::test(shared)]
 async fn test_user_endpoint() -> Result<()> {
@@ -179,5 +184,90 @@ async fn test_get_details() -> Result<()> {
     )
     .await?;
 
+    Ok(())
+}
+
+// ##### Social graph status #####
+// Fixture (docker/test-graph/mocks/wot.cypher): D1 0.4, D2 0.2, D1B 0.1, and no
+// other user carries a trust score, so the ranking is exactly three deep and
+// `ceil(3 * 0.05)` puts only its top in `established`.
+const WOT_D1: &str = "qjftuwjog819ki1wktuy5tndebce36bmxxwtjjm3z1fr97jk9yuo";
+const WOT_D2: &str = "smf4xrqfhx7stnufkjzhbjyu3rbgb3gga64srqmzcyyoyzefse9y";
+const WOT_D1B: &str = "t5ixbtatg4tq5q5ixg16qqrg1bmem75ksg6cweuftuydwzw91pzy";
+const UNRANKED_USER: &str = "4snwyct86m383rsduhw5xgcxpw7c63j3pq8x4ycqikxgik8y64ro";
+
+/// Returns the field itself rather than the whole body, so a caller can tell an
+/// explicit `null` from a field that was omitted: `Value` indexing answers
+/// `Null` for both, and the frontend branches on the field being there.
+async fn social_graph_status(user_id: &str) -> Result<serde_json::Value> {
+    let res = get_request(&format!("/v0/user/{user_id}")).await?;
+    Ok(res
+        .get("social_graph_status")
+        .cloned()
+        .expect("social_graph_status must always be serialized, null included"))
+}
+
+/// Both halves live in one test on purpose: the ranking is a single global key,
+/// so a separate test that dropped it could race this one and see its own null.
+#[tokio_shared_rt::test(shared)]
+async fn test_social_graph_status() -> Result<()> {
+    assert_eq!(social_graph_status(WOT_D1).await?, "established");
+    assert_eq!(social_graph_status(WOT_D2).await?, "networked");
+    assert_eq!(social_graph_status(WOT_D1B).await?, "networked");
+    // Carries no trust at all, so it is absent from a ranking that exists.
+    assert_eq!(social_graph_status(UNRANKED_USER).await?, "new");
+
+    // With no ranking at all the field must be null, never "new". Production
+    // ships with an empty seed set, so a non-optional field would hang a NEW
+    // badge on every profile in the app.
+    TestServiceServer::get_test_server().await;
+    let mut redis_conn = get_redis_conn().await?;
+    let key = format!("Sorted:{}", USER_SOCIAL_GRAPH_KEY_PARTS.join(":"));
+    let _: () = redis_conn.del(&key).await?;
+
+    // Probed without `?` so an error between the delete and the rebuild cannot
+    // strand the ranking for every other test.
+    let probe = async {
+        let unavailable = social_graph_status(WOT_D1).await?;
+        // The batch read has to return one slot per requested id even with no
+        // ranking, or the positional zip in `UserView::get_by_ids` truncates and
+        // every user stream comes back empty.
+        let stream = get_request("/v0/stream/users?source=most_followed&limit=5").await?;
+        anyhow::Ok((unavailable, stream.as_array().map(Vec::len).unwrap_or_default()))
+    }
+    .await;
+
+    SocialGraphStatus::reindex().await?;
+    let (unavailable, streamed) = probe?;
+
+    // Present and null, never omitted: the frontend branches on the field
+    // existing, and `is_null` alone would also pass for a missing key.
+    assert!(
+        unavailable.is_null(),
+        "expected null without a ranking, got {unavailable}"
+    );
+    assert_eq!(streamed, 5, "a missing ranking must not empty user streams");
+    assert_eq!(social_graph_status(WOT_D1).await?, "established");
+
+    Ok(())
+}
+
+/// The path production is on today: with no seed set nothing carries trust, so
+/// the rebuild has nothing to write and must drop the key. Leaving a stale set
+/// behind would serve an old ranking forever.
+#[tokio_shared_rt::test(shared)]
+async fn test_replacing_a_sorted_set_with_nothing_drops_it() -> Result<()> {
+    TestServiceServer::get_test_server().await;
+    let key_parts = ["Test", "SocialGraphReplace"];
+    let mut redis_conn = get_redis_conn().await?;
+
+    SocialGraphStatus::replace_index_sorted_set(&key_parts, &[(1.0, "someone")], None, None).await?;
+    let populated: bool = redis_conn.exists("Sorted:Test:SocialGraphReplace").await?;
+
+    SocialGraphStatus::replace_index_sorted_set(&key_parts, &[], None, None).await?;
+    let after_empty: bool = redis_conn.exists("Sorted:Test:SocialGraphReplace").await?;
+
+    assert!(populated, "a non-empty replace should create the key");
+    assert!(!after_empty, "an empty replace should drop the key");
     Ok(())
 }

--- a/nexus-webapi/tests/user/views.rs
+++ b/nexus-webapi/tests/user/views.rs
@@ -233,7 +233,10 @@ async fn test_social_graph_status() -> Result<()> {
         // ranking, or the positional zip in `UserView::get_by_ids` truncates and
         // every user stream comes back empty.
         let stream = get_request("/v0/stream/users?source=most_followed&limit=5").await?;
-        anyhow::Ok((unavailable, stream.as_array().map(Vec::len).unwrap_or_default()))
+        anyhow::Ok((
+            unavailable,
+            stream.as_array().map(Vec::len).unwrap_or_default(),
+        ))
     }
     .await;
 
@@ -261,7 +264,8 @@ async fn test_replacing_a_sorted_set_with_nothing_drops_it() -> Result<()> {
     let key_parts = ["Test", "SocialGraphReplace"];
     let mut redis_conn = get_redis_conn().await?;
 
-    SocialGraphStatus::replace_index_sorted_set(&key_parts, &[(1.0, "someone")], None, None).await?;
+    SocialGraphStatus::replace_index_sorted_set(&key_parts, &[(1.0, "someone")], None, None)
+        .await?;
     let populated: bool = redis_conn.exists("Sorted:Test:SocialGraphReplace").await?;
 
     SocialGraphStatus::replace_index_sorted_set(&key_parts, &[], None, None).await?;

--- a/nexusd/src/trust/job.rs
+++ b/nexusd/src/trust/job.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use nexus_common::models::user::SocialGraphStatus;
 use nexus_common::types::DynError;
 use nexus_common::TrustRankConfig;
 use opentelemetry::global;
@@ -16,6 +17,25 @@ use crate::jobs::Job;
 /// OpenTelemetry meter name for all trust-rank metrics.
 const METER_NAME: &str = "nexus.trust";
 
+/// Publishes a finished ranking to whatever serves it. Injected into the job
+/// for the same reason the engine is: so the unit tests can drive `run` without
+/// a database behind it.
+#[async_trait]
+pub(crate) trait TrustProjection: Send + Sync {
+    /// Republishes the read model from the scores just written to the graph.
+    async fn publish(&self) -> Result<(), DynError>;
+}
+
+/// Rebuilds the Redis ranking that backs the social graph badge.
+pub(crate) struct SocialGraphProjection;
+
+#[async_trait]
+impl TrustProjection for SocialGraphProjection {
+    async fn publish(&self) -> Result<(), DynError> {
+        SocialGraphStatus::reindex().await.map_err(Into::into)
+    }
+}
+
 /// The trust-rank recompute as a runnable [`Job`]: runs the seeded PageRank
 /// computation and, when a report dir is set, writes a CSV report of the run.
 /// Build from resolved inputs with [`TrustRecomputeJob::new`] or from config
@@ -24,6 +44,7 @@ const METER_NAME: &str = "nexus.trust";
 pub struct TrustRecomputeJob {
     params: TrustRankParams,
     engine: Box<dyn TrustRankEngine>,
+    projection: Box<dyn TrustProjection>,
     report_dir: Option<PathBuf>,
     report_limit: usize,
     /// Runs that exhausted `max_iterations` without converging, so the written
@@ -36,15 +57,17 @@ impl TrustRecomputeJob {
     /// Builds the job from inputs. `report_dir` is `Some` to write a CSV, `None` to skip;
     /// `report_limit` caps rows in the report. Instruments come from the global
     /// meter (no-ops until an `SdkMeterProvider` is installed).
-    pub fn new(
+    pub(crate) fn new(
         params: TrustRankParams,
         engine: Box<dyn TrustRankEngine>,
+        projection: Box<dyn TrustProjection>,
         report_dir: Option<PathBuf>,
         report_limit: usize,
     ) -> Self {
         Self::with_meter(
             params,
             engine,
+            projection,
             report_dir,
             report_limit,
             global::meter(METER_NAME),
@@ -56,6 +79,7 @@ impl TrustRecomputeJob {
     pub(crate) fn with_meter(
         params: TrustRankParams,
         engine: Box<dyn TrustRankEngine>,
+        projection: Box<dyn TrustProjection>,
         report_dir: Option<PathBuf>,
         report_limit: usize,
         meter: Meter,
@@ -67,6 +91,7 @@ impl TrustRecomputeJob {
         Self {
             params,
             engine,
+            projection,
             report_dir,
             report_limit,
             max_iterations_reached,
@@ -80,6 +105,7 @@ impl TrustRecomputeJob {
         Self::new(
             TrustRankParams::from(config),
             Box::new(GdsNeo4j::new(true, Duration::from_secs(2 * lock_ttl_secs))),
+            Box::new(SocialGraphProjection),
             config.report_enabled.then(|| config.report_dir.clone()),
             config.report_limit,
         )
@@ -119,6 +145,12 @@ impl Job for TrustRecomputeJob {
                 Err(e) => error!("Failed to read trust scores for report: {e:?}"),
             }
         }
+
+        // Last, so a Redis blip cannot cost the report of a compute that already
+        // succeeded. Still fatal: fresh scores nobody can read leave the badge on
+        // yesterday's ranking, and that should not pass as a clean run.
+        self.projection.publish().await?;
+
         Ok(())
     }
 }
@@ -134,6 +166,17 @@ mod tests {
 
     use super::super::engine::{TrustRankEngine, TrustRankParams, TrustRankStats};
     use super::*;
+
+    // The real projection needs Neo4j and Redis; these tests drive `run` with
+    // no infrastructure at all.
+    struct NoOpProjection;
+
+    #[async_trait]
+    impl TrustProjection for NoOpProjection {
+        async fn publish(&self) -> Result<(), DynError> {
+            Ok(())
+        }
+    }
 
     // Dumb stub: bumps a shared counter and replays a canned result. The counter
     // is shared so the test can inspect it after the engine moves into the job.
@@ -177,7 +220,14 @@ mod tests {
         let provider = SdkMeterProvider::builder()
             .with_periodic_exporter(exporter.clone())
             .build();
-        let job = TrustRecomputeJob::with_meter(params(), engine, None, 10, provider.meter("test"));
+        let job = TrustRecomputeJob::with_meter(
+            params(),
+            engine,
+            Box::new(NoOpProjection),
+            None,
+            10,
+            provider.meter("test"),
+        );
         (job, provider, exporter)
     }
 
@@ -212,7 +262,13 @@ mod tests {
     async fn run_without_report_computes_and_skips_report() {
         let calls = Arc::new(AtomicU32::new(0));
         let engine = MockEngine::new(&calls, false);
-        let job = TrustRecomputeJob::new(params(), Box::new(engine), None, 10);
+        let job = TrustRecomputeJob::new(
+            params(),
+            Box::new(engine),
+            Box::new(NoOpProjection),
+            None,
+            10,
+        );
 
         job.run().await.expect("run should succeed");
 
@@ -228,6 +284,7 @@ mod tests {
         let job = TrustRecomputeJob::new(
             params(),
             Box::new(engine),
+            Box::new(NoOpProjection),
             Some(PathBuf::from("/does-not-matter")),
             10,
         );


### PR DESCRIPTION
Adds one field to `UserView` for the badge in Aldert's design:

```json
"social_graph_status": "established"
```

Can be `null`, `new`, `networked` or `established`.

It is optional. `null` means we have no ranking and the app should hide the badge.

Nexus decides the category, not the client. The raw score is a share that sums to 1, so from
outside you cannot tell if 0.00003 is good or bad without the whole distribution. So we send the
category and never the number.

The label is refreshed at the end of the trustrank job, so no new cron.

Not here: picking the seed accounts. Once that is set and the job runs, badges show up on their
own, no frontend change needed.

One thing to decide: the `established` cut is the top 5%, I made that number up. Maybe we look at
the real distribution after a couple of runs on staging and change it? It is one constant, cheap to
move.
