### PR TITLE
chore: add 7-day Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       interval: "weekly"
       time: "08:00"
       day: "sunday"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "deps"
     rebase-strategy: "auto"


### PR DESCRIPTION
Set  on every Dependabot update entry that did not have one, per the org-wide convention from the Slack thread per @andrei-21: do not adopt brand-new releases until they have been out for at least 7 days.

Draft PR, one change per repo. Already covered: , .