### PR TITLE
chore: drop stale pubky-core name from watcher crate description

### DIFF
--- a/nexus-watcher/Cargo.toml
+++ b/nexus-watcher/Cargo.toml
@@ -2,7 +2,7 @@
 name = "nexus-watcher"
 version = "0.4.1"
 edition = "2021"
-description = "Nexus Watcher constructs a social graph out of all of the events on pubky-core homeservers"
+description = "Nexus Watcher constructs a social graph out of all of the events on Pubky homeservers"
 homepage = "https://github.com/pubky/pubky-nexus"
 repository = "https://github.com/pubky/pubky-nexus"
 license = "MIT"


### PR DESCRIPTION
Per @SHAcollision: sweep stale `pubky-core` references now that `pubky/pubky-core` is renamed to `pubky/pubky-homeserver`. First fix was pubky-docker #38 by Gabriel.

One-line crate description change in nexus-watcher/Cargo.toml.