### PR TITLE
feat(common): centralize RediSearch schema bootstrap in setup_cache

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -12,3 +12,16 @@ influencers-sorted-set = { max-threads = 1 }
 [[profile.default.overrides]]
 filter = 'test(=stream::user::influencers::test_global_influencers) | test(=stream::user::influencers::test_global_influencers_skip_limit) | test(=stream::user::influencers::test_global_influencers_alltime_cache_recovery)'
 test-group = 'influencers-sorted-set'
+
+# nexusd/tests/cache_setup/main.rs calls clear_redis(), which issues FLUSHDB
+# against the shared Redis instance. It must not overlap with any other test in
+# the run, including nexus-webapi's search suite under --workspace, or that
+# test sees its keys and FT index vanish mid-flight. A [test-groups] entry
+# would not help: group limits only apply between members of the same group,
+# so a one-test group protects nothing. threads-required = 'num-test-threads'
+# is what gives global exclusivity: nextest waits for every running test to
+# finish, runs this binary alone, then resumes the rest.
+
+[[profile.default.overrides]]
+filter = 'package(nexusd) and binary(cache_setup)'
+threads-required = 'num-test-threads'

--- a/nexus-common/src/db/connectors/redis.rs
+++ b/nexus-common/src/db/connectors/redis.rs
@@ -1,4 +1,5 @@
-use crate::db::kv::{setup_cache, RedisError, RedisResult};
+use crate::db::kv::setup::setup_cache_on;
+use crate::db::kv::{RedisError, RedisResult};
 use crate::types::DynError;
 use deadpool_redis::{Config, Connection, Pool, Runtime};
 use std::fmt;
@@ -18,13 +19,22 @@ impl RedisConnector {
 
         redis_connector.ping(redis_uri).await?;
 
+        // Apply the search schema on this pool before registering the connector,
+        // so a failed FT.CREATE leaves the global slot empty and a later init can
+        // still succeed with a different URI.
+        {
+            let mut conn = redis_connector
+                .pool()
+                .get()
+                .await
+                .map_err(|e| RedisError::ConnectionPoolError(Box::new(e)))?;
+            setup_cache_on(&mut conn).await?;
+        }
+
         match REDIS_CONNECTOR.set(redis_connector) {
             Err(e) => debug!("RedisConnector was already set: {:?}", e),
             Ok(()) => info!("RedisConnector successfully set up on {}", redis_uri),
         }
-
-        // Set Redis search indexes
-        setup_cache().await?;
         Ok(())
     }
 

--- a/nexus-common/src/db/connectors/redis.rs
+++ b/nexus-common/src/db/connectors/redis.rs
@@ -1,4 +1,4 @@
-use crate::db::kv::{RedisError, RedisResult};
+use crate::db::kv::{setup_cache, RedisError, RedisResult};
 use crate::types::DynError;
 use deadpool_redis::{Config, Connection, Pool, Runtime};
 use std::fmt;
@@ -22,6 +22,9 @@ impl RedisConnector {
             Err(e) => debug!("RedisConnector was already set: {:?}", e),
             Ok(()) => info!("RedisConnector successfully set up on {}", redis_uri),
         }
+
+        // Set Redis search indexes
+        setup_cache().await?;
         Ok(())
     }
 

--- a/nexus-common/src/db/kv/flush.rs
+++ b/nexus-common/src/db/kv/flush.rs
@@ -2,9 +2,12 @@ use crate::db::get_redis_conn;
 use crate::db::kv::{setup_cache, RedisResult};
 
 pub async fn clear_redis() -> RedisResult<()> {
-    let mut redis_conn = get_redis_conn().await?;
-    let _: () = redis::cmd("FLUSHDB").query_async(&mut redis_conn).await?;
+    {
+        let mut redis_conn = get_redis_conn().await?;
+        let _: () = redis::cmd("FLUSHDB").query_async(&mut redis_conn).await?;
+    }
     // FLUSHDB drops the RediSearch index along with the keys, so re-apply the schema here.
+    // The FLUSHDB connection is returned to the pool first; setup_cache checks out its own.
     setup_cache().await?;
     Ok(())
 }

--- a/nexus-common/src/db/kv/flush.rs
+++ b/nexus-common/src/db/kv/flush.rs
@@ -1,8 +1,10 @@
 use crate::db::get_redis_conn;
-use crate::db::kv::RedisResult;
+use crate::db::kv::{setup_cache, RedisResult};
 
 pub async fn clear_redis() -> RedisResult<()> {
     let mut redis_conn = get_redis_conn().await?;
     let _: () = redis::cmd("FLUSHDB").query_async(&mut redis_conn).await?;
+    // FLUSHDB drops the RediSearch index along with the keys, so re-apply the schema here.
+    setup_cache().await?;
     Ok(())
 }

--- a/nexus-common/src/db/kv/index/search.rs
+++ b/nexus-common/src/db/kv/index/search.rs
@@ -1,6 +1,7 @@
 use crate::db::config::FT_SEARCH_TIMEOUT_MS;
 use crate::db::get_redis_conn;
 use crate::db::kv::error::{RedisError, RedisResult};
+use deadpool_redis::Connection;
 use std::sync::OnceLock;
 use tracing::warn;
 
@@ -18,9 +19,13 @@ fn ft_search_timeout_ms() -> usize {
 /// Creates the post content index: $.content TEXT + $.author TAG CASESENSITIVE + $.kind TAG CASESENSITIVE.
 /// NOOFFSETS/NOHL kept; NOFIELDS dropped to allow field-targeted queries.
 /// Idempotent: short-circuits on "already exists".
-pub(crate) async fn ft_create_post_content_index(prefix: &str) -> RedisResult<()> {
-    let mut conn = get_redis_conn().await?;
-
+///
+/// Takes the connection explicitly so the connector can apply the schema on
+/// its own pool before registering itself globally.
+pub(crate) async fn ft_create_post_content_index(
+    conn: &mut Connection,
+    prefix: &str,
+) -> RedisResult<()> {
     // Adding or changing a field here requires a matching index migration.
     // PostContentIndexAuthorSetup1780531200 drops and recreates from a frozen
     // v2 copy, so a fresh environment would boot on this schema and then be
@@ -49,7 +54,7 @@ pub(crate) async fn ft_create_post_content_index(prefix: &str) -> RedisResult<()
         .arg("kind")
         .arg("TAG")
         .arg("CASESENSITIVE")
-        .query_async::<()>(&mut conn)
+        .query_async::<()>(conn)
         .await;
 
     match result {

--- a/nexus-common/src/db/kv/index/search.rs
+++ b/nexus-common/src/db/kv/index/search.rs
@@ -55,29 +55,6 @@ pub(crate) async fn ft_create_post_content_index(prefix: &str) -> RedisResult<()
     }
 }
 
-/// Drops the post content index without deleting the underlying documents.
-/// Idempotent: swallows "Unknown index name" so repeated calls are safe.
-pub(crate) async fn drop_post_content_index() -> RedisResult<()> {
-    let mut conn = get_redis_conn().await?;
-
-    let result = deadpool_redis::redis::cmd("FT.DROPINDEX")
-        .arg("postContentIdx")
-        .query_async::<()>(&mut conn)
-        .await;
-
-    match result {
-        Ok(()) => Ok(()),
-        Err(e) => {
-            let msg = e.to_string().to_lowercase();
-            if msg.contains("unknown index name") || msg.contains("no such index") {
-                Ok(())
-            } else {
-                Err(RedisError::CommandFailed(e.to_string().into()))
-            }
-        }
-    }
-}
-
 /// Assembles the RediSearch query string from a content fragment, optional author
 /// filter, and optional kind filter.
 ///

--- a/nexus-common/src/db/kv/index/search.rs
+++ b/nexus-common/src/db/kv/index/search.rs
@@ -29,7 +29,7 @@ pub(crate) async fn ft_create_post_content_index(
     // Adding or changing a field here requires a matching index migration.
     // PostContentIndexAuthorSetup1780531200 drops and recreates from a frozen
     // v2 copy, so a fresh environment would boot on this schema and then be
-    // silently downgraded to v2 by `nexusd db migration run`. See issue #N.
+    // silently downgraded to v2 by `nexusd db migration run`.
     let result = deadpool_redis::redis::cmd("FT.CREATE")
         .arg("postContentIdx")
         .arg("ON")

--- a/nexus-common/src/db/kv/index/search.rs
+++ b/nexus-common/src/db/kv/index/search.rs
@@ -21,6 +21,10 @@ fn ft_search_timeout_ms() -> usize {
 pub(crate) async fn ft_create_post_content_index(prefix: &str) -> RedisResult<()> {
     let mut conn = get_redis_conn().await?;
 
+    // Adding or changing a field here requires a matching index migration.
+    // PostContentIndexAuthorSetup1780531200 drops and recreates from a frozen
+    // v2 copy, so a fresh environment would boot on this schema and then be
+    // silently downgraded to v2 by `nexusd db migration run`. See issue #N.
     let result = deadpool_redis::redis::cmd("FT.CREATE")
         .arg("postContentIdx")
         .arg("ON")

--- a/nexus-common/src/db/kv/mod.rs
+++ b/nexus-common/src/db/kv/mod.rs
@@ -3,6 +3,7 @@ mod flush;
 mod index;
 mod last_save;
 mod lock;
+mod setup;
 mod traits;
 
 pub use error::{ensure_cursor_not_backwards, RedisError, RedisResult};
@@ -13,4 +14,5 @@ pub use index::sets;
 pub use index::sorted_sets::{ScoreAction, SortOrder};
 pub use last_save::get_last_rdb_save_time;
 pub use lock::{release_lock, try_acquire_lock};
+pub use setup::setup_cache;
 pub use traits::RedisOps;

--- a/nexus-common/src/db/kv/mod.rs
+++ b/nexus-common/src/db/kv/mod.rs
@@ -3,7 +3,7 @@ mod flush;
 mod index;
 mod last_save;
 mod lock;
-mod setup;
+pub(crate) mod setup;
 mod traits;
 
 pub use error::{ensure_cursor_not_backwards, RedisError, RedisResult};

--- a/nexus-common/src/db/kv/setup.rs
+++ b/nexus-common/src/db/kv/setup.rs
@@ -1,5 +1,8 @@
-use crate::db::kv::RedisResult;
-use crate::models::post::create_post_content_index;
+use crate::db::get_redis_conn;
+use crate::db::kv::index::search::ft_create_post_content_index;
+use crate::db::kv::{RedisOps, RedisResult};
+use crate::models::post::PostDetails;
+use deadpool_redis::Connection;
 use tracing::info;
 
 /// Ensure the Redis cache has the required RediSearch indexes.
@@ -16,16 +19,26 @@ use tracing::info;
 /// path that flushes Redis mid-process (e.g. the reindex bench) without a search
 /// index. Every index created here is idempotent, so repeated calls are cheap.
 ///
-/// Safe to call during connector init: the key prefix is derived from the type
-/// name and needs no live connection beyond the one used to issue `FT.CREATE`.
-///
 /// Nexus requires a Redis that ships the query engine (`docker-compose` pins
 /// `redis:8.0.6-alpine`). A failed `FT.CREATE` is fatal at connector init, so a
 /// Redis without it stops every binary from starting instead of degrading
 /// search. This is deliberate: a missing index is a misconfigured environment,
 /// not a runtime condition to route around.
+///
+/// Uses the global connector. [`RedisConnector::init`](crate::db::RedisConnector::init)
+/// calls [`setup_cache_on`] with a connection from its own pool instead, so the
+/// schema is applied before the connector is registered and a failed init
+/// leaves nothing behind.
 pub async fn setup_cache() -> RedisResult<()> {
-    create_post_content_index().await?;
+    let mut conn = get_redis_conn().await?;
+    setup_cache_on(&mut conn).await
+}
+
+/// Applies the search schema over `conn`. The key prefix is derived from the
+/// type name, so this needs no live connection beyond the one issuing `FT.CREATE`.
+pub(crate) async fn setup_cache_on(conn: &mut Connection) -> RedisResult<()> {
+    let prefix = format!("{}:", PostDetails::prefix().await);
+    ft_create_post_content_index(conn, &prefix).await?;
 
     info!("Redis search indexes have been applied successfully");
 

--- a/nexus-common/src/db/kv/setup.rs
+++ b/nexus-common/src/db/kv/setup.rs
@@ -18,6 +18,12 @@ use tracing::info;
 ///
 /// Safe to call during connector init: the key prefix is derived from the type
 /// name and needs no live connection beyond the one used to issue `FT.CREATE`.
+///
+/// Nexus requires a Redis that ships the query engine (`docker-compose` pins
+/// `redis:8.0.6-alpine`). A failed `FT.CREATE` is fatal at connector init, so a
+/// Redis without it stops every binary from starting instead of degrading
+/// search. This is deliberate: a missing index is a misconfigured environment,
+/// not a runtime condition to route around.
 pub async fn setup_cache() -> RedisResult<()> {
     create_post_content_index().await?;
 

--- a/nexus-common/src/db/kv/setup.rs
+++ b/nexus-common/src/db/kv/setup.rs
@@ -1,0 +1,27 @@
+use crate::db::kv::RedisResult;
+use crate::models::post::create_post_content_index;
+use tracing::info;
+
+/// Ensure the Redis cache has the required RediSearch indexes.
+///
+/// This is the Redis counterpart of [`crate::db::setup::setup_graph`]: the single
+/// declaration of the search schema that must exist in every environment. Future
+/// RediSearch indexes get added here.
+///
+/// Unlike `setup_graph`, this is deliberately **not** wrapped in a `OnceCell`.
+/// Neo4j's `MATCH (n) DETACH DELETE n` preserves constraints and indexes, so the
+/// graph DDL only ever needs to run once per process. `FLUSHDB` destroys the FT
+/// index along with the keys, so `setup_cache` must be re-runnable after every
+/// flush (see [`crate::db::kv::clear_redis`]). A `OnceCell` here would leave any
+/// path that flushes Redis mid-process (e.g. the reindex bench) without a search
+/// index. Every index created here is idempotent, so repeated calls are cheap.
+///
+/// Safe to call during connector init: the key prefix is derived from the type
+/// name and needs no live connection beyond the one used to issue `FT.CREATE`.
+pub async fn setup_cache() -> RedisResult<()> {
+    create_post_content_index().await?;
+
+    info!("Redis search indexes have been applied successfully");
+
+    Ok(())
+}

--- a/nexus-common/src/db/mod.rs
+++ b/nexus-common/src/db/mod.rs
@@ -14,4 +14,4 @@ pub use graph::exec::*;
 pub use graph::queries;
 pub use graph::setup;
 pub use graph::GraphOps;
-pub use kv::{release_lock, try_acquire_lock, RedisError, RedisOps, RedisResult};
+pub use kv::{release_lock, setup_cache, try_acquire_lock, RedisError, RedisOps, RedisResult};

--- a/nexus-common/src/models/post/mod.rs
+++ b/nexus-common/src/models/post/mod.rs
@@ -11,7 +11,7 @@ pub use bookmark::Bookmark;
 pub use counts::PostCounts;
 pub use details::PostDetails;
 pub use relationships::PostRelationships;
-pub use search::{create_post_content_index, drop_post_content_index, PostsByContentSearch};
+pub use search::{create_post_content_index, PostsByContentSearch};
 pub use stream::{
     KindFilter, PostKeyStream, PostStream, StreamSource, POST_PER_USER_KEY_PARTS,
     POST_REPLIES_PER_POST_KEY_PARTS, POST_REPLIES_PER_USER_KEY_PARTS, POST_TIMELINE_KEY_PARTS,

--- a/nexus-common/src/models/post/mod.rs
+++ b/nexus-common/src/models/post/mod.rs
@@ -11,7 +11,7 @@ pub use bookmark::Bookmark;
 pub use counts::PostCounts;
 pub use details::PostDetails;
 pub use relationships::PostRelationships;
-pub use search::{create_post_content_index, PostsByContentSearch};
+pub use search::PostsByContentSearch;
 pub use stream::{
     KindFilter, PostKeyStream, PostStream, StreamSource, POST_PER_USER_KEY_PARTS,
     POST_REPLIES_PER_POST_KEY_PARTS, POST_REPLIES_PER_USER_KEY_PARTS, POST_TIMELINE_KEY_PARTS,

--- a/nexus-common/src/models/post/search.rs
+++ b/nexus-common/src/models/post/search.rs
@@ -1,7 +1,7 @@
 use crate::db::graph::Query;
 use crate::db::kv::{search, RedisResult, ScoreAction, SortOrder};
 use crate::db::queries::get::{global_tags_by_post, global_tags_by_post_engagement};
-use crate::db::{fetch_all_rows_from_graph, get_redis_conn, RedisOps};
+use crate::db::{fetch_all_rows_from_graph, RedisOps};
 use crate::models::error::ModelResult;
 use crate::models::post::PostDetails;
 use crate::models::tag::post::TagPost;
@@ -145,16 +145,6 @@ impl PostsByTagSearch {
         }
         Ok(())
     }
-}
-
-/// Creates the post content full-text index: $.content TEXT + $.author TAG CASESENSITIVE + $.kind TAG CASESENSITIVE.
-/// Includes NOOFFSETS/NOHL; NOFIELDS dropped to allow field-targeted queries.
-/// Idempotent: no-ops if the index already exists.
-pub async fn create_post_content_index() -> RedisResult<()> {
-    let prefix = format!("{}:", PostDetails::prefix().await);
-    let mut conn = get_redis_conn().await?;
-    search::ft_create_post_content_index(&mut conn, &prefix).await?;
-    Ok(())
 }
 
 // Results come from FT.SEARCH, not key-value lookups — no RedisOps impl.

--- a/nexus-common/src/models/post/search.rs
+++ b/nexus-common/src/models/post/search.rs
@@ -1,7 +1,7 @@
 use crate::db::graph::Query;
 use crate::db::kv::{search, RedisResult, ScoreAction, SortOrder};
 use crate::db::queries::get::{global_tags_by_post, global_tags_by_post_engagement};
-use crate::db::{fetch_all_rows_from_graph, RedisOps};
+use crate::db::{fetch_all_rows_from_graph, get_redis_conn, RedisOps};
 use crate::models::error::ModelResult;
 use crate::models::post::PostDetails;
 use crate::models::tag::post::TagPost;
@@ -152,7 +152,8 @@ impl PostsByTagSearch {
 /// Idempotent: no-ops if the index already exists.
 pub async fn create_post_content_index() -> RedisResult<()> {
     let prefix = format!("{}:", PostDetails::prefix().await);
-    search::ft_create_post_content_index(&prefix).await?;
+    let mut conn = get_redis_conn().await?;
+    search::ft_create_post_content_index(&mut conn, &prefix).await?;
     Ok(())
 }
 

--- a/nexus-common/src/models/post/search.rs
+++ b/nexus-common/src/models/post/search.rs
@@ -8,7 +8,6 @@ use crate::models::tag::post::TagPost;
 use crate::models::tag::traits::TaggersCollection;
 use crate::types::{Pagination, StreamSorting};
 use serde::{Deserialize, Serialize};
-use tracing::info;
 use utoipa::ToSchema;
 
 pub const TAG_GLOBAL_POST_TIMELINE: [&str; 4] = ["Tags", "Global", "Post", "Timeline"];
@@ -148,15 +147,12 @@ impl PostsByTagSearch {
     }
 }
 
-const POST_CONTENT_INDEX: &str = "postContentIdx";
-
 /// Creates the post content full-text index: $.content TEXT + $.author TAG CASESENSITIVE + $.kind TAG CASESENSITIVE.
 /// Includes NOOFFSETS/NOHL; NOFIELDS dropped to allow field-targeted queries.
 /// Idempotent: no-ops if the index already exists.
 pub async fn create_post_content_index() -> RedisResult<()> {
     let prefix = format!("{}:", PostDetails::prefix().await);
     search::ft_create_post_content_index(&prefix).await?;
-    info!("RediSearch index '{POST_CONTENT_INDEX}' created or already exists");
     Ok(())
 }
 

--- a/nexus-common/src/models/post/search.rs
+++ b/nexus-common/src/models/post/search.rs
@@ -160,14 +160,6 @@ pub async fn create_post_content_index() -> RedisResult<()> {
     Ok(())
 }
 
-/// Drops the post content index without deleting underlying JSON documents.
-/// Idempotent: swallows "Unknown index name" errors.
-pub async fn drop_post_content_index() -> RedisResult<()> {
-    search::drop_post_content_index().await?;
-    info!("RediSearch index '{POST_CONTENT_INDEX}' dropped or already absent");
-    Ok(())
-}
-
 // Results come from FT.SEARCH, not key-value lookups — no RedisOps impl.
 #[derive(Serialize, Deserialize, ToSchema, Default)]
 pub struct PostsByContentSearch {

--- a/nexus-webapi/benches/setup.rs
+++ b/nexus-webapi/benches/setup.rs
@@ -12,7 +12,9 @@ pub fn run_setup() {
                 log_level: Level::Error,
                 ..Default::default()
             };
-            let _ = StackManager::setup(&config).await;
+            StackManager::setup(&config)
+                .await
+                .expect("stack setup failed; benches need the docker stack up");
         });
     });
 }

--- a/nexus-webapi/benches/setup.rs
+++ b/nexus-webapi/benches/setup.rs
@@ -1,4 +1,4 @@
-use nexus_common::{models::post::create_post_content_index, Level, StackConfig, StackManager};
+use nexus_common::{Level, StackConfig, StackManager};
 use std::sync::Once;
 use tokio::runtime::Runtime;
 
@@ -13,8 +13,6 @@ pub fn run_setup() {
                 ..Default::default()
             };
             let _ = StackManager::setup(&config).await;
-            // index is create through migration script, we call it explicitly here
-            create_post_content_index().await.unwrap();
         });
     });
 }

--- a/nexus-webapi/src/mock.rs
+++ b/nexus-webapi/src/mock.rs
@@ -1,7 +1,6 @@
 use clap::ValueEnum;
 use nexus_common::{
     db::{get_neo4j_graph, graph::Query, kv::clear_redis, reindex},
-    models::post::create_post_content_index,
     StackConfig, StackManager,
 };
 use std::process::Stdio;
@@ -90,11 +89,6 @@ impl MockDb {
 
     async fn sync_redis() {
         Self::drop_cache().await;
-        // TODO: test framework should run migrations after resetting to a fresh database;
-        // that would recreate this index automatically and remove the need for this call.
-        create_post_content_index()
-            .await
-            .expect("Failed to create post content FT index");
         info!("Starting reindexing process...");
         reindex::sync().await;
     }

--- a/nexusd/src/migrations/migrations_list/post_content_index_author_setup_1780531200.rs
+++ b/nexusd/src/migrations/migrations_list/post_content_index_author_setup_1780531200.rs
@@ -2,23 +2,96 @@
 ///
 /// # Deployment expectation: stop → migrate → start
 ///
-/// Between `drop_post_content_index` and `create_post_content_index` the
+/// Between `drop_post_content_index_v2` and `create_post_content_index_v2` the
 /// index is absent, so global content search returns empty results. After
 /// FT.CREATE the PREFIX clause triggers a background scan that indexes all
 /// existing PostDetails JSON documents against the new schema — both `author`
 /// and `kind` fields are already present in every document, so no re-persistence
 /// is needed. For zero-downtime deployments, schedule this migration during a
 /// maintenance window or accept a brief gap where search is unavailable.
+///
+/// The FT.CREATE arg list is frozen in this file on purpose: the live schema is
+/// owned by `nexus_common::db::setup_cache`, and this migration must keep
+/// producing the v2 index even after that schema evolves.
 use async_trait::async_trait;
 
 use crate::migrations::manager::Migration;
-use nexus_common::{
-    models::post::{create_post_content_index, drop_post_content_index},
-    types::DynError,
-};
+use nexus_common::{db::get_redis_conn, db::RedisOps, models::post::PostDetails, types::DynError};
 use tracing::info;
 
 pub struct PostContentIndexAuthorSetup1780531200;
+
+const POST_CONTENT_INDEX: &str = "postContentIdx";
+
+/// Creates the v2 post content index: $.content TEXT, $.author TAG CASESENSITIVE
+/// and $.kind TAG CASESENSITIVE. Includes NOOFFSETS/NOHL; NOFIELDS dropped to
+/// allow field-targeted queries.
+/// Idempotent: no-ops if the index already exists.
+async fn create_post_content_index_v2() -> Result<(), DynError> {
+    let prefix = format!("{}:", PostDetails::prefix().await);
+    let mut conn = get_redis_conn().await?;
+
+    let result = redis::cmd("FT.CREATE")
+        .arg(POST_CONTENT_INDEX)
+        .arg("ON")
+        .arg("JSON")
+        .arg("PREFIX")
+        .arg("1")
+        .arg(&prefix)
+        .arg("NOOFFSETS")
+        .arg("NOHL")
+        .arg("SCHEMA")
+        .arg("$.content")
+        .arg("AS")
+        .arg("content")
+        .arg("TEXT")
+        .arg("$.author")
+        .arg("AS")
+        .arg("author")
+        .arg("TAG")
+        .arg("CASESENSITIVE")
+        .arg("$.kind")
+        .arg("AS")
+        .arg("kind")
+        .arg("TAG")
+        .arg("CASESENSITIVE")
+        .query_async::<()>(&mut conn)
+        .await;
+
+    match result {
+        Ok(()) => Ok(()),
+        Err(e) if e.to_string().contains("already exists") => {
+            info!("RediSearch index '{POST_CONTENT_INDEX}' already exists");
+            Ok(())
+        }
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// Drops the post content index without deleting the underlying JSON documents
+/// (no `DD` flag).
+/// Idempotent: swallows "Unknown index name" so repeated calls are safe.
+async fn drop_post_content_index_v2() -> Result<(), DynError> {
+    let mut conn = get_redis_conn().await?;
+
+    let result = redis::cmd("FT.DROPINDEX")
+        .arg(POST_CONTENT_INDEX)
+        .query_async::<()>(&mut conn)
+        .await;
+
+    match result {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            let msg = e.to_string().to_lowercase();
+            if msg.contains("unknown index name") || msg.contains("no such index") {
+                info!("RediSearch index '{POST_CONTENT_INDEX}' already absent");
+                Ok(())
+            } else {
+                Err(e.into())
+            }
+        }
+    }
+}
 
 #[async_trait]
 impl Migration for PostContentIndexAuthorSetup1780531200 {
@@ -36,14 +109,14 @@ impl Migration for PostContentIndexAuthorSetup1780531200 {
 
     async fn backfill(&self) -> Result<(), DynError> {
         // Drop existing index (idempotent — no-ops if already absent).
-        drop_post_content_index().await?;
+        drop_post_content_index_v2().await?;
         info!("Dropped post content index for schema upgrade");
 
-        // Recreate with the new schema ($.content TEXT + $.author TAG + $.kind TAG).
+        // Recreate with the v2 schema ($.content TEXT + $.author TAG + $.kind TAG).
         // FT.CREATE with PREFIX triggers a background scan that indexes all existing
         // PostDetails JSON documents against the new schema — both `author` and `kind`
         // fields are already present in every document, so no re-persistence is needed.
-        create_post_content_index().await?;
+        create_post_content_index_v2().await?;
         info!("Recreated post content index with author and kind fields");
 
         Ok(())

--- a/nexusd/tests/cache_setup/main.rs
+++ b/nexusd/tests/cache_setup/main.rs
@@ -9,10 +9,10 @@
 //! bench. This test pins that behavior.
 //!
 //! It lives in its own binary and is the only nexusd test that flushes Redis.
-//! The other nexusd integration tests assert on graph state, not Redis, so no
-//! nextest serialization is needed. The cache is rebuilt with
-//! `reindex::sync()` before returning so a local run leaves the mock data
-//! in place for whatever runs next.
+//! `.config/nextest.toml` gives this binary `threads-required =
+//! 'num-test-threads'` so it never overlaps with any other test in the run.
+//! The cache is rebuilt with `reindex::sync()` before returning so a local
+//! run leaves the mock data in place for whatever runs next.
 
 use anyhow::{Context, Result};
 use nexus_common::db::{get_redis_conn, kv::clear_redis, reindex, RedisOps};
@@ -79,7 +79,7 @@ async fn clear_redis_recreates_post_content_index() -> Result<()> {
     // Same derivation as setup_cache, so a rename of PostDetails moves both sides.
     let prefix = format!("{}:", PostDetails::prefix().await);
 
-    // Connector init already applied the schema.
+    // Connector init already applied the schema before registering the pool.
     let before = post_content_index_info().await?;
     assert_post_content_schema(&before, &prefix, "after stack setup");
 

--- a/nexusd/tests/cache_setup/main.rs
+++ b/nexusd/tests/cache_setup/main.rs
@@ -1,0 +1,105 @@
+//! Regression test for the Redis schema bootstrap (`setup_cache`). Requires the
+//! docker stack (Redis with the query engine + Neo4j) to be up.
+//!
+//! `clear_redis()` issues FLUSHDB, which destroys the RediSearch index along
+//! with the keys, so `setup_cache` must run again on every flush rather than
+//! once per process. Wrapping it in a `OnceCell` (the way `setup_graph` is)
+//! would pass every other test, because they boot the stack once and never
+//! flush, while silently breaking `nexusd db clear --yes` and the reindex
+//! bench. This test pins that behavior.
+//!
+//! It lives in its own binary and is the only nexusd test that flushes Redis.
+//! The other nexusd integration tests assert on graph state, not Redis, so no
+//! nextest serialization is needed. The cache is rebuilt with
+//! `reindex::sync()` before returning so a local run leaves the mock data
+//! in place for whatever runs next.
+
+use anyhow::{Context, Result};
+use nexus_common::db::{get_redis_conn, kv::clear_redis, reindex};
+use nexus_common::{StackConfig, StackManager};
+use redis::Value;
+
+const POST_CONTENT_INDEX: &str = "postContentIdx";
+
+/// Flattens an FT.INFO reply into its leaf strings so assertions don't depend
+/// on the exact nesting RediSearch uses for the `attributes` section.
+fn flatten(value: Value, out: &mut Vec<String>) {
+    match value {
+        Value::Array(items) | Value::Set(items) => items.into_iter().for_each(|v| flatten(v, out)),
+        Value::Map(pairs) => pairs.into_iter().for_each(|(k, v)| {
+            flatten(k, out);
+            flatten(v, out);
+        }),
+        Value::BulkString(bytes) => out.push(String::from_utf8_lossy(&bytes).into_owned()),
+        Value::SimpleString(s) | Value::VerbatimString { text: s, .. } => out.push(s),
+        Value::Int(i) => out.push(i.to_string()),
+        _ => {}
+    }
+}
+
+/// Returns every leaf string of `FT.INFO postContentIdx`, or the error the
+/// server replied with (e.g. "Unknown index name" when the index is absent).
+async fn post_content_index_info() -> Result<Vec<String>> {
+    let mut conn = get_redis_conn().await?;
+    let raw: Value = redis::cmd("FT.INFO")
+        .arg(POST_CONTENT_INDEX)
+        .query_async(&mut conn)
+        .await
+        .with_context(|| format!("FT.INFO {POST_CONTENT_INDEX} failed"))?;
+    let mut leaves = Vec::new();
+    flatten(raw, &mut leaves);
+    Ok(leaves)
+}
+
+async fn db_size() -> Result<i64> {
+    let mut conn = get_redis_conn().await?;
+    Ok(redis::cmd("DBSIZE").query_async(&mut conn).await?)
+}
+
+fn assert_post_content_schema(info: &[String], stage: &str) {
+    for field in ["$.content", "$.author", "$.kind"] {
+        assert!(
+            info.iter().any(|s| s == field),
+            "{stage}: {POST_CONTENT_INDEX} should index {field}, got {info:?}"
+        );
+    }
+    assert!(
+        info.iter().any(|s| s == "Post:Details:"),
+        "{stage}: {POST_CONTENT_INDEX} should be scoped to the PostDetails prefix, got {info:?}"
+    );
+}
+
+#[tokio_shared_rt::test(shared)]
+async fn clear_redis_recreates_post_content_index() -> Result<()> {
+    StackManager::setup(&StackConfig::default())
+        .await
+        .map_err(|e| anyhow::anyhow!("could not initialise the stack: {e:?}"))?;
+
+    // Connector init already applied the schema.
+    let before = post_content_index_info().await?;
+    assert_post_content_schema(&before, "after stack setup");
+
+    // FLUSHDB destroys the index together with the keys; clear_redis must bring
+    // the schema back on its own, without a migration run.
+    clear_redis().await?;
+    assert_eq!(
+        db_size().await?,
+        0,
+        "FLUSHDB should have emptied the database"
+    );
+
+    let after = post_content_index_info()
+        .await
+        .context("post content index must survive clear_redis()")?;
+    assert_post_content_schema(&after, "after clear_redis");
+
+    // Restore the mock cache from the graph so the flush is not observable
+    // by whatever runs after this test.
+    reindex::sync().await;
+    assert!(
+        db_size().await? > 0,
+        "reindex::sync should have repopulated Redis from the graph"
+    );
+
+    Ok(())
+}

--- a/nexusd/tests/cache_setup/main.rs
+++ b/nexusd/tests/cache_setup/main.rs
@@ -82,11 +82,6 @@ async fn clear_redis_recreates_post_content_index() -> Result<()> {
     // FLUSHDB destroys the index together with the keys; clear_redis must bring
     // the schema back on its own, without a migration run.
     clear_redis().await?;
-    assert_eq!(
-        db_size().await?,
-        0,
-        "FLUSHDB should have emptied the database"
-    );
 
     let after = post_content_index_info()
         .await

--- a/nexusd/tests/cache_setup/main.rs
+++ b/nexusd/tests/cache_setup/main.rs
@@ -15,7 +15,8 @@
 //! in place for whatever runs next.
 
 use anyhow::{Context, Result};
-use nexus_common::db::{get_redis_conn, kv::clear_redis, reindex};
+use nexus_common::db::{get_redis_conn, kv::clear_redis, reindex, RedisOps};
+use nexus_common::models::post::PostDetails;
 use nexus_common::{StackConfig, StackManager};
 use redis::Value;
 
@@ -56,7 +57,7 @@ async fn db_size() -> Result<i64> {
     Ok(redis::cmd("DBSIZE").query_async(&mut conn).await?)
 }
 
-fn assert_post_content_schema(info: &[String], stage: &str) {
+fn assert_post_content_schema(info: &[String], prefix: &str, stage: &str) {
     for field in ["$.content", "$.author", "$.kind"] {
         assert!(
             info.iter().any(|s| s == field),
@@ -64,8 +65,8 @@ fn assert_post_content_schema(info: &[String], stage: &str) {
         );
     }
     assert!(
-        info.iter().any(|s| s == "Post:Details:"),
-        "{stage}: {POST_CONTENT_INDEX} should be scoped to the PostDetails prefix, got {info:?}"
+        info.iter().any(|s| s == prefix),
+        "{stage}: {POST_CONTENT_INDEX} should be scoped to the {prefix} prefix, got {info:?}"
     );
 }
 
@@ -75,9 +76,12 @@ async fn clear_redis_recreates_post_content_index() -> Result<()> {
         .await
         .map_err(|e| anyhow::anyhow!("could not initialise the stack: {e:?}"))?;
 
+    // Same derivation as setup_cache, so a rename of PostDetails moves both sides.
+    let prefix = format!("{}:", PostDetails::prefix().await);
+
     // Connector init already applied the schema.
     let before = post_content_index_info().await?;
-    assert_post_content_schema(&before, "after stack setup");
+    assert_post_content_schema(&before, &prefix, "after stack setup");
 
     // FLUSHDB destroys the index together with the keys; clear_redis must bring
     // the schema back on its own, without a migration run.
@@ -86,7 +90,7 @@ async fn clear_redis_recreates_post_content_index() -> Result<()> {
     let after = post_content_index_info()
         .await
         .context("post content index must survive clear_redis()")?;
-    assert_post_content_schema(&after, "after clear_redis");
+    assert_post_content_schema(&after, &prefix, "after clear_redis");
 
     // Restore the mock cache from the graph so the flush is not observable
     // by whatever runs after this test.


### PR DESCRIPTION
## Summary

`setup_graph()` is the single bootstrap point for Neo4j constraints and indexes, called from `Neo4jConnector::init`. Redis had no equivalent: the `postContentIdx` RediSearch index was created only by migrations, so `MockDb::sync_redis` and the bench setup hand-patched it in, while `db clear --yes` and the reindex bench loop flushed Redis without recreating it and silently lost full-text search.

This PR adds `nexus_common::db::setup_cache()` as the Redis counterpart and deletes the hand-patching.

- **`nexus-common/src/db/kv/setup.rs`** (new): `setup_cache()` is the single declaration of the search schema; future RediSearch indexes go here. It fetches a connection from the global connector and delegates to `pub(crate) setup_cache_on(conn)`, which issues the `FT.CREATE`. Deliberately **not** wrapped in a `OnceCell`: `MATCH (n) DETACH DELETE n` preserves Neo4j indexes so `setup_graph` can run once per process, but `FLUSHDB` destroys the FT index along with the keys, so `setup_cache` must be re-runnable after every flush. The doc comment states the boot requirement: Nexus needs a Redis with the query engine (docker-compose pins `redis:8.0.6-alpine`), and a failed `FT.CREATE` is fatal at connector init. A Redis without it stops every binary from starting rather than degrading search. This is a deliberate choice.
- **`RedisConnector::init`**: after the PING, applies the schema with `setup_cache_on` over a connection from the freshly built pool, **before** `REDIS_CONNECTOR.set(...)`. A failed `FT.CREATE` therefore leaves the global slot empty, so a later `StackManager::setup` with a different URI can still succeed in the same process. This mirrors `setup_graph()` in the Neo4j connector, minus the set-then-fail window.
- **`clear_redis()`**: re-applies the schema immediately after `FLUSHDB`, returning the flush connection to the pool first. This is the only flush path in the workspace, so it fixes `sync_redis`, `clear_database` and the reindex bench at once.
- **`nexus-webapi/src/mock.rs`, `benches/setup.rs`**: removed the hand-patched `create_post_content_index()` calls and the TODO. The bench setup now `.expect`s `StackManager::setup` instead of discarding its result, since the removed unwrap was what used to surface a broken Redis before any bench flushed the cache.
- **`post_content_index_author_setup_1780531200.rs`**: the v2 migration previously called the *shared* create/drop helpers, so it would silently start producing a v3 index the day a field is added to `setup_cache`. Its `FT.CREATE` / `FT.DROPINDEX` arg lists are now inlined and frozen, the same way the v1 migration already does. Both migrations stay registered; they are idempotent and still needed by deployed environments.
- **`kv/index/search.rs`**: `drop_post_content_index` is removed (-23 lines); its only caller was the v2 migration, which now carries a frozen copy. `ft_create_post_content_index` takes the connection explicitly so the connector can run it on its own pool. The `FT.CREATE` arg list is unchanged, but it now has a warning comment above it: adding or changing a field requires a matching index migration, because the frozen v2 migration would otherwise drop the new index and recreate v2 on a fresh environment during `nexusd db migration run`.
- **Public API break** for `nexus-common`: `pub nexus_common::models::post::drop_post_content_index` and `create_post_content_index` is removed.
- **`nexusd/tests/cache_setup/main.rs`** (new): `clear_redis_recreates_post_content_index` pins the no-`OnceCell` behavior. It asserts via `FT.INFO` that `postContentIdx` indexes `$.content`, `$.author`, `$.kind` over the `PostDetails::prefix()`-derived prefix both after stack setup and again after `clear_redis()`, then rebuilds the cache with `reindex::sync()` so a local run leaves the mock data in place. It lives in its own binary and is the only nexusd test that flushes Redis.
- **`.config/nextest.toml`**: the `cache_setup` binary gets `threads-required = 'num-test-threads'` so its `FLUSHDB` never overlaps with any other test in the run, including nexus-webapi's search suite under `--workspace`. A `[test-groups]` entry would not help: group limits only apply between members of the same group, so a one-test group protects nothing.

Untouched: `import_migrations`, the `Migration` trait, and the v1 migration.

Note: the reindex bench now runs with a live `postContentIdx` over `Post:Details:`, since `MockDb::drop_cache` recreates it on every iteration. Previously the first `FLUSHDB` destroyed the index and all later samples ran un-indexed. Its numbers are not comparable to previous runs.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo check --workspace --all-targets`
- [x] Dropped `postContentIdx` by hand, ran `nexusd db mock`: index recreated at connector init and again right after `FLUSHDB` before reindex
- [x] `FT.INFO postContentIdx` lists `content`, `author`, `kind` with prefix `Post:Details:`
- [x] `cargo nextest run -p nexus-webapi search --no-fail-fast`: 64 passed
- [x] `cargo nextest run -p nexusd -E 'binary(cache_setup)'`: 1 passed
- [x] `cargo nextest list --workspace -E 'package(nexusd) and binary(cache_setup)'` selects exactly the one test; nextest rejects an invalid `threads-required` value at config parse, so the override is honored
- [x] `nexusd db clear --yes` then `FT.INFO postContentIdx`: index still exists with all three fields (previously "Unknown index name")
