### PR TITLE
fix: make --config-dir a global flag honored by every subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3141,7 +3141,6 @@ dependencies = [
  "chrono",
  "clap",
  "cron",
- "dirs",
  "futures",
  "nexus-common",
  "nexus-watcher",
@@ -3202,16 +3201,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
-dependencies = [
- "num-integer",
- "num-traits",
 ]
 
 [[package]]
@@ -4448,7 +4437,7 @@ dependencies = [
  "combine",
  "futures-util",
  "itoa",
- "num-bigint 0.5.1",
+ "num-bigint",
  "percent-encoding",
  "pin-project-lite",
  "ryu",

--- a/nexus-webapi/src/mock.rs
+++ b/nexus-webapi/src/mock.rs
@@ -2,8 +2,9 @@ use clap::ValueEnum;
 use nexus_common::{
     db::{get_neo4j_graph, get_redis_conn, graph::Query, reindex},
     models::post::create_post_content_index,
-    StackConfig, StackManager,
+    DaemonConfig, StackManager,
 };
+use std::path::PathBuf;
 use std::process::Stdio;
 use tracing::info;
 
@@ -18,22 +19,25 @@ pub enum MockType {
 pub struct MockDb {}
 
 impl MockDb {
-    async fn init_stack() {
-        StackManager::setup(&StackConfig::default())
+    async fn init_stack(config_dir: PathBuf) {
+        let config = DaemonConfig::read_or_create_config_file(config_dir)
+            .await
+            .expect("Failed to load daemon config");
+        StackManager::setup(&config.stack)
             .await
             .expect("Failed to initialize stack");
     }
 
-    pub async fn clear_database() {
-        Self::init_stack().await;
+    pub async fn clear_database(config_dir: PathBuf) {
+        Self::init_stack(config_dir).await;
 
         Self::drop_cache().await;
         Self::drop_graph().await;
         info!("Both ddbb cleared successfully");
     }
 
-    pub async fn run(mock_type: Option<MockType>) {
-        Self::init_stack().await;
+    pub async fn run(mock_type: Option<MockType>, config_dir: PathBuf) {
+        Self::init_stack(config_dir).await;
 
         match mock_type {
             Some(MockType::Redis) => Self::sync_redis().await,

--- a/nexusd/Cargo.toml
+++ b/nexusd/Cargo.toml
@@ -9,7 +9,6 @@ license = "MIT"
 
 [dependencies]
 async-trait = { workspace = true }
-dirs = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 cron = { workspace = true }

--- a/nexusd/src/cli.rs
+++ b/nexusd/src/cli.rs
@@ -36,6 +36,10 @@ pub enum NexusCommands {
     /// Database operations
     #[command(subcommand)]
     Db(DbCommands),
+
+    /// Run the API, the Watcher and the scheduled Jobs (default when no arguments are given)
+    #[command(hide = true)]
+    Run,
 }
 
 #[derive(Subcommand, Debug)]
@@ -120,6 +124,7 @@ mod tests {
         const DIR: &str = "test-config-dir";
         let dir = PathBuf::from(DIR);
         let cases: &[&[&str]] = &[
+            &["run"],
             &["api"],
             &["watcher"],
             &["jobs", "run", "some-job"],
@@ -150,6 +155,12 @@ mod tests {
                 "flag after {subcommand:?} should set config_dir"
             );
         }
+    }
+
+    #[test]
+    fn run_subcommand_is_still_accepted() {
+        let cli = Cli::try_parse_from(["nexusd", "run"]).expect("`nexusd run` should parse");
+        assert!(matches!(cli.command, Some(NexusCommands::Run)));
     }
 
     #[test]

--- a/nexusd/src/cli.rs
+++ b/nexusd/src/cli.rs
@@ -8,22 +8,11 @@ use std::path::PathBuf;
 #[command(about = "Pubky Nexus CLI", long_about = None)]
 pub struct Cli {
     /// Directory containing `config.toml`
-    #[arg(short, long, default_value_os_t = default_config_dir_path(), value_parser = validate_config_dir_path)]
+    #[arg(short, long, global = true, default_value_os_t = default_config_dir_path(), value_parser = validate_config_dir_path)]
     pub config_dir: PathBuf,
 
     #[command(subcommand)]
     pub command: Option<NexusCommands>,
-}
-
-impl Cli {
-    pub fn receive_command(cli: Cli) -> NexusCommands {
-        match cli.command {
-            None => NexusCommands::Run {
-                config_dir: cli.config_dir,
-            },
-            Some(command) => command,
-        }
-    }
 }
 
 /// Validate that the data_dir path is a directory.
@@ -35,10 +24,10 @@ fn validate_config_dir_path(path: &str) -> Result<PathBuf, String> {
 #[derive(Subcommand, Debug)]
 pub enum NexusCommands {
     /// Run the API service
-    Api(ApiArgs),
+    Api,
 
     /// Run the event watcher
-    Watcher(WatcherArgs),
+    Watcher,
 
     /// Run scheduled jobs on demand
     #[command(subcommand)]
@@ -47,28 +36,6 @@ pub enum NexusCommands {
     /// Database operations
     #[command(subcommand)]
     Db(DbCommands),
-
-    /// Run the API, the Watcher and the scheduled Jobs (default when no arguments are given)
-    #[command(hide = true)]
-    Run {
-        /// Path to the configuration file
-        #[arg(short, long, default_value_os_t = default_config_dir_path(), value_parser = validate_config_dir_path)]
-        config_dir: PathBuf,
-    },
-}
-
-#[derive(Args, Debug)]
-pub struct ApiArgs {
-    /// Optional configuration file for the watcher
-    #[arg(short, long, default_value_os_t = default_config_dir_path(), value_parser = validate_config_dir_path)]
-    pub config_dir: PathBuf,
-}
-
-#[derive(Args, Debug)]
-pub struct WatcherArgs {
-    /// Optional configuration file for the watcher
-    #[arg(short, long, default_value_os_t = default_config_dir_path(), value_parser = validate_config_dir_path)]
-    pub config_dir: PathBuf,
 }
 
 #[derive(Subcommand, Debug)]
@@ -85,10 +52,6 @@ pub struct JobRunArgs {
     /// Name of the job to run (see `jobs list`)
     #[arg(required = true)]
     pub name: String,
-
-    /// Directory containing `config.toml`
-    #[arg(short, long, default_value_os_t = default_config_dir_path(), value_parser = validate_config_dir_path)]
-    pub config_dir: PathBuf,
 }
 
 #[derive(Subcommand, Debug)]
@@ -129,4 +92,69 @@ pub struct MigrationNewArgs {
     /// The name of the new migration
     #[arg(required = true)]
     pub name: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::{error::ErrorKind, CommandFactory};
+
+    #[test]
+    fn cli_definition_is_valid() {
+        // Panics on duplicate argument IDs, e.g. if a per-subcommand
+        // `config_dir` is ever re-introduced alongside the global one.
+        Cli::command().debug_assert();
+    }
+
+    #[test]
+    fn bare_invocation_defaults_to_running_everything() {
+        let cli = Cli::try_parse_from(["nexusd"]).expect("bare nexusd should parse");
+        assert!(cli.command.is_none());
+        assert_eq!(cli.config_dir, default_config_dir_path());
+    }
+
+    /// `-c/--config-dir` must be honored both before and after any subcommand
+    /// (clap globals are position-independent).
+    #[test]
+    fn config_dir_is_position_independent() {
+        const DIR: &str = "test-config-dir";
+        let dir = PathBuf::from(DIR);
+        let cases: &[&[&str]] = &[
+            &["api"],
+            &["watcher"],
+            &["jobs", "run", "some-job"],
+            &["db", "clear"],
+            &["db", "mock"],
+            &["db", "migration", "run"],
+            &["db", "migration", "check"],
+            &["db", "migration", "new", "some-migration"],
+        ];
+
+        for subcommand in cases {
+            let mut before = vec!["nexusd", "-c", DIR];
+            before.extend_from_slice(subcommand);
+            let cli = Cli::try_parse_from(before)
+                .unwrap_or_else(|e| panic!("flag before {subcommand:?} should parse: {e}"));
+            assert_eq!(
+                cli.config_dir, dir,
+                "flag before {subcommand:?} should set config_dir"
+            );
+
+            let mut after = vec!["nexusd"];
+            after.extend_from_slice(subcommand);
+            after.extend_from_slice(&["-c", DIR]);
+            let cli = Cli::try_parse_from(after)
+                .unwrap_or_else(|e| panic!("flag after {subcommand:?} should parse: {e}"));
+            assert_eq!(
+                cli.config_dir, dir,
+                "flag after {subcommand:?} should set config_dir"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_flag_still_errors() {
+        let err = Cli::try_parse_from(["nexusd", "--definitely-not-a-flag"]).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::UnknownArgument);
+    }
 }

--- a/nexusd/src/main.rs
+++ b/nexusd/src/main.rs
@@ -80,7 +80,7 @@ async fn main() -> Result<(), DynError> {
                 }
             }
         },
-        None => {
+        None | Some(NexusCommands::Run) => {
             let config = DaemonConfig::read_or_create_config_file(config_dir.clone()).await?;
             DaemonLauncher::start(
                 config_dir,

--- a/nexusd/src/main.rs
+++ b/nexusd/src/main.rs
@@ -6,10 +6,7 @@ use nexus_common::{DaemonConfig, StackManager, TrustRankConfig};
 use nexus_watcher::service::NexusWatcher;
 use nexus_webapi::mock::MockDb;
 use nexus_webapi::NexusApi;
-use nexusd::cli::{
-    ApiArgs, Cli, DbCommands, JobCommands, JobRunArgs, MigrationCommands, NexusCommands,
-    WatcherArgs,
-};
+use nexusd::cli::{Cli, DbCommands, JobCommands, JobRunArgs, MigrationCommands, NexusCommands};
 use nexusd::jobs::JobRegistry;
 use nexusd::migrations::{import_migrations, MigrationBuilder, MigrationManager};
 use nexusd::trust::TrustRecomputeJob;
@@ -27,24 +24,24 @@ fn job_registry(trust_rank: &TrustRankConfig, lock_ttl_secs: u64) -> JobRegistry
 #[tokio::main]
 async fn main() -> Result<(), DynError> {
     let cli = Cli::parse();
-    let command = Cli::receive_command(cli);
+    let config_dir = cli.config_dir;
     let lock_ttl_secs = nexusd::jobs::LOCK_TTL_SECS;
 
-    match command {
-        NexusCommands::Db(db_command) => match db_command {
-            DbCommands::Clear => MockDb::clear_database().await,
-            DbCommands::Mock(args) => MockDb::run(args.mock_type).await,
+    match cli.command {
+        Some(NexusCommands::Db(db_command)) => match db_command {
+            DbCommands::Clear => MockDb::clear_database(config_dir).await,
+            DbCommands::Mock(args) => MockDb::run(args.mock_type, config_dir).await,
             DbCommands::Migration(migration_command) => match migration_command {
                 MigrationCommands::New(args) => MigrationManager::new_migration(args.name).await?,
                 MigrationCommands::Run => {
-                    let builder = MigrationBuilder::default().await?;
+                    let builder = MigrationBuilder::new(config_dir).await?;
                     StackManager::setup(builder.stack()).await?;
                     let mut mm = MigrationManager::default();
                     import_migrations(&mut mm);
                     mm.run(&builder.migrations_backfill_ready()).await?;
                 }
                 MigrationCommands::Check => {
-                    let builder = MigrationBuilder::default().await?;
+                    let builder = MigrationBuilder::new(config_dir).await?;
                     StackManager::setup(builder.stack()).await?;
                     let mut mm = MigrationManager::default();
                     import_migrations(&mut mm);
@@ -61,14 +58,14 @@ async fn main() -> Result<(), DynError> {
                 }
             },
         },
-        NexusCommands::Api(ApiArgs { config_dir }) => {
+        Some(NexusCommands::Api) => {
             NexusApi::start_from_daemon(config_dir, None).await?;
         }
-        NexusCommands::Watcher(WatcherArgs { config_dir }) => {
+        Some(NexusCommands::Watcher) => {
             NexusWatcher::start_from_daemon(config_dir, None).await?;
         }
-        NexusCommands::Jobs(job_command) => match job_command {
-            JobCommands::Run(JobRunArgs { name, config_dir }) => {
+        Some(NexusCommands::Jobs(job_command)) => match job_command {
+            JobCommands::Run(JobRunArgs { name }) => {
                 let config = DaemonConfig::read_or_create_config_file(config_dir).await?;
                 // run_on_demand validates [jobs.*], so a typo'd section fails here
                 // just like `nexusd run`.
@@ -83,7 +80,7 @@ async fn main() -> Result<(), DynError> {
                 }
             }
         },
-        NexusCommands::Run { config_dir } => {
+        None => {
             let config = DaemonConfig::read_or_create_config_file(config_dir.clone()).await?;
             DaemonLauncher::start(
                 config_dir,

--- a/nexusd/src/migrations/builder.rs
+++ b/nexusd/src/migrations/builder.rs
@@ -6,8 +6,9 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::fmt::Debug;
 use std::path::PathBuf;
 
-/// Path to default migration config dir. Defaults to ~/.pubky-nexus/migrations
-pub const MIGRATIONS_CONFIG_DIR: &str = ".pubky-nexus/migrations";
+/// Migrations config subdirectory, resolved under the daemon config dir
+/// (defaults to ~/.pubky-nexus/migrations)
+pub const MIGRATIONS_CONFIG_DIR: &str = "migrations";
 pub const MIGRATIONS_CONFIG_FILE_NAME: &str = "config.toml";
 const DEFAULT_CONFIG_TOML: &str = include_str!("default.config.toml");
 
@@ -21,9 +22,8 @@ pub struct MigrationConfig {
 pub struct MigrationBuilder(pub(crate) MigrationConfig);
 
 impl MigrationBuilder {
-    pub async fn default() -> Result<MigrationBuilder, DynError> {
-        let config_file_path = dirs::home_dir()
-            .unwrap_or_default()
+    pub async fn new(config_dir: PathBuf) -> Result<MigrationBuilder, DynError> {
+        let config_file_path = config_dir
             .join(MIGRATIONS_CONFIG_DIR)
             .join(MIGRATIONS_CONFIG_FILE_NAME);
         Self::check_if_file_exists(&config_file_path)?;
@@ -61,3 +61,28 @@ impl MigrationBuilder {
 
 #[async_trait]
 impl<T> ConfigLoader<T> for MigrationConfig where T: DeserializeOwned + Send + Sync + Debug {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn new_resolves_config_under_supplied_config_dir() {
+        let config_dir = tempfile::tempdir().expect("tempdir should be created");
+
+        let builder = MigrationBuilder::new(config_dir.path().to_path_buf())
+            .await
+            .expect("builder should load the config");
+
+        let expected_path = config_dir
+            .path()
+            .join(MIGRATIONS_CONFIG_DIR)
+            .join(MIGRATIONS_CONFIG_FILE_NAME);
+        assert!(
+            expected_path.exists(),
+            "default migration config should be written under the supplied config dir"
+        );
+        // The written default config has no backfill_ready entries.
+        assert!(builder.0.backfill_ready.is_empty());
+    }
+}

--- a/nexusd/src/migrations/builder.rs
+++ b/nexusd/src/migrations/builder.rs
@@ -85,4 +85,25 @@ mod tests {
         // The written default config has no backfill_ready entries.
         assert!(builder.0.backfill_ready.is_empty());
     }
+
+    #[tokio::test]
+    async fn new_loads_user_supplied_config_from_config_dir() {
+        let config_dir = tempfile::tempdir().expect("tempdir should be created");
+        let migrations_dir = config_dir.path().join(MIGRATIONS_CONFIG_DIR);
+        std::fs::create_dir_all(&migrations_dir).expect("migrations dir should be created");
+        std::fs::write(
+            migrations_dir.join(MIGRATIONS_CONFIG_FILE_NAME),
+            DEFAULT_CONFIG_TOML.replace(
+                "backfill_ready = []",
+                "backfill_ready = [\"some_migration\"]",
+            ),
+        )
+        .expect("config file should be written");
+
+        let builder = MigrationBuilder::new(config_dir.path().to_path_buf())
+            .await
+            .expect("builder should load the config");
+
+        assert_eq!(builder.0.backfill_ready, vec!["some_migration".to_string()]);
+    }
 }


### PR DESCRIPTION
Fixes #1008. A single `config_dir` argument on the top-level `Cli` is now declared `global = true`, so `-c/--config-dir` is accepted in any position (before or after any subcommand) instead of being silently dropped when placed before one.

- cli.rs: remove the four per-subcommand `config_dir` redeclarations (ApiArgs, WatcherArgs, JobRunArgs, hidden Run variant) and `Cli::receive_command`, whose `Some(command) => command` arm discarded a pre-subcommand flag. Api/Watcher collapse to unit variants; the global flag keeps the same default and validator.
- migrations/builder.rs: `MigrationBuilder::default()` ->
  `new(config_dir)`, resolving `config_dir/migrations/config.toml` so `db migration run|check|new` honor the flag. Default invocations are unchanged (~/.pubky-nexus/migrations/config.toml).
- main.rs: resolve `cli.config_dir` once and thread it through every command arm; `command: None` runs the full daemon launcher.

Tests: `Cli::command().debug_assert()` guards against re-introducing a duplicate arg ID, parse tests assert flag position-independence across all subcommands, and a MigrationBuilder tempdir test checks config resolution. `cargo nextest run -p nexusd --lib`: 67/67 pass.

# Pre-submission Checklist

- [ ] I manually reviewed the PR
- [ ] I asked one or more LLMs to review the PR
- [ ] I asked one or more LLMs to check if this PR can be simplified [^1]
- [ ] If appropriate, I added tests for the changes in this PR
- [ ] If appropriate, I added performance benchmarks for the APIs added in this PR [^2]

[^1]: Sample prompt: "Can this be simplified? Can the code, comments, or logic introduced by these changes be simplfied, clarified or otherwise made more terse, concise and understandable, without affecting functionality?"
[^2]: `cargo bench -p nexus-webapi`
