### PR TITLE
feat(observability): mount Prometheus alerting rules file into the local stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,28 @@ The bundled stack runs independently of the database services and combines the O
 docker compose -f docker/docker-compose.observability.yml up -d
 ```
 
+#### Alerting rules
+
+Prometheus loads alerting rules from `docker/otel/alerts.yaml`, which is mounted into the container at `/etc/prometheus/alerts.yaml`. To use your own rules file, set `PROMETHEUS_ALERTS_FILE` in `docker/.env` (paths are resolved relative to the `docker/` folder):
+
+```bash
+PROMETHEUS_ALERTS_FILE=./otel/my-alerts.yaml
+```
+
+After editing the rules, reload Prometheus without restarting the stack:
+
+```bash
+curl -X POST http://localhost:9090/-/reload
+```
+
+Validate a rules file before mounting it:
+
+```bash
+docker run --rm -v "$PWD/docker/otel:/rules:ro" --entrypoint promtool prom/prometheus:v2.55.1 check rules /rules/alerts.yaml
+```
+
+Active alerts are listed at [http://localhost:9090/alerts](http://localhost:9090/alerts) and in Grafana under Alerting.
+
 ### SigNoz
 
 SigNoz remains supported as an alternative OpenTelemetry backend. Follow the [SigNoz installation guide](https://signoz.io/docs/install), then replace the local endpoint above with the SigNoz OTLP endpoint. Its local dashboard is available at [http://localhost:3301](http://localhost:3301).

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Validate a rules file before mounting it:
 docker run --rm -v "$PWD/docker/otel:/rules:ro" --entrypoint promtool prom/prometheus:v2.55.1 check rules /rules/alerts.yaml
 ```
 
-Active alerts are listed at [http://localhost:9090/alerts](http://localhost:9090/alerts) and in Grafana under Alerting.
+Active alerts are listed at [http://localhost:9090/alerts](http://localhost:9090/alerts). Grafana also shows them under **Alerting > Alert rules** as data source-managed rules of the Prometheus datasource.
 
 ### SigNoz
 

--- a/docker/.env-sample
+++ b/docker/.env-sample
@@ -1,6 +1,9 @@
 # Uncomment to always start optional services (postgres) with `docker compose up -d`
 # COMPOSE_PROFILES=tests
 
+# Prometheus alerting rules file mounted into the observability stack (relative to the docker/ folder)
+# PROMETHEUS_ALERTS_FILE=./otel/alerts.yaml
+
 # Neo4J Community Edition does not support custom db_name and db_username
 # the default ones are `neo4j`
 NEO4J_DB_NAME=neo4j

--- a/docker/docker-compose.observability.yml
+++ b/docker/docker-compose.observability.yml
@@ -50,8 +50,11 @@ services:
       - '--storage.tsdb.path=/prometheus'
       - '--storage.tsdb.retention.time=24h'
       - '--web.enable-remote-write-receiver'
+      - '--web.enable-lifecycle'
     volumes:
       - ./otel/prometheus.yaml:/etc/prometheus/prometheus.yml:ro
+      # Alerting rules; override the host path via PROMETHEUS_ALERTS_FILE in docker/.env
+      - ${PROMETHEUS_ALERTS_FILE:-./otel/alerts.yaml}:/etc/prometheus/alerts.yaml:ro
       - prometheus_data:/prometheus
     ports:
       - 127.0.0.1:9090:9090

--- a/docker/otel/alerts.yaml
+++ b/docker/otel/alerts.yaml
@@ -1,0 +1,33 @@
+# Prometheus alerting rules for the local observability stack.
+#
+# This file is mounted into the Prometheus container at /etc/prometheus/alerts.yaml
+# (see docker-compose.observability.yml). Override the host path with the
+# PROMETHEUS_ALERTS_FILE variable in docker/.env to use your own rules file.
+#
+# Metrics exported by Nexus arrive via the OpenTelemetry Collector's Prometheus
+# remote-write exporter. OTLP dot-separated names are translated to underscores
+# (e.g. `neo4j.query.errors` -> `neo4j_query_errors_total`) and `service.name`
+# becomes the `service_name` label.
+#
+# Reload without restarting the container:
+#   curl -X POST http://localhost:9090/-/reload
+groups:
+  - name: nexus
+    rules:
+      - alert: NexusNeo4jQueryErrors
+        expr: sum(rate(neo4j_query_errors_total[5m])) > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Nexus is reporting Neo4j query errors"
+          description: "{{ $value | printf \"%.2f\" }} Neo4j query errors/s over the last 5 minutes."
+
+      - alert: NexusWatcherCursorStalled
+        expr: increase(watcher_primary_hs_cursor_stalled_total[15m]) > 0
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Nexus watcher cursor is stalled"
+          description: "The primary homeserver cursor did not advance during the last 15 minutes."

--- a/docker/otel/grafana-datasources.yaml
+++ b/docker/otel/grafana-datasources.yaml
@@ -7,6 +7,9 @@ datasources:
     access: proxy
     url: http://prometheus:9090
     isDefault: true
+    jsonData:
+      # Surface Prometheus-managed alerting rules under Alerting > Alert rules
+      manageAlerts: true
 
   - name: Tempo
     type: tempo

--- a/docker/otel/prometheus.yaml
+++ b/docker/otel/prometheus.yaml
@@ -2,6 +2,10 @@ global:
   scrape_interval: 15s
   evaluation_interval: 15s
 
+# Alerting rules mounted by docker-compose.observability.yml
+rule_files:
+  - /etc/prometheus/alerts.yaml
+
 scrape_configs:
   - job_name: prometheus
     static_configs:


### PR DESCRIPTION
## Summary

- Mount a Prometheus alerting rules file (`docker/otel/alerts.yaml`) into the local observability stack and register it via `rule_files` in `docker/otel/prometheus.yaml`.
- Allow overriding the host path with `PROMETHEUS_ALERTS_FILE` in `docker/.env` (documented in `.env-sample`).
- Enable `--web.enable-lifecycle` on Prometheus so rules can be reloaded with `curl -X POST http://localhost:9090/-/reload` without restarting the container.
- Document the setup, reload, and `promtool` validation flow in the README.

## Initial rules

| Alert | Expression | Fires when |
|-------|------------|------------|
| `NexusNeo4jQueryErrors` | `sum(rate(neo4j_query_errors_total[5m])) > 0` for 5m | Nexus reports Neo4j query errors for a sustained 5 minutes |
| `NexusWatcherCursorStalled` | `increase(watcher_primary_hs_cursor_stalled_total[15m]) > 0` | The watcher rejected a primary HS batch that carried events but did not advance the cursor within the last 15 minutes |

Metric names follow the collector's `prometheusremotewrite` translation: OTLP dotted names become underscores and counters gain a `_total` suffix.

## Test plan

- [ ] `docker run --rm -v "$PWD/docker/otel:/rules:ro" --entrypoint promtool prom/prometheus:v2.55.1 check rules /rules/alerts.yaml` passes
- [ ] `docker compose -f docker/docker-compose.observability.yml up -d` starts Prometheus with the rules mounted
- [ ] http://localhost:9090/alerts lists both rules as inactive
- [ ] `curl -X POST http://localhost:9090/-/reload` returns 200 after editing the rules file
- [ ] Setting `PROMETHEUS_ALERTS_FILE` in `docker/.env` swaps the mounted file
